### PR TITLE
example(skill-timeline): add Skill Timeline

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -16,6 +16,7 @@ End-to-end, runnable **example projects** built from (and demonstrating) skills 
 | [skill-doctor](skill-doctor/)       | Skill Doctor — zero-dep linter for SKILL.md and knowledge/*.md, CI-ready exit codes | node, cli | 2026-04-16 |
 | [skill-graph](skill-graph/)         | Skill Graph — browser-based force-directed graph of skills ↔ knowledge relationships | node, html, svg, js | 2026-04-16 |
 | [skill-stats](skill-stats/)         | Skill Stats — aggregate KPIs, category donut, ranked tag/project bars | node, html, svg, js | 2026-04-16 |
+| [skill-timeline](skill-timeline/)   | Skill Timeline — git-history commit heatmap + top-churned slugs for a hub working copy | node, html, svg, js | 2026-04-16 |
 
 ## Adding an example
 

--- a/example/skill-timeline/README.md
+++ b/example/skill-timeline/README.md
@@ -1,0 +1,26 @@
+# skill-timeline
+
+> **Why.** `skills-explorer` lets you search the hub; `skill-graph` shows relationships; `skill-stats` shows aggregates. None of them answer *when did what change*, or *which entries have been thrashed*. This tool walks `git log` on a skills-hub working copy and renders a GitHub-style commit heatmap plus a top-churned leaderboard — the "drift over time" view that was missing.
+
+## Run
+
+```bash
+# 1. generate timeline.json from a hub working copy (must be a git repo)
+node build-timeline.mjs --root=~/.claude/skills-hub/remote --since="1 year ago"
+
+# 2. browse
+node serve.mjs   # → http://localhost:4177/
+```
+
+`--root` defaults to `~/.claude/skills-hub/remote`. Override with `HUB_REPO` env or the flag.
+
+## What it shows
+
+- **KPIs**: total commits, files changed, active days, authors, peak-day.
+- **Heatmap**: one cell per day, colored by commit count (GitHub palette).
+- **Top churned**: 20 most-changed skill / knowledge / example / bootstrap slugs.
+- **Type mix**: how changes distribute across `skills/`, `knowledge/`, `example/`, `bootstrap/`, `other`.
+- **Authors**: commit counts per author.
+- **Recent log**: last 30 commits with file counts.
+
+Zero dependencies. Ships three files: `build-timeline.mjs`, `serve.mjs`, `index.html`.

--- a/example/skill-timeline/build-timeline.mjs
+++ b/example/skill-timeline/build-timeline.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// Walk git log on a skills-hub working copy → timeline.json
+// (daily heatmap buckets, top-churned slugs, author/type breakdowns).
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const args = Object.fromEntries(process.argv.slice(2).map(a => {
+  const [k, v] = a.replace(/^--/, '').split('=');
+  return [k, v === undefined ? true : v];
+}));
+const ROOT = path.resolve(args.root || process.env.HUB_REPO || path.join(process.env.USERPROFILE || process.env.HOME || '.', '.claude', 'skills-hub', 'remote'));
+const SINCE = args.since || '1 year ago';
+const OUT = path.join(HERE, 'timeline.json');
+
+if (!fs.existsSync(path.join(ROOT, '.git'))) {
+  console.error(`✗ not a git repo: ${ROOT}\n  pass --root=<hub working copy> or set HUB_REPO`);
+  process.exit(2);
+}
+
+const MARK = '__C__';
+const FS = '\u0002';
+const fmt = MARK + ['%H', '%ai', '%an', '%s'].join(FS);
+const raw = execSync(
+  `git log --since="${SINCE}" --name-status --pretty=format:"${fmt}"`,
+  { cwd: ROOT, maxBuffer: 64 * 1024 * 1024, encoding: 'utf8' }
+);
+
+const classify = (p) => {
+  const parts = p.split('/');
+  if (parts[0] === 'skills' && parts.length >= 3) return { type: 'skill', slug: parts[2] };
+  if (parts[0] === 'knowledge' && parts.length >= 3) return { type: 'knowledge', slug: parts[2] };
+  if (parts[0] === 'example' && parts.length >= 2) return { type: 'example', slug: parts[1] };
+  if (parts[0] === 'bootstrap') return { type: 'bootstrap', slug: parts[1] || 'root' };
+  return { type: 'other', slug: parts[0] || 'root' };
+};
+
+const commits = [];
+const daily = new Map();
+const churn = new Map();
+const authors = new Map();
+const typeBuckets = new Map();
+const statusCounts = { A: 0, M: 0, D: 0, R: 0, C: 0, T: 0 };
+
+const bump = (m, k, n = 1) => m.set(k, (m.get(k) || 0) + n);
+
+for (const rec of raw.split(MARK)) {
+  if (!rec.trim()) continue;
+  const nl = rec.indexOf('\n');
+  const header = nl === -1 ? rec : rec.slice(0, nl);
+  const body = nl === -1 ? '' : rec.slice(nl + 1);
+  const [sha, ai, an, ...rest] = header.split(FS);
+  if (!sha || !ai) continue;
+  const subject = rest.join(FS);
+  const day = ai.slice(0, 10);
+  const files = [];
+  for (const line of body.split('\n')) {
+    if (!line.trim()) continue;
+    const parts = line.split('\t');
+    const status = parts[0][0];
+    const target = parts[parts.length - 1];
+    if (!target) continue;
+    files.push({ s: status, p: target });
+    if (status in statusCounts) statusCounts[status]++;
+    const c = classify(target);
+    bump(typeBuckets, c.type);
+    bump(churn, `${c.type}:${c.slug}`);
+  }
+  commits.push({ sha: sha.slice(0, 10), day, author: an, subject, files: files.length });
+  bump(daily, day);
+  bump(authors, an);
+}
+
+const topChurn = [...churn.entries()]
+  .sort((a, b) => b[1] - a[1])
+  .slice(0, 40)
+  .map(([k, v]) => {
+    const i = k.indexOf(':');
+    return { type: k.slice(0, i), slug: k.slice(i + 1), count: v };
+  });
+
+const dailyArr = [...daily.entries()].sort((a, b) => a[0].localeCompare(b[0])).map(([d, v]) => ({ d, v }));
+
+const totals = {
+  commits: commits.length,
+  filesChanged: commits.reduce((s, c) => s + c.files, 0),
+  uniqueDays: daily.size,
+  uniqueAuthors: authors.size,
+  busiestDay: dailyArr.reduce((m, e) => (e.v > (m?.v || 0) ? e : m), null),
+};
+
+const out = {
+  generatedAt: new Date().toISOString(),
+  root: ROOT,
+  since: SINCE,
+  totals,
+  statusCounts,
+  typeBuckets: [...typeBuckets.entries()].sort((a, b) => b[1] - a[1]).map(([k, v]) => ({ k, v })),
+  authors: [...authors.entries()].sort((a, b) => b[1] - a[1]).map(([k, v]) => ({ k, v })),
+  daily: dailyArr,
+  topChurn,
+  recent: commits.slice(0, 30),
+};
+
+fs.writeFileSync(OUT, JSON.stringify(out, null, 2));
+const kb = (fs.statSync(OUT).size / 1024).toFixed(1);
+console.log(`✓ timeline → timeline.json (${kb} KB) — ${totals.commits} commits, ${daily.size} days, ${authors.size} authors`);

--- a/example/skill-timeline/index.html
+++ b/example/skill-timeline/index.html
@@ -1,0 +1,212 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Skill Timeline</title>
+<style>
+:root {
+  --bg: #0b0d10; --bg-2: #11151a; --bg-3: #161b22;
+  --fg: #c9d1d9; --fg-dim: #7d8590; --border: #21262d;
+  --accent: #7ee787; --accent-2: #79c0ff; --amber: #ffa657;
+  --mag: #d2a8ff; --red: #ff7b72;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; background: var(--bg); color: var(--fg);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px; line-height: 1.5; }
+.wrap { max-width: 1280px; margin: 0 auto; padding: 24px 28px 60px; }
+header { display: flex; align-items: baseline; gap: 14px; margin-bottom: 22px; padding-bottom: 14px; border-bottom: 1px solid var(--border); }
+header h1 { font-family: system-ui, sans-serif; font-size: 22px; margin: 0; color: var(--accent); font-weight: 600; }
+header h1::before { content: "▶ "; color: var(--fg-dim); }
+header .sub { color: var(--fg-dim); font-size: 12px; }
+.kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 10px; margin-bottom: 24px; }
+.kpi { background: var(--bg-2); border: 1px solid var(--border); border-radius: 6px; padding: 12px 14px; }
+.kpi .label { color: var(--fg-dim); font-size: 10px; text-transform: uppercase; letter-spacing: 0.6px; margin-bottom: 4px; }
+.kpi .value { font-size: 22px; font-weight: 600; color: var(--fg); }
+.grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
+.card { background: var(--bg-2); border: 1px solid var(--border); border-radius: 6px; padding: 16px 18px; }
+.card h2 { font-size: 13px; margin: 0 0 12px; color: var(--accent-2); font-family: system-ui, sans-serif; font-weight: 600; display: flex; justify-content: space-between; align-items: baseline; }
+.card h2 .count { color: var(--fg-dim); font-weight: 400; font-size: 11px; }
+.card.full { grid-column: 1 / -1; }
+#heatmap { width: 100%; height: auto; display: block; }
+#heatmap rect { stroke: var(--bg); stroke-width: 1.5; }
+.legend { display: flex; align-items: center; gap: 6px; justify-content: flex-end; font-size: 10px; color: var(--fg-dim); margin-top: 6px; }
+.legend .sw { width: 11px; height: 11px; border-radius: 2px; display: inline-block; }
+.bar-row { display: grid; grid-template-columns: 140px 1fr 44px; align-items: center; gap: 10px; margin: 4px 0; font-size: 11px; }
+.bar-row .name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bar-row .type { color: var(--fg-dim); font-size: 9px; text-transform: uppercase; letter-spacing: 0.5px; }
+.bar-row .bar-bg { background: var(--bg-3); border-radius: 3px; height: 14px; position: relative; }
+.bar-row .bar-fill { background: var(--accent); height: 100%; border-radius: 3px; }
+.bar-row .bar-fill.skill { background: var(--accent); }
+.bar-row .bar-fill.knowledge { background: var(--mag); }
+.bar-row .bar-fill.example { background: var(--amber); }
+.bar-row .bar-fill.bootstrap { background: var(--accent-2); }
+.bar-row .bar-fill.other { background: var(--fg-dim); }
+.bar-row .v { color: var(--fg-dim); text-align: right; font-size: 10px; }
+.log { font-size: 11px; max-height: 380px; overflow-y: auto; }
+.log .row { display: grid; grid-template-columns: 80px 90px 1fr 42px; gap: 10px; padding: 4px 0; border-bottom: 1px dashed var(--border); }
+.log .row .sha { color: var(--amber); }
+.log .row .day { color: var(--fg-dim); }
+.log .row .msg { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.log .row .files { color: var(--fg-dim); text-align: right; font-size: 10px; }
+footer { color: var(--fg-dim); text-align: right; font-size: 10px; margin-top: 24px; }
+@media (max-width: 720px) { .grid { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>skill-timeline</h1>
+    <span class="sub" id="sub">loading…</span>
+  </header>
+  <div class="kpis" id="kpis"></div>
+  <section class="card full" style="margin-bottom:16px">
+    <h2>commit heatmap <span class="count" id="hm-range"></span></h2>
+    <svg id="heatmap" viewBox="0 0 800 140" preserveAspectRatio="xMidYMid meet"></svg>
+    <div class="legend">less
+      <span class="sw" style="background:var(--bg-3)"></span>
+      <span class="sw" style="background:#0e4429"></span>
+      <span class="sw" style="background:#006d32"></span>
+      <span class="sw" style="background:#26a641"></span>
+      <span class="sw" style="background:#39d353"></span>
+    more</div>
+  </section>
+  <div class="grid">
+    <section class="card">
+      <h2>top churned <span class="count" id="churn-count"></span></h2>
+      <div id="churn"></div>
+    </section>
+    <section class="card">
+      <h2>by type</h2>
+      <div id="types"></div>
+    </section>
+    <section class="card">
+      <h2>authors <span class="count" id="auth-count"></span></h2>
+      <div id="authors"></div>
+    </section>
+    <section class="card">
+      <h2>recent commits <span class="count" id="recent-count"></span></h2>
+      <div class="log" id="recent"></div>
+    </section>
+  </div>
+  <footer>generated <span id="gen"></span> · rebuild: <b>node build-timeline.mjs</b></footer>
+</div>
+<script>
+const $ = (s) => document.querySelector(s);
+fetch('timeline.json').then(r => r.json()).then(render).catch(e => {
+  $('#sub').textContent = 'error: ' + e.message;
+});
+
+function render(d) {
+  $('#sub').textContent = `${d.root} · since "${d.since}"`;
+  $('#gen').textContent = d.generatedAt;
+  renderKpis(d.totals);
+  renderHeatmap(d.daily);
+  renderChurn(d.topChurn);
+  renderTypes(d.typeBuckets);
+  renderAuthors(d.authors);
+  renderRecent(d.recent);
+  $('#churn-count').textContent = `${d.topChurn.length} slugs`;
+  $('#auth-count').textContent = `${d.authors.length} authors`;
+  $('#recent-count').textContent = `${d.recent.length}`;
+}
+function renderKpis(t) {
+  const cells = [
+    ['commits', t.commits],
+    ['files changed', t.filesChanged],
+    ['active days', t.uniqueDays],
+    ['authors', t.uniqueAuthors],
+    ['peak day', t.busiestDay ? `${t.busiestDay.v} on ${t.busiestDay.d}` : '—'],
+  ];
+  $('#kpis').innerHTML = cells.map(([l, v]) =>
+    `<div class="kpi"><div class="label">${l}</div><div class="value">${v}</div></div>`
+  ).join('');
+}
+function renderHeatmap(daily) {
+  if (!daily.length) return;
+  const byDay = new Map(daily.map(e => [e.d, e.v]));
+  const start = new Date(daily[0].d + 'T00:00:00Z');
+  const end = new Date(daily[daily.length - 1].d + 'T00:00:00Z');
+  // snap to sunday before
+  start.setUTCDate(start.getUTCDate() - start.getUTCDay());
+  const cells = [];
+  const cell = 13, gap = 2, cellw = cell + gap;
+  let col = 0;
+  const monthLabels = [];
+  let lastMonth = -1;
+  for (let d = new Date(start); d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
+    const iso = d.toISOString().slice(0, 10);
+    const row = d.getUTCDay();
+    const v = byDay.get(iso) || 0;
+    cells.push({ x: col * cellw, y: row * cellw, v, iso });
+    if (d.getUTCMonth() !== lastMonth && row === 0) {
+      lastMonth = d.getUTCMonth();
+      monthLabels.push({ x: col * cellw, label: d.toLocaleString('en', { month: 'short' }) });
+    }
+    if (row === 6) col++;
+  }
+  const max = Math.max(...cells.map(c => c.v));
+  const scale = (v) => {
+    if (!v) return 'var(--bg-3)';
+    const q = v / max;
+    if (q < 0.25) return '#0e4429';
+    if (q < 0.5) return '#006d32';
+    if (q < 0.75) return '#26a641';
+    return '#39d353';
+  };
+  const w = (col + 2) * cellw + 30;
+  const h = 7 * cellw + 20;
+  const svg = $('#heatmap');
+  svg.setAttribute('viewBox', `0 0 ${w} ${h}`);
+  const rects = cells.map(c =>
+    `<rect x="${c.x + 30}" y="${c.y + 14}" width="${cell}" height="${cell}" fill="${scale(c.v)}" rx="2"><title>${c.iso} — ${c.v} commits</title></rect>`
+  ).join('');
+  const months = monthLabels.map(m =>
+    `<text x="${m.x + 30}" y="10" font-size="9" fill="#7d8590" font-family="ui-monospace,monospace">${m.label}</text>`
+  ).join('');
+  const dayLabels = ['', 'Mon', '', 'Wed', '', 'Fri', ''].map((l, i) =>
+    l ? `<text x="0" y="${i * cellw + 14 + 10}" font-size="9" fill="#7d8590" font-family="ui-monospace,monospace">${l}</text>` : ''
+  ).join('');
+  svg.innerHTML = months + dayLabels + rects;
+  $('#hm-range').textContent = `${daily[0].d} → ${daily[daily.length - 1].d}`;
+}
+function renderChurn(items) {
+  const max = Math.max(1, ...items.map(i => i.count));
+  $('#churn').innerHTML = items.slice(0, 20).map(i => `
+    <div class="bar-row" title="${i.type} / ${i.slug}: ${i.count} changes">
+      <div class="name">${i.slug}<div class="type">${i.type}</div></div>
+      <div class="bar-bg"><div class="bar-fill ${i.type}" style="width:${(i.count / max) * 100}%"></div></div>
+      <div class="v">${i.count}</div>
+    </div>`).join('');
+}
+function renderTypes(items) {
+  const max = Math.max(1, ...items.map(i => i.v));
+  $('#types').innerHTML = items.map(i => `
+    <div class="bar-row">
+      <div class="name">${i.k}</div>
+      <div class="bar-bg"><div class="bar-fill ${i.k}" style="width:${(i.v / max) * 100}%"></div></div>
+      <div class="v">${i.v}</div>
+    </div>`).join('');
+}
+function renderAuthors(items) {
+  const max = Math.max(1, ...items.map(i => i.v));
+  $('#authors').innerHTML = items.slice(0, 12).map(i => `
+    <div class="bar-row">
+      <div class="name">${i.k}</div>
+      <div class="bar-bg"><div class="bar-fill" style="width:${(i.v / max) * 100}%"></div></div>
+      <div class="v">${i.v}</div>
+    </div>`).join('');
+}
+function renderRecent(items) {
+  $('#recent').innerHTML = items.map(c => `
+    <div class="row">
+      <div class="sha">${c.sha}</div>
+      <div class="day">${c.day}</div>
+      <div class="msg" title="${c.subject.replace(/"/g, '&quot;')}">${c.subject}</div>
+      <div class="files">${c.files}f</div>
+    </div>`).join('');
+}
+</script>
+</body>
+</html>

--- a/example/skill-timeline/manifest.json
+++ b/example/skill-timeline/manifest.json
@@ -1,0 +1,12 @@
+{
+  "slug": "skill-timeline",
+  "title": "Skill Timeline",
+  "summary": "Zero-dep git-history dashboard for a skills-hub working copy — commit heatmap, top-churned skills, author/type breakdowns.",
+  "stack": ["node", "html", "svg", "js"],
+  "tags": ["timeline", "heatmap", "git-history", "churn", "skills-hub"],
+  "created_at": "2026-04-16",
+  "source_project": "getskills",
+  "runtime": "node >=18",
+  "entrypoint": "serve.mjs",
+  "author": "kjuhwa@nkia.co.kr"
+}

--- a/example/skill-timeline/serve.mjs
+++ b/example/skill-timeline/serve.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// Tiny zero-dep static server for skill-timeline.
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PORT = Number(process.env.PORT || 4177);
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js':   'application/javascript; charset=utf-8',
+  '.mjs':  'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.css':  'text/css; charset=utf-8',
+};
+
+http.createServer((req, res) => {
+  const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
+  const rel = urlPath === '/' ? 'index.html' : urlPath.replace(/^\/+/, '');
+  const file = path.join(HERE, rel);
+  if (!file.startsWith(HERE)) { res.statusCode = 403; return res.end('forbidden'); }
+  fs.readFile(file, (err, buf) => {
+    if (err) { res.statusCode = 404; return res.end('not found'); }
+    res.setHeader('content-type', MIME[path.extname(file)] || 'application/octet-stream');
+    res.end(buf);
+  });
+}).listen(PORT, () => {
+  console.log(`▶ skill timeline → http://localhost:${PORT}/`);
+});

--- a/example/skill-timeline/timeline.json
+++ b/example/skill-timeline/timeline.json
@@ -1,0 +1,483 @@
+{
+  "generatedAt": "2026-04-15T16:50:45.488Z",
+  "root": "C:\\Users\\kjuhwa\\.claude\\skills-hub\\remote",
+  "since": "1 year ago",
+  "totals": {
+    "commits": 387,
+    "filesChanged": 776,
+    "uniqueDays": 3,
+    "uniqueAuthors": 2,
+    "busiestDay": {
+      "d": "2026-04-15",
+      "v": 368
+    }
+  },
+  "statusCounts": {
+    "A": 665,
+    "M": 89,
+    "D": 2,
+    "R": 20,
+    "C": 0,
+    "T": 0
+  },
+  "typeBuckets": [
+    {
+      "k": "skill",
+      "v": 418
+    },
+    {
+      "k": "knowledge",
+      "v": 224
+    },
+    {
+      "k": "other",
+      "v": 60
+    },
+    {
+      "k": "bootstrap",
+      "v": 43
+    },
+    {
+      "k": "example",
+      "v": 31
+    }
+  ],
+  "authors": [
+    {
+      "k": "kjuhwa",
+      "v": 311
+    },
+    {
+      "k": "Your Name",
+      "v": 76
+    }
+  ],
+  "daily": [
+    {
+      "d": "2026-04-14",
+      "v": 3
+    },
+    {
+      "d": "2026-04-15",
+      "v": 368
+    },
+    {
+      "d": "2026-04-16",
+      "v": 16
+    }
+  ],
+  "topChurn": [
+    {
+      "type": "other",
+      "slug": "index.json",
+      "count": 40
+    },
+    {
+      "type": "bootstrap",
+      "slug": "commands",
+      "count": 38
+    },
+    {
+      "type": "other",
+      "slug": "README.md",
+      "count": 11
+    },
+    {
+      "type": "example",
+      "slug": "skill-doctor",
+      "count": 8
+    },
+    {
+      "type": "example",
+      "slug": "skill-graph",
+      "count": 7
+    },
+    {
+      "type": "example",
+      "slug": "skill-stats",
+      "count": 7
+    },
+    {
+      "type": "example",
+      "slug": "skills-explorer",
+      "count": 7
+    },
+    {
+      "type": "skill",
+      "slug": "tdd",
+      "count": 6
+    },
+    {
+      "type": "skill",
+      "slug": "gradle-jacoco-exclusion-strategy",
+      "count": 4
+    },
+    {
+      "type": "skill",
+      "slug": "gradle-shared-exclusions-jacoco-sonar",
+      "count": 4
+    },
+    {
+      "type": "skill",
+      "slug": "querydsl-q-class-exclusion-pattern",
+      "count": 4
+    },
+    {
+      "type": "skill",
+      "slug": "spring-bootrun-local-dev-env-block",
+      "count": 4
+    },
+    {
+      "type": "skill",
+      "slug": "paired-flag-multi-instance-registration",
+      "count": 4
+    },
+    {
+      "type": "skill",
+      "slug": "mcp-capability-negotiated-initialize",
+      "count": 4
+    },
+    {
+      "type": "skill",
+      "slug": "identifier-truncate-with-hash-suffix",
+      "count": 4
+    },
+    {
+      "type": "skill",
+      "slug": "mcp-runtime-prompt-refresh",
+      "count": 4
+    },
+    {
+      "type": "skill",
+      "slug": "openapi-to-mcp-tag-grouping",
+      "count": 4
+    },
+    {
+      "type": "skill",
+      "slug": "github-triage",
+      "count": 3
+    },
+    {
+      "type": "skill",
+      "slug": "claude-code-skill-scaffold",
+      "count": 3
+    },
+    {
+      "type": "skill",
+      "slug": "claude-plugin-catalog-publish",
+      "count": 3
+    },
+    {
+      "type": "skill",
+      "slug": "dual-jre-docker-oz-report",
+      "count": 3
+    },
+    {
+      "type": "skill",
+      "slug": "font-cache-alpine-locale-docker",
+      "count": 3
+    },
+    {
+      "type": "skill",
+      "slug": "jenkins-dual-registry-docker-push",
+      "count": 3
+    },
+    {
+      "type": "skill",
+      "slug": "skill-md-validator",
+      "count": 3
+    },
+    {
+      "type": "bootstrap",
+      "slug": "skills",
+      "count": 3
+    },
+    {
+      "type": "skill",
+      "slug": "avro-gradle-kafka-schema-pipeline",
+      "count": 3
+    },
+    {
+      "type": "knowledge",
+      "slug": "annotation-driven-authz-via-function-id.md",
+      "count": 2
+    },
+    {
+      "type": "knowledge",
+      "slug": "polymorphic-metadata-via-enum-switch.md",
+      "count": 2
+    },
+    {
+      "type": "knowledge",
+      "slug": "tenant-context-per-request-interceptor.md",
+      "count": 2
+    },
+    {
+      "type": "knowledge",
+      "slug": "wait-for-services-eureka-startup-init.md",
+      "count": 2
+    },
+    {
+      "type": "knowledge",
+      "slug": "god-controller-split-by-resource.md",
+      "count": 2
+    },
+    {
+      "type": "knowledge",
+      "slug": "prefer-static-import-over-constant-inheritance.md",
+      "count": 2
+    },
+    {
+      "type": "knowledge",
+      "slug": "mongo-timeseries-forced-hint-kills-pushdown.md",
+      "count": 2
+    },
+    {
+      "type": "knowledge",
+      "slug": "mongo-timeseries-match-split-for-pushdown.md",
+      "count": 2
+    },
+    {
+      "type": "knowledge",
+      "slug": "mongo-timeseries-view-pushdown-broken-8_2_3.md",
+      "count": 2
+    },
+    {
+      "type": "knowledge",
+      "slug": "sonar-token-hardcoded-build-gradle.md",
+      "count": 2
+    },
+    {
+      "type": "knowledge",
+      "slug": "user-sql-source-requires-select-only-and-readonly.md",
+      "count": 2
+    },
+    {
+      "type": "example",
+      "slug": "README.md",
+      "count": 2
+    },
+    {
+      "type": "skill",
+      "slug": "git-guardrails-claude-code",
+      "count": 2
+    },
+    {
+      "type": "skill",
+      "slug": "improve-codebase-architecture",
+      "count": 2
+    }
+  ],
+  "recent": [
+    {
+      "sha": "fe18a9a5f2",
+      "day": "2026-04-16",
+      "author": "kjuhwa",
+      "subject": "Merge pull request #66 from kjuhwa/example/skill-doctor-ui",
+      "files": 0
+    },
+    {
+      "sha": "97e5119737",
+      "day": "2026-04-16",
+      "author": "kjuhwa",
+      "subject": "example(skill-doctor): add web UI (serve.mjs + index.html)",
+      "files": 3
+    },
+    {
+      "sha": "bf57ca7137",
+      "day": "2026-04-16",
+      "author": "kjuhwa",
+      "subject": "Merge pull request #65 from kjuhwa/fix/knowledge-frontmatter-defects",
+      "files": 0
+    },
+    {
+      "sha": "3f81afc68b",
+      "day": "2026-04-16",
+      "author": "kjuhwa",
+      "subject": "fix(knowledge): repair 11 frontmatter defects surfaced by skill-doctor",
+      "files": 11
+    },
+    {
+      "sha": "182de2e011",
+      "day": "2026-04-16",
+      "author": "kjuhwa",
+      "subject": "Merge pull request #64 from kjuhwa/bugfix/yaml-parser-skills-explorer",
+      "files": 0
+    },
+    {
+      "sha": "c5e4757d1e",
+      "day": "2026-04-16",
+      "author": "kjuhwa",
+      "subject": "fix(diagnostics-trio): apply same YAML parser upgrade to doctor/graph/stats",
+      "files": 3
+    },
+    {
+      "sha": "8e2fcbd90c",
+      "day": "2026-04-16",
+      "author": "kjuhwa",
+      "subject": "fix(skills-explorer): YAML parser missed block lists and block scalars",
+      "files": 1
+    },
+    {
+      "sha": "a00a887d23",
+      "day": "2026-04-16",
+      "author": "kjuhwa",
+      "subject": "Merge pull request #63 from kjuhwa/example/diagnostics-trio",
+      "files": 0
+    },
+    {
+      "sha": "412e3da932",
+      "day": "2026-04-16",
+      "author": "kjuhwa",
+      "subject": "example: add skill-doctor, skill-graph, skill-stats",
+      "files": 17
+    },
+    {
+      "sha": "0503f555a8",
+      "day": "2026-04-16",
+      "author": "kjuhwa",
+      "subject": "Merge pull request #61 from kjuhwa/example/skills-explorer",
+      "files": 0
+    },
+    {
+      "sha": "dad49f5251",
+      "day": "2026-04-16",
+      "author": "kjuhwa",
+      "subject": "Merge pull request #62 from kjuhwa/bootstrap/release-v1.6.0",
+      "files": 0
+    },
+    {
+      "sha": "297e1ccdf9",
+      "day": "2026-04-16",
+      "author": "kjuhwa",
+      "subject": "Bootstrap v1.6.0: add /example_list, /example_add, /make_something",
+      "files": 3
+    },
+    {
+      "sha": "645343f7f8",
+      "day": "2026-04-16",
+      "author": "kjuhwa",
+      "subject": "example(skills-explorer): add offline search dashboard for skills-hub",
+      "files": 7
+    },
+    {
+      "sha": "09b22f500c",
+      "day": "2026-04-16",
+      "author": "kjuhwa",
+      "subject": "Merge pull request #60 from kjuhwa/bootstrap/release-v1.5.0",
+      "files": 0
+    },
+    {
+      "sha": "4f784601e2",
+      "day": "2026-04-16",
+      "author": "Your Name",
+      "subject": "docs: document /init_skills_all in README",
+      "files": 1
+    },
+    {
+      "sha": "9f4668fc87",
+      "day": "2026-04-16",
+      "author": "Your Name",
+      "subject": "Bootstrap v1.5.0: add /init_skills_all for bulk install of all skills and knowledge",
+      "files": 1
+    },
+    {
+      "sha": "a4eb92e12a",
+      "day": "2026-04-15",
+      "author": "kjuhwa",
+      "subject": "Merge pull request #53 from kjuhwa/docs/readme-and-license-20260415",
+      "files": 0
+    },
+    {
+      "sha": "c04953b3dc",
+      "day": "2026-04-15",
+      "author": "Your Name",
+      "subject": "docs: add hero, badges, and MIT LICENSE",
+      "files": 2
+    },
+    {
+      "sha": "feaaa61530",
+      "day": "2026-04-15",
+      "author": "kjuhwa",
+      "subject": "Merge pull request #52 from kjuhwa/skills/reindex-20260415",
+      "files": 0
+    },
+    {
+      "sha": "987906dc0c",
+      "day": "2026-04-15",
+      "author": "Your Name",
+      "subject": "chore(index): reindex after mattpocock import (PR #51)",
+      "files": 1
+    },
+    {
+      "sha": "274891eecc",
+      "day": "2026-04-15",
+      "author": "kjuhwa",
+      "subject": "Merge pull request #51 from kjuhwa/release/mattpocock-skills-import-20260415",
+      "files": 0
+    },
+    {
+      "sha": "2164f0eb36",
+      "day": "2026-04-15",
+      "author": "Your Name",
+      "subject": "feat(skills): import 19 skills from mattpocock/skills",
+      "files": 28
+    },
+    {
+      "sha": "a3e0192685",
+      "day": "2026-04-15",
+      "author": "kjuhwa",
+      "subject": "Merge pull request #50 from kjuhwa/skills/cleanup-20260415",
+      "files": 0
+    },
+    {
+      "sha": "d85afc18da",
+      "day": "2026-04-15",
+      "author": "Your Name",
+      "subject": "feat(skills_import_git): redesign to stage drafts identically to /skills_extract_project",
+      "files": 1
+    },
+    {
+      "sha": "164eeae936",
+      "day": "2026-04-15",
+      "author": "kjuhwa",
+      "subject": "Merge pull request #49 from kjuhwa/skills/cleanup-20260415",
+      "files": 0
+    },
+    {
+      "sha": "a1f3993675",
+      "day": "2026-04-15",
+      "author": "Your Name",
+      "subject": "chore(index): regenerate index.json from filesystem",
+      "files": 1
+    },
+    {
+      "sha": "61ebd5646a",
+      "day": "2026-04-15",
+      "author": "Your Name",
+      "subject": "refactor(skills): reassign 13 skills to canonical categories",
+      "files": 20
+    },
+    {
+      "sha": "b232888f54",
+      "day": "2026-04-15",
+      "author": "Your Name",
+      "subject": "chore(skills): add missing frontmatter fields to 7 malformed SKILL.md",
+      "files": 7
+    },
+    {
+      "sha": "0cb609859a",
+      "day": "2026-04-15",
+      "author": "kjuhwa",
+      "subject": "Merge pull request #48 from kjuhwa/chore/flatten-refactor-commands",
+      "files": 0
+    },
+    {
+      "sha": "33ff4362a1",
+      "day": "2026-04-15",
+      "author": "Your Name",
+      "subject": "chore(bootstrap): flatten merge/split/refactor commands",
+      "files": 4
+    }
+  ]
+}


### PR DESCRIPTION
## Why

The current `example/` corpus covers:

- **skills-explorer** — fuzzy search
- **skill-graph** — relationships
- **skill-stats** — aggregates
- **skill-doctor** — lint

But none of them answer *when* things changed, or *which slugs keep getting edited*. `skill-timeline` fills that drift-over-time gap.

## What it ships

- GitHub-style commit heatmap (one cell per day, GitHub palette).
- Top-20 churned leaderboard across `skills/` / `knowledge/` / `example/` / `bootstrap/`.
- KPIs: commits, files changed, active days, authors, peak-day.
- By-type mix + author leaderboard + recent-commit log.

## Stack

Zero-dep Node + HTML + SVG. Three source files (`build-timeline.mjs`, `serve.mjs`, `index.html`) + `manifest.json` + pre-built `timeline.json` fixture.

## Run

\`\`\`bash
node build-timeline.mjs --root=~/.claude/skills-hub/remote --since="1 year ago"
node serve.mjs  # http://localhost:4177/
\`\`\`

Preview: https://github.com/kjuhwa/skills-hub/tree/example/skill-timeline/example/skill-timeline