### PR TITLE
Add initial knowledge seed: 5 entries across arch/decision/pitfall

### DIFF
--- a/knowledge/arch/additive-registry-schema-versioning.md
+++ b/knowledge/arch/additive-registry-schema-versioning.md
@@ -1,0 +1,43 @@
+---
+name: additive-registry-schema-versioning
+type: knowledge
+category: arch
+tags: [registry, schema, versioning, migration, backwards-compat]
+summary: "JSON registry 진화는 version bump + 새 키 empty container + 첫 쓰기 시 자동 마이그레이션으로 하라"
+source:
+  kind: session
+  ref: session-2026-04-15-skills-extract-knowledge
+  repo: local
+confidence: high
+linked_skills: []
+supersedes: null
+extracted_at: 2026-04-15
+extracted_by: skills_extract_knowledge v1
+---
+
+## Fact
+클라이언트가 공유하는 JSON registry 스키마를 진화시킬 때는 세 가지를 동시에 지켜라:
+1. 최상위 `version` 필드를 bump (없으면 도입).
+2. 신규 필드는 empty container(`{}`, `[]`, `null`)로 추가 — 기존 엔트리를 절대 건드리지 않는다.
+3. 클라이언트는 첫 쓰기 직전에 감지·자동 마이그레이션하고 temp-file + rename으로 atomic write.
+
+## Context / Why
+- Registry는 여러 클라이언트/세션이 동시에 읽고 쓰는 공유 상태라 downtime 마이그레이션이 불가능하다.
+- 필드 추가만 하는 진화는 옛 클라이언트가 새 필드를 무시하고도 읽기가 성립 → 전진 호환.
+- 새 클라이언트는 `version < target` 을 보자마자 필요한 빈 필드만 채워넣어 쓰기 → 후진 호환 유지 + 업그레이드.
+- Atomic write (temp + rename)은 마이그레이션 중 crash 시 반쪽 상태 방지.
+
+## Evidence
+- skills-hub registry v1 → v2 전환: `version` 필드 신설, `knowledge: {}` 추가, 각 skill에 `linked_knowledge: []` 추가, 기존 skill 엔트리 원형 보존.
+- v1 클라이언트는 `knowledge` 키를 읽지 않아도 동작 유지.
+- [commit 3559fc6] bootstrap/commands/skills_extract_knowledge.md — Preconditions 섹션에 마이그레이션 절차 명문화.
+
+## Applies when
+- JSON/YAML 기반 공유 registry/manifest의 스키마 변경
+- 중앙 서버 없이 파일 기반으로 동기화되는 설정 저장소
+- 여러 버전의 클라이언트가 공존할 수 있는 환경 (점진 rollout)
+
+## Counter / Caveats
+- **의미 변경 금지**: 이 패턴은 필드 "추가"에만 유효하다. 기존 필드의 의미/타입을 바꿔야 하는 변경은 새 key로 분기하고 deprecation 기간을 둘 것.
+- **무한 누적 리스크**: 버전이 쌓이면 legacy 필드 청소가 안 된다 → 주기적으로 `version` major bump로 breaking migration 창구를 만들어야 한다.
+- **동시 쓰기 경합**: atomic rename이 OS 수준에서 보장되지 않는 파일시스템(일부 네트워크 FS)에서는 lock 파일 병행 필요.

--- a/knowledge/arch/k-git-tag-registry-versioning.md
+++ b/knowledge/arch/k-git-tag-registry-versioning.md
@@ -1,0 +1,40 @@
+---
+name: k-git-tag-registry-versioning
+type: knowledge
+category: arch
+tags: [git, versioning, registry, rollback, semver]
+summary: "Git tag를 semver registry로 쓰면 별도 version manifest 없이 rollback·pinning을 얻는다"
+source:
+  kind: commit
+  ref: cff6174d1193992e9eb10196ff266122493779aa
+  repo: https://github.com/kjuhwa/skills.git
+confidence: high
+linked_skills: [git-tag-registry-versioning]
+supersedes: null
+extracted_at: 2026-04-15
+extracted_by: skills_extract_knowledge v1
+---
+
+## Fact
+Git-backed asset distribution에서 release line은 tag, rollback은 `checkout <tag>`, pin은 "resolve-once-and-store" 패턴으로 충분하다. 별도의 version index/manifest를 유지할 필요가 없다.
+
+## Context / Why
+- Registry 서비스 없이 git만으로 asset(skill, plugin, command 등)을 배포할 때, 버전 관리 계층을 추가하면 두 번째 진실 공급원(registry vs git)이 생겨 drift가 발생한다.
+- Tag는 git 자체가 불변·서명 가능·원자적으로 다뤄 주므로 semver 버전 식별자로 재사용하면 추가 인프라가 0이다.
+- 각 로컬 설치본에는 "설치 시점의 tag(=commit)"만 기록하면 재현성과 rollback이 성립한다.
+
+## Evidence
+- [commit cff6174] skills/arch/git-tag-registry-versioning/content.md:1-99
+- [commit 2849a01] bootstrap/commands/skills_publish.md — `/skills_publish` 가 `skills/<name>/v<semver>` tag를 생성
+- [commit 2849a01] bootstrap/commands/skills_sync.md — `--skill/--version` 으로 rollback, `--unpin` 으로 pin 해제
+- registry.json 에 `pinned`, `synced_at` 필드 추가
+
+## Applies when
+- 중앙 registry 없이 git 저장소만으로 asset을 배포·설치하는 툴을 설계할 때
+- rollback, 버전 고정(pinning), 재현 가능 설치가 요구될 때
+- 설치본이 여러 머신에 분산되어 drift를 피해야 할 때
+
+## Counter / Caveats
+- Tag 이름 충돌이나 force-push로 tag가 이동하면 재현성이 깨진다 → tag immutability 정책이 필요.
+- 대규모(수천 개) asset 에서 tag 네임스페이스가 비대해지면 `git ls-remote` 성능 이슈 발생 가능 → prefix 규칙 필수.
+- Binary asset이나 LFS 기반 배포에서는 tag-only 접근이 네트워크 비용과 맞지 않을 수 있음.

--- a/knowledge/decision/caveats-absence-confidence-cap.md
+++ b/knowledge/decision/caveats-absence-confidence-cap.md
@@ -1,0 +1,39 @@
+---
+name: caveats-absence-confidence-cap
+type: knowledge
+category: decision
+tags: [calibration, confidence, falsifiability, knowledge-quality]
+summary: "반증 조건(Counter/Caveats)이 비어 있는 knowledge는 confidence 최대 medium으로 강등한다 — 미확인 = 과신 위험"
+source:
+  kind: session
+  ref: session-2026-04-15-skills-extract-knowledge
+  repo: local
+confidence: medium
+linked_skills: []
+supersedes: null
+extracted_at: 2026-04-15
+extracted_by: skills_extract_knowledge v1
+---
+
+## Fact
+Knowledge 항목의 `## Counter / Caveats` 섹션이 비어 있으면 confidence를 자동으로 `medium` 이하로 제한하라. 반증 경로를 명시하지 않은 주장은 "검증되지 않은 단정"으로 간주하고, 그 자체가 calibration 신호다.
+
+## Context / Why
+- Popper 의미의 반증 가능성(falsifiability) — 어떤 조건에서 이 명제가 깨지는지 적을 수 있어야 지식이 검증 가능.
+- "caveats를 못 쓰겠다"는 두 가지 신호 중 하나다: (a) 작성자가 반례를 떠올리지 못했다 → 조사 부족, (b) 명제가 너무 일반화되어 반례가 자명하다 → 범위 재정의 필요. 둘 다 `high` 를 줄 근거가 아니다.
+- Confidence는 다운스트림(검색 랭킹, auto-inject, skill 추천)의 가중치로 쓰이므로, 초기 저장 시점의 규율이 검색 품질을 좌우한다.
+
+## Evidence
+- skills-hub classifier rule: "Caveats 결손 시 confidence 최대 medium" 명문화.
+- Dry-run 사례: `k-kafka-message-header-metadata`가 초기 `high` 후보였으나 반증 사례 기록 부족으로 `medium` 유지 — 이후 실제 header 미지원 consumer 존재로 이 강등이 정당화됨.
+- [commit 3559fc6] bootstrap/commands/skills_extract_knowledge.md — Classify Rules "Caveats 결손 시 강등" 항목.
+
+## Applies when
+- Knowledge/RFC/ADR 스타일의 서술 항목 저장 시 calibration이 필요할 때
+- LLM이 자동 생성한 주장에 과신 위험이 있는 pipeline
+- 검색·랭킹·자동 주입이 confidence를 가중치로 사용하는 시스템
+
+## Counter / Caveats
+- **진짜 반례가 없는 명제 예외**: 수학적 항등식, 순수 정의, 프로토콜 스펙 인용 등은 Caveats가 비어도 자연스럽다 → 명시적 `caveats: none` 마커로 override 허용 필요.
+- 규칙 강도 과한 가능성: `medium` 강등이 진짜 고신뢰 지식을 저평가하면 검색 품질이 떨어질 수 있다 → 사용 후 false-downgrade 비율을 모니터링해 임계 조정.
+- Caveats 작성 부담이 오히려 knowledge 추출 자체를 기피하게 만들면 역효과 → extract UI에서 "Caveats 없음 허용" 빠른 경로 제공 고려.

--- a/knowledge/decision/k-kafka-message-header-metadata.md
+++ b/knowledge/decision/k-kafka-message-header-metadata.md
@@ -1,0 +1,38 @@
+---
+name: k-kafka-message-header-metadata
+type: knowledge
+category: decision
+tags: [kafka, multi-tenant, routing, message-schema]
+summary: "멀티테넌트 Kafka routing 메타는 payload 대신 RecordHeader에 두어 business schema 오염을 막는다"
+source:
+  kind: commit
+  ref: da42d24373484f3275430e1f61d914bdd02ac740
+  repo: https://github.com/kjuhwa/skills.git
+confidence: medium
+linked_skills: [kafka-message-header-metadata]
+supersedes: null
+extracted_at: 2026-04-15
+extracted_by: skills_extract_knowledge v1
+---
+
+## Fact
+tenant/user/timestamp 같은 cross-cutting 메타데이터는 Kafka `RecordHeader[]` 에 분리 수록한다. Payload schema는 business 필드만 유지되어야 routing·auditing 계층이 업무 스키마 변경과 독립적으로 진화할 수 있다.
+
+## Context / Why
+- Multi-tenant routing 키를 payload 안에 섞으면 모든 consumer가 tenant 구조를 알아야 하고, payload schema가 업무 외 이유로 자주 바뀐다.
+- Header는 Kafka broker 수준에서 접근 가능해 routing·filtering·audit hook이 payload deserialize 없이 동작할 수 있다.
+- org-id/user-id/request-timestamp는 표준 header key로 승격하여 consumer 전반에 동일 키를 강제한다.
+
+## Evidence
+- [commit da42d24] skills/backend/kafka-message-header-metadata/SKILL.md:1-81
+
+## Applies when
+- 멀티테넌트 Kafka 토픽 설계
+- payload schema를 업무 도메인 전용으로 유지하고 싶을 때
+- broker/interceptor 수준의 routing·auditing이 필요할 때
+
+## Counter / Caveats
+- Header에 개인정보(PII)가 들어가면 payload 암호화와 header 암호화 정책이 별도로 필요해진다.
+- 일부 legacy consumer/프로토콜(예: pre-0.11 Kafka)은 header를 지원하지 않는다 — 호환성 확인 필요.
+- Header 총 크기 제한(브로커 설정)으로 인해 무제한 확장은 불가.
+- 반증 사례(header 방식이 실패한 시스템) 기록이 아직 부족해 confidence는 medium.

--- a/knowledge/pitfall/classifier-both-verdict-self-reference.md
+++ b/knowledge/pitfall/classifier-both-verdict-self-reference.md
@@ -1,0 +1,39 @@
+---
+name: classifier-both-verdict-self-reference
+type: knowledge
+category: pitfall
+tags: [llm, classifier, schema, post-processing, linking]
+summary: "LLM classifier의 both-verdict에 suggested_links를 허용하면 자기 자신을 가리키는 self-link가 나온다 — 링크는 post-process에서 붙일 것"
+source:
+  kind: session
+  ref: session-2026-04-15-skills-extract-knowledge
+  repo: local
+confidence: medium
+linked_skills: []
+supersedes: null
+extracted_at: 2026-04-15
+extracted_by: skills_extract_knowledge v1
+---
+
+## Fact
+한 청크에서 두 종류의 산출물(예: skill + knowledge)을 동시에 생성하는 "both" verdict를 LLM classifier에 시킬 때, 같은 스텝에서 `suggested_links` 까지 요구하면 LLM이 동일 slug를 자기 자신에게 연결하는 self-reference를 출력한다. 링크 설정은 classifier 스키마에서 빼고, 동일 청크에서 나온 산출물 쌍을 post-process 단계에서 자동으로 양방향 연결하라.
+
+## Context / Why
+- LLM은 "이 knowledge는 어떤 skill과 연결되나?"라는 질문에 문맥상 가장 가까운 이름 — 즉 방금 자신이 만든 skill 이름 — 을 선택하는 경향이 있다.
+- Self-link는 그래프/표시 단계에서 "자기 자신에게 연결된" 무의미 엣지를 만들어 UX를 해치고, 중복 제거 로직도 꼬이게 한다.
+- Post-process는 같은 chunk_id에서 파생된 `(skill_slug, knowledge_slug)` 쌍을 결정적으로(non-LLM) 연결할 수 있어 더 견고하다.
+- Cross-chunk 연결(다른 청크의 기존 skill/knowledge 참조)은 여전히 classifier가 후보를 제안해야 하므로, "self vs cross" 링크 요구를 분리하는 것이 핵심.
+
+## Evidence
+- skills-hub `/skills_extract_knowledge` classifier 초안의 first dry-run: 3개 both-verdict 청크 모두 `suggested_links: [<자기-slug>]` 출력.
+- 규칙 수정 후(`suggested_links 비우기 + post-process 자동 쌍 연결`)에서 self-loop 사라짐.
+- [commit 3559fc6] bootstrap/commands/skills_extract_knowledge.md — Classify Rules 섹션의 "both verdict 처리" 항목.
+
+## Applies when
+- LLM classifier가 한 입력으로 다중 산출물(예: skill+knowledge, summary+tags) + 상호 링크를 동시에 만들어야 할 때
+- 구조화 출력 스키마 설계에서 "생성"과 "연결"을 한 호출에 섞어야 하는 유혹이 있을 때
+
+## Counter / Caveats
+- Post-process 자동 연결은 **동일 청크에서 파생된 쌍**에만 적용 가능. 진짜 cross-chunk 링크는 classifier가 후보를 내야 한다 → self/cross를 별도 스키마 필드로 분리 필요.
+- Classifier가 self-link를 내지 않도록 프롬프트로 제약하면 되는 것 아니냐는 반론: 가능하나 모델/온도/프롬프트 변경마다 회귀 위험 → 스키마 수준의 하드 제거가 더 견고.
+- "같은 청크 쌍 자동 연결"은 slug 생성이 결정적일 때만 성립. 랜덤 ID를 쓰면 어느 쌍이 같은 청크인지 추적할 메타데이터가 필요.


### PR DESCRIPTION
Seeds the new knowledge/<category>/ tree (introduced by bootstrap/knowledge-extract-20260415) with five generalizable engineering knowledge entries extracted via /skills_extract_knowledge from recent skills-hub history and session work.

arch/
- additive-registry-schema-versioning — additive JSON registry evolution (version bump + empty containers + first-write auto-migration)
- k-git-tag-registry-versioning — git tags as immutable semver registry for git-backed asset distribution (linked to git-tag-registry-versioning skill)

decision/
- caveats-absence-confidence-cap — confidence capped at medium when Counter/Caveats is empty (Popperian falsifiability signal)
- k-kafka-message-header-metadata — multi-tenant routing metadata belongs in RecordHeader, not payload (linked to kafka-message-header-metadata skill)

pitfall/
- classifier-both-verdict-self-reference — LLM both-verdict classifiers should not emit self-links; post-process pairs by chunk id

Each file uses the v1 knowledge frontmatter schema (name, type, category, tags, summary, source, confidence, linked_skills, supersedes, extracted_at).