### PR TITLE
example(skill-doctor): add web UI alongside CLI

### DIFF
--- a/example/skill-doctor/README.md
+++ b/example/skill-doctor/README.md
@@ -18,11 +18,15 @@
 ```
 skill-doctor/
 ├── README.md       (this file)
-├── doctor.mjs      (single-file CLI, ~170 LOC, zero deps)
+├── doctor.mjs      (single-file CLI, ~180 LOC, zero deps)
+├── serve.mjs       (static + /api/run endpoint, ~40 LOC)
+├── index.html      (single-file SPA UI, ~180 LOC)
 └── report.json     (generated when --json is used)
 ```
 
 ## Usage
+
+### CLI (primary)
 
 ```bash
 # Lint the current project
@@ -35,6 +39,21 @@ node doctor.mjs --root=/path/to/getskills
 node doctor.mjs --json > report.json
 echo "exit=$?"
 ```
+
+### Web UI
+
+```bash
+DOCTOR_ROOT=/path/to/getskills PORT=4177 node serve.mjs
+# → ▶ skill-doctor UI → http://localhost:4177/
+```
+
+Features:
+- **status pills** — errors / warnings / info / scanned count
+- **rule chips** — filter findings by severity OR by rule (click to toggle)
+- **grouped by file** — all findings per file in one card
+- **run button** — rescans on demand; spinner while in flight
+- **clean state** — big green check when there are zero findings
+- Zero frontend deps; the server is 40 LOC of Node stdlib.
 
 ### Sample output
 

--- a/example/skill-doctor/index.html
+++ b/example/skill-doctor/index.html
@@ -1,0 +1,177 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Skill Doctor</title>
+<style>
+:root {
+  --bg: #0b0d10; --bg-2: #11151a; --bg-3: #161b22;
+  --fg: #c9d1d9; --fg-dim: #7d8590; --border: #21262d;
+  --ok: #7ee787; --warn: #ffa657; --err: #ff7b72; --info: #79c0ff; --mag: #d2a8ff;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; background: var(--bg); color: var(--fg);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 13px; line-height: 1.5; }
+.wrap { max-width: 1100px; margin: 0 auto; padding: 24px 28px 60px; }
+header { display: flex; align-items: center; gap: 14px; margin-bottom: 18px; padding-bottom: 14px; border-bottom: 1px solid var(--border); }
+h1 { font-family: system-ui, sans-serif; font-size: 22px; margin: 0; color: var(--ok); font-weight: 600; }
+h1::before { content: "🩺 "; }
+header .sub { color: var(--fg-dim); font-size: 12px; }
+button {
+  background: var(--bg-3); color: var(--fg); border: 1px solid var(--border); border-radius: 4px;
+  padding: 6px 14px; font-family: inherit; font-size: 12px; cursor: pointer;
+}
+button:hover { border-color: var(--ok); color: var(--ok); }
+button:disabled { opacity: 0.5; cursor: wait; }
+
+.status { display: flex; gap: 12px; margin-bottom: 18px; }
+.pill {
+  padding: 10px 14px; border-radius: 6px; border: 1px solid var(--border); background: var(--bg-2);
+  min-width: 120px; display: flex; align-items: baseline; gap: 8px;
+}
+.pill .label { color: var(--fg-dim); font-size: 10px; text-transform: uppercase; letter-spacing: 0.6px; }
+.pill .value { font-size: 22px; font-weight: 600; }
+.pill.err.hit    { border-color: #ff7b7255; background: #ff7b7211; }
+.pill.warn.hit   { border-color: #ffa65755; background: #ffa65711; }
+.pill.info.hit   { border-color: #79c0ff55; background: #79c0ff11; }
+.pill.err  .value { color: var(--err);  }
+.pill.warn .value { color: var(--warn); }
+.pill.info .value { color: var(--info); }
+.pill.ok   .value { color: var(--ok); }
+
+.bar { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 18px; }
+.chip { padding: 3px 10px; border-radius: 12px; font-size: 11px;
+  background: var(--bg-3); color: var(--fg-dim); border: 1px solid var(--border); cursor: pointer; user-select: none; }
+.chip.active { background: var(--border); color: var(--fg); border-color: var(--ok); }
+.chip .n { color: var(--ok); margin-left: 4px; font-weight: 600; }
+
+.file {
+  background: var(--bg-2); border: 1px solid var(--border); border-radius: 6px;
+  padding: 10px 14px; margin-bottom: 8px;
+}
+.file h3 { margin: 0 0 6px; font-size: 12px; font-weight: 600; color: var(--fg); }
+.file .finding {
+  display: grid; grid-template-columns: 56px 140px 1fr; gap: 10px; align-items: start;
+  padding: 4px 0; font-size: 12px;
+}
+.finding .sev { font-weight: 600; letter-spacing: 0.5px; }
+.finding.error .sev { color: var(--err); }
+.finding.warn  .sev { color: var(--warn); }
+.finding.info  .sev { color: var(--info); }
+.finding .rule { color: var(--mag); }
+.finding .msg { color: var(--fg); }
+.empty {
+  text-align: center; padding: 60px 20px; background: var(--bg-2);
+  border: 1px solid var(--border); border-radius: 6px;
+}
+.empty .big { font-size: 32px; color: var(--ok); margin-bottom: 6px; }
+.empty .small { color: var(--fg-dim); font-size: 12px; }
+
+footer { color: var(--fg-dim); text-align: right; font-size: 10px; margin-top: 24px; }
+.spinner { display: inline-block; width: 10px; height: 10px; border: 2px solid var(--border);
+  border-top-color: var(--ok); border-radius: 50%; animation: spin .7s linear infinite; margin-left: 6px; }
+@keyframes spin { to { transform: rotate(360deg); } }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>skill-doctor</h1>
+    <span class="sub" id="sub">click run to scan</span>
+    <button id="run" style="margin-left:auto">run scan</button>
+  </header>
+  <div class="status" id="status"></div>
+  <div class="bar" id="bar"></div>
+  <div id="list"></div>
+  <footer id="meta"></footer>
+</div>
+
+<script>
+const $ = (s) => document.querySelector(s);
+let report = null, ruleFilter = null, sevFilter = null;
+
+function esc(s) { return String(s||'').replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c])); }
+
+async function run() {
+  $('#run').disabled = true;
+  $('#sub').innerHTML = 'scanning<span class="spinner"></span>';
+  try {
+    const r = await fetch('/api/run');
+    if (!r.ok) throw new Error('scan failed');
+    report = await r.json();
+    render();
+  } catch (e) {
+    $('#status').innerHTML = `<div class="pill err hit"><span class="label">error</span><span class="value">${esc(e.message)}</span></div>`;
+  } finally {
+    $('#run').disabled = false;
+  }
+}
+
+function render() {
+  const t = report.counts, n = report.findings;
+  $('#sub').textContent = `${report.skillsScanned} skills · ${report.knowScanned} knowledge — ${n.length} findings`;
+  $('#meta').textContent = `root: ${report.root}`;
+
+  const total = t.error + t.warn + t.info;
+  $('#status').innerHTML = total === 0
+    ? `<div class="pill ok"><span class="label">status</span><span class="value">clean</span></div>
+       <div class="pill"><span class="label">scanned</span><span class="value">${report.skillsScanned + report.knowScanned}</span></div>`
+    : `
+       <div class="pill err  ${t.error>0?'hit':''}"><span class="label">errors</span><span class="value">${t.error}</span></div>
+       <div class="pill warn ${t.warn>0?'hit':''}"><span class="label">warnings</span><span class="value">${t.warn}</span></div>
+       <div class="pill info ${t.info>0?'hit':''}"><span class="label">info</span><span class="value">${t.info}</span></div>
+       <div class="pill"><span class="label">scanned</span><span class="value">${report.skillsScanned + report.knowScanned}</span></div>`;
+
+  // rule chips
+  const ruleCounts = {};
+  for (const f of n) ruleCounts[f.rule] = (ruleCounts[f.rule] || 0) + 1;
+  const rules = Object.entries(ruleCounts).sort((a,b) => b[1]-a[1]);
+  $('#bar').innerHTML = [
+    `<span class="chip ${ruleFilter===null&&sevFilter===null?'active':''}" data-reset>all<span class="n">${n.length}</span></span>`,
+    ...['error','warn','info'].filter(s => t[s]).map(s =>
+      `<span class="chip ${sevFilter===s?'active':''}" data-sev="${s}">${s}<span class="n">${t[s]}</span></span>`),
+    ...rules.map(([r, c]) => `<span class="chip ${ruleFilter===r?'active':''}" data-rule="${esc(r)}">${esc(r)}<span class="n">${c}</span></span>`),
+  ].join('');
+
+  $('#bar').querySelectorAll('.chip').forEach(c => {
+    c.addEventListener('click', () => {
+      if (c.hasAttribute('data-reset')) { ruleFilter = null; sevFilter = null; }
+      else if (c.dataset.sev)  { sevFilter = sevFilter === c.dataset.sev ? null : c.dataset.sev; ruleFilter = null; }
+      else if (c.dataset.rule) { ruleFilter = ruleFilter === c.dataset.rule ? null : c.dataset.rule; sevFilter = null; }
+      render();
+    });
+  });
+
+  // filtered list
+  let filtered = n;
+  if (sevFilter) filtered = filtered.filter(f => f.sev === sevFilter);
+  if (ruleFilter) filtered = filtered.filter(f => f.rule === ruleFilter);
+
+  if (!filtered.length) {
+    $('#list').innerHTML = `<div class="empty">
+      <div class="big">${total === 0 ? '✅' : '🔍'}</div>
+      <div class="small">${total === 0 ? 'no findings — your hub is clean' : 'nothing matches this filter'}</div>
+    </div>`;
+    return;
+  }
+
+  const byFile = filtered.reduce((a, f) => ((a[f.file] ||= []).push(f), a), {});
+  $('#list').innerHTML = Object.keys(byFile).sort().map(file => `
+    <div class="file">
+      <h3>${esc(file)}</h3>
+      ${byFile[file].map(f => `
+        <div class="finding ${f.sev}">
+          <span class="sev">${f.sev.toUpperCase()}</span>
+          <span class="rule">${esc(f.rule)}</span>
+          <span class="msg">${esc(f.msg)}</span>
+        </div>`).join('')}
+    </div>
+  `).join('');
+}
+
+$('#run').addEventListener('click', run);
+run();
+</script>
+</body>
+</html>

--- a/example/skill-doctor/serve.mjs
+++ b/example/skill-doctor/serve.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// Static server + /api/run endpoint that re-runs doctor.mjs and streams JSON.
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PORT = Number(process.env.PORT || 4177);
+const ROOT = path.resolve(process.env.DOCTOR_ROOT || path.join(HERE, '..'));
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js':   'application/javascript; charset=utf-8',
+  '.mjs':  'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.css':  'text/css; charset=utf-8',
+};
+
+http.createServer((req, res) => {
+  const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
+
+  if (urlPath === '/api/run') {
+    const proc = spawn(process.execPath, [path.join(HERE, 'doctor.mjs'), '--json', `--root=${ROOT}`]);
+    let out = '', err = '';
+    proc.stdout.on('data', d => out += d);
+    proc.stderr.on('data', d => err += d);
+    proc.on('close', (code) => {
+      res.setHeader('content-type', 'application/json; charset=utf-8');
+      res.setHeader('cache-control', 'no-store');
+      try { JSON.parse(out); res.end(out); }
+      catch { res.statusCode = 500; res.end(JSON.stringify({ error: 'doctor failed', code, stderr: err, stdout: out })); }
+    });
+    return;
+  }
+
+  const rel = urlPath === '/' ? 'index.html' : urlPath.replace(/^\/+/, '');
+  const file = path.join(HERE, rel);
+  if (!file.startsWith(HERE)) { res.statusCode = 403; return res.end('forbidden'); }
+  fs.readFile(file, (e, buf) => {
+    if (e) { res.statusCode = 404; return res.end('not found'); }
+    res.setHeader('content-type', MIME[path.extname(file)] || 'application/octet-stream');
+    res.end(buf);
+  });
+}).listen(PORT, () => {
+  console.log(`▶ skill-doctor UI → http://localhost:${PORT}/`);
+  console.log(`  scanning: ${ROOT}`);
+});


### PR DESCRIPTION
## What

Web UI for the skill-doctor linter. The CLI (\`doctor.mjs\`) was the only mode before; this adds a browser frontend.

### Files

- \`example/skill-doctor/serve.mjs\` — 40 LOC Node stdlib server: static files + \`/api/run\` endpoint that spawns \`doctor.mjs\` fresh and streams the JSON report.
- \`example/skill-doctor/index.html\` — single-file SPA, inline CSS/JS, zero frontend deps.
- \`example/skill-doctor/README.md\` — updated with a *Web UI* section.

## Screens you'll see

- **status pills** (errors / warnings / info / scanned) — hit pills get a red / amber / blue tinted background so problems pop.
- **rule chips** — filter by severity (\`error\`/\`warn\`/\`info\`) or by specific rule (\`frontmatter-required\`, \`name-mismatch\`, etc.). Click-toggle; \`all\` resets.
- **findings grouped by file** — each file gets a card; each finding is SEV · rule · message on one row.
- **run button** — click to rescan on demand, spinner while in flight.
- **clean state** — big ✅ with "your hub is clean" when \`errors + warnings + info === 0\`.

## Run

\`\`\`bash
DOCTOR_ROOT=/path/to/getskills PORT=4177 node example/skill-doctor/serve.mjs
# → http://localhost:4177/
\`\`\`

CLI usage unchanged — the entrypoint in \`manifest.json\` remains \`doctor.mjs\`.