### PR TITLE
fix(knowledge): repair 11 frontmatter defects (missing summary × 6 · name-mismatch × 5)

### DIFF
--- a/knowledge/arch/annotation-driven-authz-via-function-id.md
+++ b/knowledge/arch/annotation-driven-authz-via-function-id.md
@@ -1,5 +1,6 @@
 ---
-name: Annotation-driven coarse-grained authorization via @FunctionId
+name: annotation-driven-authz-via-function-id
+title: Annotation-driven coarse-grained authorization via @FunctionId
 description: Controllers declare required capability with a method-level enum annotation; an interceptor enforces it against JWT-derived roles
 type: knowledge
 category: arch

--- a/knowledge/arch/polymorphic-metadata-via-enum-switch.md
+++ b/knowledge/arch/polymorphic-metadata-via-enum-switch.md
@@ -1,5 +1,6 @@
 ---
-name: Polymorphic metadata persisted as BSON via enum-switch deserialization
+name: polymorphic-metadata-via-enum-switch
+title: Polymorphic metadata persisted as BSON via enum-switch deserialization
 description: Store heterogeneous domain payloads under one field as raw Document, then deserialize with Gson chosen by an enum discriminator
 type: knowledge
 category: arch

--- a/knowledge/arch/tenant-context-per-request-interceptor.md
+++ b/knowledge/arch/tenant-context-per-request-interceptor.md
@@ -1,5 +1,6 @@
 ---
-name: Per-request tenant context via HandlerInterceptor
+name: tenant-context-per-request-interceptor
+title: Per-request tenant context via HandlerInterceptor
 description: Extract tenant id from JWT/header in preHandle, store in ThreadLocal, clear in afterCompletion to isolate multi-tenant data access
 type: knowledge
 category: arch

--- a/knowledge/arch/wait-for-services-eureka-startup-init.md
+++ b/knowledge/arch/wait-for-services-eureka-startup-init.md
@@ -1,5 +1,6 @@
 ---
-name: Gate startup initialization on dependent-service readiness via @WaitForServices
+name: wait-for-services-eureka-startup-init
+title: Gate startup initialization on dependent-service readiness via @WaitForServices
 description: Defer schema/index/data bootstrap until named services report ready in discovery, with bounded exponential backoff and leader election
 type: knowledge
 category: arch

--- a/knowledge/decision/god-controller-split-by-resource.md
+++ b/knowledge/decision/god-controller-split-by-resource.md
@@ -1,6 +1,7 @@
 ---
 name: god-controller-split-by-resource
 category: decision
+summary: "Split an oversized controller along URL sub-resource boundaries (one controller per sub-path like /page, /widget, /file) and keep the common @RequestMapping prefix — clearer per-class responsibility without breaking the external API surface."
 scope: global
 source:
   kind: project

--- a/knowledge/decision/prefer-static-import-over-constant-inheritance.md
+++ b/knowledge/decision/prefer-static-import-over-constant-inheritance.md
@@ -1,6 +1,7 @@
 ---
 name: prefer-static-import-over-constant-inheritance
 category: decision
+summary: "Access shared constants via `import static SomeConstants.*` instead of `extends SomeConstants` — inheritance for constants pollutes the single-inheritance slot, leaks protected visibility, and makes subclasses nonsensically \"is-a\" a constants bag."
 scope: global
 source:
   kind: project

--- a/knowledge/pitfall/mongo-timeseries-forced-hint-kills-pushdown.md
+++ b/knowledge/pitfall/mongo-timeseries-forced-hint-kills-pushdown.md
@@ -1,6 +1,7 @@
 ---
 name: mongo-timeseries-forced-hint-kills-pushdown
 category: pitfall
+summary: "Forcing `hint(indexName)` on a MongoDB time-series aggregation bypasses the optimizer's bucket-index rewrite — the plan scans every bucket with `control.min/max.timestamp = [MinKey, MaxKey]` instead of honoring the timestamp predicate."
 scope: global
 source:
   kind: project

--- a/knowledge/pitfall/mongo-timeseries-match-split-for-pushdown.md
+++ b/knowledge/pitfall/mongo-timeseries-match-split-for-pushdown.md
@@ -1,6 +1,7 @@
 ---
 name: mongo-timeseries-match-split-for-pushdown
 category: pitfall
+summary: "On MongoDB time-series collections, combining timestamp range + metadata filters in a single `$match` disables bucket-level push-down — split into two sequential `$match` stages (timestamp first, metadata second) so the optimizer can synthesize `control.*.timestamp` bounds."
 scope: global
 source:
   kind: project

--- a/knowledge/pitfall/mongo-timeseries-view-pushdown-broken-8_2_3.md
+++ b/knowledge/pitfall/mongo-timeseries-view-pushdown-broken-8_2_3.md
@@ -1,6 +1,7 @@
 ---
 name: mongo-timeseries-view-pushdown-broken-8_2_3
 category: pitfall
+summary: "On MongoDB 8.2.3, aggregations run against a view whose source is a time-series collection lose the timestamp bucket-index push-down — hot queries must target the base collection directly. Retest after server upgrades."
 scope: global
 source:
   kind: project

--- a/knowledge/pitfall/sonar-token-hardcoded-build-gradle.md
+++ b/knowledge/pitfall/sonar-token-hardcoded-build-gradle.md
@@ -1,5 +1,6 @@
 ---
-name: build-gradle-secret-and-insecure-protocol
+name: sonar-token-hardcoded-build-gradle
+title: build-gradle-secret-and-insecure-protocol
 description: Hardcoded SonarQube login token in build.gradle plus `allowInsecureProtocol = true` on an internal Nexus are two common DevSecOps anti-patterns to fix together
 category: pitfall
 confidence: high

--- a/knowledge/pitfall/user-sql-source-requires-select-only-and-readonly.md
+++ b/knowledge/pitfall/user-sql-source-requires-select-only-and-readonly.md
@@ -1,6 +1,7 @@
 ---
 name: user-sql-source-requires-select-only-and-readonly
 category: pitfall
+summary: "When a feature lets end-users paste raw SQL for display, no single guard is enough — layer four defenses: SELECT-only keyword allow-list, token-aware destructive-keyword blocklist, JDBC `setReadOnly(true)`, and `setQueryTimeout` + `setMaxRows` caps."
 scope: global
 source:
   kind: project


### PR DESCRIPTION
## Why

Ran \`skill-doctor\` (from #63, now on \`main\`) against a working copy. It flagged 6 errors (missing \`summary\`/\`description\`) and 5 warnings (\`name:\` was a human sentence, not the kebab-slug filename).

## What

**6 entries gained a one-sentence summary** covering the core claim:

| path | summary (new) |
|---|---|
| \`decision/god-controller-split-by-resource\` | Split by URL sub-resource boundaries, keep common \`@RequestMapping\`. |
| \`decision/prefer-static-import-over-constant-inheritance\` | Use \`import static\` not \`extends\` for constants. |
| \`pitfall/mongo-timeseries-forced-hint-kills-pushdown\` | Forced hint → \`[MinKey, MaxKey]\` full scan. |
| \`pitfall/mongo-timeseries-match-split-for-pushdown\` | Split timestamp + metadata into 2 \`$match\` stages. |
| \`pitfall/mongo-timeseries-view-pushdown-broken-8_2_3\` | 8.2.3: aggregations via view over TS lose push-down. |
| \`pitfall/user-sql-source-requires-select-only-and-readonly\` | Layer 4 defenses, not just a keyword filter. |

**5 entries had name renamed to the kebab-slug** that matches the filename; original sentence preserved in a new \`title:\` field:

- \`arch/annotation-driven-authz-via-function-id\`
- \`arch/polymorphic-metadata-via-enum-switch\`
- \`arch/tenant-context-per-request-interceptor\`
- \`arch/wait-for-services-eureka-startup-init\`
- \`pitfall/sonar-token-hardcoded-build-gradle\`

## After-state

\`\`\`
scanned 217 skills · 213 knowledge
errors 0 · warnings 0 · info 0
\`\`\`

## Related

- #64 fixes the parser so block-style lists and block scalars are also read correctly — without that, the doctor still flags phantom warnings.