### PR TITLE
chore(index): reindex after mattpocock import (PR #51)

### DIFF
--- a/index.json
+++ b/index.json
@@ -300,6 +300,16 @@
       "path": "arch/definition-registry-helper-cache"
     },
     {
+      "name": "design-an-interface",
+      "description": "Generate multiple radically different interface designs for a module using parallel sub-agents. Use when user wants to design an API, explore interface options, compare module shapes, or mentions \"design it twice\".",
+      "category": "misc",
+      "tags": "[design, api-design, sub-agents, design-it-twice]",
+      "triggers": "",
+      "source_project": "mattpocock-skills",
+      "version": "0.1.0-draft",
+      "path": "misc/design-an-interface"
+    },
+    {
       "name": "deterministic-coverage-verification",
       "description": "Run LLVM-instrumented tests multiple times and verify identical coverage reports — catches compiler/env non-determinism that can mask real bugs.",
       "category": "testing",
@@ -418,6 +428,16 @@
       "source_project": "scouter",
       "version": "1.0.0",
       "path": "apm/eclipse-rcp-rich-client-for-apm-ui"
+    },
+    {
+      "name": "edit-article",
+      "description": "Edit and improve articles by restructuring sections, improving clarity, and tightening prose. Use when user wants to edit, revise, or improve an article draft.",
+      "category": "docs",
+      "tags": "[writing, editing, clarity]",
+      "triggers": "",
+      "source_project": "mattpocock-skills",
+      "version": "0.1.0-draft",
+      "path": "docs/edit-article"
     },
     {
       "name": "elasticsearch-xpack-ssl-transport",
@@ -561,6 +581,16 @@
       "path": "game-dev/gacha-soft-hard-pity"
     },
     {
+      "name": "git-guardrails-claude-code",
+      "description": "Set up Claude Code hooks to block dangerous git commands (push, reset --hard, clean, branch -D, etc.) before they execute. Use when user wants to prevent destructive git operations, add git safety hooks, or block git push/reset in Claude Code.",
+      "category": "cli",
+      "tags": "[git, hooks, claude-code, guardrails, safety]",
+      "triggers": "",
+      "source_project": "mattpocock-skills",
+      "version": "0.1.0-draft",
+      "path": "cli/git-guardrails-claude-code"
+    },
+    {
       "name": "git-tag-registry-versioning",
       "description": "Add semver rollback and pinning to any git-backed asset registry (skills, prompts, commands, snippets) using namespaced annotated tags per item and per-release bundle.",
       "category": "arch",
@@ -569,6 +599,16 @@
       "source_project": "skills-hub",
       "version": "1.0.0",
       "path": "arch/git-tag-registry-versioning"
+    },
+    {
+      "name": "github-triage",
+      "description": "Triage GitHub issues through a label-based state machine with interactive grilling sessions. Use when user wants to triage issues, review incoming bugs or feature requests, prepare issues for an AFK agent, or manage issue workflow.",
+      "category": "workflow",
+      "tags": "[github, triage, issues, labels, state-machine]",
+      "triggers": "",
+      "source_project": "mattpocock-skills",
+      "version": "0.1.0-draft",
+      "path": "workflow/github-triage"
     },
     {
       "name": "gradle-bootjar-conditional-archive-bundle",
@@ -622,6 +662,16 @@
       "path": "backend/grid-filter-to-criteria-converter"
     },
     {
+      "name": "grill-me",
+      "description": "Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions \"grill me\".",
+      "category": "workflow",
+      "tags": "[interview, planning, clarification, socratic]",
+      "triggers": "",
+      "source_project": "mattpocock-skills",
+      "version": "0.1.0-draft",
+      "path": "workflow/grill-me"
+    },
+    {
       "name": "hibernate-multi-dialect-swap",
       "description": "Ship one WAR that connects to Oracle, PostgreSQL, MSSQL, Tibero, DB2, or MariaDB based on Spring profile — all JDBC drivers bundled, dialect and datasource resolved from externalized config",
       "category": "backend",
@@ -660,6 +710,16 @@
       "source_project": "veda-chronicles",
       "version": "0.1.0-draft",
       "path": "arch/immutable-action-event-log"
+    },
+    {
+      "name": "improve-codebase-architecture",
+      "description": "Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. Use when user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more AI-navigable.",
+      "category": "refactor",
+      "tags": "[architecture, codebase, exploration]",
+      "triggers": "",
+      "source_project": "mattpocock-skills",
+      "version": "0.1.0-draft",
+      "path": "refactor/improve-codebase-architecture"
     },
     {
       "name": "init-deadline-guard",
@@ -1011,6 +1071,16 @@
       "path": "frontend/mfa-plain-html-dropdown-escape-hatch"
     },
     {
+      "name": "migrate-to-shoehorn",
+      "description": "Migrate test files from `as` type assertions to @total-typescript/shoehorn. Use when user mentions shoehorn, wants to replace `as` in tests, or needs partial test data.",
+      "category": "refactor",
+      "tags": "[typescript, shoehorn, type-assertions, migration]",
+      "triggers": "",
+      "source_project": "mattpocock-skills",
+      "version": "0.1.0-draft",
+      "path": "refactor/migrate-to-shoehorn"
+    },
+    {
       "name": "migration-processor-pipeline",
       "description": "Abstract migration processor template — validate → load → transform → emit Kafka Avro event with org-id header → audit log, multi-tenant safe",
       "category": "backend",
@@ -1205,6 +1275,16 @@
       "path": "security/oauth-token-env-persistence"
     },
     {
+      "name": "obsidian-vault",
+      "description": "Search, create, and manage notes in the Obsidian vault with wikilinks and index notes. Use when user wants to find, create, or organize notes in Obsidian.",
+      "category": "docs",
+      "tags": "[obsidian, notes, wikilinks, vault]",
+      "triggers": "",
+      "source_project": "mattpocock-skills",
+      "version": "0.1.0-draft",
+      "path": "docs/obsidian-vault"
+    },
+    {
       "name": "openapi-to-mcp-tag-grouping",
       "description": "Convert OpenAPI specs into MCP tools by grouping operations under their OpenAPI tag, exposing one tool per tag with an operation selector and per-operation arguments.",
       "category": "ai",
@@ -1369,6 +1449,36 @@
       "path": "backend/polymorphic-command-entities"
     },
     {
+      "name": "prd-to-issues",
+      "description": "Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. Use when user wants to convert a PRD to issues, create implementation tickets, or break down a PRD into work items.",
+      "category": "workflow",
+      "tags": "[prd, github, issues, tracer-bullet, planning]",
+      "triggers": "",
+      "source_project": "mattpocock-skills",
+      "version": "0.1.0-draft",
+      "path": "workflow/prd-to-issues"
+    },
+    {
+      "name": "prd-to-plan",
+      "description": "Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in ./plans/. Use when user wants to break down a PRD, create an implementation plan, plan phases from a PRD, or mentions \"tracer bullets\".",
+      "category": "workflow",
+      "tags": "[prd, planning, phased, tracer-bullet]",
+      "triggers": "",
+      "source_project": "mattpocock-skills",
+      "version": "0.1.0-draft",
+      "path": "workflow/prd-to-plan"
+    },
+    {
+      "name": "qa",
+      "description": "Interactive QA session where user reports bugs or issues conversationally, and the agent files GitHub issues. Explores the codebase in the background for context and domain language. Use when user wants to report bugs, do QA, file issues conversationally, or mentions \"QA session\".",
+      "category": "testing",
+      "tags": "[qa, interactive, bug-reports]",
+      "triggers": "",
+      "source_project": "mattpocock-skills",
+      "version": "0.1.0-draft",
+      "path": "testing/qa"
+    },
+    {
       "name": "querydsl-q-class-exclusion-pattern",
       "description": "One `exclusionPatterns` list drives Jacoco report + verification + Sonar exclusions; catches generated Querydsl Q-classes via `('A'..'Z').collect { \"**/**/Q${it}*\" }`.",
       "category": "devops",
@@ -1432,6 +1542,16 @@
       "path": "backend/redis-lock-recheck-flag-pattern"
     },
     {
+      "name": "request-refactor-plan",
+      "description": "Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.",
+      "category": "refactor",
+      "tags": "[planning, commits, interview]",
+      "triggers": "",
+      "source_project": "mattpocock-skills",
+      "version": "0.1.0-draft",
+      "path": "refactor/request-refactor-plan"
+    },
+    {
       "name": "resource-provider-registry",
       "description": "Spring DI plugin registry where @Component implementations of a typed interface are auto-discovered and looked up at runtime by a string type key",
       "category": "arch",
@@ -1451,6 +1571,16 @@
       "source_project": "lucida-domain-sms",
       "version": "1.0.0",
       "path": "arch/resource-summary-resolve-override-template"
+    },
+    {
+      "name": "scaffold-exercises",
+      "description": "Create exercise directory structures with sections, problems, solutions, and explainers that pass linting. Use when user wants to scaffold exercises, create exercise stubs, or set up a new course section.",
+      "category": "misc",
+      "tags": "[scaffolding, exercises, template]",
+      "triggers": "",
+      "source_project": "mattpocock-skills",
+      "version": "0.1.0-draft",
+      "path": "misc/scaffold-exercises"
     },
     {
       "name": "second-aggregation-snapshot-merge",
@@ -1521,6 +1651,16 @@
       "source_project": "lucida-domain-dpm",
       "version": "1.0.0",
       "path": "backend/session-lock-tree-blocking-chain-modeling"
+    },
+    {
+      "name": "setup-pre-commit",
+      "description": "Set up Husky pre-commit hooks with lint-staged (Prettier), type checking, and tests in the current repo. Use when user wants to add pre-commit hooks, set up Husky, configure lint-staged, or add commit-time formatting/typechecking/testing.",
+      "category": "cli",
+      "tags": "[husky, lint-staged, pre-commit, prettier, typescript]",
+      "triggers": "",
+      "source_project": "mattpocock-skills",
+      "version": "0.1.0-draft",
+      "path": "cli/setup-pre-commit"
     },
     {
       "name": "shared-apis-endpoint-service-pattern",
@@ -1797,6 +1937,16 @@
       "path": "workflow/swagger-spec-baseline-from-git"
     },
     {
+      "name": "tdd",
+      "description": "Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions \"red-green-refactor\", wants integration tests, or asks for test-first development.",
+      "category": "testing",
+      "tags": "[tdd, red-green-refactor]",
+      "triggers": "",
+      "source_project": "mattpocock-skills",
+      "version": "0.1.0-draft",
+      "path": "testing/tdd"
+    },
+    {
       "name": "tenant-context-holder-propagation",
       "description": "Set TenantContextHolder.INSTANCE.setTenantId(orgId) on the current thread so MongoDB tenant-isolated templates route queries correctly, always clearing in a finally block",
       "category": "arch",
@@ -1908,6 +2058,16 @@
       "path": "apm/transaction-trace-pack-serialization-with-step-hierarchy"
     },
     {
+      "name": "triage-issue",
+      "description": "Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. Use when user reports a bug, wants to file an issue, mentions \"triage\", or wants to investigate and plan a fix for a problem.",
+      "category": "debug",
+      "tags": "[bug, triage, root-cause, investigation]",
+      "triggers": "",
+      "source_project": "mattpocock-skills",
+      "version": "0.1.0-draft",
+      "path": "debug/triage-issue"
+    },
+    {
       "name": "triple-env-file-split-loader",
       "description": "Split operator-facing env into three files (.env / .version / .memory) and load them in a fixed order",
       "category": "devops",
@@ -1936,6 +2096,16 @@
       "source_project": "lucida-account",
       "version": "1.0.0",
       "path": "backend/tsv-driven-permission-bootstrap"
+    },
+    {
+      "name": "ubiquitous-language",
+      "description": "Extract a DDD-style ubiquitous language glossary from the current conversation, flagging ambiguities and proposing canonical terms. Saves to UBIQUITOUS_LANGUAGE.md. Use when user wants to define domain terms, build a glossary, harden terminology, create a ubiquitous language, or mentions \"domain model\" or \"DDD\".",
+      "category": "docs",
+      "tags": "[ddd, glossary, language, domain]",
+      "triggers": "",
+      "source_project": "mattpocock-skills",
+      "version": "0.1.0-draft",
+      "path": "docs/ubiquitous-language"
     },
     {
       "name": "udp-with-tcp-fallback-metrics-transport",
@@ -1996,6 +2166,26 @@
       "source_project": "lucida-domain-sms",
       "version": "1.0.0",
       "path": "frontend/widget-grid-type-registration-checklist"
+    },
+    {
+      "name": "write-a-prd",
+      "description": "Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. Use when user wants to write a PRD, create a product requirements document, or plan a new feature.",
+      "category": "workflow",
+      "tags": "[prd, requirements, interview, planning]",
+      "triggers": "",
+      "source_project": "mattpocock-skills",
+      "version": "0.1.0-draft",
+      "path": "workflow/write-a-prd"
+    },
+    {
+      "name": "write-a-skill",
+      "description": "Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, or build a new skill.",
+      "category": "misc",
+      "tags": "[skills, meta, authoring, progressive-disclosure]",
+      "triggers": "",
+      "source_project": "mattpocock-skills",
+      "version": "0.1.0-draft",
+      "path": "misc/write-a-skill"
     },
     {
       "name": "x-filterable-fields-extraction",


### PR DESCRIPTION
## Summary

- Adds 19 skill entries to `index.json` for the mattpocock import landed in #51
- No existing entries modified; list re-sorted alphabetically by `name`
- Total: 217 skills (was 198)

## Test plan

- [ ] `jq '.skills | length' index.json` returns 217
- [ ] `jq '.skills | map(.path) | unique | length' index.json` returns 217 (no dup paths)
- [ ] Spot-check 2–3 new entries match their SKILL.md frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)