### PR TITLE
Add bootstrap + skill versioning via git tags

### DIFF
--- a/bootstrap/commands/init_skills.md
+++ b/bootstrap/commands/init_skills.md
@@ -1,6 +1,6 @@
 ---
-description: Search kjuhwa/skills.git by keyword/category and install matching skills locally
-argument-hint: <keyword> [--global] [--category=<name>]
+description: Search kjuhwa/skills.git by keyword/category and install matching skills locally, optionally pinning a version
+argument-hint: <keyword | name@version> [--global] [--category=<name>] [--version=<x.y.z>]
 ---
 
 # /init_skills $ARGUMENTS
@@ -11,31 +11,45 @@ Install skills from the central repository matching the keyword.
 
 1. **Ensure remote cache exists**
    - Path: `~/.claude/skills-hub/remote/`
-   - If missing: `git clone --depth=1 https://github.com/kjuhwa/skills.git ~/.claude/skills-hub/remote`
-   - If present and older than 1h: `git -C ~/.claude/skills-hub/remote pull --ff-only` (run in background if slow)
+   - If missing: `git clone https://github.com/kjuhwa/skills.git ~/.claude/skills-hub/remote` (full clone — shallow drops tags needed for version pinning).
+   - If present and older than 1h: `git -C ~/.claude/skills-hub/remote fetch --tags --prune origin` then `git pull --ff-only` (run in background if slow).
    - If clone fails (network/auth), report clearly and stop — do NOT fabricate skills.
 
-2. **Search**
+2. **Parse version spec**
+   - `$ARGUMENTS` of form `name@version` → split into keyword=`name`, version=`version`.
+   - Explicit `--version=<x.y.z>` flag takes precedence.
+   - Default (no version): install from `main` HEAD (latest).
+
+3. **Search**
    - Read `~/.claude/skills-hub/remote/index.json` if present; else scan `**/SKILL.md` frontmatter.
    - Match keyword against: `name`, `description`, `tags`, `triggers`, `category` (case-insensitive).
    - If `--category=<name>` flag present, restrict to that category.
 
-3. **Present matches**
+4. **Present matches**
    - Show: `category/skill-name — description (tags)` in a numbered list.
    - If zero matches: suggest closest categories from `CATEGORIES.md` and stop.
    - If many (>10): show top 10 by tag-match score; ask user to narrow.
 
-4. **Ask user** which to install (accept numbers, `all`, or `cancel`).
+5. **Ask user** which to install (accept numbers, `all`, or `cancel`).
 
-5. **Install selected**
+6. **Resolve ref per skill**
+   - If a version was specified: verify tag `skills/<name>/v<version>` exists (`git -C ~/.claude/skills-hub/remote rev-parse --verify refs/tags/skills/<name>/v<version>`). If missing, list available tags for that skill via `git tag -l "skills/<name>/v*"` and stop.
+   - Checkout that skill's files from the tag into a temp staging dir: `git -C <remote> show <tag>:skills/<category>/<name>/<file>` per file (keeps main working tree untouched).
+   - No version → use current `main` checkout.
+
+7. **Install selected**
    - Destination:
      - `--global` flag OR no `.claude/` dir in cwd → `~/.claude/skills/<name>/`
      - else → `.claude/skills/<name>/`
-   - On name collision: show diff of existing vs remote SKILL.md, ask overwrite/skip/rename.
+   - On name collision: show diff of existing vs remote SKILL.md (including version), ask overwrite/skip/rename.
    - Copy entire skill directory (SKILL.md + content.md + examples/).
-   - Update `~/.claude/skills-hub/registry.json` with entry (category, source_commit, scope, installed_at).
+   - Update `~/.claude/skills-hub/registry.json` entry:
+     - `category`, `scope`, `installed_at`
+     - `version` (resolved version string)
+     - `source_commit` (tag's commit SHA, or `main` HEAD SHA if unversioned)
+     - `pinned: true` when an explicit version was supplied — `/skills_sync` must skip pinned entries unless `--force`.
 
-6. **Report**
+8. **Report**
    - List installed skills with their local path.
    - Remind user they may need to restart Claude Code session to pick up new skills.
 

--- a/bootstrap/commands/skills_bootstrap_publish.md
+++ b/bootstrap/commands/skills_bootstrap_publish.md
@@ -1,0 +1,55 @@
+---
+description: Publish local slash-command edits to kjuhwa/skills.git bootstrap/commands/ with a version tag
+argument-hint: [--bump=major|minor|patch] [--version=<x.y.z>] [--pr] [--branch=<name>]
+---
+
+# /skills_bootstrap_publish $ARGUMENTS
+
+Stage `~/.claude/commands/*.md` edits into `bootstrap/commands/` on the remote repo, commit, and push a `bootstrap/v<semver>` annotated tag so `/skills_bootstrap_update` can roll forward or back.
+
+## Steps
+
+1. **Refresh cache**
+   - `git -C ~/.claude/skills-hub/remote fetch --tags --prune origin`.
+   - Clean checkout `main`: `git checkout main && git reset --hard origin/main` (stop if cache is dirty).
+
+2. **Determine next version**
+   - Read `~/.claude/skills-hub/bootstrap.json` → `installed_version` (or use latest `bootstrap/v*` tag if absent).
+   - Resolve target:
+     - `--version=<x.y.z>`: explicit. Refuse if tag already exists.
+     - `--bump=major|minor|patch`: compute next.
+     - Default: `patch` bump.
+   - Reject pre-existing tags unless a different explicit version is supplied.
+
+3. **Diff bootstrap vs local**
+   - For each file in `~/.claude/commands/*.md` that also exists in `bootstrap/commands/`:
+     - Show unified diff.
+   - Detect new files (in local but not remote) and prompt user to include / skip per file.
+   - Files only in remote but not local → not deleted (user may have removed locally on purpose); prompt: keep-in-remote / delete-in-remote.
+
+4. **Create branch + copy**
+   - Branch: `--branch=<name>` OR auto `bootstrap/release-v<version>`.
+   - `git checkout -b <branch>`.
+   - Copy approved local files into `bootstrap/commands/<file>`.
+   - If any file was removed upstream per user decision, `git rm` it.
+
+5. **Commit + tag**
+   - Single commit: `Bootstrap v<version>: <summary>`. Summary is auto-generated from changed filenames (user may edit).
+   - Annotated tag: `git tag -a bootstrap/v<version> -m "Bootstrap commands v<version>"`.
+
+6. **Push** (confirmation required)
+   - `git push -u origin <branch>`.
+   - `git push origin bootstrap/v<version>`.
+   - If `--pr` and `gh` CLI present: `gh pr create --title "Bootstrap v<version>" --body <changelog>`.
+   - Otherwise print branch, tag, and compare URL.
+
+7. **Report**
+   - Published version, tag name, branch, commit SHA, file list.
+   - Reminder: tag is immediately usable for `/skills_bootstrap_update --version=<x.y.z>` once pushed, even before PR merge.
+
+## Rules
+
+- **Never push to `main` directly** — always via feature branch + PR.
+- Refuse to overwrite an existing tag (tags are immutable history).
+- Skip files not in the `bootstrap/commands/` manifest (user-private commands stay local).
+- If there are zero differences vs remote HEAD, report and stop — don't create empty version bumps.

--- a/bootstrap/commands/skills_bootstrap_update.md
+++ b/bootstrap/commands/skills_bootstrap_update.md
@@ -1,0 +1,52 @@
+---
+description: Update local slash commands (init_skills, skills_*) from kjuhwa/skills.git — latest or a specific version
+argument-hint: [--version=<x.y.z>] [--dry-run] [--force]
+---
+
+# /skills_bootstrap_update $ARGUMENTS
+
+Pull slash-command files from `bootstrap/commands/` in the remote repo and install them into `~/.claude/commands/`. Supports latest (HEAD) or a specific tagged version for rollback.
+
+## Steps
+
+1. **Refresh cache**
+   - `git -C ~/.claude/skills-hub/remote fetch --tags --prune origin`.
+   - If working tree clean: `git -C ~/.claude/skills-hub/remote checkout main && git -C ~/.claude/skills-hub/remote reset --hard origin/main`.
+   - If cache dirty or has local commits: report and stop.
+
+2. **Resolve ref**
+   - `--version=<x.y.z>`: use tag `bootstrap/v<x.y.z>`. Verify it exists via `git -C <remote> rev-parse --verify refs/tags/bootstrap/v<x.y.z>`. If missing, list `git -C <remote> tag -l "bootstrap/v*" | sort -V` and stop.
+   - No flag: use `main` HEAD.
+
+3. **Diff preview**
+   - For each file in `bootstrap/commands/` at the resolved ref, compare against `~/.claude/commands/<file>`.
+   - Show list: `NEW / UPDATED / UNCHANGED / LOCAL-MODIFIED`.
+   - `LOCAL-MODIFIED` = user edited their local copy; updating will overwrite — warn and offer `.bak`.
+
+4. **Apply**
+   - `--dry-run`: print plan only, write nothing.
+   - Otherwise: extract each file via `git -C <remote> show <ref>:bootstrap/commands/<file>` → write to `~/.claude/commands/<file>`.
+   - For `LOCAL-MODIFIED` files without `--force`: skip and report.
+
+5. **Record version**
+   - Write `~/.claude/skills-hub/bootstrap.json`:
+     ```json
+     {
+       "installed_version": "1.2.0",
+       "installed_commit": "<sha>",
+       "installed_at": "<iso>",
+       "source_ref": "bootstrap/v1.2.0"
+     }
+     ```
+   - If installing from `main` HEAD (no version flag), set `installed_version: "main"` and record the commit SHA.
+
+6. **Report**
+   - Show: previous version → new version, list of changed commands, any skipped due to local modifications.
+   - Remind user that newly added slash commands may need a Claude Code restart to register.
+
+## Rules
+
+- Never touch `~/.claude/commands/` files outside `bootstrap/commands/` scope — user-authored commands stay untouched.
+- Never `reset --hard` if the remote cache has uncommitted work (guard with `git status --porcelain`).
+- Rollback (downgrade to older tag) is allowed; confirm explicitly when target version is lower than `installed_version`.
+- If `bootstrap.json` is missing, treat as first install and proceed.

--- a/bootstrap/commands/skills_list.md
+++ b/bootstrap/commands/skills_list.md
@@ -14,7 +14,7 @@ Report installed skills tracked by the hub registry.
    - `~/.claude/skills/*/SKILL.md` (global scope)
    - `.claude/skills/*/SKILL.md` if cwd has `.claude/` (project scope)
 3. Cross-reference:
-   - **Tracked + present**: normal entry → show name, scope, category, source_commit, installed_at.
+   - **Tracked + present**: normal entry → show name, scope, category, version, `PINNED` marker when `pinned: true`, source_commit, installed_at.
    - **Tracked + missing**: `[ORPHAN REGISTRY]` — offer to remove from registry.
    - **Untracked + present**: `[UNTRACKED]` — manually authored or pre-hub install.
 4. Apply flag filter: `--global`, `--project`, `--orphans`.

--- a/bootstrap/commands/skills_publish.md
+++ b/bootstrap/commands/skills_publish.md
@@ -1,6 +1,6 @@
 ---
-description: Review skill drafts and push them to kjuhwa/skills.git as a branch
-argument-hint: [--all | --draft=<name>] [--pr] [--branch=<name>]
+description: Review skill drafts and push them to kjuhwa/skills.git as a branch, with per-skill version tags
+argument-hint: [--all | --draft=<name>] [--pr] [--branch=<name>] [--bump=major|minor|patch]
 ---
 
 # /skills_publish $ARGUMENTS
@@ -25,13 +25,20 @@ Publish `.skills-draft/` contents to the remote repository.
    - Ensure `~/.claude/skills-hub/remote` is on latest main: `git fetch && git checkout main && git reset --hard origin/main`.
    - Create branch: `--branch=<name>` OR auto `skills/add-<primary-category>-<YYYYMMDD>`.
    - Copy approved drafts into `skills/<category>/<skill-name>/`.
-   - Rebuild `index.json` (scan all SKILL.md frontmatter → flat JSON).
-   - Commit per skill with message: `Add <category>/<name>: <one-line description>`.
+   - **Version resolution per skill**:
+     - Read SKILL.md `version` field from the draft.
+     - Check if tag `skills/<name>/v<ver>` already exists on origin (`git ls-remote --tags origin`).
+     - If exists: refuse to publish until user bumps — suggest next version based on `--bump` flag (default `patch`). Rewrite draft's SKILL.md frontmatter to the bumped value.
+     - If `version` missing in frontmatter: set to `1.0.0` for new skills, or latest remote tag + bump for existing skills.
+   - Rebuild `index.json` (scan all SKILL.md frontmatter → flat JSON; include `version`).
+   - Commit per skill with message: `Add <category>/<name> v<version>: <one-line description>` (use `Update` verb when skill already exists remotely).
 
-4. **Push** (requires confirmation)
+4. **Push + tag** (requires confirmation)
    - `git push -u origin <branch>`.
-   - If `--pr` flag and `gh` CLI available: `gh pr create --title ... --body ...` using draft's description + source_project.
-   - Otherwise print the branch name and compare URL.
+   - For each published skill, create annotated tag: `git tag -a skills/<name>/v<version> -m "<name> v<version>"` pointing at that skill's commit, then `git push origin skills/<name>/v<version>`.
+   - Tags are pushed even before PR merge so `skills_sync --version=` can resolve them from the branch; note in output that tags on feature branches are discoverable but only authoritative after merge.
+   - If `--pr` flag and `gh` CLI available: `gh pr create --title ... --body ...` using draft's description + source_project; include published version list in PR body.
+   - Otherwise print the branch name, tag list, and compare URL.
 
 5. **Cleanup drafts**
    - Move published drafts to `.skills-draft/_published/<date>/` (don't delete outright — user may want reference).

--- a/bootstrap/commands/skills_search.md
+++ b/bootstrap/commands/skills_search.md
@@ -14,13 +14,14 @@ Read-only search of the remote skill repository.
 3. Filter by keyword (name/description/tags/triggers/category, case-insensitive) and optional `--category`.
 4. For each match, output:
    ```
-   <category>/<skill-name>  v<version>
+   <category>/<skill-name>  v<version> (latest)
      description: ...
      tags: [..]
      triggers: [..]
      path: remote/skills/<category>/<skill-name>/
+     versions: v1.0.0, v1.1.0, v1.2.0   # from `git tag -l "skills/<skill-name>/v*" | sort -V`
    ```
-5. If user asks to view one, read its `content.md` and display.
+5. If user asks to view one, read its `content.md` and display. If they want a specific version, `git -C <remote> show skills/<name>/v<ver>:skills/<category>/<name>/content.md`.
 
 ## Rules
 

--- a/bootstrap/commands/skills_sync.md
+++ b/bootstrap/commands/skills_sync.md
@@ -1,35 +1,51 @@
 ---
-description: Refresh remote cache and update installed skills to latest versions
-argument-hint: [--dry-run] [--force]
+description: Refresh remote cache and update installed skills — to latest, to a specific version, or rollback
+argument-hint: [--dry-run] [--force] [--skill=<name>] [--version=<x.y.z>] [--unpin]
 ---
 
 # /skills_sync $ARGUMENTS
 
-Pull remote updates and bring local installs up to date.
+Bring local installs to latest — or pin/rollback a specific skill to an exact version via git tags.
+
+## Modes
+
+- **Bulk update** (no flags): update every non-pinned skill to latest `main`.
+- **Targeted version**: `--skill=<name> --version=<x.y.z>` → install that skill at tag `skills/<name>/v<x.y.z>` (rollback or forward-pin). Automatically sets `pinned: true`.
+- **Unpin**: `--skill=<name> --unpin` → clear pin flag so next bulk sync tracks latest again.
 
 ## Steps
 
 1. **Refresh cache**
-   - `git -C ~/.claude/skills-hub/remote fetch origin` then `git reset --hard origin/main` *only if* the cache has no local commits (verify with `git status`). If local commits exist, report and stop.
+   - `git -C ~/.claude/skills-hub/remote fetch --tags --prune origin`.
+   - `git reset --hard origin/main` *only if* the cache has no local commits (verify with `git status`). If local commits exist, report and stop.
 
-2. **Diff per tracked skill**
-   - For each entry in `registry.json`:
-     - Compare `source_commit` vs current remote HEAD for that skill's path.
-     - If unchanged: skip.
-     - If changed: show diff summary (files changed, version bump).
+2. **Resolve targets**
+   - Targeted mode: verify `refs/tags/skills/<name>/v<version>` exists. If missing, run `git tag -l "skills/<name>/v*" | sort -V` and print the list; stop.
+   - Bulk mode: iterate `registry.json`; skip entries where `pinned: true` (unless `--force`).
 
-3. **Prompt user** per changed skill: update / skip / show-diff.
-   - `--force` applies all updates without prompt.
+3. **Diff per skill**
+   - Compare local `source_commit` vs the target ref's commit for that skill's path.
+   - Unchanged → skip.
+   - Changed → show diff summary (files changed, version field before/after, tag name for targeted mode).
+
+4. **Prompt user** per changed skill: update / skip / show-diff.
+   - `--force` applies without prompt.
    - `--dry-run` shows the diff only, writes nothing.
 
-4. **Apply updates**
-   - Overwrite local skill directory with remote version.
-   - Update registry entry (`source_commit`, `version`, `synced_at`).
+5. **Apply updates**
+   - Extract files via `git -C <remote> show <ref>:skills/<category>/<name>/<file>` into a staging dir, then replace the local skill directory.
+   - Update registry entry:
+     - `source_commit` (commit SHA the tag or main points at)
+     - `version` (from SKILL.md frontmatter at that ref)
+     - `synced_at` (ISO timestamp)
+     - `pinned` — set `true` for targeted version installs, clear on `--unpin`, preserve otherwise.
 
-5. **Local-modified detection**
+6. **Local-modified detection**
    - If local SKILL.md/content.md differs from stored commit content, warn user — updating will lose local edits. Offer to save a `.bak` copy.
 
 ## Rules
 
 - Never `reset --hard` if the cache has uncommitted changes (shouldn't happen, but guard).
-- Report summary at end: updated / skipped / conflicted.
+- Pinned skills are skipped in bulk mode; report them as `pinned (version)` in the summary so the user knows they are frozen.
+- Downgrades (rollback to older tag) are allowed — confirm explicitly when the target version is lower than the installed version.
+- Report summary at end: updated / skipped / pinned / conflicted.

--- a/bootstrap/skills/skills-hub/SKILL.md
+++ b/bootstrap/skills/skills-hub/SKILL.md
@@ -40,11 +40,22 @@ Registry entry format:
     "category": "apm",
     "source_commit": "a1b2c3",
     "installed_at": "2026-04-14T10:00:00Z",
+    "synced_at": "2026-04-15T09:30:00Z",
     "scope": "project|global",
-    "version": "1.0.0"
+    "version": "1.0.0",
+    "pinned": false
   }
 }
 ```
+
+## Versioning Contract (git tags)
+
+- Every published skill version gets an annotated tag: `skills/<name>/v<semver>` (e.g. `skills/foo/v1.2.0`).
+- `/skills_publish` creates and pushes the tag as part of the publish flow; bumps the version in SKILL.md frontmatter if the existing tag is unchanged.
+- `/init_skills foo@1.2.0` (or `--version=1.2.0`) installs the files at that tag and sets `pinned: true` in the registry.
+- `/skills_sync --skill=foo --version=1.1.0` performs a rollback to that tag (also pins).
+- `/skills_sync --skill=foo --unpin` clears the pin so the skill tracks latest again.
+- Bulk `/skills_sync` skips pinned skills unless `--force`.
 
 ## Command Map
 
@@ -60,6 +71,8 @@ Registry entry format:
 | `/skills_finalize` | End-of-project: extract → review → publish → cleanup drafts |
 | `/skills_cleanup` | Remote maintenance: dedupe, re-index, stale removal (dry-run default) |
 | `/skills_remove <name>` | Uninstall local skill |
+| `/skills_bootstrap_update [--version=x.y.z]` | Update slash-command files themselves to latest or a tagged version |
+| `/skills_bootstrap_publish [--bump=…]` | Publish local command edits to remote with a `bootstrap/v<ver>` tag |
 
 ## Safety Rules
 


### PR DESCRIPTION
- Skills: /skills_publish now tags skills/<name>/v<semver> per release; /init_skills supports name@version and --version pinning; /skills_sync adds --skill/--version (rollback) and --unpin flows; registry.json gains pinned + synced_at fields.
- Bootstrap: new /skills_bootstrap_publish tags bootstrap/v<semver>
  for slash-command releases; new /skills_bootstrap_update installs or rolls back command files by tag, tracked in bootstrap.json.
- skills-hub SKILL.md: document Versioning Contract and command map.