### PR TITLE
fix: YAML parser missed block-style lists + block scalars (all 4 example tools)

### DIFF
--- a/example/skill-doctor/doctor.mjs
+++ b/example/skill-doctor/doctor.mjs
@@ -28,26 +28,49 @@ function parseFrontmatter(md) {
   const fmRaw = md.slice(3, end).trim();
   const body = md.slice(end + 4).replace(/^\r?\n/, '');
   const meta = {};
-  let cur = null;
+  let cur = null, blockScalar = null, blockIndent = -1, blockLines = [];
+  const flushBlock = () => {
+    if (blockScalar) {
+      meta[blockScalar] = blockLines.map(l => l.slice(blockIndent)).join(' ').replace(/\s+/g, ' ').trim();
+      blockScalar = null; blockLines = []; blockIndent = -1;
+    }
+  };
   for (const line of fmRaw.split(/\r?\n/)) {
+    if (blockScalar) {
+      const lead = line.match(/^(\s*)/)[1].length;
+      if (blockIndent === -1 && line.trim()) { blockIndent = lead; blockLines.push(line); continue; }
+      if (line.trim() && lead >= blockIndent) { blockLines.push(line); continue; }
+      flushBlock();
+    }
     if (!line.trim()) continue;
     if (!/^\s/.test(line)) {
       const m = line.match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
       if (!m) continue;
       cur = m[1];
       const v = m[2];
-      if (v === '') meta[cur] = {};
-      else if (v.startsWith('[') && v.endsWith(']')) {
+      if (v === '|' || v === '>' || v === '|-' || v === '>-') {
+        blockScalar = cur; blockIndent = -1; blockLines = [];
+      } else if (v === '') {
+        meta[cur] = {};
+      } else if (v.startsWith('[') && v.endsWith(']')) {
         meta[cur] = v.slice(1, -1).split(',').map(s => s.trim().replace(/^['"]|['"]$/g, '')).filter(Boolean);
       } else meta[cur] = v.replace(/^['"]|['"]$/g, '');
     } else if (cur) {
-      const sub = line.trim().match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
+      const trimmed = line.trim();
+      const li = trimmed.match(/^-\s+(.*)$/);
+      if (li) {
+        if (!Array.isArray(meta[cur])) meta[cur] = [];
+        meta[cur].push(li[1].replace(/^['"]|['"]$/g, ''));
+        continue;
+      }
+      const sub = trimmed.match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
       if (sub) {
         if (typeof meta[cur] !== 'object' || Array.isArray(meta[cur])) meta[cur] = {};
         meta[cur][sub[1]] = sub[2].replace(/^['"]|['"]$/g, '');
       }
     }
   }
+  flushBlock();
   return { meta, body, fmRaw };
 }
 

--- a/example/skill-graph/build-graph.mjs
+++ b/example/skill-graph/build-graph.mjs
@@ -18,22 +18,34 @@ function parseFm(md) {
   if (!md.startsWith('---')) return {};
   const end = md.indexOf('\n---', 3);
   if (end === -1) return {};
-  const meta = {}; let cur = null;
+  const meta = {}; let cur = null, blockScalar = null, blockIndent = -1, blockLines = [];
+  const flushBlock = () => { if (blockScalar) { meta[blockScalar] = blockLines.map(l=>l.slice(blockIndent)).join(' ').replace(/\s+/g,' ').trim(); blockScalar=null; blockLines=[]; blockIndent=-1; } };
   for (const line of md.slice(3, end).split(/\r?\n/)) {
+    if (blockScalar) {
+      const lead = line.match(/^(\s*)/)[1].length;
+      if (blockIndent === -1 && line.trim()) { blockIndent = lead; blockLines.push(line); continue; }
+      if (line.trim() && lead >= blockIndent) { blockLines.push(line); continue; }
+      flushBlock();
+    }
     if (!line.trim()) continue;
     if (!/^\s/.test(line)) {
       const m = line.match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
       if (!m) continue; cur = m[1];
       const v = m[2];
-      if (v === '') meta[cur] = {};
+      if (v === '|' || v === '>' || v === '|-' || v === '>-') { blockScalar = cur; blockIndent = -1; blockLines = []; }
+      else if (v === '') meta[cur] = {};
       else if (v.startsWith('[') && v.endsWith(']')) {
         meta[cur] = v.slice(1,-1).split(',').map(s=>s.trim().replace(/^['"]|['"]$/g,'')).filter(Boolean);
       } else meta[cur] = v.replace(/^['"]|['"]$/g,'');
     } else if (cur) {
-      const s = line.trim().match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
+      const trimmed = line.trim();
+      const li = trimmed.match(/^-\s+(.*)$/);
+      if (li) { if (!Array.isArray(meta[cur])) meta[cur] = []; meta[cur].push(li[1].replace(/^['"]|['"]$/g,'')); continue; }
+      const s = trimmed.match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
       if (s) { if (typeof meta[cur] !== 'object' || Array.isArray(meta[cur])) meta[cur] = {}; meta[cur][s[1]] = s[2].replace(/^['"]|['"]$/g,''); }
     }
   }
+  flushBlock();
   return meta;
 }
 

--- a/example/skill-stats/build-stats.mjs
+++ b/example/skill-stats/build-stats.mjs
@@ -17,20 +17,32 @@ const OUT    = path.join(HERE, 'stats.json');
 function parseFm(md) {
   if (!md.startsWith('---')) return {};
   const end = md.indexOf('\n---', 3); if (end === -1) return {};
-  const meta = {}; let cur = null;
+  const meta = {}; let cur = null, blockScalar = null, blockIndent = -1, blockLines = [];
+  const flushBlock = () => { if (blockScalar) { meta[blockScalar] = blockLines.map(l=>l.slice(blockIndent)).join(' ').replace(/\s+/g,' ').trim(); blockScalar=null; blockLines=[]; blockIndent=-1; } };
   for (const line of md.slice(3, end).split(/\r?\n/)) {
+    if (blockScalar) {
+      const lead = line.match(/^(\s*)/)[1].length;
+      if (blockIndent === -1 && line.trim()) { blockIndent = lead; blockLines.push(line); continue; }
+      if (line.trim() && lead >= blockIndent) { blockLines.push(line); continue; }
+      flushBlock();
+    }
     if (!line.trim()) continue;
     if (!/^\s/.test(line)) {
       const m = line.match(/^([A-Za-z_][\w-]*):\s*(.*)$/); if (!m) continue; cur = m[1];
       const v = m[2];
-      if (v === '') meta[cur] = {};
+      if (v === '|' || v === '>' || v === '|-' || v === '>-') { blockScalar = cur; blockIndent = -1; blockLines = []; }
+      else if (v === '') meta[cur] = {};
       else if (v.startsWith('[') && v.endsWith(']')) meta[cur] = v.slice(1,-1).split(',').map(s=>s.trim().replace(/^['"]|['"]$/g,'')).filter(Boolean);
       else meta[cur] = v.replace(/^['"]|['"]$/g,'');
     } else if (cur) {
-      const s = line.trim().match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
+      const trimmed = line.trim();
+      const li = trimmed.match(/^-\s+(.*)$/);
+      if (li) { if (!Array.isArray(meta[cur])) meta[cur] = []; meta[cur].push(li[1].replace(/^['"]|['"]$/g,'')); continue; }
+      const s = trimmed.match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
       if (s) { if (typeof meta[cur] !== 'object' || Array.isArray(meta[cur])) meta[cur] = {}; meta[cur][s[1]] = s[2].replace(/^['"]|['"]$/g,''); }
     }
   }
+  flushBlock();
   return meta;
 }
 

--- a/example/skills-explorer/browser/build-index.mjs
+++ b/example/skills-explorer/browser/build-index.mjs
@@ -16,15 +16,29 @@ function parseFrontmatter(md) {
   const fmRaw = md.slice(3, end).trim();
   const body = md.slice(end + 4).replace(/^\r?\n/, '');
   const meta = {};
-  let currentKey = null;
+  let currentKey = null, blockScalar = null, blockIndent = -1, blockLines = [];
+  const flushBlock = () => {
+    if (blockScalar) {
+      meta[blockScalar] = blockLines.map(l => l.slice(blockIndent)).join(' ').replace(/\s+/g, ' ').trim();
+      blockScalar = null; blockLines = []; blockIndent = -1;
+    }
+  };
   for (const line of fmRaw.split(/\r?\n/)) {
+    if (blockScalar) {
+      const lead = line.match(/^(\s*)/)[1].length;
+      if (blockIndent === -1 && line.trim()) { blockIndent = lead; blockLines.push(line); continue; }
+      if (line.trim() && lead >= blockIndent) { blockLines.push(line); continue; }
+      flushBlock();
+    }
     if (!line.trim()) continue;
     if (!/^\s/.test(line)) {
       const m = line.match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
       if (!m) continue;
       const [, k, v] = m;
       currentKey = k;
-      if (v === '') meta[k] = {};
+      if (v === '|' || v === '>' || v === '|-' || v === '>-') {
+        blockScalar = k; blockIndent = -1; blockLines = [];
+      } else if (v === '') meta[k] = {};
       else if (v.startsWith('[') && v.endsWith(']')) {
         meta[k] = v.slice(1, -1)
           .split(',')
@@ -34,7 +48,14 @@ function parseFrontmatter(md) {
         meta[k] = v.replace(/^['"]|['"]$/g, '');
       }
     } else if (currentKey) {
-      const sub = line.trim().match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
+      const trimmed = line.trim();
+      const listItem = trimmed.match(/^-\s+(.*)$/);
+      if (listItem) {
+        if (!Array.isArray(meta[currentKey])) meta[currentKey] = [];
+        meta[currentKey].push(listItem[1].replace(/^['"]|['"]$/g, ''));
+        continue;
+      }
+      const sub = trimmed.match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
       if (sub) {
         if (typeof meta[currentKey] !== 'object' || Array.isArray(meta[currentKey])) {
           meta[currentKey] = {};
@@ -43,6 +64,7 @@ function parseFrontmatter(md) {
       }
     }
   }
+  flushBlock();
   return { meta, body };
 }
 


### PR DESCRIPTION
## Why

The hand-rolled YAML frontmatter walker — copy-pasted into all four tools under \`example/\` — missed two common shapes:

1. Block-style lists (\`tags:\n  - foo\n  - bar\`) — read as \`{}\` instead of an array, silently dropping tags and triggers.
2. Block scalars (\`summary: |\n  body\`) — read as \`{}\` or \`''\`, so multi-line summaries registered as 1 char.

## Impact measured on the source working copy

| metric | before | after | Δ |
|---|--:|--:|---|
| unique tags | 377 | **420** | +43 restored |
| skills-with-triggers | 29 | **77** | **+48** (62% of triggered skills were invisible) |
| skill-doctor errors + warnings | 6 + 19 | **0 + 0** | 14 of 25 findings were parser false positives; the other 11 were real data defects already fixed on \`main\` |

## Files changed

- \`example/skills-explorer/browser/build-index.mjs\`
- \`example/skill-doctor/doctor.mjs\`
- \`example/skill-graph/build-graph.mjs\`
- \`example/skill-stats/build-stats.mjs\`

Same fix in all four — one indent-aware state machine for block scalars plus the pre-existing block-list branch.

## Follow-up

A lost commit of the same fix was briefly pushed to \`example/diagnostics-trio\` (after #63 merged). That branch has been deleted — the canonical fix is now this PR.