### PR TITLE
Bootstrap v1.4.0: merge/split/refactor commands + recursive subdir sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ skills/                       # category-separated skill registry
       content.md              # main prompt / knowledge body (required)
       examples/               # optional
 bootstrap/
-  commands/                   # slash-command markdown files
+  commands/                   # slash-command markdown files (recursive: subdirs become command namespaces)
     init_skills.md
     skills_search.md
     skills_list.md
@@ -29,14 +29,21 @@ bootstrap/
     skills_finalize.md
     skills_cleanup.md
     skills_remove.md
-    skills_bootstrap_update.md      # pull command files (latest or tagged version)
-    skills_bootstrap_publish.md     # publish command edits + bootstrap/v<ver> tag
+    skills_import_git.md            # import skills/knowledge from an arbitrary git repo (authored or extracted)
+    skills_bootstrap_update.md      # pull command files (latest or tagged version; recursive)
+    skills_bootstrap_publish.md     # publish command edits + bootstrap/v<ver> tag (recursive)
     skills_extract_knowledge.md     # extract skills + non-executable knowledge (session/diff/commits)
     skills_extract_project.md       # full-project scan → drafts BOTH skills and knowledge
     knowledge_list.md               # list locally installed knowledge entries
     knowledge_search.md             # search knowledge and optionally inject matches into context
     knowledge_publish.md            # review knowledge drafts → push to remote branch (no version tags)
     publish_all.md                  # one-shot publish of both skills and knowledge on a single branch / PR
+    merge/
+      skills_merge.md               # combine 2+ remote entries into one new draft (/merge:skills_merge)
+    split/
+      skills_split.md               # decompose one remote entry into N focused drafts (/split:skills_split)
+    refactor/
+      skills_refactor.md            # scan remote for merge + split candidates in one pass (/refactor:skills_refactor)
   skills/
     skills-hub/SKILL.md       # umbrella OMC skill
   install.sh                  # bash installer
@@ -101,6 +108,9 @@ Should report "no skills installed yet" plus the empty registry — proves the h
 | `/knowledge_search <keyword> [--inject]` | Search knowledge; optionally inject top matches into current context | no (inject = context only) |
 | `/knowledge_publish [--all/--draft=.../--pr]` | Review knowledge drafts → push to a feature branch, update `registry.json` knowledge section. No version tags. | remote branch |
 | `/publish_all [--all/--pr/--only ...]` | One-shot publish of BOTH `.skills-draft/` and `.knowledge-draft/` on a single branch + PR, knowledge-first commit order for cross-link resolution | remote branch + skill tags |
+| `/merge:skills_merge <selector1> <selector2> [...]` | Combine 2+ remote skills/knowledge into one new draft. Supports cross-kind (skill+knowledge), version pinning (`@v1.2.0`), mandatory `merged_from` provenance | local drafts |
+| `/split:skills_split <selector> [--by=section\|step\|concern\|auto]` | Decompose one remote entry into N focused drafts. Refuses trivially-small inputs; records `split_from`/`replaces`/`siblings` | local drafts |
+| `/refactor:skills_refactor [--scope/--merge-threshold/...]` | Scan remote for merge + split candidates in one pass, delegate to the two commands above. Bias toward merge when an entry qualifies for both | local drafts |
 
 ### Typical Workflow
 
@@ -275,6 +285,48 @@ Body sections: `## Fact` / `## Context / Why` / `## Evidence` / `## Applies when
 ```
 
 Knowledge publishing is now supported. Use `/knowledge_publish` to push drafts under `.knowledge-draft/` to a feature branch (no version tags — knowledge is content-addressed, history is the trail). For releases that contain both skills and knowledge from the same extraction round, use `/publish_all` to ship them on a single branch + PR; knowledge commits land first so skills can reference the knowledge slug in the same branch. Registry schema is `v2` (`knowledge: {}` key + `linked_knowledge` on each skill).
+
+---
+
+## Remote Maintenance: merge / split / refactor
+
+Once the registry has grown, three commands help keep it coherent. All three are **read-only on the remote cache** — they produce drafts under `.skills-draft/` / `.knowledge-draft/` that ship via the normal publish flow (`/skills_publish`, `/knowledge_publish`, or `/publish_all`).
+
+### Selectors
+
+`/merge:skills_merge` and `/split:skills_split` accept selectors pointing to existing remote entries:
+
+- `skill:<category>/<name>` — e.g. `skill:backend/retry-with-jitter-backoff`
+- `knowledge:<category>/<slug>` — e.g. `knowledge:pitfall/retry-storms-without-jitter`
+- `<category>/<name>` — kind auto-detected; ambiguous → error, require prefix
+- `@v<semver>` suffix on any of the above pins to a tag (skills only): `skill:backend/retry@v1.2.0`
+
+### Merge — consolidate overlapping entries
+
+```
+/merge:skills_merge skill:backend/retry-with-jitter skill:backend/retry-on-5xx \
+    knowledge:pitfall/retry-storms --name=unified-retry-strategy
+```
+
+Produces one new skill draft with the union of problems, a single unified `Pattern`, preserved `Alternative examples`, and mandatory `merged_from` / `## Provenance` attribution. Knowledge sources are summarized into a `## Background` section and cross-linked via `linked_knowledge`, not duplicated as files. Default behavior marks sources with `supersedes: [...]` so `/skills_cleanup` can later propose deprecation; `--keep-sources` omits the hint.
+
+### Split — break up multi-purpose entries
+
+```
+/split:skills_split skill:backend/retry-strategy --by=concern
+```
+
+Strategies: `section` (split by topical `##` headers), `step` (skills-only — per-step decomposition), `concern` (cluster paragraphs by dominant tag), `auto` (try `concern` → `section` → `step`). Refuses to split entries below ~400 body lines. Each child draft inherits confidence (knowledge) and lists its `siblings` for navigation. Oversize alone doesn't qualify — the detector must find ≥2 clean clusters.
+
+### Refactor — one pass, both operations
+
+```
+/refactor:skills_refactor --scope=backend --merge-threshold=0.75
+```
+
+Scans the remote, finds merge candidates (tag + content similarity clusters) **and** split candidates (large entries with ≥2 concerns), resolves overlap (merge wins when an entry qualifies for both), presents a single review table, then delegates to `/merge:skills_merge` and `/split:skills_split` for accepted candidates. Results aggregate into `.skills-draft/_REFACTOR_MANIFEST.md`. Ship with `/publish_all --pr` so cross-links land in one branch.
+
+Use `/refactor:skills_refactor` periodically (monthly, or after a burst of publish activity). For targeted single operations, call `/merge:skills_merge` or `/split:skills_split` directly — they're cheaper.
 
 ---
 

--- a/bootstrap/commands/merge/skills_merge.md
+++ b/bootstrap/commands/merge/skills_merge.md
@@ -1,0 +1,159 @@
+---
+description: Merge two or more skills and/or knowledge entries from kjuhwa/skills.git into a single new skill or knowledge draft
+argument-hint: <selector1> <selector2> [<selectorN>...] [--as=skill|knowledge|auto] [--name=<slug>] [--category=<cat>] [--keep-sources] [--dry-run] [--yes]
+---
+
+# /skills_merge $ARGUMENTS
+
+Combine 2+ existing entries from the remote skills repo (`kjuhwa/skills.git`) into one new draft. The new draft is **not** published automatically — it lands in `.skills-draft/` or `.knowledge-draft/` so you can review, edit, then ship via `/skills_publish` / `/knowledge_publish` / `/publish_all`.
+
+Use when you discover overlapping skills/knowledge that should be a single, more coherent unit (e.g. three near-duplicate retry-pattern skills, or a skill plus three knowledge notes that always travel together).
+
+## Selectors
+
+A selector identifies one source entry in the remote. Accepted forms:
+
+- `skill:<category>/<name>` — explicit skill, e.g. `skill:backend/retry-with-jitter-backoff`
+- `skill:<name>` — shorthand if the skill name is unique across categories
+- `knowledge:<category>/<slug>` — explicit knowledge entry, e.g. `knowledge:api/idempotency-key-per-tenant`
+- `knowledge:<slug>` — shorthand if the slug is unique
+- `<category>/<name>` — kind auto-detected by which tree contains it; ambiguous → error, require prefix
+- `@<version>` suffix on any of the above pins to a tag (skills only): `skill:backend/retry-with-jitter-backoff@v1.2.0`
+
+You must provide **at least 2** selectors. Mixing kinds (skill + knowledge) is allowed; see `--as` for output type rules.
+
+## Arguments
+
+- `<selector1> ... <selectorN>` (required, ≥2) — entries to merge.
+- `--as=skill|knowledge|auto` — output kind. Default `auto`:
+  - All sources are skills → output is **skill**.
+  - All sources are knowledge → output is **knowledge**.
+  - Mixed → output is **skill**, and every knowledge source is recorded under `linked_knowledge` in the new SKILL.md frontmatter (their bodies are summarized into the skill's `content.md` "Background" section, not duplicated as files).
+- `--name=<slug>` — slug for the merged entry. Default: derived from the dominant theme of the sources, sanitized to `[a-z0-9-]+`. If you don't pass this, the dry-run will show the proposed slug and you can override before persist.
+- `--category=<cat>` — category for the merged entry. Default: the most-common category among the sources; if all sources are in different categories, you **must** pass `--category` explicitly.
+- `--keep-sources` — record-only flag for the draft frontmatter; does NOT delete or deprecate the source entries on the remote. Default behavior writes a `supersedes: [<list>]` field that `/skills_cleanup` later interprets as a deprecation hint. With `--keep-sources`, that field is omitted.
+- `--dry-run` — show the planned merged draft (frontmatter + content outline) and stop without writing.
+- `--yes` — skip the interactive accept/edit prompt; write the draft immediately after the dry-run preview.
+
+## Steps
+
+1. **Validate input**
+   - Require ≥2 selectors; if fewer, stop with a clear error pointing at `/skills_split` for the opposite operation.
+   - Refuse if the same selector appears twice (after normalization).
+
+2. **Refresh remote cache**
+   - `git -C ~/.claude/skills-hub/remote fetch --tags --prune origin`
+   - Checkout `main` (read-only; we never modify the remote cache here).
+
+3. **Resolve selectors**
+   - For each selector, locate the source file under `~/.claude/skills-hub/remote/skills/<cat>/<name>/` or `~/.claude/skills-hub/remote/knowledge/<cat>/<slug>.md`.
+   - For `@<version>` skill selectors: `git -C <remote> show skills/<name>/v<ver>:skills/<cat>/<name>/SKILL.md` (and `content.md`).
+   - On miss: report the selector, list 3 closest matches by edit distance, stop. Do not invent content.
+
+4. **Load + parse**
+   - Read each source's frontmatter and body verbatim into memory.
+   - Compute: union of `tags`, union of `triggers`, set of categories present, set of versions, source git ref/SHA per entry.
+
+5. **Decide output kind** (`--as` resolution above). If `auto` cannot decide unambiguously (e.g. `--as=auto` with mixed kinds AND user passed `--category=knowledge-only-cat`), stop and ask.
+
+6. **Synthesize the merged draft** (in-memory only at this stage)
+   - **Skill output** (`SKILL.md` + `content.md`):
+     - `name`: `--name` if given, else derived dominant-theme slug.
+     - `description`: one sentence rewritten to cover the union of source intents — do NOT just concatenate source descriptions.
+     - `category`: resolved per `--category` rules.
+     - `tags`: union, deduped, capped at 8 (drop lowest-frequency first).
+     - `triggers`: union, deduped, capped at 6.
+     - `version`: `0.1.0-draft`.
+     - `source_project`: `merged`.
+     - `merged_from`: ordered list `["<kind>:<category>/<name>[@<ver>]", ...]`.
+     - `linked_knowledge`: present only if any source was knowledge OR any source skill already had this field; union across sources.
+     - `supersedes`: same list as `merged_from` UNLESS `--keep-sources` is set.
+     - `content.md` outline (do not just paste — synthesize):
+       1. **Problem** — combined problem statement.
+       2. **Pattern** — unified recipe; if sources disagree on steps, surface the disagreement under "Variants" rather than picking one silently.
+       3. **Example** — one canonical example; if sources had distinct examples worth keeping, list as "Alternative examples" with one-line context each.
+       4. **When to use / When not to use** — merged guidance.
+       5. **Background** (only if knowledge sources merged in) — short summary of each knowledge source's `Fact` + `Applies when`, with `[from knowledge:<slug>]` attribution per bullet.
+       6. **Pitfalls** — union of pitfalls across sources.
+       7. **Provenance** — bullet list `- <kind>:<category>/<name> @ <commit-sha-short>` for every source.
+   - **Knowledge output** (single `*.md`):
+     - Same frontmatter conventions as `/skills_extract_knowledge`'s template (`type: knowledge`, `category`, `confidence`, `source`).
+     - `confidence`: minimum across sources (worst case wins; merging a `low` and a `high` yields `low`).
+     - `summary`: rewritten one-liner.
+     - `merged_from`: same shape as above.
+     - Body sections: `## Fact` (synthesized), `## Context / Why`, `## Evidence` (concatenated, deduped, each line keeps its original source attribution), `## Applies when`, `## Counter / Caveats` (union; if any source had no caveats, note "source `<x>` did not document caveats" — don't fabricate).
+
+7. **Dry-run preview** (always shown, even with `--yes`)
+   - Render:
+     ```
+     === skills_merge dry-run ===
+     Sources (N):
+       1. skill:backend/retry-with-jitter-backoff@v1.2.0     (tags: retry, backoff)
+       2. skill:backend/retry-on-5xx                         (tags: retry, http)
+       3. knowledge:pitfall/retry-storms-without-jitter      (conf: high)
+
+     Output:
+       kind:        skill
+       slug:        backend/unified-retry-strategy
+       category:    backend
+       version:     0.1.0-draft
+       merged_from: [3 entries]
+       supersedes:  [3 entries]   # (omit-flag: --keep-sources)
+       linked_knowledge: [retry-storms-without-jitter]
+
+     Frontmatter:
+       <yaml block>
+
+     Content outline:
+       - Problem ............... 12 lines
+       - Pattern ............... 28 lines (1 Variants subsection)
+       - Example ............... 18 lines (+1 Alternative)
+       - When to use ........... 6 lines
+       - Background ............ 9 lines (1 knowledge source)
+       - Pitfalls .............. 11 lines
+       - Provenance ............ 3 lines
+
+     Draft path (on persist):
+       .skills-draft/backend/unified-retry-strategy/
+     ```
+   - If `--dry-run` → stop here.
+   - Else prompt: `accept / edit-name / edit-category / edit-content / cancel`. `--yes` accepts immediately.
+
+8. **Persist draft**
+   - Write under `.skills-draft/<category>/<name>/` (skill) or `.knowledge-draft/<category>/<slug>.md` (knowledge).
+   - If draft path already exists: prompt overwrite/rename/cancel (never silently overwrite).
+   - Add a sibling note `_MERGE_SOURCES.md` listing each source's path, version, commit SHA, and a one-line rationale. Publish commands ignore files starting with `_`.
+
+9. **Report**
+   - Show the final draft path, the slug, the proposed publish command (`/skills_publish --draft=<name>` or `/knowledge_publish --draft=<slug>`).
+   - Remind: the source entries on the remote are **not modified**. To formally retire them, publish the merged draft, then run `/skills_cleanup` which will see `supersedes` and propose the deprecation PR.
+
+## Rules
+
+- **Read-only on the remote cache.** Never push, never modify `~/.claude/skills-hub/remote/`. All output goes to drafts.
+- **Never auto-publish.** This command stops at draft creation; publishing is a separate, deliberate step.
+- **Synthesize, do not concatenate.** A merged draft that is just three source bodies stitched together is a bug — flag and refuse to write if the synthesis step couldn't actually produce a unified Pattern section.
+- **Provenance is mandatory.** Every merged draft must carry `merged_from` in frontmatter and a `## Provenance` (skill) or `## Evidence` (knowledge) section listing every source with commit SHA. If any source SHA cannot be resolved, stop.
+- **No cross-cleanup.** This command does NOT delete or rewrite the source entries. Deprecation, if any, happens at publish time via the `supersedes` field, and only after the user runs `/skills_cleanup` and approves it.
+- **Sanitization** inherits from `/skills_publish`: strip absolute paths, emails, tokens, internal hostnames in the synthesized body before writing the draft.
+- **Selector ambiguity is fatal.** If `<category>/<name>` matches both a skill and a knowledge entry, refuse with a message asking the user to add `skill:` or `knowledge:` prefix.
+- **Confidence floor for knowledge merges.** Output `confidence` = `min(sources)`. Never upgrade a `low`-confidence source by averaging.
+
+## Examples
+
+```
+# Merge three near-duplicate skills into one canonical skill
+/skills_merge skill:backend/retry-with-jitter-backoff skill:backend/retry-on-5xx skill:backend/exponential-backoff --name=unified-retry-strategy
+
+# Merge a skill with two knowledge notes; output is a skill carrying linked_knowledge
+/skills_merge skill:backend/retry-with-jitter-backoff knowledge:pitfall/retry-storms knowledge:pitfall/thundering-herd
+
+# Merge two knowledge entries into one consolidated note
+/skills_merge knowledge:api/idempotency-key-per-tenant knowledge:api/idempotency-key-conflict-resolution --as=knowledge
+
+# Pin to specific skill versions
+/skills_merge skill:backend/retry@v1.2.0 skill:backend/retry-on-5xx@v0.3.1 --dry-run
+
+# Auto-everything (still shows preview, then writes)
+/skills_merge skill:devops/blue-green-deploy skill:devops/canary-deploy --as=skill --yes
+```

--- a/bootstrap/commands/refactor/skills_refactor.md
+++ b/bootstrap/commands/refactor/skills_refactor.md
@@ -1,0 +1,136 @@
+---
+description: Scan kjuhwa/skills.git for merge and split candidates and produce both kinds of refactor drafts in one pass
+argument-hint: [--scope=all|<category>] [--merge-threshold=<float>] [--split-min-lines=<n>] [--max-merges=<n>] [--max-splits=<n>] [--dry-run] [--yes]
+---
+
+# /skills_refactor $ARGUMENTS
+
+One-shot refactor pass over the remote skills repo. Identifies:
+
+- **Merge candidates** — clusters of skills/knowledge with overlapping intent, similar tags, or near-duplicate content.
+- **Split candidates** — entries that are too large or cover multiple distinct concerns.
+
+For each candidate, produces a draft (or set of drafts) in `.skills-draft/` / `.knowledge-draft/` by delegating to `/skills_merge` and `/skills_split` respectively. Nothing on the remote is modified. Output is reviewed and shipped via `/publish_all`.
+
+Use this periodically (monthly, or after a burst of `/skills_publish` activity) to keep the remote registry coherent. For targeted single-operation refactors, use `/skills_merge` or `/skills_split` directly.
+
+## Arguments
+
+- `--scope=all|<category>` — restrict the scan. Default `all`.
+- `--merge-threshold=<float>` — cosine-style similarity floor for merge candidates, on `[0.0, 1.0]`. Default `0.72`. Higher → fewer, tighter clusters.
+- `--split-min-lines=<n>` — skill/knowledge must exceed this body line count before being considered for split. Default `400`.
+- `--max-merges=<n>` — cap on merge proposals. Default `5`.
+- `--max-splits=<n>` — cap on split proposals. Default `5`.
+- `--dry-run` — print the candidate report and stop without writing any drafts.
+- `--yes` — auto-accept every candidate the scan surfaces (still shows the report). **Use with care** — for a healthy remote you usually want to review per-candidate.
+
+## Steps
+
+1. **Refresh remote cache**
+   - `git -C ~/.claude/skills-hub/remote fetch --tags --prune origin`. Read-only.
+
+2. **Inventory**
+   - Walk `skills/<category>/<name>/SKILL.md` and `knowledge/<category>/<slug>.md` (filtered by `--scope`).
+   - For each entry, record: kind, category, slug, body line count, frontmatter (`name`, `description`, `tags`, `triggers`, `summary`).
+
+3. **Detect merge candidates**
+   - Build per-entry feature vectors from: `name`, `description`, `tags`, `triggers`, top tokens from body. Cheap bag-of-tokens + IDF weighting is enough — this is heuristic, not ML.
+   - Pairwise similarity within (kind, category) cohort. Cross-category pairs are considered only if tag overlap ≥ 3.
+   - Cluster pairs above `--merge-threshold` using single-linkage; clusters of size ≥2 become merge candidates.
+   - Drop any cluster where one member is already marked `superseded` in remote frontmatter.
+   - Rank clusters by (max-pairwise-similarity × cluster-size); take top `--max-merges`.
+
+4. **Detect split candidates**
+   - For each entry with body lines ≥ `--split-min-lines`:
+     - Run a lightweight version of `/skills_split`'s strategy detector (`auto` mode dry-run) to confirm at least 2 clean splits would emerge.
+     - If yes, mark as split candidate. If detector says "no clean splits" — even though the entry is large — skip; oversize alone isn't a reason.
+   - Rank by (body-lines × detected-cluster-count); take top `--max-splits`.
+
+5. **Resolve overlap**
+   - If an entry is both inside a merge cluster AND a split candidate, prefer **merge** (consolidating duplicates first leaves a cleaner target for any later split). Drop it from the split list and note this in the report.
+
+6. **Candidate report** (always shown)
+   - Two tables:
+     ```
+     === skills_refactor candidates (scope: all) ===
+
+     MERGE candidates (3):
+       M1  cluster-size=3  max-sim=0.81
+           ⊕ skill:backend/retry-with-jitter-backoff
+           ⊕ skill:backend/retry-on-5xx
+           ⊕ skill:backend/exponential-backoff
+           proposed slug:  backend/unified-retry-strategy
+
+       M2  cluster-size=2  max-sim=0.74
+           ⊕ knowledge:api/idempotency-key-per-tenant
+           ⊕ knowledge:api/idempotency-key-conflict-resolution
+           proposed slug:  api/idempotency-key-handling
+
+       ...
+
+     SPLIT candidates (2):
+       S1  skill:backend/retry-strategy
+           body: 612 lines, strategy: concern → 3 splits
+           proposed slugs: retry-strategy-read-path, retry-strategy-write-path, retry-strategy-observability
+
+       S2  knowledge:arch/event-sourcing-everything
+           body: 540 lines, strategy: section → 4 splits
+           ...
+
+     Skipped (overlap): skill:backend/retry-strategy was also a split candidate but is now part of merge cluster M1's outcome; revisit on the next pass.
+     ```
+   - If `--dry-run` → stop here.
+   - Else prompt per candidate: `accept / skip / edit-args / cancel-all`. `--yes` accepts everything.
+     - `edit-args` lets the user override `--name`, `--category`, `--by`, `--max` for that candidate before delegation.
+
+7. **Delegate to /skills_merge and /skills_split**
+   - For each accepted **merge** candidate: invoke `/skills_merge <selectors...> --as=<auto-or-user-override> --name=<proposed-or-user> --category=<resolved> --yes` (the inner `--yes` is safe here because the outer prompt already constituted the per-candidate review).
+   - For each accepted **split** candidate: invoke `/skills_split <selector> --by=<auto-or-user> --max=<auto-or-user> --yes`.
+   - Aggregate the resulting draft paths.
+
+8. **Persist a refactor manifest**
+   - Write `.skills-draft/_REFACTOR_MANIFEST.md` with:
+     - Date, scope, thresholds used.
+     - Per-candidate outcome: merge → resulting draft slug + sources; split → resulting draft slugs + source.
+     - "Pending" entries that the user skipped (so the next refactor pass starts with that context).
+   - Publish commands ignore files starting with `_`.
+
+9. **Report**
+   - Print summary: `M merge drafts written, S × splits-per-source split drafts written, K skipped`.
+   - Recommend next step: `/publish_all --pr` so all refactor drafts ship as one branch + one PR with cross-links intact.
+
+## Rules
+
+- **Read-only on the remote cache.** All output is drafts.
+- **Never auto-publish.** Refactor proposals always go through `/publish_all` (or `/skills_publish` + `/knowledge_publish`) under user control.
+- **Heuristic only.** Similarity scoring is bag-of-tokens; it surfaces *candidates*, not decisions. The user is the arbiter — never proceed past the candidate prompt without explicit acceptance unless `--yes` was passed.
+- **Bias toward merge over split** when an entry qualifies for both (Step 5). Splitting a duplicate produces more duplicates.
+- **No cascading refactors in one run.** A skill produced by Step 7's merge isn't fed back into Step 4's split detector — that would oscillate. Run `/skills_refactor` again after publishing if needed.
+- **Honor caps strictly.** `--max-merges` and `--max-splits` are hard caps. The cluster ranker discards low-rank candidates rather than expanding the queue.
+- **Inherits sanitization, provenance, and "do not modify source" rules** from `/skills_merge` and `/skills_split`.
+- **Refuse empty scope.** If the inventory under `--scope` has fewer than 5 entries, refuse with a clear message — the heuristic isn't useful at small N.
+
+## Examples
+
+```
+# Periodic full-repo refactor pass (interactive review)
+/skills_refactor
+
+# Just look — no drafts written
+/skills_refactor --dry-run
+
+# Tighter merge threshold, only the backend category
+/skills_refactor --scope=backend --merge-threshold=0.80
+
+# Split-heavy pass: only consider entries above 600 lines
+/skills_refactor --split-min-lines=600 --max-merges=0
+
+# Trust the heuristic for everything (still preview, then auto-write)
+/skills_refactor --yes
+```
+
+## When NOT to use
+
+- You already know exactly which entries to merge or split → use `/skills_merge` or `/skills_split` directly. They're cheaper and don't waste a heuristic pass.
+- You haven't published anything in a while → there's nothing new to refactor.
+- The remote has fewer than ~10 entries in the chosen scope — heuristics need volume to be useful.

--- a/bootstrap/commands/skills_bootstrap_publish.md
+++ b/bootstrap/commands/skills_bootstrap_publish.md
@@ -21,17 +21,18 @@ Stage `~/.claude/commands/*.md` edits into `bootstrap/commands/` on the remote r
      - Default: `patch` bump.
    - Reject pre-existing tags unless a different explicit version is supplied.
 
-3. **Diff bootstrap vs local**
-   - For each file in `~/.claude/commands/*.md` that also exists in `bootstrap/commands/`:
-     - Show unified diff.
-   - Detect new files (in local but not remote) and prompt user to include / skip per file.
+3. **Diff bootstrap vs local (recursive)**
+   - Walk `~/.claude/commands/**/*.md` (all subdirectories, any depth).
+   - For each file, compute its repo-relative path (the part after `~/.claude/commands/`) and compare against `bootstrap/commands/<relative-path>` in the remote:
+     - Show unified diff when both sides exist.
+   - Detect new files (in local but not remote) and prompt user to include / skip per file. Subfolder layout (e.g. `merge/skills_merge.md`, `split/skills_split.md`, `refactor/skills_refactor.md`) is preserved verbatim.
    - Files only in remote but not local → not deleted (user may have removed locally on purpose); prompt: keep-in-remote / delete-in-remote.
 
 4. **Create branch + copy**
    - Branch: `--branch=<name>` OR auto `bootstrap/release-v<version>`.
    - `git checkout -b <branch>`.
-   - Copy approved local files into `bootstrap/commands/<file>`.
-   - If any file was removed upstream per user decision, `git rm` it.
+   - For each approved local file: `mkdir -p bootstrap/commands/<dir>` if needed, then copy to `bootstrap/commands/<relative-path>`. Relative path and subdirectory structure are preserved exactly.
+   - If any file was removed upstream per user decision, `git rm bootstrap/commands/<relative-path>`. If the removal empties a subdirectory, remove the directory too (no empty directories committed).
 
 5. **Commit + tag**
    - Single commit: `Bootstrap v<version>: <summary>`. Summary is auto-generated from changed filenames (user may edit).
@@ -52,4 +53,5 @@ Stage `~/.claude/commands/*.md` edits into `bootstrap/commands/` on the remote r
 - **Never push to `main` directly** — always via feature branch + PR.
 - Refuse to overwrite an existing tag (tags are immutable history).
 - Skip files not in the `bootstrap/commands/` manifest (user-private commands stay local).
+- Traversal is recursive: `~/.claude/commands/<subdir>/<file>.md` maps to `bootstrap/commands/<subdir>/<file>.md` with the relative path preserved. Never flatten subdirectories.
 - If there are zero differences vs remote HEAD, report and stop — don't create empty version bumps.

--- a/bootstrap/commands/skills_bootstrap_update.md
+++ b/bootstrap/commands/skills_bootstrap_update.md
@@ -18,15 +18,19 @@ Pull slash-command files from `bootstrap/commands/` in the remote repo and insta
    - `--version=<x.y.z>`: use tag `bootstrap/v<x.y.z>`. Verify it exists via `git -C <remote> rev-parse --verify refs/tags/bootstrap/v<x.y.z>`. If missing, list `git -C <remote> tag -l "bootstrap/v*" | sort -V` and stop.
    - No flag: use `main` HEAD.
 
-3. **Diff preview**
-   - For each file in `bootstrap/commands/` at the resolved ref, compare against `~/.claude/commands/<file>`.
-   - Show list: `NEW / UPDATED / UNCHANGED / LOCAL-MODIFIED`.
+3. **Diff preview (recursive)**
+   - Enumerate every file under `bootstrap/commands/` at the resolved ref via `git -C <remote> ls-tree -r --name-only <ref> -- bootstrap/commands/` (recursive, all subdirectories).
+   - For each path, compute its relative form (strip `bootstrap/commands/` prefix) and compare against `~/.claude/commands/<relative-path>`.
+   - Show list: `NEW / UPDATED / UNCHANGED / LOCAL-MODIFIED`. Subdirectory layout (e.g. `merge/skills_merge.md`) is preserved in the report so the user can see structural changes.
    - `LOCAL-MODIFIED` = user edited their local copy; updating will overwrite — warn and offer `.bak`.
 
 4. **Apply**
    - `--dry-run`: print plan only, write nothing.
-   - Otherwise: extract each file via `git -C <remote> show <ref>:bootstrap/commands/<file>` → write to `~/.claude/commands/<file>`.
+   - Otherwise, for each file:
+     - `mkdir -p ~/.claude/commands/<dir>` if the relative path includes subdirectories.
+     - Extract via `git -C <remote> show <ref>:bootstrap/commands/<relative-path>` → write to `~/.claude/commands/<relative-path>`.
    - For `LOCAL-MODIFIED` files without `--force`: skip and report.
+   - If an update moves a file across subdirectories (same content, new path), apply as (write new, delete old) and report the move explicitly so the user understands the reorganization.
 
 5. **Record version**
    - Write `~/.claude/skills-hub/bootstrap.json`:
@@ -46,7 +50,8 @@ Pull slash-command files from `bootstrap/commands/` in the remote repo and insta
 
 ## Rules
 
-- Never touch `~/.claude/commands/` files outside `bootstrap/commands/` scope — user-authored commands stay untouched.
+- Never touch `~/.claude/commands/` files outside `bootstrap/commands/` scope — user-authored commands stay untouched. Scope comparison uses the same relative paths, so a user-authored `~/.claude/commands/myteam/secret.md` is ignored as long as the remote has no matching `bootstrap/commands/myteam/secret.md`.
+- Traversal is recursive: `bootstrap/commands/<subdir>/<file>.md` maps to `~/.claude/commands/<subdir>/<file>.md` with the relative path preserved. Never flatten subdirectories.
 - Never `reset --hard` if the remote cache has uncommitted work (guard with `git status --porcelain`).
 - Rollback (downgrade to older tag) is allowed; confirm explicitly when target version is lower than `installed_version`.
 - If `bootstrap.json` is missing, treat as first install and proceed.

--- a/bootstrap/commands/split/skills_split.md
+++ b/bootstrap/commands/split/skills_split.md
@@ -1,0 +1,152 @@
+---
+description: Split a single skill or knowledge entry from kjuhwa/skills.git into multiple smaller, focused drafts
+argument-hint: <selector> [--by=section|step|concern|auto] [--max=<n>] [--keep-original] [--dry-run] [--yes]
+---
+
+# /skills_split $ARGUMENTS
+
+Decompose one oversized or multi-purpose entry from the remote skills repo (`kjuhwa/skills.git`) into N smaller, single-purpose drafts. Each split draft is independent and can be published separately. The original on the remote is **not** modified.
+
+Use when an existing skill has grown to cover multiple distinct procedures, or a knowledge entry conflates several facts that should be looked up independently.
+
+## Selector
+
+Same form as `/skills_merge`:
+
+- `skill:<category>/<name>[@<version>]`
+- `knowledge:<category>/<slug>`
+- `<category>/<name>` — kind auto-detected; ambiguous selectors are an error.
+
+Exactly **one** selector. To split multiple sources in one shot, use `/skills_refactor`.
+
+## Arguments
+
+- `<selector>` (required) — the entry to split.
+- `--by=section|step|concern|auto` — split strategy. Default `auto`.
+  - `section`: split by top-level (`##`) headers in `content.md` (skill) or body (knowledge). Each section becomes one draft. Headers `## Problem`, `## Pattern`, `## Example` etc. are kept together as a single skill — the splitter only fires when there are ≥2 *distinct topical* sections (e.g. `## Read path` + `## Write path`).
+  - `step`: skill-only — split a numbered procedure into per-step skills. Useful when each step is independently invokable (e.g. a 5-step migration where users sometimes only need step 3).
+  - `concern`: split by orthogonal concerns detected in the body — different categories of advice (e.g. "performance" vs "security" vs "observability") become separate drafts. Heuristic: clusters of tags + repeated keywords across paragraphs.
+  - `auto`: try `concern` first; if it yields fewer than 2 clean clusters, fall back to `section`; if that also fails, fall back to `step` (skills only). If nothing yields ≥2 splits, refuse with a clear message — the entry doesn't actually need splitting.
+- `--max=<n>` — cap the number of resulting drafts. Default `5`. If the strategy would produce more, the smallest groups are merged into a single residual draft slug `<original>-misc` (preview will show this clearly).
+- `--keep-original` — record-only flag; the source entry on the remote is not touched regardless. With this flag set, frontmatter omits the `replaces: <original-slug>` hint that `/skills_cleanup` would otherwise use to propose retiring the original.
+- `--dry-run` — preview the proposed splits and stop without writing.
+- `--yes` — accept the proposed split set without the interactive review step.
+
+## Steps
+
+1. **Refresh remote cache**
+   - `git -C ~/.claude/skills-hub/remote fetch --tags --prune origin`. Read-only.
+
+2. **Resolve selector**
+   - Same resolution as `/skills_merge` step 3 (including `@<version>` tag resolution for skills).
+   - On miss: list 3 closest matches by edit distance, stop.
+
+3. **Load + parse**
+   - Read frontmatter + body verbatim.
+   - Compute structural inventory:
+     - Top-level (`##`) sections + their byte sizes.
+     - Numbered/bulleted step lists (`1.`, `- Step:`, etc.).
+     - Tag clusters by paragraph (for `concern` strategy).
+     - Total body size.
+
+4. **Reject trivially-small inputs**
+   - Refuse if the body is `<400` lines AND has fewer than 2 top-level sections AND fewer than 5 steps. Splitting a tiny entry produces noise, not value. Suggest the user edit it directly instead.
+
+5. **Apply strategy**
+   - **`section`**:
+     - Group `## Problem` / `## Pattern` / `## Example` / `## When to use` / `## Pitfalls` together as the "core" of each split (they form the standard skill template). The splitter operates on **above-template sections** like `## Read path`, `## Write path`, `## Migration mode`, etc.
+     - If the input has none of these "topical" extra sections, fall back to next strategy or refuse.
+   - **`step`** (skills only):
+     - Each numbered step becomes a draft IF the step has its own preconditions / outputs / failure modes spelled out. Steps that are purely sequential glue ("then commit", "then push") get folded into the previous draft.
+   - **`concern`**:
+     - Cluster paragraphs by dominant tag/keyword. Each cluster of size ≥3 paragraphs becomes a draft.
+     - Cross-cluster references stay as `linked_skills` / `linked_knowledge` in frontmatter.
+   - **`auto`**: chain as documented above.
+
+6. **Synthesize each split draft**
+   - **Skill split** (per child skill):
+     - `name`: `<original-name>-<strategy-derived-suffix>` (e.g. `retry-strategy-read-path`, `migration-step-3-backfill`). User can rename in the review prompt.
+     - `description`: rewritten one-liner scoped to that split's concern.
+     - `category`: inherited from the original unless the split clearly belongs elsewhere (preview will flag suggested category changes for user approval).
+     - `tags`: subset of the original's tags relevant to this split + at most 1 new tag derived from the split's heading.
+     - `triggers`: subset of the original's triggers; if a trigger doesn't apply to any split, it's kept on the largest split and a warning is logged.
+     - `version`: `0.1.0-draft`.
+     - `source_project`: `split-from:<original-category>/<original-name>`.
+     - `split_from`: `"<kind>:<category>/<name>[@<ver>]"` (single value, not a list).
+     - `replaces`: `"<kind>:<category>/<name>"` UNLESS `--keep-original` is set.
+     - `siblings`: list of the other split slugs produced in the same run (helps users navigate).
+     - `content.md`: the standard template populated from the corresponding source section/cluster. Include a `## See also` block listing siblings.
+   - **Knowledge split** (per child entry):
+     - Same conventions as `/skills_extract_knowledge` template.
+     - `confidence`: inherits from the original — never upgraded by splitting.
+     - `summary`: rewritten one-liner per split.
+     - `split_from`, `replaces`, `siblings`: as above.
+     - `## Evidence`: each split keeps only the evidence lines relevant to its scope; if an evidence line was global, it's duplicated across splits (with a note).
+
+7. **Dry-run preview** (always shown)
+   - Render:
+     ```
+     === skills_split dry-run ===
+     Source: skill:backend/retry-strategy@v1.4.0
+       body: 612 lines, 4 top-level sections, 7 numbered steps
+       chosen strategy: auto → concern (3 clusters, 4 lines residual)
+
+     Proposed splits (3 + 1 residual):
+       1. backend/retry-strategy-read-path     (~180 lines, tags: retry, read)
+       2. backend/retry-strategy-write-path    (~210 lines, tags: retry, write, idempotency)
+       3. backend/retry-strategy-observability (~120 lines, tags: retry, metrics)
+       4. backend/retry-strategy-misc          (~ 40 lines, residual under --max=5)
+
+     Frontmatter for split 1:
+       <yaml block>
+
+     Cross-links: each split lists the others under `siblings`.
+     replaces: skill:backend/retry-strategy   (omit-flag: --keep-original)
+
+     Draft paths (on persist):
+       .skills-draft/backend/retry-strategy-read-path/
+       .skills-draft/backend/retry-strategy-write-path/
+       .skills-draft/backend/retry-strategy-observability/
+       .skills-draft/backend/retry-strategy-misc/
+     ```
+   - If `--dry-run` → stop here.
+   - Else prompt per split: `accept / rename / change-category / drop / edit-content` and a final `proceed / cancel`. `--yes` accepts the entire set as-shown.
+
+8. **Persist drafts**
+   - Write each accepted split under `.skills-draft/<category>/<name>/` or `.knowledge-draft/<category>/<slug>.md`.
+   - Collision: prompt overwrite/rename/skip per draft.
+   - Write a sibling note `_SPLIT_SOURCE.md` next to the first draft only (not duplicated per split): records the original selector, commit SHA, strategy used, and the full split list with their paths. Publish commands ignore files starting with `_`.
+
+9. **Report**
+   - Show every draft path and the proposed publish command (`/publish_all` is usually the right call for split sets so cross-links land together).
+   - Remind: original entry on remote is **not modified**. Use `/skills_cleanup` after publishing to act on the `replaces` hint (proposes deprecation PR).
+
+## Rules
+
+- **Read-only on the remote cache.** Never push, never modify `~/.claude/skills-hub/remote/`.
+- **Never auto-publish.** Always stop at draft creation.
+- **No silent dropping.** Every paragraph from the source must end up in some split (or in the residual `-misc` draft). If the strategy would orphan content, the preview must surface it for the user to assign.
+- **No fabrication.** Splits inherit content from the source; do not invent new examples, pitfalls, or evidence to "round out" a small split. Smaller is fine.
+- **Refuse trivial inputs.** Per Step 4. Splitting a 100-line skill is busywork, not value.
+- **Inherit confidence (knowledge).** A `low`-confidence source produces `low`-confidence splits. Splitting cannot improve confidence.
+- **Sanitization** inherits from `/skills_publish` rules.
+- **Selector ambiguity is fatal.** Same as `/skills_merge`.
+
+## Examples
+
+```
+# Auto-strategy split of a sprawling skill
+/skills_split skill:backend/retry-strategy
+
+# Force per-section split, cap at 4 drafts
+/skills_split skill:devops/full-deploy-pipeline --by=section --max=4
+
+# Step-wise split of a numbered procedure (skills only)
+/skills_split skill:db/zero-downtime-migration --by=step
+
+# Knowledge split — separate orthogonal facts
+/skills_split knowledge:arch/event-sourcing-everything --by=concern --dry-run
+
+# Pin to a specific version
+/skills_split skill:backend/retry-strategy@v1.4.0 --by=concern --yes
+```

--- a/bootstrap/skills/skills-hub/SKILL.md
+++ b/bootstrap/skills/skills-hub/SKILL.md
@@ -68,6 +68,9 @@ Registry entry format:
 | `/skills_extract` | **Full project scan** → generate skill drafts in `.skills-draft/` |
 | `/skills_extract_session` | **Current session only** → drafts from recent changes |
 | `/skills_publish` | Review drafts → push to remote as branch + optional PR |
+| `/skills_merge <selectors...>` | Combine 2+ remote skills/knowledge into one new draft (read-only on remote) |
+| `/skills_split <selector>` | Decompose one remote skill/knowledge into N smaller drafts (read-only on remote) |
+| `/skills_refactor` | Scan remote for merge + split candidates and produce both kinds of drafts in one pass |
 | `/skills_finalize` | End-of-project: extract → review → publish → cleanup drafts |
 | `/skills_cleanup` | Remote maintenance: dedupe, re-index, stale removal (dry-run default) |
 | `/skills_remove <name>` | Uninstall local skill |


### PR DESCRIPTION
## Summary

Adds three new slash commands for managing existing entries in `kjuhwa/skills-hub`, organized into category subfolders, and upgrades the bootstrap sync flow to handle subdirectories recursively.

### New commands (all read-only on the remote cache; output goes to `.skills-draft/` / `.knowledge-draft/`)

- **`/merge:skills_merge <selector1> <selector2> [<selectorN>...]`** — synthesize 2+ existing skills/knowledge into one new draft. Supports cross-kind merges (skill + knowledge → skill with `linked_knowledge`), tag/version pinning via `skill:cat/name@v1.2.0`, and mandatory `merged_from` / `supersedes` provenance.
- **`/split:skills_split <selector>`** — decompose one oversized entry into N focused drafts. Strategies: `section | step | concern | auto`. Refuses trivially-small inputs. Records `split_from` / `replaces` / `siblings` for traceability.
- **`/refactor:skills_refactor`** — scans the remote for merge candidates (tag/content similarity clusters) AND split candidates (oversized entries with multiple concerns) in one pass, then delegates to the two commands above. Bias toward merge over split when an entry qualifies for both.

### Recursive subdirectory support

- `skills_bootstrap_publish` and `skills_bootstrap_update` now walk `~/.claude/commands/**/*.md` and `bootstrap/commands/**/*.md` recursively, preserving subdirectory layout in both directions. Subfolder moves are detected and reported as explicit moves.

### Skill metadata

- `bootstrap/skills/skills-hub/SKILL.md` command map updated to list the three new commands.

## Test plan

- [ ] On a second machine: `/skills_bootstrap_update --version=1.4.0` should install the three new commands under `~/.claude/commands/{merge,split,refactor}/` with paths preserved.
- [ ] `/skills_bootstrap_update` dry-run output should correctly classify NEW/UPDATED/UNCHANGED for subfolder entries.
- [ ] Invoke `/merge:skills_merge`, `/split:skills_split`, `/refactor:skills_refactor` to confirm Claude Code loads them (namespaced slash commands).
- [ ] Sanity: a future `/skills_bootstrap_publish` pass from a machine with new subfolders should not flatten the layout.

## Risk notes

- Existing `/skills_bootstrap_update` clients pre-v1.4.0 will flatten the new subdirectories into `~/.claude/commands/` when they sync (old implementation didn't know about subfolders). This only bites users who pin to v1.3.2 while the remote has v1.4.0+ content — a non-issue at merge time, but worth noting for staged rollouts.