### PR TITLE
docs: add hero, badges, and MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 kjuhwa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,30 @@
 # skills-hub
 
-Personal skill & knowledge hub for Claude Code. Discover, install, extract, and publish reusable skills across projects.
+> **Skill & knowledge registry for Claude Code** — 217 reusable skills you can install into any project with a single slash command.
 
-- **Remote**: `https://github.com/kjuhwa/skills.git`
-- **Layout**: category-separated skills + bootstrap scripts
-- **Client**: Claude Code + oh-my-claudecode (OMC) compatible
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+[![Skills](https://img.shields.io/badge/skills-217-blue)](./index.json)
+![GitHub last commit](https://img.shields.io/github/last-commit/kjuhwa/skills-hub)
+![GitHub stars](https://img.shields.io/github/stars/kjuhwa/skills-hub?style=social)
+
+Stop re-deriving the same patterns in every Claude Code session. `skills-hub` is a curated, versioned catalog of battle-tested skills and domain knowledge — searchable, installable, and extractable — so your agent starts every project already knowing what worked last time.
+
+```bash
+# One-line install into ~/.claude
+curl -fsSL https://raw.githubusercontent.com/kjuhwa/skills-hub/main/bootstrap/install.sh | bash
+
+# Then in any Claude Code session
+/init_skills react testing        # search + install matching skills
+/skills_extract_project           # mine this repo for new skills
+/skills_publish                   # ship them back to the hub
+```
+
+**Highlights**
+- 🔎 **Search before you code** — `/skills_search "kafka retry"` finds prior-art from every project you've shipped.
+- 📦 **Category-separated registry** — 19 canonical categories (`apm`, `backend`, `ai`, `arch`, …), one skill per folder, frontmatter-driven.
+- 🧠 **Two kinds of memory** — executable **skills** (recipes with triggers) + non-executable **knowledge** (facts, decisions, pitfalls).
+- 🔁 **Round-trip workflow** — extract drafts from a session or full project → review → publish via one PR.
+- 🤝 **Claude Code + [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) compatible** — works with vanilla Claude Code; integrates deeper with OMC.
 
 ---
 


### PR DESCRIPTION
## Summary

Discoverability pass to complement the `description` + `topics` just set on the repo.

- Rewrites README header — one-line value prop, install snippet, and highlights section
- Fixes outdated remote URL (`kjuhwa/skills.git` → `kjuhwa/skills-hub.git`)
- Adds 4 shields.io badges (license, skill count, last commit, stars)
- Adds MIT `LICENSE` so external users can fork/reuse safely

## Test plan

- [ ] Badges render on github.com (MIT, skills=217, last-commit, stars)
- [ ] Install command in hero copy-pastes cleanly
- [ ] Highlights list reads well on mobile width
- [ ] `LICENSE` visible in repo sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)