### PR TITLE
Add /knowledge_publish + /publish_all commands (bootstrap v1.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ bootstrap/
     skills_extract_project.md       # full-project scan → drafts BOTH skills and knowledge
     knowledge_list.md               # list locally installed knowledge entries
     knowledge_search.md             # search knowledge and optionally inject matches into context
+    knowledge_publish.md            # review knowledge drafts → push to remote branch (no version tags)
+    publish_all.md                  # one-shot publish of both skills and knowledge on a single branch / PR
   skills/
     skills-hub/SKILL.md       # umbrella OMC skill
   install.sh                  # bash installer
@@ -97,6 +99,8 @@ Should report "no skills installed yet" plus the empty registry — proves the h
 | `/skills_extract_project [--scope=... --max=... --only=...]` | **Full project scan** → drafts BOTH skills *and* knowledge (project-wide counterpart of `/skills_extract_knowledge`) | local drafts |
 | `/knowledge_list [--category/--tag/--linked-to/--orphans]` | List locally installed knowledge entries | no |
 | `/knowledge_search <keyword> [--inject]` | Search knowledge; optionally inject top matches into current context | no (inject = context only) |
+| `/knowledge_publish [--all/--draft=.../--pr]` | Review knowledge drafts → push to a feature branch, update `registry.json` knowledge section. No version tags. | remote branch |
+| `/publish_all [--all/--pr/--only ...]` | One-shot publish of BOTH `.skills-draft/` and `.knowledge-draft/` on a single branch + PR, knowledge-first commit order for cross-link resolution | remote branch + skill tags |
 
 ### Typical Workflow
 
@@ -270,7 +274,7 @@ Body sections: `## Fact` / `## Context / Why` / `## Evidence` / `## Applies when
 /knowledge_search "kafka routing" --inject          # prime context before work
 ```
 
-Knowledge remains **local** for now — remote publish (`/knowledge_publish`) is a v2 feature. Registry schema is `v2` (`knowledge: {}` key + `linked_knowledge` on each skill).
+Knowledge publishing is now supported. Use `/knowledge_publish` to push drafts under `.knowledge-draft/` to a feature branch (no version tags — knowledge is content-addressed, history is the trail). For releases that contain both skills and knowledge from the same extraction round, use `/publish_all` to ship them on a single branch + PR; knowledge commits land first so skills can reference the knowledge slug in the same branch. Registry schema is `v2` (`knowledge: {}` key + `linked_knowledge` on each skill).
 
 ---
 

--- a/bootstrap/commands/knowledge_publish.md
+++ b/bootstrap/commands/knowledge_publish.md
@@ -1,0 +1,95 @@
+---
+description: Review knowledge drafts and push them to kjuhwa/skills.git as a branch, updating registry.json knowledge section
+argument-hint: [--all | --draft=<slug>] [--pr] [--branch=<name>]
+---
+
+# /knowledge_publish $ARGUMENTS
+
+Publish `.knowledge-draft/` contents to the remote repository. Counterpart to `/skills_publish` — same flow, but for non-executable knowledge artifacts (facts, decisions, pitfalls, arch notes, domain invariants, API contracts).
+
+## Preconditions
+
+- `~/.claude/skills-hub/registry.json` present and `version >= 2` (knowledge is a v2-only concept). If v1, instruct user to migrate first.
+- `~/.claude/skills-hub/remote/` initialized as a git clone of `kjuhwa/skills.git`.
+- `.knowledge-draft/` directory exists in cwd with at least one `*.md` file under `<category>/`.
+
+## Steps
+
+1. **Enumerate drafts** in `.knowledge-draft/<category>/*.md` (non-recursive past category).
+   - If none: report and stop.
+   - Skip any file starting with `_` (e.g. `_DUPLICATE_CHECK.md`).
+   - Validate each file has `type: knowledge`-compatible frontmatter (`name`, `description`, `category`, `source`, `confidence`). Flag `[MALFORMED]` and exclude from publish set.
+
+2. **Dry-run review** (always first)
+   - For each draft, show:
+     - Target path in remote: `knowledge/<category>/<slug>.md`
+     - Frontmatter (name, category, confidence, source.ref, linked_skills, tags)
+     - Body preview (first 40 lines, skipping frontmatter)
+     - Collision status:
+       - Exact path already in remote → `[UPDATE]` (content overwrite).
+       - Similar name / same `summary` field elsewhere → `[NEAR-DUPLICATE]`, prompt to merge or rename.
+       - New path → `[NEW]`.
+   - Ask user per draft: publish / skip / edit-first / delete-draft.
+   - `--all` auto-selects publish for all well-formed drafts (still shows dry-run).
+   - `--draft=<slug>` limits the set to a single entry.
+
+3. **Branch + commit in remote cache**
+   - Ensure `~/.claude/skills-hub/remote` is on latest main: `git fetch && git checkout main && git reset --hard origin/main`.
+   - Create branch: `--branch=<name>` OR auto `knowledge/add-<primary-category>-<YYYYMMDD>`.
+   - Copy approved drafts into `knowledge/<category>/<slug>.md`.
+   - **Confidence & source validation per entry**:
+     - `confidence` must be one of `high | medium | low`.
+     - `source.kind` must be one of `commit | project | session | manual`.
+     - `source.ref` must be non-empty.
+     - If `Counter / Caveats` / rationale section is missing from the body, cap confidence at `medium` (rewrite frontmatter if needed).
+   - Rebuild `knowledge` section of `registry.json`:
+     - Key = `<slug>` (filename without `.md`).
+     - Fields: `category`, `scope: global`, `path`, `source`, `confidence`, `linked_skills`, `tags`, `extracted_at` (today's date).
+     - Preserve existing entries for files not being updated; merge over conflicts.
+   - Commit per knowledge entry with message: `Add knowledge/<category>/<slug>: <summary>` (use `Update` verb for overwrites). Include `registry.json` update in the same commit as the file it describes.
+
+4. **Push + PR** (requires confirmation)
+   - `git push -u origin <branch>`.
+   - **No version tags** — knowledge entries are not versioned (unlike skills). Content is the contract; history is the trail.
+   - If `--pr` flag and `gh` CLI available: `gh pr create --title "Add <N> knowledge entries (<categories>)" --body ...` using each draft's `description` + `source_project`.
+   - Otherwise print the branch name and compare URL.
+
+5. **Cleanup drafts**
+   - Move published drafts to `.knowledge-draft/_published/<date>/` (preserve for reference; don't delete).
+
+## Rules
+
+- **Never push to `main` directly.** Always a feature branch.
+- **Never skip the dry-run step.**
+- Respect repo's commit style — check `git log --oneline -20` in the cache first to match format.
+- Sanitize before copy: strip absolute paths, emails, tokens, internal hostnames, business names from the body. If sanitization would gut the entry, flag for manual edit instead.
+- Don't cross-publish: knowledge drafts only. Skill drafts in `.skills-draft/` are ignored here — use `/skills_publish` or `/publish_all` for those.
+- If `linked_skills` references a skill not present in `registry.json`, warn but do not block (skill may land in a sibling PR).
+- If remote push fails (auth), report precisely and leave branch intact locally for retry.
+- Do not include draft metadata files (`_DUPLICATE_CHECK.md`, `_new-categories.md`, files starting with `_`) in commits.
+
+## Frontmatter contract (what we validate and persist)
+
+```yaml
+---
+name: <slug>                    # required; kebab-case; matches filename
+description: <one-line>         # required; used in dry-run and PR body
+category: api|arch|pitfall|decision|domain   # required
+source:
+  kind: commit|project|session|manual        # required
+  ref: <commit-sha|project@sha|session-id|"manual">   # required
+confidence: high|medium|low     # required; capped to medium if no Counter/Caveats
+linked_skills: [<skill-slug>]   # optional; surfaces cross-links in registry
+tags: [<keyword>, ...]          # optional; fuels knowledge_search
+---
+```
+
+Body convention (not enforced, but preferred):
+
+```
+**Fact:** ...
+**Why:** ...
+**How to apply:** ...
+**Evidence:** ...
+(optional) **Counter / Caveats:** ...
+```

--- a/bootstrap/commands/publish_all.md
+++ b/bootstrap/commands/publish_all.md
@@ -1,0 +1,75 @@
+---
+description: One-shot publish of both `.skills-draft/` and `.knowledge-draft/` to kjuhwa/skills.git on a single branch with a single PR
+argument-hint: [--all] [--pr] [--branch=<name>] [--bump=major|minor|patch] [--only skills|knowledge]
+---
+
+# /publish_all $ARGUMENTS
+
+Combined publisher — runs the `/skills_publish` and `/knowledge_publish` pipelines back-to-back, on the **same feature branch**, producing one PR that captures both the procedure (skills) and the rationale (knowledge) from a single extraction round.
+
+Use when `/skills_extract_project` (or `/skills_extract_knowledge`) produced drafts in **both** `.skills-draft/` and `.knowledge-draft/` and you want them shipped as one logical change.
+
+## Preconditions
+
+- Union of `/skills_publish` and `/knowledge_publish` preconditions.
+- At least one draft under `.skills-draft/` OR `.knowledge-draft/` (if both empty, stop).
+- `~/.claude/skills-hub/remote/` clean (no uncommitted local changes).
+
+## Steps
+
+1. **Enumerate both draft trees**.
+   - Skills: `.skills-draft/<category>/<name>/SKILL.md`.
+   - Knowledge: `.knowledge-draft/<category>/<slug>.md`.
+   - `--only skills` or `--only knowledge` restricts the run to one kind (in which case just defer to the underlying command).
+   - If both trees empty: report and stop.
+
+2. **Combined dry-run** (always first)
+   - Render one table with both kinds, e.g.:
+     ```
+     KIND       | CATEGORY | SLUG                              | STATUS  | VERSION/CONF
+     skill      | backend  | retry-with-jitter-backoff         | NEW     | v0.1.0-draft → v1.0.0
+     skill      | arch     | event-replay-from-offset-store    | UPDATE  | v1.2.1 → v1.2.2
+     knowledge  | api      | idempotency-key-per-tenant        | NEW     | high
+     knowledge  | pitfall  | feature-flag-sunset-policy        | NEW     | medium
+     ```
+   - Ask once: publish all / review per-row / abort. Per-row review walks both pipelines' per-draft prompts.
+   - `--all` auto-selects publish for every well-formed draft.
+
+3. **Single branch, interleaved commits**
+   - Ensure `~/.claude/skills-hub/remote` is on latest main (same reset as the individual commands).
+   - Branch name: `--branch=<name>` OR auto `release/combined-<YYYYMMDD>` so it's clear the branch carries both kinds.
+   - **Commit order**: knowledge first, then skills.
+     - Reason: skills can declare `linked_knowledge` in their SKILL.md; landing knowledge first means the skill commit can already reference the knowledge slug in the same branch.
+   - Per-knowledge commit: same as `/knowledge_publish` step 3.
+   - Per-skill commit: same as `/skills_publish` step 3 (version resolution, tag prep). If a skill's `linked_knowledge` names a slug published in this run, record the cross-link in registry.json (skills entry → `linked_knowledge: [<slug>]`, knowledge entry → `linked_skills: [<skill>]`).
+   - `registry.json` rebuilt once at the end of the commit sequence, not per-commit, to avoid churn — add a final `Rebuild registry.json` commit if any entries changed.
+
+4. **Push + tag + PR** (requires confirmation)
+   - `git push -u origin <branch>`.
+   - For each **skill**, create annotated tag `skills/<name>/v<version>` (knowledge has no tags).
+   - Push tags: `git push origin --tags` restricted to this run's tags.
+   - If `--pr` and `gh` available:
+     - `gh pr create --title "Publish <N> skills + <M> knowledge entries" --body ...`
+     - Body sections: `## Skills`, `## Knowledge`, `## Cross-links` (skill ↔ knowledge pairs created this run), `## Source` (project/session/commit refs).
+   - Otherwise print branch name, tag list, and compare URL.
+
+5. **Cleanup drafts**
+   - Move published skill drafts → `.skills-draft/_published/<date>/`.
+   - Move published knowledge drafts → `.knowledge-draft/_published/<date>/`.
+   - Leave unpublished drafts in place.
+
+## Rules
+
+- **Never push to `main` directly.** One feature branch per run.
+- **Never skip the dry-run step.**
+- If either pipeline aborts mid-run, the branch is kept as-is for inspection — no automatic rollback, no force-push.
+- Cross-linking is **opt-in**: only link when a skill's SKILL.md explicitly names a `linked_knowledge` slug, or a knowledge file's frontmatter names `linked_skills`. Never infer links from name similarity.
+- Sanitization rules from both underlying commands apply.
+- On conflict between `--only` and the presence of drafts in the excluded kind, warn and proceed with the requested kind only; don't silently publish the other.
+- If `gh` is unavailable, still push the branch and print a ready-to-paste PR URL + title + body draft.
+
+## When NOT to use
+
+- If you only have skill drafts → `/skills_publish` is simpler.
+- If you only have knowledge drafts → `/knowledge_publish` is simpler.
+- If drafts come from unrelated sessions → publish separately so PR history stays coherent.


### PR DESCRIPTION
- bootstrap/commands/knowledge_publish.md: review and push .knowledge-draft/ entries to a feature branch, update registry.json knowledge section (no version tags).
- bootstrap/commands/publish_all.md: one-shot publisher for both .skills-draft/ and .knowledge-draft/ on a single branch; knowledge-first commit order for cross-link resolution.
- README: add both commands to bootstrap/commands/ listing + command reference table; update Knowledge section to reflect that remote publish is no longer v2-only.