### PR TITLE
example(skill-diff): add Skill Diff

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -16,6 +16,7 @@ End-to-end, runnable **example projects** built from (and demonstrating) skills 
 | [skill-doctor](skill-doctor/)       | Skill Doctor — zero-dep linter for SKILL.md and knowledge/*.md, CI-ready exit codes | node, cli | 2026-04-16 |
 | [skill-graph](skill-graph/)         | Skill Graph — browser-based force-directed graph of skills ↔ knowledge relationships | node, html, svg, js | 2026-04-16 |
 | [skill-stats](skill-stats/)         | Skill Stats — aggregate KPIs, category donut, ranked tag/project bars | node, html, svg, js | 2026-04-16 |
+| [skill-diff](skill-diff/)           | Skill Diff — per-slug added/modified/removed viewer with description/tag/trigger deltas between two hub refs | node, html, js | 2026-04-16 |
 
 ## Adding an example
 

--- a/example/skill-diff/README.md
+++ b/example/skill-diff/README.md
@@ -1,0 +1,25 @@
+# skill-diff
+
+> **Why.** The hub gains and loses skills constantly — but there's no release-notes surface. You can `git log`, but a raw log doesn't tell you *which slug* changed or *how its description/triggers/tags differ*. This tool diffs two refs of a hub working copy and shows per-slug added / modified / removed cards with the frontmatter delta expanded inline. Good for audit trails and curation.
+
+## Run
+
+```bash
+# 1. compute diff between two refs (defaults: HEAD~20 → HEAD)
+node build-diff.mjs --root=~/.claude/skills-hub/remote --from=HEAD~20 --to=HEAD
+
+# 2. browse
+node serve.mjs   # → http://localhost:4179/
+```
+
+Env `HUB_REPO` overrides `--root`. Refs accept anything `git rev-parse` does — tags, branches, SHAs.
+
+## What you see
+
+- **KPIs**: totals per status (added / modified / removed) + other-file count.
+- **Kind mix**: side-by-side counts for `skill`, `knowledge`, `example`, `bootstrap`.
+- **Three sections** (added / modified / removed) of collapsible slug cards.
+- Expand a card for: description before→after, tags before→after, triggers before→after, and file-level changes.
+- Filter chips toggle which kinds show.
+
+Zero dependencies. Three files: `build-diff.mjs`, `serve.mjs`, `index.html`.

--- a/example/skill-diff/build-diff.mjs
+++ b/example/skill-diff/build-diff.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+// Compare two refs of a skills-hub working copy → diff.json
+// Classifies changes into added/removed/modified × (skill|knowledge|example|bootstrap|other)
+// and captures before/after description + triggers for modified SKILL.md files.
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const args = Object.fromEntries(process.argv.slice(2).map(a => {
+  const [k, v] = a.replace(/^--/, '').split('=');
+  return [k, v === undefined ? true : v];
+}));
+const ROOT = path.resolve(args.root || process.env.HUB_REPO || path.join(process.env.USERPROFILE || process.env.HOME || '.', '.claude', 'skills-hub', 'remote'));
+const FROM = args.from || 'HEAD~20';
+const TO = args.to || 'HEAD';
+const OUT = path.join(HERE, 'diff.json');
+
+if (!fs.existsSync(path.join(ROOT, '.git'))) {
+  console.error(`✗ not a git repo: ${ROOT}\n  pass --root=<hub working copy> or set HUB_REPO`);
+  process.exit(2);
+}
+
+const git = (cmd) => execSync(`git ${cmd}`, { cwd: ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+const safeShow = (ref, p) => {
+  try { return execSync(`git show ${ref}:"${p}"`, { cwd: ROOT, encoding: 'utf8', maxBuffer: 16 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'] }); }
+  catch { return null; }
+};
+
+const fromSha = git(`rev-parse ${FROM}`).trim();
+const toSha = git(`rev-parse ${TO}`).trim();
+const fromDate = git(`show -s --format=%ai ${FROM}`).trim();
+const toDate = git(`show -s --format=%ai ${TO}`).trim();
+
+const raw = git(`diff --name-status ${FROM}..${TO}`);
+
+const classify = (p) => {
+  const parts = p.split('/');
+  if (parts[0] === 'skills' && parts.length >= 3) return { kind: 'skill', slug: parts[2], category: parts[1] };
+  if (parts[0] === 'knowledge' && parts.length >= 3) return { kind: 'knowledge', slug: parts[2], category: parts[1] };
+  if (parts[0] === 'example' && parts.length >= 2) return { kind: 'example', slug: parts[1] };
+  if (parts[0] === 'bootstrap') return { kind: 'bootstrap', slug: parts.slice(1).join('/') || 'root' };
+  return { kind: 'other', slug: parts[0] };
+};
+
+function parseFm(md) {
+  if (!md || !md.startsWith('---')) return {};
+  const end = md.indexOf('\n---', 3); if (end === -1) return {};
+  const meta = {}; let cur = null, blockScalar = null, blockIndent = -1, blockLines = [];
+  const flush = () => { if (blockScalar) { meta[blockScalar] = blockLines.map(l => l.slice(blockIndent)).join(' ').replace(/\s+/g, ' ').trim(); blockScalar = null; blockLines = []; blockIndent = -1; } };
+  for (const line of md.slice(3, end).split(/\r?\n/)) {
+    if (blockScalar) {
+      const lead = line.match(/^(\s*)/)[1].length;
+      if (blockIndent === -1 && line.trim()) { blockIndent = lead; blockLines.push(line); continue; }
+      if (line.trim() && lead >= blockIndent) { blockLines.push(line); continue; }
+      flush();
+    }
+    if (!line.trim()) continue;
+    if (!/^\s/.test(line)) {
+      const m = line.match(/^([A-Za-z_][\w-]*):\s*(.*)$/); if (!m) continue; cur = m[1];
+      const v = m[2];
+      if (v === '|' || v === '>' || v === '|-' || v === '>-') { blockScalar = cur; blockIndent = -1; blockLines = []; }
+      else if (v === '') meta[cur] = {};
+      else if (v.startsWith('[') && v.endsWith(']')) meta[cur] = v.slice(1, -1).split(',').map(s => s.trim().replace(/^['"]|['"]$/g, '')).filter(Boolean);
+      else meta[cur] = v.replace(/^['"]|['"]$/g, '');
+    } else if (cur) {
+      const trimmed = line.trim();
+      const li = trimmed.match(/^-\s+(.*)$/);
+      if (li) { if (!Array.isArray(meta[cur])) meta[cur] = []; meta[cur].push(li[1].replace(/^['"]|['"]$/g, '')); continue; }
+    }
+  }
+  flush();
+  return meta;
+}
+
+// Aggregate file-level status into per-slug entries.
+const entries = new Map();   // key = kind:slug → { kind, slug, category, status:'A'|'M'|'D', files:[{s,p}] }
+const other = [];
+const tallyTags = { added: new Map(), removed: new Map() };
+
+const bump = (m, k, n = 1) => m.set(k, (m.get(k) || 0) + n);
+
+for (const line of raw.split('\n')) {
+  if (!line.trim()) continue;
+  const parts = line.split('\t');
+  const status = parts[0][0];
+  const target = parts[parts.length - 1];
+  const c = classify(target);
+  if (c.kind === 'other') { other.push({ status, path: target }); continue; }
+  const key = `${c.kind}:${c.slug}`;
+  if (!entries.has(key)) entries.set(key, { kind: c.kind, slug: c.slug, category: c.category, status: null, files: [] });
+  const e = entries.get(key);
+  e.files.push({ s: status, p: target });
+  e.status = !e.status ? status : (e.status === status ? status : 'M');
+}
+
+const enriched = [];
+for (const e of entries.values()) {
+  const out = { ...e };
+  const skillMd = e.files.find(f => f.p.endsWith('SKILL.md') || f.p.endsWith('/content.md') || f.p.endsWith('.md'));
+  if (skillMd && (e.kind === 'skill' || e.kind === 'knowledge')) {
+    const primary = e.files.find(f => f.p.endsWith('SKILL.md')) || skillMd;
+    const before = out.status === 'A' ? null : parseFm(safeShow(FROM, primary.p));
+    const after = out.status === 'D' ? null : parseFm(safeShow(TO, primary.p));
+    out.before = before && { description: before.description || '', triggers: before.triggers || [], tags: before.tags || [], category: before.category || e.category };
+    out.after = after && { description: after.description || '', triggers: after.triggers || [], tags: after.tags || [], category: after.category || e.category };
+    if (out.after && !out.before) for (const t of out.after.tags) bump(tallyTags.added, t);
+    if (out.before && !out.after) for (const t of out.before.tags) bump(tallyTags.removed, t);
+  }
+  enriched.push(out);
+}
+
+const bucket = (status) => enriched.filter(e => e.status === status).sort((a, b) => a.slug.localeCompare(b.slug));
+
+const out = {
+  generatedAt: new Date().toISOString(),
+  root: ROOT,
+  range: { from: FROM, to: TO, fromSha: fromSha.slice(0, 10), toSha: toSha.slice(0, 10), fromDate, toDate },
+  totals: {
+    added: enriched.filter(e => e.status === 'A').length,
+    modified: enriched.filter(e => e.status === 'M').length,
+    removed: enriched.filter(e => e.status === 'D').length,
+    byKind: ['skill', 'knowledge', 'example', 'bootstrap'].map(k => ({
+      k,
+      added: enriched.filter(e => e.kind === k && e.status === 'A').length,
+      modified: enriched.filter(e => e.kind === k && e.status === 'M').length,
+      removed: enriched.filter(e => e.kind === k && e.status === 'D').length,
+    })),
+    otherFiles: other.length,
+  },
+  added: bucket('A'),
+  modified: bucket('M'),
+  removed: bucket('D'),
+  tagDelta: {
+    added: [...tallyTags.added.entries()].sort((a, b) => b[1] - a[1]).slice(0, 20).map(([k, v]) => ({ k, v })),
+    removed: [...tallyTags.removed.entries()].sort((a, b) => b[1] - a[1]).slice(0, 20).map(([k, v]) => ({ k, v })),
+  },
+  otherSample: other.slice(0, 20),
+};
+
+fs.writeFileSync(OUT, JSON.stringify(out, null, 2));
+const kb = (fs.statSync(OUT).size / 1024).toFixed(1);
+console.log(`✓ diff → diff.json (${kb} KB) — ${FROM}(${fromSha.slice(0, 7)}) → ${TO}(${toSha.slice(0, 7)}) · +${out.totals.added} ~${out.totals.modified} -${out.totals.removed}`);

--- a/example/skill-diff/diff.json
+++ b/example/skill-diff/diff.json
@@ -1,0 +1,8905 @@
+{
+  "generatedAt": "2026-04-15T16:55:00.733Z",
+  "root": "C:\\Users\\kjuhwa\\.claude\\skills-hub\\remote",
+  "range": {
+    "from": "HEAD~50",
+    "to": "HEAD",
+    "fromSha": "d8927396d7",
+    "toSha": "fe18a9a5f2",
+    "fromDate": "2026-04-15 10:24:12 +0900",
+    "toDate": "2026-04-16 01:43:46 +0900"
+  },
+  "totals": {
+    "added": 388,
+    "modified": 5,
+    "removed": 0,
+    "byKind": [
+      {
+        "k": "skill",
+        "added": 165,
+        "modified": 2,
+        "removed": 0
+      },
+      {
+        "k": "knowledge",
+        "added": 208,
+        "modified": 0,
+        "removed": 0
+      },
+      {
+        "k": "example",
+        "added": 5,
+        "modified": 0,
+        "removed": 0
+      },
+      {
+        "k": "bootstrap",
+        "added": 10,
+        "modified": 3,
+        "removed": 0
+      }
+    ],
+    "otherFiles": 3
+  },
+  "added": [
+    {
+      "kind": "knowledge",
+      "slug": "account-lockout-configurable-threshold.md",
+      "category": "domain",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/domain/account-lockout-configurable-threshold.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "domain"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "actuator-endpoints-skip-auth-by-design.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/actuator-endpoints-skip-auth-by-design.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "In a monitoring collector, target-level BASIC/BEARER auth is stored but intentionally NOT applied when calling /actuator/health and /actuator/metrics.",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "actuator-metric-call-aggressive-timeout.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/actuator-metric-call-aggressive-timeout.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Use aggressive HTTP timeouts (100ms–1s) for /actuator/health and /actuator/metrics polling, but keep long timeouts for /actuator/threaddump and /actuator/heapdump — mixing them stalls the collector.",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "actuator-path-dual-compatibility.md",
+      "category": "api",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/api/actuator-path-dual-compatibility.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "api"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "admin-role-disabled-secretkey.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/admin-role-disabled-secretkey.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "ai-guess-mark-and-review-checklist.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/ai-guess-mark-and-review-checklist.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "When AI fills gaps the source doc doesn't specify, annotate the guess inline and output a review checklist alongside the artifact",
+        "triggers": [],
+        "tags": [
+          "ai-inference",
+          "uncertainty",
+          "review",
+          "openapi-extraction",
+          "transparency"
+        ],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "alarm-raw-over-1min-aggregate.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/alarm-raw-over-1min-aggregate.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "annotation-driven-authz-via-function-id.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/annotation-driven-authz-via-function-id.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Controllers declare required capability with a method-level enum annotation; an interceptor enforces it against JWT-derived roles",
+        "triggers": [],
+        "tags": [
+          "authorization",
+          "jwt",
+          "annotation",
+          "interceptor",
+          "rbac"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "anonymize-examples-in-skill-docs.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/anonymize-examples-in-skill-docs.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "asm-based-classloader-instrumentation-caveats.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/asm-based-classloader-instrumentation-caveats.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "asm",
+          "pitfall",
+          "instrumentation",
+          "lambda",
+          "jvm"
+        ],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "assume-semantics-for-compiler-hints.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/assume-semantics-for-compiler-hints.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "cpp",
+          "assertions",
+          "invariants",
+          "design"
+        ],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "assumeutxo-snapshot-chainstate-phases.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/assumeutxo-snapshot-chainstate-phases.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "blockchain",
+          "utxo",
+          "snapshot",
+          "bitcoin",
+          "phased-validation"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "async-subagent-resume-on-missing-artifact",
+      "category": "workflow",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/workflow/async-subagent-resume-on-missing-artifact/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "When an async subagent is reported \"completed\" but its final message hints at unfinished work (e.g., \"Now let me build…\"), verify the expected on-disk artifact before moving on; if missing, use SendMessage to the agent id to finalize rather than re-dispatching a fresh agent.",
+        "triggers": [
+          "agent completed but artifact missing",
+          "subagent incomplete output"
+        ],
+        "tags": [
+          "agents",
+          "async",
+          "verification",
+          "send-message"
+        ],
+        "category": "workflow"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "audit-change-data-capture-pattern",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/audit-change-data-capture-pattern/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/audit-change-data-capture-pattern/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Compute before/after diffs for audit logs by comparing two BSON/JSON documents field-by-field — always iterate the BEFORE doc and read from AFTER to avoid prev/after swap bugs",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "audit-changed-prev-after-field-swap-bug.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/audit-changed-prev-after-field-swap-bug.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "auto-lock-must-not-bump-lastEditedTime.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/auto-lock-must-not-bump-lastEditedTime.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "availability-ttl-punctuate-processor",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/availability-ttl-punctuate-processor/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/availability-ttl-punctuate-processor/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Kafka Streams processor schedules a wall-clock `punctuate` for TTL eviction of the state store, and emits downstream only on value change. Wall-clock (not stream-time) so idle inputs still trigger cleanup.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "avro-event-change-flags",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/avro-event-change-flags/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/avro-event-change-flags/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Design Kafka Avro event schemas that carry an actionType enum plus boolean \"changed\" flags per mutable section so consumers can branch cheaply without diffing payloads.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "avro-gradle-kafka-schema-pipeline",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/avro-gradle-kafka-schema-pipeline/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/avro-gradle-kafka-schema-pipeline/_DUPLICATE_CHECK.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/avro-gradle-kafka-schema-pipeline/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Wire the davidmc24 Avro Gradle plugin so .avsc schemas generate Java sources consumed by Kafka producers/consumers with Confluent Schema Registry",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "avro-private-fields-no-setters.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/avro-private-fields-no-setters.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "baseline-historical-comparison-threshold",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/baseline-historical-comparison-threshold/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/baseline-historical-comparison-threshold/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Evaluate a current metric against a historical baseline (prev hour/day/week/month/year, with MIN/AVG/MAX aggregation) as a dynamic threshold; supports RATE or VALUE change modes and dampening.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "bilingual-user-facing-strings.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/bilingual-user-facing-strings.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "cpp",
+          "i18n",
+          "localization",
+          "logging",
+          "ui"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "binsize-zero-fallback-to-one.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/binsize-zero-fallback-to-one.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "boilerplate-generated-business-logic-manual.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/boilerplate-generated-business-logic-manual.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Split AI codegen scope along the boilerplate/business-logic line — AI produces skeletons, humans fill domain rules",
+        "triggers": [],
+        "tags": [
+          "codegen",
+          "hexagonal",
+          "scope",
+          "ai-automation",
+          "skeleton"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "bootrun-jvmargs-jdwp-opens-java21",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/bootrun-jvmargs-jdwp-opens-java21/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/bootrun-jvmargs-jdwp-opens-java21/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Bake JDWP debug port and required --add-opens flags into Gradle bootRun so every dev gets the same Java 17/21-compatible local runtime",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "bucket-parallel-java-annotation-dispatch",
+      "category": "workflow",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/workflow/bucket-parallel-java-annotation-dispatch/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "For bulk Java annotation work (200+ @Operation methods across many controllers, or 500+ @Schema fields across many DTOs), dispatch N parallel executor subagents with disjoint file buckets. Leader runs a single compile at the end; agents never run gradle themselves.",
+        "triggers": [
+          "bulk annotation",
+          "전수 적용",
+          "controller 전체 주석",
+          "DTO @Schema 전수"
+        ],
+        "tags": [
+          "parallel-agents",
+          "java",
+          "annotation",
+          "spring",
+          "swagger",
+          "gradle"
+        ],
+        "category": "workflow"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "byte-aware-sms-truncation-with-ellipsis",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/byte-aware-sms-truncation-with-ellipsis/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/byte-aware-sms-truncation-with-ellipsis/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Truncate SMS message body to a byte budget (not char count) per charset, appending '...' without exceeding the budget",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "cache-even-when-enable-false.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/cache-even-when-enable-false.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "cache-variance-ttl-jitter",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/cache-variance-ttl-jitter/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/cache-variance-ttl-jitter/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Add ±N% random jitter to cache TTLs so keys written together don't all expire in the same tick, avoiding synchronized recompute storms",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "calendar-cron-vs-spring-cron-migration",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/calendar-cron-vs-spring-cron-migration/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/calendar-cron-vs-spring-cron-migration/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Convert between Spring 6-field cron and Quartz/calendar 7-field cron without DST/leap-year regressions",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "catalina-urlencoder-internal-api.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/catalina-urlencoder-internal-api.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "org.apache.catalina.util.URLEncoder는 톰캣 내부 API — 컨테이너 교체/버전업에 깨지기 쉽다. java.net.URLEncoder 또는 Spring UriUtils 사용",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "challenge-response-auth-redis-ttl",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/challenge-response-auth-redis-ttl/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/challenge-response-auth-redis-ttl/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Replay-resistant two-step login — server issues a short-lived random challenge stored in Redis with TTL, client signs/hashes response, bounded attempts per key",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "chunked-resource-id-batch-fetch",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/chunked-resource-id-batch-fetch/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/chunked-resource-id-batch-fetch/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Split large ID lists into ~1000-item chunks before querying DB or Elasticsearch to avoid bind-parameter limits (MSSQL 2100, Oracle 1000) and OOM on bulk responses",
+        "triggers": [
+          "`WHERE id IN (?, ?, …)` with thousands of IDs",
+          "ES `terms` query near 65536-item ceiling",
+          "monitor/report accepts an unbounded target ID list"
+        ],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "circular-dependency-detection-script.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/circular-dependency-detection-script.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "cpp",
+          "build",
+          "dependencies",
+          "tooling",
+          "ci"
+        ],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "clang-tidy-integration-workflow",
+      "category": "devops",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/devops/clang-tidy-integration-workflow/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Automated static analysis pipeline using clang-tidy with project-specific checks and suppression strategies for large multi-file C++ codebases.",
+        "triggers": [],
+        "tags": [
+          "cpp",
+          "static-analysis",
+          "clang-tidy",
+          "ci",
+          "linting"
+        ],
+        "category": "devops"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "claude-code-skill-scaffold",
+      "category": "devops",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/devops/claude-code-skill-scaffold/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "[Tooling] Claude Code 스킬 표준 구조(SKILL.md + prompts/ + scripts/ + references/)를 자동 생성하는 스캐폴딩.",
+        "triggers": [],
+        "tags": [],
+        "category": "devops"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "claude-plugin-catalog-publish",
+      "category": "devops",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/devops/claude-plugin-catalog-publish/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "[Tooling] 로컬 스킬을 원격 Git repo에 배포하고 AGENTS.md 카탈로그를 자동 갱신하는 publish 플로우.",
+        "triggers": [],
+        "tags": [],
+        "category": "devops"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "claude-plugin-marketplace-owner-required.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/claude-plugin-marketplace-owner-required.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "claude-plugin-skill-md-is-sufficient.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/claude-plugin-skill-md-is-sufficient.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "collection-routing-by-period",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/collection-routing-by-period/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/collection-routing-by-period/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Single resolver maps `(Period.Mode, from, to)` → time-series collection (raw view / 1-min / hour-with-monthly-suffix / day). Callers never hardcode collection names.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "bootstrap",
+      "slug": "commands/example_add.md",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "bootstrap/commands/example_add.md"
+        }
+      ]
+    },
+    {
+      "kind": "bootstrap",
+      "slug": "commands/example_list.md",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "bootstrap/commands/example_list.md"
+        }
+      ]
+    },
+    {
+      "kind": "bootstrap",
+      "slug": "commands/init_skills_all.md",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "bootstrap/commands/init_skills_all.md"
+        }
+      ]
+    },
+    {
+      "kind": "bootstrap",
+      "slug": "commands/knowledge_publish.md",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "bootstrap/commands/knowledge_publish.md"
+        }
+      ]
+    },
+    {
+      "kind": "bootstrap",
+      "slug": "commands/make_something.md",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "bootstrap/commands/make_something.md"
+        }
+      ]
+    },
+    {
+      "kind": "bootstrap",
+      "slug": "commands/publish_all.md",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "bootstrap/commands/publish_all.md"
+        }
+      ]
+    },
+    {
+      "kind": "bootstrap",
+      "slug": "commands/skills_import_git.md",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "bootstrap/commands/skills_import_git.md"
+        }
+      ]
+    },
+    {
+      "kind": "bootstrap",
+      "slug": "commands/skills_merge.md",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "bootstrap/commands/skills_merge.md"
+        }
+      ]
+    },
+    {
+      "kind": "bootstrap",
+      "slug": "commands/skills_refactor.md",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "bootstrap/commands/skills_refactor.md"
+        }
+      ]
+    },
+    {
+      "kind": "bootstrap",
+      "slug": "commands/skills_split.md",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "bootstrap/commands/skills_split.md"
+        }
+      ]
+    },
+    {
+      "kind": "knowledge",
+      "slug": "common-alarm-policy-init-gotcha.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/common-alarm-policy-init-gotcha.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Policy loader that \"only runs on first boot if records exist\" silently skips later-added policies for tenants that started empty",
+        "triggers": [],
+        "tags": [
+          "initialization",
+          "bootstrap",
+          "tenant",
+          "policy-loader",
+          "silent-failure"
+        ],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "commons-logging-exclusion-strategy.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/commons-logging-exclusion-strategy.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "compact-binary-wire-protocol-with-variable-length-encoding",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/compact-binary-wire-protocol-with-variable-length-encoding/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Define a custom binary wire format with variable-length integer encodings (e.g. 3-byte / 5-byte) to minimize UDP packet size for high-volume metric or telemetry streams",
+        "triggers": [],
+        "tags": [
+          "protocol",
+          "binary",
+          "varint",
+          "udp",
+          "telemetry",
+          "perf"
+        ],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "compare-counts-exclude-added-deleted.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/compare-counts-exclude-added-deleted.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "composite-alarm-all-deleted-npe.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/composite-alarm-all-deleted-npe.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "concurrent-jdbc-pool-datasource-lifecycle",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/concurrent-jdbc-pool-datasource-lifecycle/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Manage a pool of short-lived JDBC targets for monitoring agents with dual maps (active vs all) and periodic revalidation",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "conditional-feature-flag-rollout",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/conditional-feature-flag-rollout/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/conditional-feature-flag-rollout/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "@ConditionalOnProperty로 구/신 구현을 공존시키고 런타임 속성 하나로 전환하는 점진적 롤아웃 패턴",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "conf-info-may-lack-resource-type.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/conf-info-may-lack-resource-type.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "confid-only-query-over-resource-tuple.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/confid-only-query-over-resource-tuple.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "confid-vs-resourceid-routing.md",
+      "category": "api",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/api/confid-vs-resourceid-routing.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "api"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "copy-naming-suffix-numbered.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/copy-naming-suffix-numbered.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "cors-allow-credentials-star-origin.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/cors-allow-credentials-star-origin.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "서비스 레벨 allowCredentials=true + allowedOriginPatterns(\"*\") 유지 — 엣지(Traefik/Istio)에서 CORS를 제어하는 아키텍처 전제",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "csp-frame-ancestors-required.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/csp-frame-ancestors-required.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "custom-actuator-command-whitelist",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/custom-actuator-command-whitelist/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/custom-actuator-command-whitelist/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Expose safe remote OS command execution on a Spring Boot service via a custom Actuator endpoint, restricted by a command whitelist, an argument sanitizer, and an execution timeout.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "data-patch-package-for-migrations.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/data-patch-package-for-migrations.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "dataavro-json-wrapper-pattern.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/dataavro-json-wrapper-pattern.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "여러 이벤트 타입마다 Avro 스키마를 만들지 않고 DataAvro{jsonData,jsonDataClass} 하나로 통일 — TCM 선례 채택",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "debug-lockorder-detection-system",
+      "category": "debug",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/debug/debug-lockorder-detection-system/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Runtime lock-order deadlock detection via a DEBUG_LOCKORDER compile flag that tracks lock acquisition order and reports circular dependencies.",
+        "triggers": [],
+        "tags": [
+          "cpp",
+          "threading",
+          "deadlock",
+          "debugging",
+          "instrumentation"
+        ],
+        "category": "debug"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "design-an-interface",
+      "category": "misc",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/misc/design-an-interface/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Generate multiple radically different interface designs for a module using parallel sub-agents. Use when user wants to design an API, explore interface options, compare module shapes, or mentions \"design it twice\".",
+        "triggers": [],
+        "tags": [
+          "design",
+          "api-design",
+          "sub-agents",
+          "design-it-twice"
+        ],
+        "category": "misc"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "deterministic-coverage-verification",
+      "category": "testing",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/testing/deterministic-coverage-verification/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Run LLVM-instrumented tests multiple times and verify identical coverage reports — catches compiler/env non-determinism that can mask real bugs.",
+        "triggers": [],
+        "tags": [
+          "coverage",
+          "llvm",
+          "testing",
+          "determinism",
+          "ci"
+        ],
+        "category": "testing"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "dev-controller-tenant-wrapping-helper",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/dev-controller-tenant-wrapping-helper/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/dev-controller-tenant-wrapping-helper/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Dev/로컬 전용 컨트롤러의 테넌트+JWT 반복 래핑을 함수형 인터페이스 + 헬퍼 컴포넌트로 추출",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "distributed-lock-mongodb",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/distributed-lock-mongodb/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/distributed-lock-mongodb/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "MongoDB findAndModify-based distributed lock with TTL expiry, owner tagging, and retry loop for multi-instance Spring Boot services.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "divide-by-zero-rate-guard",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/divide-by-zero-rate-guard/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Guard rate/percentage calculations against zero denominators to prevent NaN from poisoning downstream metrics and serialization.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "do-not-ask-planners-for-api-design.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/do-not-ask-planners-for-api-design.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Product planners own screens and UX, not endpoint shapes — push API design to AI extraction + developer review instead of template-driven planner input",
+        "triggers": [],
+        "tags": [
+          "planning-doc",
+          "api-design",
+          "role-boundary",
+          "ai-extraction",
+          "review-gate"
+        ],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "docker-compose-service-inventory-files",
+      "category": "devops",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/devops/docker-compose-service-inventory-files/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/devops/docker-compose-service-inventory-files/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Manage large Docker Compose service fleets using flat inventory files with '#' as an EX (exclude) marker",
+        "triggers": [],
+        "tags": [],
+        "category": "devops"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "docker-compose-v1-v2-auto-detect",
+      "category": "devops",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/devops/docker-compose-v1-v2-auto-detect/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/devops/docker-compose-v1-v2-auto-detect/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Shell helper that prefers `docker compose` (v2) over `docker-compose` (v1) with graceful fallback",
+        "triggers": [],
+        "tags": [],
+        "category": "devops"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "docker-engine-29-requires-traefik-upgrade.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/docker-engine-29-requires-traefik-upgrade.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Docker Engine 29.x raises the minimum client API to 1.44, breaking older Traefik versions that pin an older API",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "domain-registry-plus-projects-yaml.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/domain-registry-plus-projects-yaml.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Central domain registry + per-user path map for multi-repo codegen",
+        "triggers": [],
+        "tags": [
+          "multi-repo",
+          "codegen",
+          "routing",
+          "registry",
+          "local-config"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "dry-run-confirm-retry-write-flow",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/dry-run-confirm-retry-write-flow/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "[Backend] 트래커/외부 API 쓰기 작업에 적용하는 공통 플로우: 미리보기 → 사용자 확인 → 쓰기 → 재시도.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "dual-jre-docker-oz-report",
+      "category": "devops",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/devops/dual-jre-docker-oz-report/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/devops/dual-jre-docker-oz-report/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Package a Java 21 Spring Boot app that bundles a legacy JRE 8 + sidecar Tomcat (OZ Report engine) in one Alpine container",
+        "triggers": [],
+        "tags": [],
+        "category": "devops"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "dual-redis-lock-vs-access-control.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/dual-redis-lock-vs-access-control.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "dynamic-gridfs-template-multi-tenant",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/dynamic-gridfs-template-multi-tenant/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/dynamic-gridfs-template-multi-tenant/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Resolve MongoDB GridFsTemplate per (tenant-db, bucket) pair with lazy caching, for storing large binary assets per tenant",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "eclipse-rcp-rich-client-for-apm-ui",
+      "category": "apm",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/apm/eclipse-rcp-rich-client-for-apm-ui/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Build a desktop-class APM / observability client on Eclipse RCP + ZEST/GEF for high-throughput real-time visualization that HTTP + JSON browsers struggle with",
+        "triggers": [],
+        "tags": [
+          "rcp",
+          "eclipse",
+          "desktop",
+          "apm",
+          "visualization"
+        ],
+        "category": "apm"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "edit-article",
+      "category": "docs",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/docs/edit-article/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Edit and improve articles by restructuring sections, improving clarity, and tightening prose. Use when user wants to edit, revise, or improve an article draft.",
+        "triggers": [],
+        "tags": [
+          "writing",
+          "editing",
+          "clarity"
+        ],
+        "category": "docs"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "elasticsearch-xpack-ssl-transport",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/elasticsearch-xpack-ssl-transport/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/elasticsearch-xpack-ssl-transport/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Gate `PreBuiltXPackTransportClient` vs `PreBuiltTransportClient` on auth flag (not SSL flag) and configure keystore/truststore as independent ES X-Pack settings",
+        "triggers": [
+          "connect Java client to X-Pack-secured Elasticsearch cluster",
+          "production ES requires auth and optional transport TLS"
+        ],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "enable-async-tenant-aware",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/enable-async-tenant-aware/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/enable-async-tenant-aware/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Place @EnableAsync on a dedicated @Configuration that extends a tenant-aware AsyncConfigurer, so tenant/MDC context propagates across the executor boundary",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "encrypted-pii-decode-on-export.md",
+      "category": "domain",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/domain/encrypted-pii-decode-on-export.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "domain"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "encrypted-pii-decrypt-before-send",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/encrypted-pii-decrypt-before-send/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/encrypted-pii-decrypt-before-send/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Store user email/phone encrypted at rest; decrypt only inside the sender, never in cache/DTO/log boundaries",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "enum-notnull-comparison-pitfall.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/enum-notnull-comparison-pitfall.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "In Java, comparing an enum field with `==` without a null guard NPEs on the left operand; prefer constant-on-the-left or an explicit @NotNull contract",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "enum-whitelist-blocks-time-based-sqli.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/enum-whitelist-blocks-time-based-sqli.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Validate user-supplied identifiers (metric aliases, column names, value-type keys) against a known definition/enum before they reach any query builder — string-only sinks are still injectable",
+        "triggers": [],
+        "tags": [
+          "security",
+          "sql-injection",
+          "mongodb",
+          "validation",
+          "zap"
+        ],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "env-override-last-wins-chain.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/env-override-last-wins-chain.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "es-xpack-transport-vs-rest-ssl.md",
+      "category": "api",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/api/es-xpack-transport-vs-rest-ssl.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "api"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "eureka-service-discovery-wait-annotation",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/eureka-service-discovery-wait-annotation/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/eureka-service-discovery-wait-annotation/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Declarative @WaitForServices annotation on @EventListener methods — blocks initialization until named Eureka services are healthy, with optional leader-only execution",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "event-driven-init-wait-for-services.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/event-driven-init-wait-for-services.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "event-driven-kafka-scheduling",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/event-driven-kafka-scheduling/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/event-driven-kafka-scheduling/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Replace Spring @Scheduled with a Kafka-delivered JobExecuteNotice so a central scheduler service fans out tick events — with a skip-if-previous-still-running guard to prevent pile-up.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "excel-download-null-date-range-handling",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/excel-download-null-date-range-handling/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/excel-download-null-date-range-handling/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Defensive pattern for grid/list excel-export endpoints — null-check every filter value and normalize field names before querying",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "existing-code-patterns-over-standard-rules.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/existing-code-patterns-over-standard-rules.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "When generating into an established repo, mirror the repo's existing style first; apply the written standard only when the repo is empty or silent",
+        "triggers": [],
+        "tags": [
+          "codegen",
+          "style-matching",
+          "convention",
+          "rulebook",
+          "hexagonal"
+        ],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "feed-envelope-frame",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/feed-envelope-frame/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/feed-envelope-frame/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Uniform WebSocket payload wrapper with Type (ACK/SNAPSHOT/DELTA/ERROR), PayloadKind, and correlation requestId, including null-safe factory methods",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "folder-coloc-style-types",
+      "category": "frontend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/frontend/folder-coloc-style-types/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/frontend/folder-coloc-style-types/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Keep component, style, and types files at the same depth; never split into styles/ or types/ subfolders",
+        "triggers": [],
+        "tags": [],
+        "category": "frontend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "font-cache-alpine-locale-docker",
+      "category": "devops",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/devops/font-cache-alpine-locale-docker/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/devops/font-cache-alpine-locale-docker/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Make CJK/custom fonts usable inside an Alpine container by copying TTF/OTF and rebuilding the fontconfig cache",
+        "triggers": [],
+        "tags": [],
+        "category": "devops"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "freemarker-two-phase-expression-subst",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/freemarker-two-phase-expression-subst/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/freemarker-two-phase-expression-subst/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Render templates by first replacing raw ${var} placeholders via string-replace, then running FreeMarker for expression-object binding, avoiding double-evaluation and escape conflicts",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "frozen-detection-consecutive-count",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/frozen-detection-consecutive-count/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/frozen-detection-consecutive-count/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Detect a stuck/frozen metric (identical value for N consecutive samples) by CONSECUTIVE-dampening equality check; catches sensor/collector failures that threshold alarms miss.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "fuzz-corpus-seed-management",
+      "category": "testing",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/testing/fuzz-corpus-seed-management/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Structured libFuzzer workflow — seed corpora in a separate asset repo, determinism verification, and reproducible crash workflows.",
+        "triggers": [],
+        "tags": [
+          "fuzzing",
+          "libfuzzer",
+          "llvm",
+          "testing",
+          "corpus"
+        ],
+        "category": "testing"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "git-guardrails-claude-code",
+      "category": "cli",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/cli/git-guardrails-claude-code/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/cli/git-guardrails-claude-code/scripts/block-dangerous-git.sh"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Set up Claude Code hooks to block dangerous git commands (push, reset --hard, clean, branch -D, etc.) before they execute. Use when user wants to prevent destructive git operations, add git safety hooks, or block git push/reset in Claude Code.",
+        "triggers": [],
+        "tags": [
+          "git",
+          "hooks",
+          "claude-code",
+          "guardrails",
+          "safety"
+        ],
+        "category": "cli"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "github-triage",
+      "category": "workflow",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/workflow/github-triage/AGENT-BRIEF.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/workflow/github-triage/OUT-OF-SCOPE.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/workflow/github-triage/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Triage GitHub issues through a label-based state machine with interactive grilling sessions. Use when user wants to triage issues, review incoming bugs or feature requests, prepare issues for an AFK agent, or manage issue workflow.",
+        "triggers": [],
+        "tags": [
+          "github",
+          "triage",
+          "issues",
+          "labels",
+          "state-machine"
+        ],
+        "category": "workflow"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "god-controller-split-by-resource.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/god-controller-split-by-resource.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "refactor",
+          "controller",
+          "srp",
+          "spring"
+        ],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "gradle-avro-plugin-config.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/gradle-avro-plugin-config.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "gradle-bootjar-conditional-archive-bundle",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/arch/gradle-bootjar-conditional-archive-bundle/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/arch/gradle-bootjar-conditional-archive-bundle/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Gradle Spring Boot build that conditionally bundles the fat JAR plus externalized resources into a dated zip/tar for on-prem delivery, gated by a flag",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "gradle-bootrun-local-dev-env",
+      "category": "devops",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/devops/gradle-bootrun-local-dev-env/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/devops/gradle-bootrun-local-dev-env/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Gradle bootRun task recipe that wires local MongoDB/Kafka/Redis/MQTT/Eureka/Quartz via environment variables — no docker-compose needed",
+        "triggers": [],
+        "tags": [],
+        "category": "devops"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "gradle-jacoco-exclusion-strategy",
+      "category": "devops",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/devops/gradle-jacoco-exclusion-strategy/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/devops/gradle-jacoco-exclusion-strategy/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Curated Jacoco/Sonar exclusion patterns for Spring Boot projects — skips config/DAO/entity/generated layers and Querydsl Q-classes",
+        "triggers": [],
+        "tags": [],
+        "category": "devops"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "gradle-shared-exclusions-jacoco-sonar",
+      "category": "devops",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/devops/gradle-shared-exclusions-jacoco-sonar/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/devops/gradle-shared-exclusions-jacoco-sonar/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Keep Jacoco report, Jacoco coverage verification, and SonarQube exclusions in sync by defining one `exclusionPatterns` list in Gradle ext",
+        "triggers": [
+          "jacoco and sonarqube exclusion lists drift apart",
+          "adding a new package to coverage exclusions requires editing multiple blocks",
+          "querydsl Q-classes / generated code leaking into coverage reports"
+        ],
+        "tags": [],
+        "category": "devops"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "gridfs-template-upload-data-loss-pitfall.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/gridfs-template-upload-data-loss-pitfall.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "MongoDB GridFS uploads can silently drop file bytes if the bucket/db selection or stream flush is wrong — always verify metadata size equals input size",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "grill-me",
+      "category": "workflow",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/workflow/grill-me/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions \"grill me\".",
+        "triggers": [],
+        "tags": [
+          "interview",
+          "planning",
+          "clarification",
+          "socratic"
+        ],
+        "category": "workflow"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "hibernate-date-format-lowercase.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/hibernate-date-format-lowercase.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "hibernate-multi-dialect-swap",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/hibernate-multi-dialect-swap/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/hibernate-multi-dialect-swap/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Ship one WAR that connects to Oracle, PostgreSQL, MSSQL, Tibero, DB2, or MariaDB based on Spring profile — all JDBC drivers bundled, dialect and datasource resolved from externalized config",
+        "triggers": [
+          "one deployable must support multiple RDBMS vendors without rebuild",
+          "hibernate dialect chosen at startup, not compile time",
+          "customer deployments dictate DB vendor"
+        ],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "hierarchical-agents-md-catalog.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/hierarchical-agents-md-catalog.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "hierarchical-group-entity",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/hierarchical-group-entity/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/hierarchical-group-entity/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Model a tree-structured group entity in MongoDB with parentId + path + pathIds + level, plus recursive child-path update on move and cycle detection.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "history-view-yearly-partition-pitfall.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/history-view-yearly-partition-pitfall.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "hyperloglog-for-unique-user-counting.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/hyperloglog-for-unique-user-counting.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "hyperloglog",
+          "cardinality",
+          "decision",
+          "scouter"
+        ],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "improve-codebase-architecture",
+      "category": "refactor",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/refactor/improve-codebase-architecture/REFERENCE.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/refactor/improve-codebase-architecture/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. Use when user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more AI-navigable.",
+        "triggers": [],
+        "tags": [
+          "architecture",
+          "codebase",
+          "exploration"
+        ],
+        "category": "refactor"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "init-deadline-guard",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/init-deadline-guard/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/init-deadline-guard/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Watchdog that force-exits a Spring Boot service if startup initialization (external discovery, topic creation, warmup) does not complete within a deadline",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "injectmocks-generics-type-erasure.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/injectmocks-generics-type-erasure.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "@InjectMocks가 제네릭 필드에 Mock을 주입할 때 타입 소거로 잘못된 후보를 고르는 flaky 원인",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "interface-abstraction-for-modularity.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/interface-abstraction-for-modularity.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "cpp",
+          "architecture",
+          "modularity",
+          "ipc",
+          "dependency-inversion"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "ip-allowlist-cidr-validator",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/ip-allowlist-cidr-validator/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/ip-allowlist-cidr-validator/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Validate client IPs against user-supplied allow-lists accepting mixed notations — plain IPv4, CIDR, octet wildcards (192.168.*.*), and octet ranges (192.168.10-20.*)",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "ipv6-colon-detection-edge.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/ipv6-colon-detection-edge.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "jackson-version-pinning-2.17.1.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/jackson-version-pinning-2.17.1.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "jacoco-exclude-boilerplate-layers",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/jacoco-exclude-boilerplate-layers/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/jacoco-exclude-boilerplate-layers/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Configure JaCoCo + SonarQube to exclude generated/boilerplate layers (avro, config, dto, entity, kafka, *Dev) from coverage so coverage % reflects business logic only",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "jacoco-exclude-business-layers.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/jacoco-exclude-business-layers.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "jacoco-sonar-exclusion-policy.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/jacoco-sonar-exclusion-policy.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "jacoco-sonar-exclusion-rationale.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/jacoco-sonar-exclusion-rationale.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Classes under config/, dto/, entity/, kafka/, avro/, exception/, advice/, schedule/, service/websocket/, and generated Q-classes are excluded from Jacoco coverage gates. Only business logic (routers, guards, services) is measured.",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "jacoco-sonar-shared-exclusion-list",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/jacoco-sonar-shared-exclusion-list/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/jacoco-sonar-shared-exclusion-list/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Define coverage/quality exclusions once in ext.exclusionPatterns and reuse across jacoco, sonar, and packaging tasks to prevent report drift",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "jar-task-disabled-bootjar-only.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/jar-task-disabled-bootjar-only.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "java-21-upgrade-rationale.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/java-21-upgrade-rationale.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "java-agent-bytecode-instrumentation-with-asm",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/java-agent-bytecode-instrumentation-with-asm/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Build a JVM agent using ASM's ClassFileTransformer to inject profiling/monitoring hooks into application classes via pluggable visitor chains",
+        "triggers": [],
+        "tags": [
+          "java",
+          "jvm",
+          "apm",
+          "instrumentation",
+          "asm",
+          "bytecode"
+        ],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "jdbc-configurable-sql-insert-sender",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/jdbc-configurable-sql-insert-sender/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/jdbc-configurable-sql-insert-sender/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Ship a notification/integration channel that writes to a user-configured external DB via user-supplied INSERT SQL with ${var} placeholders",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "jdbc-template-var-xml-escape-bypass.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/jdbc-template-var-xml-escape-bypass.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "jenkins-dual-registry-docker-push",
+      "category": "devops",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/devops/jenkins-dual-registry-docker-push/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/devops/jenkins-dual-registry-docker-push/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Jenkins pipeline that builds one image and tags+pushes it to two registries (SaaS + on-prem) with both build-specific and rolling-latest tags",
+        "triggers": [],
+        "tags": [],
+        "category": "devops"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "jest-coverage-80-threshold.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/jest-coverage-80-threshold.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Global Jest coverage threshold is 80% on branches, functions, lines, and statements",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "jest-test-file-naming-test-only",
+      "category": "frontend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/frontend/jest-test-file-naming-test-only/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/frontend/jest-test-file-naming-test-only/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Use .test.ts naming (not .spec.ts) and explicitly import jest globals; .spec.ts is excluded from the runner",
+        "triggers": [],
+        "tags": [],
+        "category": "frontend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "jvm-module-opens-java21-spring-kafka.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/jvm-module-opens-java21-spring-kafka.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Java 21 runs Spring Boot + Kafka/MongoDB clients under strict module access; two --add-opens flags are required or reflective serializers fail at runtime.",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "jwt-extraction-via-base-controller",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/jwt-extraction-via-base-controller/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Consolidate repeated `JwtTokenService.getXxxFromBearerToken(headerAuthorization)` calls across Spring controllers by moving the service and helper methods onto a shared `BaseController`. Subclass controllers call `getOrganizationId(h)` / `getLoginId(h)` / `getRoleIds(h)` directly.",
+        "triggers": [
+          "jwt extraction controller duplication",
+          "base controller jwt",
+          "getXxxFromBearerToken 중복 제거"
+        ],
+        "tags": [
+          "spring-boot",
+          "jwt",
+          "controller",
+          "refactor",
+          "base-class"
+        ],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "jwt-stateless-refresh-24h-default.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/jwt-stateless-refresh-24h-default.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "k8s-clusterrole-aggregation-npe.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/k8s-clusterrole-aggregation-npe.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "k8s-health-via-getnodelist",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/k8s-health-via-getnodelist/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/k8s-health-via-getnodelist/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Use `listNode()` with readiness check for Kubernetes cluster health — `getVersion()` succeeds on degraded clusters that will fail real work",
+        "triggers": [
+          "cluster liveness probe before running a collector pass",
+          "guard against API-server flaps"
+        ],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "kafka-1h-topic-and-nonmetric-pool.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/kafka-1h-topic-and-nonmetric-pool.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "kafka-avro-change-flag-contract.md",
+      "category": "api",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/api/kafka-avro-change-flag-contract.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "api"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "kafka-avro-producer-gzip-30mb",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/kafka-avro-producer-gzip-30mb/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/kafka-avro-producer-gzip-30mb/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Spring Kafka producer config for Avro values with gzip compression and a raised 30MB max.request.size for schema-registry payloads",
+        "triggers": [],
+        "tags": [
+          "kafka",
+          "avro",
+          "spring-kafka",
+          "schema-registry",
+          "producer"
+        ],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "kafka-avro-schedule-event-chain.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/kafka-avro-schedule-event-chain.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Collection scheduling decouples Kafka ingress from per-DBMS handlers via four typed BlockingQueues",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "kafka-avro-schema-registry-env-topology.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/kafka-avro-schema-registry-env-topology.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "kafka-avro-topic-auto-create-config",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/arch/kafka-avro-topic-auto-create-config/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/arch/kafka-avro-topic-auto-create-config/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Spring Boot Kafka config bean that auto-creates topics on startup via ApplicationRunner, with Avro serde, manual-ack listener, and bounded concurrency",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "kafka-batch-consumer-partition-tuning",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/kafka-batch-consumer-partition-tuning/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/kafka-batch-consumer-partition-tuning/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Size Kafka partition count + max-poll-records per topic volume so heavy-processing batch consumers avoid max.poll.interval.ms breaches and maintain throughput via per-partition concurrency.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "kafka-batch-size-timeout-tuning.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/kafka-batch-size-timeout-tuning.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Lowering Spring Kafka max-poll-records (e.g. 200→10) on heavy-processing consumers prevents max.poll.interval.ms timeouts and rebalance storms",
+        "triggers": [],
+        "tags": [
+          "kafka",
+          "spring-kafka",
+          "max-poll-records",
+          "max-poll-interval-ms",
+          "rebalance"
+        ],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "kafka-consumer-config-3-factories",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/kafka-consumer-config-3-factories/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/kafka-consumer-config-3-factories/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Spring Kafka consumer setup with three ListenerContainerFactory variants (standard / batch / UUID-group) and autoStartup=false to allow topic bootstrap before listeners attach",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "kafka-consumer-errorhandling-wrapper",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/kafka-consumer-errorhandling-wrapper/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/kafka-consumer-errorhandling-wrapper/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Wrap key/value deserializers in Spring Kafka's ErrorHandlingDeserializer so a single poison record doesn't halt the consumer",
+        "triggers": [],
+        "tags": [
+          "kafka",
+          "spring-kafka",
+          "avro",
+          "poison-pill",
+          "resilience"
+        ],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "kafka-consumer-group-id-hostname-not-timezone.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/kafka-consumer-group-id-hostname-not-timezone.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Kafka consumer group-id must derive from a stable node identifier (hostname), never from a timezone/locale string — a silent typo will split consumers into unintended groups.",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "kafka-consumer-semaphore-chunking",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/kafka-consumer-semaphore-chunking/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/kafka-consumer-semaphore-chunking/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Bound in-flight async work from a Kafka consumer with `Semaphore(poolSize + queueCapacity - 2)` plus fixed-size chunks; release in `whenComplete` on both success and failure.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "kafka-consumer-tenant-fan-out",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/kafka-consumer-tenant-fan-out/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/kafka-consumer-tenant-fan-out/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "@KafkaListener pattern consuming a topicPattern across tenants, using a record header for tenant identity and routing to per-tenant downstream streams",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "kafka-debounce-event-coalescing",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/kafka-debounce-event-coalescing/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/kafka-debounce-event-coalescing/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Coalesce bursts of change events into one Kafka event per tenant per debounce window using Redis state (first/last change time + changed-tenant SET), with a MAX_WAIT fallback so a never-quiet stream still fires.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "kafka-engine-distributed-job-framework",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/arch/kafka-engine-distributed-job-framework/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/arch/kafka-engine-distributed-job-framework/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Kafka 이벤트 기반 분산 작업 실행 프레임워크 스켈레톤 — Publisher→Topic→Consumer→Queue→Worker + Admission Control + Strategy SPI",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "kafka-error-handling-deserializer-fallback.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/kafka-error-handling-deserializer-fallback.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "kafka-organization-id-record-header.md",
+      "category": "api",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/api/kafka-organization-id-record-header.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Place organizationId (tenant) in the Kafka record header, not only in the payload — downstream consumers route by header before deserializing.",
+        "triggers": [],
+        "tags": [],
+        "category": "api"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "kafka-partition-topology-design.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/kafka-partition-topology-design.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Asymmetric Kafka partition counts per topic (high for hot-path, default for admin topics) match volume and concurrency needs without over-provisioning",
+        "triggers": [],
+        "tags": [
+          "kafka",
+          "partition",
+          "topology",
+          "throughput",
+          "concurrency"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "kafka-producer-async-callback",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/kafka-producer-async-callback/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/kafka-producer-async-callback/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Fire-and-log Kafka send pattern using CompletableFuture.whenComplete() for audit/event topics where the caller should not block",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "kafka-producer-config-avro-schema-registry",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/kafka-producer-config-avro-schema-registry/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/kafka-producer-config-avro-schema-registry/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Kafka producer config template for Avro + Confluent Schema Registry with LZ4 compression, 30MB max request size, and acks=1",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "kafka-sticky-partitioner-key-null.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/kafka-sticky-partitioner-key-null.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "ProducerRecord key=null일 때 Sticky Partitioner가 batch.size 동안 한 파티션에 몰리는 성질 — 소규모 환경에서 Pod 분산 안 보이는 원인",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "konva-center-coord-system.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/konva-center-coord-system.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Konva node coordinates can be center-based; when converting to top-left boxes subtract half width/height",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "large-range-query-raw-collections.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/large-range-query-raw-collections.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "For long time-range analytics over day-partitioned data, query the daily raw collections directly rather than going through an aggregated view to avoid query timeouts.",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "latest-availability-deletion-risk.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/latest-availability-deletion-risk.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "legacy-datasource-naming.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/legacy-datasource-naming.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "`dataSource` / `dataSourceFilter` in the codebase actually mean data-pipeline-select and data-pipeline-filter — not datasource",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "license-apply-window-15d.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/license-apply-window-15d.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "live-chart-timestamp-normalization.md",
+      "category": "api",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/api/live-chart-timestamp-normalization.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "api"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "live-mode-aggregation-exceptions.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/live-mode-aggregation-exceptions.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "lucida-framework-gate-annotations.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/lucida-framework-gate-annotations.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Internal framework (lucida-framework-*) uses opt-in annotations (@EnabledMessage, @EnableDataExport, @EnableSchedule, @EnableCommand) on the Application class to gate auto-config; omitting one silently disables the feature.",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "measurement-batch-send-per-config.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/measurement-batch-send-per-config.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Send one bundled Kafka message per target per tick containing all metrics, instead of one message per (target, metric).",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "measurement-grouping-combiner",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/measurement-grouping-combiner/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/measurement-grouping-combiner/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Group rows by `(resourceId, metricId, bucketTs)` into `Map<K, List<T>>`, then a per-granularity pure `combine…ByKey` merges each list into one composite record. One combiner per granularity (raw/1m/5m/hour/day).",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "mermaid-gitlab-mr-size-rules",
+      "category": "workflow",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/workflow/mermaid-gitlab-mr-size-rules/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/workflow/mermaid-gitlab-mr-size-rules/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Keep Mermaid diagrams in GitLab MRs readable — cap nodes, avoid nested subgraphs, quote IDs with special chars, connect all subgraphs",
+        "triggers": [],
+        "tags": [],
+        "category": "workflow"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "message-loader-gated-on-database-ready",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/message-loader-gated-on-database-ready/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/message-loader-gated-on-database-ready/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Gate i18n/seed loading on database readiness + per-tenant distributed lock so the first instance wins initialization in a multi-replica rollout.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "migrate-to-shoehorn",
+      "category": "refactor",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/refactor/migrate-to-shoehorn/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Migrate test files from `as` type assertions to @total-typescript/shoehorn. Use when user mentions shoehorn, wants to replace `as` in tests, or needs partial test data.",
+        "triggers": [],
+        "tags": [
+          "typescript",
+          "shoehorn",
+          "type-assertions",
+          "migration"
+        ],
+        "category": "refactor"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "module-federation-expose-react-component",
+      "category": "frontend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/frontend/module-federation-expose-react-component/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/frontend/module-federation-expose-react-component/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Expose a React component from one MF remote to be consumed by other remotes via a stable 6-step pipeline (implementation → expose wrapper → config → MF constant → RemoteApp wrapper → consumer import).",
+        "triggers": [
+          "expose a component across module federation remotes",
+          "share React component between MFA remotes",
+          "MFA expose pipeline",
+          "cross-remote import forbidden"
+        ],
+        "tags": [
+          "module-federation",
+          "micro-frontend",
+          "react",
+          "webpack",
+          "expose",
+          "monorepo"
+        ],
+        "category": "frontend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "mongo-aggregation-filter-optimization",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/mongo-aggregation-filter-optimization/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/mongo-aggregation-filter-optimization/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Replace `$unwind`+`$match` on array sub-documents with inline `$filter` so array elements are pruned before any downstream stage — avoids N× document explosion.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "mongo-criteria-maker-elemmatch-and-or",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/mongo-criteria-maker-elemmatch-and-or/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/mongo-criteria-maker-elemmatch-and-or/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Compose dynamic MongoDB Criteria with mixed AND/OR groups and elemMatch on tag-array fields using a stack-based builder",
+        "triggers": [
+          "building MongoDB queries with user-defined AND/OR filter rows",
+          "matching key/value pairs inside an array field (tags, labels, attributes)",
+          "replacing string-concatenated Mongo queries with type-safe Criteria"
+        ],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "mongo-direct-connection-flag.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/mongo-direct-connection-flag.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "MongoDB datasource connectionString requires directConnection=true in this deployment",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "mongo-repository-custom-impl-split",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/mongo-repository-custom-impl-split/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/mongo-repository-custom-impl-split/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Standard 3-file split for MongoRepository — the base interface, a *Custom interface for handwritten queries, and a *Impl class that uses MongoTemplate — so complex queries live beside the CRUD without breaking derived-query inference.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "mongo-timeseries-forced-hint-kills-pushdown.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/mongo-timeseries-forced-hint-kills-pushdown.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "mongodb",
+          "time-series",
+          "query-hint",
+          "query-optimization"
+        ],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "mongo-timeseries-match-split-for-pushdown.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/mongo-timeseries-match-split-for-pushdown.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "mongodb",
+          "time-series",
+          "query-optimization",
+          "aggregation"
+        ],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "mongo-timeseries-view-pushdown-broken-8_2_3.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/mongo-timeseries-view-pushdown-broken-8_2_3.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "mongodb",
+          "time-series",
+          "view",
+          "aggregation",
+          "version-specific"
+        ],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "mongo-timestamp-densification",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/mongo-timestamp-densification/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/mongo-timestamp-densification/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Fill sparse time-series gaps with `$dateTrunc` + `$densify` in Mongo, then a residual Java gap-fill loop for LIVE windows. Partition by series to keep multi-line charts aligned.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "mongo-ttl-with-aggregation-delta",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/mongo-ttl-with-aggregation-delta/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/mongo-ttl-with-aggregation-delta/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Store short-lived counter snapshots in MongoDB with a TTL index for auto-expiry and compute delta-from-previous at read time via an aggregation $subtract pipeline.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "mongodb-aggregated-stats-as-views.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/mongodb-aggregated-stats-as-views.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Precomputed hour/day statistics exposed as MongoDB read-only views instead of physical collections to simplify reads and keep them consistent with source",
+        "triggers": [],
+        "tags": [
+          "mongodb",
+          "views",
+          "aggregation",
+          "time-series"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "mongodb-changestream-field-filter",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/mongodb-changestream-field-filter/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/mongodb-changestream-field-filter/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Filter MongoDB change stream UPDATE events by inspecting updateDescription.updatedFields so irrelevant mutations do not trigger downstream work; INSERT/DELETE fall through as always-relevant.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "mongodb-changestream-resubscribe.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/mongodb-changestream-resubscribe.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "MongoDB change streams do not self-heal after network hiccups or replica-set elections; must be explicitly stopped and restarted to resume receiving events",
+        "triggers": [],
+        "tags": [
+          "mongodb",
+          "changestream",
+          "resilience",
+          "reconnect",
+          "resumetoken"
+        ],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "mongodb-compound-index-esr-rule",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/mongodb-compound-index-esr-rule/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Order MongoDB compound-index fields as Equality → Sort → Range so the query planner keeps a tight IXSCAN and avoids in-memory sorts.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "mongodb-compound-index-on-views.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/mongodb-compound-index-on-views.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Spring Data @CompoundIndex annotations on a view-backed @Document class are silently ignored — the annotation must live on the collection-backed class or the collection stays unindexed.",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "mongodb-datetrunc-binsize-zero-guard",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/mongodb-datetrunc-binsize-zero-guard/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/mongodb-datetrunc-binsize-zero-guard/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Guard MongoDB $dateTrunc binSize against 0 when your interval may be auto/unset; coerce to 1 to avoid runtime error",
+        "triggers": [],
+        "tags": [
+          "mongodb",
+          "aggregation",
+          "dateTrunc",
+          "pitfall"
+        ],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "mongodb-documentreference-lazy-removal.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/mongodb-documentreference-lazy-removal.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Spring Data MongoDB @DocumentReference (even with lazy=true) triggers N+1 queries on bulk reads; replace with explicit $lookup aggregation",
+        "triggers": [],
+        "tags": [
+          "mongodb",
+          "spring-data",
+          "documentreference",
+          "n-plus-one",
+          "aggregation",
+          "lookup"
+        ],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "mongodb-exclude-system-databases.md",
+      "category": "domain",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/domain/mongodb-exclude-system-databases.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "domain"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "mongodb-field-name-underscore-to-dot.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/mongodb-field-name-underscore-to-dot.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "mongodb-single-node-directconnection.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/mongodb-single-node-directconnection.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "MongoDB clients must pass directConnection=true when connecting to a single-node replSet, otherwise they hang on primary discovery",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "mongodb-string-id-field-type-mapping.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/mongodb-string-id-field-type-mapping.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Spring Data MongoDB coerces 24-char-hex @Id String values to ObjectId unless @Field(targetType = FieldType.STRING) is set",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "mongodb-volume-copy-backup",
+      "category": "devops",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/devops/mongodb-volume-copy-backup/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/devops/mongodb-volume-copy-backup/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Back up and restore MongoDB Docker volumes via rsync volume-copy instead of mongodump/tar.gz",
+        "triggers": [],
+        "tags": [],
+        "category": "devops"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "multi-dbms-resource-provider-pattern",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/multi-dbms-resource-provider-pattern/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Structure a polyglot RDBMS monitoring agent with one ResourceProvider + entity/dto/service per DBMS, sharing a common base",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "multi-domain-split-via-domain-mapping.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/multi-domain-split-via-domain-mapping.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Split multi-domain screens via a domain-mapping manifest — one OpenAPI file per owning domain",
+        "triggers": [],
+        "tags": [
+          "multi-domain",
+          "openapi",
+          "ownership",
+          "parallel-dev",
+          "cross-domain"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "multi-resource-or-batch-query",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/multi-resource-or-batch-query/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/multi-resource-or-batch-query/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Collapse N per-resource Mongo queries into one pipeline using `Criteria.orOperator` (or `$in`) over resourceId, projecting a synthetic `key` field for service-side de-multiplexing. Chunk at ~200 for index-friendly `$or`.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "multi-tenant-kafka-header-organization-context",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/multi-tenant-kafka-header-organization-context/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Propagate tenant/organization id from Kafka headers through async handler threads via a ThreadLocal context holder",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "multi-tenant-scheduler-iteration",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/multi-tenant-scheduler-iteration/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/multi-tenant-scheduler-iteration/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Pattern for scheduled jobs that must iterate every tenant DB in a database-per-tenant MongoDB setup: enumerate DBs, filter system ones, set TenantContext per tenant, isolate failures, clear in finally.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "multiprocess-architecture-via-ipc.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/multiprocess-architecture-via-ipc.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "ipc",
+          "capnp",
+          "architecture",
+          "process-isolation",
+          "codegen"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "mysql-mariadb-performance-schema-detection.md",
+      "category": "domain",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/domain/mysql-mariadb-performance-schema-detection.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "MySQL/MariaDB metric availability depends on per-instance Performance Schema state; detect at runtime, don't assume",
+        "triggers": [],
+        "tags": [],
+        "category": "domain"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "netty-tcp-reconnect-backoff",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/netty-tcp-reconnect-backoff/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/netty-tcp-reconnect-backoff/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "On Netty `channelInactive`/EOF/read-timeout, reconnect with exponential backoff (100ms → 30s cap), reset on success, keep SO_KEEPALIVE + TCP_NODELAY",
+        "triggers": [
+          "long-lived TCP client to a device or broker that drops silently",
+          "need to survive peer restarts without crashing the collector"
+        ],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "nfs-backed-volumes-for-docker-swarm.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/nfs-backed-volumes-for-docker-swarm.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Cross-node Docker Swarm persistence via a single NFS share mounted at the same host path on every swarm node",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "node-npm-pin-matches-jenkins.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/node-npm-pin-matches-jenkins.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "UI build is pinned to Node 24.6.0 + npm 11.5.1 to match the Jenkins build environment",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "non-metric-saveraw-null-rule",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/non-metric-saveraw-null-rule/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/non-metric-saveraw-null-rule/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Treat `saveRaw` as tri-state `Boolean` — `null` for non-METRIC types (Availability/Trait), `true`/`false` only for METRIC. Re-apply the rule on every policy mutation path.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "obsidian-vault",
+      "category": "docs",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/docs/obsidian-vault/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Search, create, and manage notes in the Obsidian vault with wikilinks and index notes. Use when user wants to find, create, or organize notes in Obsidian.",
+        "triggers": [],
+        "tags": [
+          "obsidian",
+          "notes",
+          "wikilinks",
+          "vault"
+        ],
+        "category": "docs"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-ai-slop-cleaner.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-ai-slop-cleaner.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "ai-slop-cleaner"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-ask.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-ask.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "ask"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-autopilot.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-autopilot.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "autopilot"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-cancel.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-cancel.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "cancel"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-ccg.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-ccg.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "ccg"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-configure-notifications.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-configure-notifications.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "configure-notifications"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-debug.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-debug.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "debug"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-deep-dive.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-deep-dive.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "deep-dive"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-deep-interview.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-deep-interview.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "deep-interview"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-deepinit.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-deepinit.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "deepinit"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-external-context.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-external-context.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "external-context"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-hud.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-hud.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "hud"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-learner.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-learner.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "learner"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-mcp-setup.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-mcp-setup.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "mcp-setup"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-omc-doctor.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-omc-doctor.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "omc-doctor"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-omc-reference.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-omc-reference.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "omc-reference"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-omc-setup.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-omc-setup.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "omc-setup"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-omc-teams.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-omc-teams.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "omc-teams"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-plan.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-plan.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "plan"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-project-session-manager.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-project-session-manager.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "project-session-manager"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-ralph.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-ralph.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "ralph"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-ralplan.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-ralplan.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "ralplan"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-release.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-release.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "release"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-remember.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-remember.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "remember"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-sciomc.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-sciomc.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "sciomc"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-self-improve.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-self-improve.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "self-improve"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-setup.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-setup.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "setup"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-skill.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-skill.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "skill"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-skillify.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-skillify.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "skillify"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-team.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-team.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "team"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-trace.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-trace.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "trace"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-ultraqa.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-ultraqa.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "ultraqa"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-ultrawork.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-ultrawork.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "ultrawork"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-verify.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-verify.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "verify"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-visual-verdict.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-visual-verdict.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "visual-verdict"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-wiki.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-wiki.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "wiki"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oh-my-claudecode-writer-memory.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/oh-my-claudecode-writer-memory.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "external-reference",
+          "oh-my-claudecode",
+          "omc",
+          "workflow",
+          "writer-memory"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "one-default-template-per-type-rule.md",
+      "category": "domain",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/domain/one-default-template-per-type-rule.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "domain"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "openapi-as-single-fe-be-contract.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/openapi-as-single-fe-be-contract.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Use OpenAPI 3.0 as the only intermediate artifact between planning and codegen; both FE and BE generators consume the same file",
+        "triggers": [],
+        "tags": [
+          "openapi",
+          "contract",
+          "codegen",
+          "fe-be-alignment",
+          "interop"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "optional-outbound-adapter-no-op-port",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/arch/optional-outbound-adapter-no-op-port/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Register a No-Op implementation of an optional outbound port with @ConditionalOnMissingBean so services boot when the real adapter (Kafka audit, tracing, notifications) is absent.",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "org-scoped-kafka-topic-bootstrap",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/org-scoped-kafka-topic-bootstrap/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/org-scoped-kafka-topic-bootstrap/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "On-startup and on-event creation of per-tenant Kafka topics, with retention overrides per topic class and a service-readiness gate",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "organization-soft-delete-grace-period.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/organization-soft-delete-grace-period.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "oz-license-file-placement-flip-flop.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/oz-license-file-placement-flip-flop.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Vendor engines (OZ Report, Crystal, Jasper-Pro) often hard-code license file search paths — pin the path in the image and document it, or you will ship it broken repeatedly",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "page-map-returns-new-instance.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/page-map-returns-new-instance.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Spring Data Page는 불변 — Page.map()은 새 인스턴스를 반환하므로 호출 결과를 반드시 재할당해야 한다",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "parallel-tasks-generic-extraction",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/parallel-tasks-generic-extraction/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/parallel-tasks-generic-extraction/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "invokeAll + Callable 반복 패턴을 제네릭 executeParallelTasks + TaskFactory로 추출",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "period-interval-naming-convention.md",
+      "category": "domain",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/domain/period-interval-naming-convention.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "domain"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "period-mode-enum-config",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/period-mode-enum-config/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/period-mode-enum-config/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "One enum `Mode` holds all (intervalMs, isFullData, dateFormat, retention, chartFormat) tuples for every time-series granularity — single source of truth across repository/service/chart layers.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "pims-write-requires-dryrun-confirm.md",
+      "category": "domain",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/domain/pims-write-requires-dryrun-confirm.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "domain"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "planning-doc-in-issue-description.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/planning-doc-in-issue-description.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "For AI pipelines that read planning docs from issue trackers, favor putting the full markdown in the issue description over wiki-link indirection",
+        "triggers": [],
+        "tags": [
+          "issue-tracker",
+          "planning-doc",
+          "redmine",
+          "ai-ingestion",
+          "single-source"
+        ],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "pluggable-sender-factory-pattern",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/arch/pluggable-sender-factory-pattern/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/arch/pluggable-sender-factory-pattern/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Register multiple notification/transport backends (SMS, EMAIL, SMTP, JDBC, REST, SLACK, SOCKET) behind a single FactoryBean that dispatches by enum type",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "plugin-architecture-runtime-vs-startup-loading.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/plugin-architecture-runtime-vs-startup-loading.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "plugin",
+          "extensibility",
+          "scouter"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "plugin-repo-scope-generic-skills-only.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/plugin-repo-scope-generic-skills-only.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "plugin-resource-provider-architecture",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/arch/plugin-resource-provider-architecture/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/arch/plugin-resource-provider-architecture/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Stable `ResourceProvider` SPI loaded via Spring component scan; each new device/resource type is a separate Gradle-module JAR packaged into the WAR — zero core edits",
+        "triggers": [
+          "extensible monitoring/management platform",
+          "vendor support must be pluggable per deployment"
+        ],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "policy-edit-saveraw-loss.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/policy-edit-saveraw-loss.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "policy-target-evaluation-with-groups-tags",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/policy-target-evaluation-with-groups-tags/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/policy-target-evaluation-with-groups-tags/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Evaluate whether a resource matches a policy via direct IDs + static/dynamic groups + tag filters, with explicit exclusion rules that take precedence over includes.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "polymorphic-metadata-via-enum-switch.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/polymorphic-metadata-via-enum-switch.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Store heterogeneous domain payloads under one field as raw Document, then deserialize with Gson chosen by an enum discriminator",
+        "triggers": [],
+        "tags": [
+          "polymorphism",
+          "bson",
+          "gson",
+          "mongodb",
+          "discriminator",
+          "content-type"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "port-out-no-optional-raise-in-adapter.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/port-out-no-optional-raise-in-adapter.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "In hexagonal codegen, single-record lookups should raise a domain exception inside the Adapter rather than return `Optional<T>` from the Port-Out interface",
+        "triggers": [],
+        "tags": [
+          "hexagonal",
+          "port-out",
+          "optional",
+          "exception-handling",
+          "error-code"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "postgres-version-rolling-support.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/postgres-version-rolling-support.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "prd-to-issues",
+      "category": "workflow",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/workflow/prd-to-issues/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. Use when user wants to convert a PRD to issues, create implementation tickets, or break down a PRD into work items.",
+        "triggers": [],
+        "tags": [
+          "prd",
+          "github",
+          "issues",
+          "tracer-bullet",
+          "planning"
+        ],
+        "category": "workflow"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "prd-to-plan",
+      "category": "workflow",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/workflow/prd-to-plan/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in ./plans/. Use when user wants to break down a PRD, create an implementation plan, plan phases from a PRD, or mentions \"tracer bullets\".",
+        "triggers": [],
+        "tags": [
+          "prd",
+          "planning",
+          "phased",
+          "tracer-bullet"
+        ],
+        "category": "workflow"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "prefer-static-import-over-constant-inheritance.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/prefer-static-import-over-constant-inheritance.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "java",
+          "refactor",
+          "anti-pattern",
+          "constants"
+        ],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "published-vs-realtime-view-pages.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/published-vs-realtime-view-pages.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "PublishedViewPage renders a frozen deploy snapshot; RealTimeViewPage renders the live editable dashboard",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "push-local-removed-use-doc-update.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/push-local-removed-use-doc-update.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "pushLocalChangesIntoRemote and its action-mapping helpers were removed; mutate Yorkie via doc.update directly",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "qa",
+      "category": "testing",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/testing/qa/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Interactive QA session where user reports bugs or issues conversationally, and the agent files GitHub issues. Explores the codebase in the background for context and domain language. Use when user wants to report bugs, do QA, file issues conversationally, or mentions \"QA session\".",
+        "triggers": [],
+        "tags": [
+          "qa",
+          "interactive",
+          "bug-reports"
+        ],
+        "category": "testing"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "query-manager-version-conversion-fallback.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/query-manager-version-conversion-fallback.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Unknown target RDBMS versions fall back to a documented default bucket rather than erroring, keeping collection alive",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "querydsl-q-class-exclusion-pattern",
+      "category": "devops",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/devops/querydsl-q-class-exclusion-pattern/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/devops/querydsl-q-class-exclusion-pattern/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "One `exclusionPatterns` list drives Jacoco report + verification + Sonar exclusions; catches generated Querydsl Q-classes via `('A'..'Z').collect { \"**/**/Q${it}*\" }`.",
+        "triggers": [],
+        "tags": [],
+        "category": "devops"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "rcp-desktop-client-design-rationale-vs-saas-web.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/rcp-desktop-client-design-rationale-vs-saas-web.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "rcp",
+          "desktop",
+          "decision",
+          "apm",
+          "scouter"
+        ],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "reactive-webclient-ssl-jdk",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/reactive-webclient-ssl-jdk/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Force reactor-netty WebClient to SslProvider.JDK so SSL works in slim containers that lack netty-tcnative native libraries.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "reactor-subscription-router-backpressure",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/reactor-subscription-router-backpressure/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/reactor-subscription-router-backpressure/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Per-session, per-destination Reactor Flux router with bounded buffer + DROP_LATEST backpressure and automatic cleanup on session disconnect",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "example",
+      "slug": "README.md",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "example/README.md"
+        }
+      ]
+    },
+    {
+      "kind": "skill",
+      "slug": "realtime-vs-polling-fallback",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/realtime-vs-polling-fallback/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/realtime-vs-polling-fallback/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Let each resource type declare `supportsRealtime`; scheduler runs push-mode at the realtime interval and falls back to a safe polling interval (e.g., 60s) otherwise",
+        "triggers": [
+          "mixed collection pipeline (some resources push, some pull)",
+          "avoid hammering APIs that do not support realtime"
+        ],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "redis-change-counter-for-versioning-trigger.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/redis-change-counter-for-versioning-trigger.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "redis-lock-recheck-flag-pattern",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/redis-lock-recheck-flag-pattern/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/redis-lock-recheck-flag-pattern/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Distributed Redis lock with a \"recheck\" flag so concurrent events arriving while the lock is held force the holder to run a second pass, instead of being silently dropped.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "refresh-token-do-not-regenerate.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/refresh-token-do-not-regenerate.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "request-refactor-plan",
+      "category": "refactor",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/refactor/request-refactor-plan/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.",
+        "triggers": [],
+        "tags": [
+          "planning",
+          "commits",
+          "interview"
+        ],
+        "category": "refactor"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "resource-mount-unmount-use-jar-defaults.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/resource-mount-unmount-use-jar-defaults.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Don't bind-mount i18n/exception/menu resource files into Spring Boot containers; let the jar ship its own defaults",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "resource-summary-resolve-override-template",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/arch/resource-summary-resolve-override-template/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "리소스 상세 화면의 \"요약\" 탭에서 `OVERRIDE → TEMPLATE → NONE` 순으로 대시보드를 결정하는 서버-클라이언트 패턴. 오버라이드 엔티티, resolve API, 상태별 UI 드롭다운 규칙까지 포함.",
+        "triggers": [
+          "resource summary",
+          "리소스 요약",
+          "resolve override template",
+          "dashboard override",
+          "resourceSummary",
+          "composition override"
+        ],
+        "tags": [
+          "resource-detail",
+          "dashboard",
+          "override",
+          "template",
+          "resolve",
+          "widget",
+          "summary"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "root-span-error-propagation.md",
+      "category": "domain",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/domain/root-span-error-propagation.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "A trace's root-span isError flag must aggregate descendant span errors; otherwise scatter and list views disagree about which traces errored.",
+        "triggers": [],
+        "tags": [],
+        "category": "domain"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "save-child-only-when-changed.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/save-child-only-when-changed.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "scaffold-exercises",
+      "category": "misc",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/misc/scaffold-exercises/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Create exercise directory structures with sections, problems, solutions, and explainers that pass linting. Use when user wants to scaffold exercises, create exercise stubs, or set up a new course section.",
+        "triggers": [],
+        "tags": [
+          "scaffolding",
+          "exercises",
+          "template"
+        ],
+        "category": "misc"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "scatter-topic-1min-retention.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/scatter-topic-1min-retention.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Per-tenant scatter-plot/summary topics use 60s retention; metric-history topics use the cluster default. Class-of-data drives retention, not tenant.",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "scouter-three-tier-architecture.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/scouter-three-tier-architecture.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "apm",
+          "architecture",
+          "tiered",
+          "scouter"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "second-aggregation-snapshot-merge",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/second-aggregation-snapshot-merge/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Per-second metric aggregation using in-memory counters + Flux.interval snapshot-and-reset + bounded parallel publish, to decouple request latency from downstream health.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "serial-pipeline-failure-compounding.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/serial-pipeline-failure-compounding.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "N-stage serial AI pipeline success = product of per-stage success rates; prefer developer-invoked skills at each boundary",
+        "triggers": [],
+        "tags": [
+          "pipeline",
+          "reliability",
+          "ai-automation",
+          "skill-boundary",
+          "review-gate"
+        ],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "server-plugin-scripting-and-builtin-extensibility",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/server-plugin-scripting-and-builtin-extensibility/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Dual plugin system for a monitoring server — hot-reload script plugins (alert rules, filters) plus compiled JAR plugins for stateful, performance-critical data handlers",
+        "triggers": [],
+        "tags": [
+          "plugin",
+          "extensibility",
+          "scripting",
+          "hot-reload",
+          "monitoring"
+        ],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "service-discovery-replica-leader-tracking",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/service-discovery-replica-leader-tracking/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/service-discovery-replica-leader-tracking/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Track Eureka replica UP/DOWN events and emit ServiceLeaderElected / ServiceReplicaAllDown Spring events for cluster-aware init",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "service-readiness-event-listener-pattern",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/service-readiness-event-listener-pattern/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/service-readiness-event-listener-pattern/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Two-phase startup where each instance initializes locally, but only the leader runs global one-time work (seed data, default report creation)",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "service-status-provider-actuator",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/service-status-provider-actuator/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/service-status-provider-actuator/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Spring Boot 3.5 ServiceStatusProvider that reports RUNNING vs READY based on MongoDB ping + Kafka listener container liveness",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "servicejar-embeddable-library-task",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/servicejar-embeddable-library-task/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/servicejar-embeddable-library-task/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Gradle task that builds a library JAR alongside bootJar for embedding inside a host Spring Boot app — excludes Application class, web/OpenAPI configs, and bundled resources",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "session-lock-tree-blocking-chain-modeling",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/session-lock-tree-blocking-chain-modeling/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Model RDBMS blocking sessions as a directed graph and persist the resolved lock tree alongside the session snapshot",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "setup-pre-commit",
+      "category": "cli",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/cli/setup-pre-commit/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Set up Husky pre-commit hooks with lint-staged (Prettier), type checking, and tests in the current repo. Use when user wants to add pre-commit hooks, set up Husky, configure lint-staged, or add commit-time formatting/typechecking/testing.",
+        "triggers": [],
+        "tags": [
+          "husky",
+          "lint-staged",
+          "pre-commit",
+          "prettier",
+          "typescript"
+        ],
+        "category": "cli"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "shallow-clone-mktemp-cleanup-pattern.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/shallow-clone-mktemp-cleanup-pattern.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "shared-apis-endpoint-service-pattern",
+      "category": "frontend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/frontend/shared-apis-endpoint-service-pattern/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Module Federation 모노레포에서 REST 엔드포인트를 추가할 때 `endpoint 상수 → services 메서드 → commonApiService 호출` 3계층 레이어링으로 도메인 일관성을 유지하는 패턴.",
+        "triggers": [
+          "엔드포인트 추가",
+          "widgetEndPoint",
+          "shared/apis",
+          "commonApiService",
+          "API 레이어 추가",
+          "endpoint constant"
+        ],
+        "tags": [
+          "api",
+          "services",
+          "endpoint",
+          "module-federation",
+          "monorepo",
+          "layering"
+        ],
+        "category": "frontend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "sibling-scoped-name-uniqueness.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/sibling-scoped-name-uniqueness.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "simpledateformat-not-thread-safe.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/simpledateformat-not-thread-safe.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "SimpleDateFormat은 스레드 안전하지 않아 공유 인스턴스 사용 시 포맷 깨짐/예외 발생 — java.time.DateTimeFormatter로 교체",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "site-per-customer-override-modules",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/arch/site-per-customer-override-modules/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/arch/site-per-customer-override-modules/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "One Gradle module per customer (`<product>-site-<customer>`) overrides core beans, auth, notification channels, and assets — keeps core customer-agnostic and scales to dozens of deployments",
+        "triggers": [
+          "B2B product delivered to many customers with bespoke requirements",
+          "feature-flag soup is polluting core"
+        ],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "example",
+      "slug": "skill-doctor",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "example/skill-doctor/.gitignore"
+        },
+        {
+          "s": "A",
+          "p": "example/skill-doctor/README.md"
+        },
+        {
+          "s": "A",
+          "p": "example/skill-doctor/doctor.mjs"
+        },
+        {
+          "s": "A",
+          "p": "example/skill-doctor/index.html"
+        },
+        {
+          "s": "A",
+          "p": "example/skill-doctor/manifest.json"
+        },
+        {
+          "s": "A",
+          "p": "example/skill-doctor/serve.mjs"
+        }
+      ]
+    },
+    {
+      "kind": "example",
+      "slug": "skill-graph",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "example/skill-graph/.gitignore"
+        },
+        {
+          "s": "A",
+          "p": "example/skill-graph/README.md"
+        },
+        {
+          "s": "A",
+          "p": "example/skill-graph/build-graph.mjs"
+        },
+        {
+          "s": "A",
+          "p": "example/skill-graph/index.html"
+        },
+        {
+          "s": "A",
+          "p": "example/skill-graph/manifest.json"
+        },
+        {
+          "s": "A",
+          "p": "example/skill-graph/serve.mjs"
+        }
+      ]
+    },
+    {
+      "kind": "skill",
+      "slug": "skill-md-validator",
+      "category": "devops",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/devops/skill-md-validator/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "[Tooling] SKILL.md frontmatter + 필수 섹션을 CRITICAL/WARNING 등급으로 검증하는 품질 게이트.",
+        "triggers": [],
+        "tags": [],
+        "category": "devops"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "skill-registry-vs-skill-config-split.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/skill-registry-vs-skill-config-split.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "example",
+      "slug": "skill-stats",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "example/skill-stats/.gitignore"
+        },
+        {
+          "s": "A",
+          "p": "example/skill-stats/README.md"
+        },
+        {
+          "s": "A",
+          "p": "example/skill-stats/build-stats.mjs"
+        },
+        {
+          "s": "A",
+          "p": "example/skill-stats/index.html"
+        },
+        {
+          "s": "A",
+          "p": "example/skill-stats/manifest.json"
+        },
+        {
+          "s": "A",
+          "p": "example/skill-stats/serve.mjs"
+        }
+      ]
+    },
+    {
+      "kind": "example",
+      "slug": "skills-explorer",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "example/skills-explorer/.gitignore"
+        },
+        {
+          "s": "A",
+          "p": "example/skills-explorer/README.md"
+        },
+        {
+          "s": "A",
+          "p": "example/skills-explorer/browser/build-index.mjs"
+        },
+        {
+          "s": "A",
+          "p": "example/skills-explorer/browser/index.html"
+        },
+        {
+          "s": "A",
+          "p": "example/skills-explorer/browser/serve.mjs"
+        },
+        {
+          "s": "A",
+          "p": "example/skills-explorer/manifest.json"
+        }
+      ]
+    },
+    {
+      "kind": "knowledge",
+      "slug": "skip-schedule-if-previous-running.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/skip-schedule-if-previous-running.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "When a periodic tick arrives and the previous execution for the same job is still running, skip the new tick — never queue it.",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "slack-webhook-notify",
+      "category": "devops",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/devops/slack-webhook-notify/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Slack Incoming Webhook으로 메시지를 전송한다. 빌드/테스트/배포 결과, 작업 완료 알림 등을 Slack 채널에 보낼 때 사용.",
+        "triggers": [
+          "slack",
+          "슬랙",
+          "slack notify",
+          "webhook 알림",
+          "빌드 알림",
+          "작업 완료 알림"
+        ],
+        "tags": [],
+        "category": "devops"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "snmp-ifindex-not-stable.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/snmp-ifindex-not-stable.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "sonar-token-hardcoded-build-gradle.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/sonar-token-hardcoded-build-gradle.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Hardcoded SonarQube login token in build.gradle plus `allowInsecureProtocol = true` on an internal Nexus are two common DevSecOps anti-patterns to fix together",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "span-hash-determinism.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/span-hash-determinism.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Span-dedup hash must be deterministic and stable; changing the hash definition produces duplicate rows during rollout and poisons historical joins.",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "span-lifetime-safety-documentation.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/span-lifetime-safety-documentation.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "cpp20",
+          "span",
+          "lifetime",
+          "ub",
+          "undefined-behavior"
+        ],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "spec-excluded-from-jest.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/spec-excluded-from-jest.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": ".spec.ts files are excluded from the Jest runner in this project — only .test.ts is discovered",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "spring-actuator-health-collector",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/spring-actuator-health-collector/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/spring-actuator-health-collector/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Poll remote Spring Boot services via Actuator (/health + /metrics/{name}) using OkHttp with per-target timeouts and a configurable metric whitelist, publishing results to a downstream bus.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "spring-bootrun-local-dev-env-block",
+      "category": "devops",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/devops/spring-bootrun-local-dev-env-block/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/devops/spring-bootrun-local-dev-env-block/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Gradle `bootRun` env block that wires local Redis/Mongo/Kafka/Eureka/MQTT for zero-config `./gradlew bootRun` developer experience",
+        "triggers": [
+          "new engineer asks \"how do I run this locally?",
+          "application-local.yaml is gitignored and no-one knows the defaults",
+          "Spring Cloud service refuses to start locally because Eureka client is enabled"
+        ],
+        "tags": [],
+        "category": "devops"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "spring-mongo-lightweight-migration",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/spring-mongo-lightweight-migration/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/spring-mongo-lightweight-migration/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Annotation-driven MongoDB migration runner for Spring Boot — `@MongoMigration` methods on `MigrationScript` beans execute in order at startup, with history in `{prefix}_migrations` collection. No Mongock dependency.",
+        "triggers": [
+          "mongo migration spring boot",
+          "mongock 없이 마이그레이션",
+          "annotation-based mongo migration"
+        ],
+        "tags": [
+          "spring-boot",
+          "mongodb",
+          "migration",
+          "annotation-driven",
+          "idempotent"
+        ],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "spring-profile-datasource-activation",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/spring-profile-datasource-activation/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/spring-profile-datasource-activation/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Select DB/Hibernate/logging config at JVM startup via `spring.profiles.active` so one build ships to dev, test, and prod without branching in code",
+        "triggers": [
+          "same WAR goes to multiple environments",
+          "Spring profile chooses datasource and credentials"
+        ],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "spring-testcontainers-multitenant-base",
+      "category": "testing",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/testing/spring-testcontainers-multitenant-base/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/testing/spring-testcontainers-multitenant-base/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Base test class that boots Testcontainers (Mongo + Kafka), pre-sets tenant/auth context, and forces JVM halt in AfterAll to avoid leaked containers.",
+        "triggers": [],
+        "tags": [],
+        "category": "testing"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "springdoc-yaml-externalization",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/springdoc-yaml-externalization/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Move long `@Operation description` and `@RequestBody examples` text out of Spring controllers into per-controller YAML files under `resources/api-docs/`, injected at runtime via a single `OperationCustomizer` bean. Swagger UI output unchanged.",
+        "triggers": [
+          "swagger externalize annotations",
+          "move swagger description to yaml",
+          "OperationCustomizer"
+        ],
+        "tags": [
+          "spring-boot",
+          "springdoc",
+          "openapi",
+          "swagger",
+          "yaml",
+          "refactor"
+        ],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "sql-hash-unsigned-integer.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/sql-hash-unsigned-integer.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "MySQL/MariaDB SQL digest hashes fit in an unsigned 32-bit range but arrive as signed Java int — negatives are legal and must not be dropped",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "sql-text-null-check-session-history-consistency.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/sql-text-null-check-session-history-consistency.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Session history rows must omit sqlHash and queryTime when SQL text is missing, else they orphan in downstream joins",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "sqlserver-sqltextinfo-index-constraint.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/sqlserver-sqltextinfo-index-constraint.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Do not put a unique index on sqlHash for SQL Server text-info collection — duplicates are legitimate",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "stack-tag-filter-to-mongo-criteria",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/stack-tag-filter-to-mongo-criteria/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/stack-tag-filter-to-mongo-criteria/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Parse a tokenized boolean filter expression (key=value, AND, OR, parens) into a MongoDB Criteria tree using a shunting-yard/stack algorithm, with elemMatch for array-of-tag subdocs.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "static-value-injection-race-condition.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/static-value-injection-race-condition.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "static 필드에 @Value 주입은 setter 호출 타이밍과 멀티스레드 가시성으로 레이스 컨디션을 유발 — 인스턴스 필드로 직접 주입하라",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "stomp-cookie-auth-handshake",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/stomp-cookie-auth-handshake/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/stomp-cookie-auth-handshake/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Authenticate STOMP WebSocket upgrade using an HttpOnly cookie extracted during the handshake, then bind identity to the STOMP session",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "stomp-heartbeat-10s-bidirectional.md",
+      "category": "api",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/api/stomp-heartbeat-10s-bidirectional.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "STOMP broker heartbeat set to 10s/10s (client↔server) is a reasonable default for detecting dead WebSocket sessions within ~20s",
+        "triggers": [],
+        "tags": [],
+        "category": "api"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "stomp-principal-jwt-channel",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/stomp-principal-jwt-channel/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/stomp-principal-jwt-channel/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "STOMP ChannelInterceptor that validates a JWT on CONNECT and binds a multi-tenant Principal (orgId + userId + sessionId) for downstream routing",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "strategy-spi-list-to-map-autoinject",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/strategy-spi-list-to-map-autoinject/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/strategy-spi-list-to-map-autoinject/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Spring이 자동 주입하는 List<T>를 생성자에서 Map<Key,T>로 변환해 Strategy를 enum 키로 O(1) 디스패치하는 패턴",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "stub-in-service-unblocks-fe-parallelism.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/stub-in-service-unblocks-fe-parallelism.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Emit stub return values inside generated Service methods (tagged `// STUB:`) so FE can connect to a live BE without waiting on business logic",
+        "triggers": [],
+        "tags": [
+          "codegen",
+          "stub",
+          "fe-be-parallelism",
+          "hexagonal",
+          "service-layer"
+        ],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "swagger-spec-baseline-from-git",
+      "category": "workflow",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/workflow/swagger-spec-baseline-from-git/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Re-run spec-based optimization workflow on a clean branch without running the Spring Boot app — restore prior baseline artifacts (swagger-before.json + scripts) via `git show <sha>:<path>` from the commit on another branch that already captured them.",
+        "triggers": [
+          "swagger 전체 재실행",
+          "rerun swagger optimization",
+          "baseline 없이 시작"
+        ],
+        "tags": [
+          "swagger",
+          "openapi",
+          "git",
+          "baseline",
+          "spring-boot"
+        ],
+        "category": "workflow"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "system-data-initializer-runner",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/system-data-initializer-runner/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/system-data-initializer-runner/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Use ApplicationRunner to seed required system/root records on startup, guarded by an exists-check and marked with a systemFlag so they can't be deleted or moved by users.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "system-notification-shared-with-2fa-and-password-find.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/system-notification-shared-with-2fa-and-password-find.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "tabular-metric-excluded-from-list.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/tabular-metric-excluded-from-list.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "tag-values-separate-collection.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/tag-values-separate-collection.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "tdd",
+      "category": "testing",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/testing/tdd/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/testing/tdd/deep-modules.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/testing/tdd/interface-design.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/testing/tdd/mocking.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/testing/tdd/refactoring.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/testing/tdd/tests.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions \"red-green-refactor\", wants integration tests, or asks for test-first development.",
+        "triggers": [],
+        "tags": [
+          "tdd",
+          "red-green-refactor"
+        ],
+        "category": "testing"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "tenant-context-clear-after-completion.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/tenant-context-clear-after-completion.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "tenant-context-per-request-interceptor.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/tenant-context-per-request-interceptor.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Extract tenant id from JWT/header in preHandle, store in ThreadLocal, clear in afterCompletion to isolate multi-tenant data access",
+        "triggers": [],
+        "tags": [
+          "multi-tenancy",
+          "thread-local",
+          "spring-mvc",
+          "interceptor",
+          "mongodb"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "tenant-context-try-finally-on-worker",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/tenant-context-try-finally-on-worker/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/tenant-context-try-finally-on-worker/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Kafka/Queue Worker에서 멀티테넌트 ThreadLocal 컨텍스트를 try-finally로 안전하게 세팅/정리하는 패턴",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "tenant-db-initialization-on-startup",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/tenant-db-initialization-on-startup/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/tenant-db-initialization-on-startup/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "On leader startup, fetch tenant/org list from metadata service and provision per-tenant MongoDB databases — idempotent, leader-only",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "tenant-flag-over-name-detection.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/tenant-flag-over-name-detection.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "tenant-isolated-mongo-collection",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/tenant-isolated-mongo-collection/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/tenant-isolated-mongo-collection/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Route each tenant to its own MongoDB collection (or collection-name suffix) via a custom annotation resolved at repository/template layer, so application code stays tenant-agnostic.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "tenant-per-database-mongo-routing",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/tenant-per-database-mongo-routing/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/tenant-per-database-mongo-routing/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Route Spring Data Mongo operations to per-tenant databases via a ThreadLocal tenant holder and two MongoTemplate beans (isolated vs shared collections).",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "testcontainers-mongo-kafka-abstract-base",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/testcontainers-mongo-kafka-abstract-base/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/testcontainers-mongo-kafka-abstract-base/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Abstract test base classes that spin up MongoDB + Kafka via Testcontainers with static start() and reuse=true, exposing mapped ports via System.setProperty",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "testcontainers-reuse-disabled",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/testcontainers-reuse-disabled/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/testcontainers-reuse-disabled/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Set TESTCONTAINERS_REUSE_ENABLE=false on the Gradle test task so CI and shared dev machines never inherit stale container state across suites",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "testcontainers-springboot-cache-conflict.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/testcontainers-springboot-cache-conflict.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "@Testcontainers + @SpringBootTest 컨텍스트 캐싱 충돌 — @DynamicPropertySource + static start() 패턴으로 대체",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "thread-pool-config-tenant-aware",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/thread-pool-config-tenant-aware/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/thread-pool-config-tenant-aware/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Property-driven ThreadPoolTaskExecutor + Scheduler config that extends TenantAsyncConfigurerSupport so @Async tasks inherit tenant context",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "thread-pool-queue-backpressure",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/thread-pool-queue-backpressure/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/thread-pool-queue-backpressure/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Bounded in-memory queue between Kafka consumer and async thread pool, with hysteretic pause/resume thresholds driving Spring Kafka container pause()/resume() so bursts do not OOM the JVM.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "time-unit-consistency-us-ms-ns.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/time-unit-consistency-us-ms-ns.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Mixed time units (ns/μs/ms) across OTLP ingestion, storage, filters, and UI are a recurring high-severity bug class — pick one canonical internal unit and convert only at edges.",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "timeselector-mode-interval-range-mapping.md",
+      "category": "api",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/api/timeselector-mode-interval-range-mapping.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "api"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "tomcat-request-timeout-1h-for-oz-report.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/tomcat-request-timeout-1h-for-oz-report.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Report-generation services should raise Tomcat connection/read timeout to ~1 hour because export of large OZ/Jasper reports is genuinely long-running",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "top-bottom-widest-collection-range.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/top-bottom-widest-collection-range.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "topn-unwind-match-to-filter.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/topn-unwind-match-to-filter.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "topresource-immediate-generation-invariant.md",
+      "category": "domain",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/domain/topresource-immediate-generation-invariant.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "In report immediate-generation, the topResource flag decides whether to query by resource-id (fast path) or the full conf-id set (slow path)",
+        "triggers": [],
+        "tags": [],
+        "category": "domain"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "trace-context-async-execution-propagation.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/trace-context-async-execution-propagation.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "async",
+          "tracing",
+          "pitfall",
+          "jvm",
+          "scouter"
+        ],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "traefik-2.11-requires-explicit-idletimeout.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/traefik-2.11-requires-explicit-idletimeout.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Traefik 2.11 silently drops idle backend connections without an explicit idleTimeout on the entrypoint/serversTransport",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "transaction-trace-pack-serialization-with-step-hierarchy",
+      "category": "apm",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/apm/transaction-trace-pack-serialization-with-step-hierarchy/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Encode per-request distributed traces as a hierarchical list of typed steps (method, DB, external call, error) in a compressed binary pack, indexed by request end-time",
+        "triggers": [],
+        "tags": [
+          "tracing",
+          "apm",
+          "xlog",
+          "serialization",
+          "perf"
+        ],
+        "category": "apm"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "triage-issue",
+      "category": "debug",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/debug/triage-issue/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. Use when user reports a bug, wants to file an issue, mentions \"triage\", or wants to investigate and plan a fix for a problem.",
+        "triggers": [],
+        "tags": [
+          "bug",
+          "triage",
+          "root-cause",
+          "investigation"
+        ],
+        "category": "debug"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "triple-env-file-split-loader",
+      "category": "devops",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/devops/triple-env-file-split-loader/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/devops/triple-env-file-split-loader/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Split operator-facing env into three files (.env / .version / .memory) and load them in a fixed order",
+        "triggers": [],
+        "tags": [],
+        "category": "devops"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "ts-type-prefix-convention",
+      "category": "frontend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/frontend/ts-type-prefix-convention/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/frontend/ts-type-prefix-convention/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Prefix interfaces with I and type aliases with T; use type for unions/literals and interface for inheritable shapes",
+        "triggers": [],
+        "tags": [],
+        "category": "frontend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "tsv-driven-permission-bootstrap",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/tsv-driven-permission-bootstrap/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/tsv-driven-permission-bootstrap/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Treat a version-controlled TSV file as source of truth for the Function/Permission/Menu catalog; the service reconciles the DB against it on startup",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "ubiquitous-language",
+      "category": "docs",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/docs/ubiquitous-language/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Extract a DDD-style ubiquitous language glossary from the current conversation, flagging ambiguities and proposing canonical terms. Saves to UBIQUITOUS_LANGUAGE.md. Use when user wants to define domain terms, build a glossary, harden terminology, create a ubiquitous language, or mentions \"domain model\" or \"DDD\".",
+        "triggers": [],
+        "tags": [
+          "ddd",
+          "glossary",
+          "language",
+          "domain"
+        ],
+        "category": "docs"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "udp-for-throughput-tcp-for-reliability.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/udp-for-throughput-tcp-for-reliability.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "network",
+          "udp",
+          "tcp",
+          "decision",
+          "apm"
+        ],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "udp-receiver-needs-large-socket-buffer.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/udp-receiver-needs-large-socket-buffer.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "UDP collectors behind Traefik/containers must raise SO_RCVBUF well above the 8KB default or drop packets under burst load",
+        "triggers": [],
+        "tags": [],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "udp-with-tcp-fallback-metrics-transport",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/udp-with-tcp-fallback-metrics-transport/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Transport telemetry via UDP for low-latency fire-and-forget streams, and fall back to TCP for critical request/response and bulk uploads that require delivery guarantees",
+        "triggers": [],
+        "tags": [
+          "network",
+          "udp",
+          "tcp",
+          "apm",
+          "telemetry"
+        ],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "unit-enum-silent-filter.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/unit-enum-silent-filter.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "When metric rows are filtered out because their `unit` is not defined in a Java enum, the symptom is \"items missing from the list UI\" — no error, no log — and the root cause is upstream data adding units faster than the enum is updated",
+        "triggers": [],
+        "tags": [
+          "enum",
+          "silent-drop",
+          "defensive-coding",
+          "observability"
+        ],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "user-sql-source-requires-select-only-and-readonly.md",
+      "category": "pitfall",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/pitfall/user-sql-source-requires-select-only-and-readonly.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "security",
+          "jdbc",
+          "user-input",
+          "data-source"
+        ],
+        "category": "pitfall"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "variable-length-integer-encoding-for-metrics-bandwidth.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/variable-length-integer-encoding-for-metrics-bandwidth.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "varint",
+          "encoding",
+          "perf",
+          "decision",
+          "scouter"
+        ],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "version-specific-sql-map-selection",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/version-specific-sql-map-selection/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Select MyBatis-style SQL maps at runtime by DBMS + version with graceful fallback to a default supported version",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "vllm-kv-cache-fp8-with-mtp.md",
+      "category": "decision",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/decision/vllm-kv-cache-fp8-with-mtp.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "vLLM serving chose fp8_e4m3 KV cache + prefix caching + MTP speculative decoding for Qwen3.5 throughput",
+        "triggers": [],
+        "tags": [],
+        "category": "decision"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "vllm-nginx-tls-single-port-routing",
+      "category": "ai",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/ai/vllm-nginx-tls-single-port-routing/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/ai/vllm-nginx-tls-single-port-routing/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Serve multiple vLLM OpenAI-API backends behind one Nginx TLS proxy on 443 using path-based routing",
+        "triggers": [],
+        "tags": [],
+        "category": "ai"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "wait-for-services-eureka-startup-init.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/wait-for-services-eureka-startup-init.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Defer schema/index/data bootstrap until named services report ready in discovery, with bounded exponential backoff and leader election",
+        "triggers": [],
+        "tags": [
+          "startup",
+          "service-discovery",
+          "eureka",
+          "zookeeper",
+          "leader-election",
+          "event-driven"
+        ],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "websocket-stomp-channel-pool-config",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/websocket-stomp-channel-pool-config/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/websocket-stomp-channel-pool-config/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Spring WebSocket STOMP config with separate inbound/outbound task executors and raised transport buffer limits, sized for burst notification fan-out to many role-filtered subscribers.",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "widget-confid-injection-sweep",
+      "category": "frontend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/frontend/widget-confid-injection-sweep/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "리소스 상세 대시보드에서 모든 위젯 데이터 요청에 `confId` 를 일관되게 주입하기 위한 위젯 fetch 지점 전수 스윕(sweep) 패턴 — 일부만 주입하면 같은 대시보드 안에서 위젯별 필터 동작이 갈라지는 버그를 방지한다.",
+        "triggers": [
+          "confId 주입",
+          "selectCondition confId",
+          "위젯 필터링",
+          "widget scope injection",
+          "resource-scoped widget"
+        ],
+        "tags": [
+          "widget",
+          "dashboard",
+          "resource-detail",
+          "data-fetch",
+          "scope-injection"
+        ],
+        "category": "frontend"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "widget-grid-type-registration-checklist",
+      "category": "frontend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/frontend/widget-grid-type-registration-checklist/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "대시보드의 TableGrid/차트 위젯에 새로운 타입을 추가할 때 드리프트 없이 5곳(columns 매핑, fetch hook, 에디터 폼, detectType, 모델 DTO) 모두 반영하게 하는 체크리스트 스킬.",
+        "triggers": [
+          "TableGridType",
+          "위젯 타입 추가",
+          "tableGridType",
+          "widget type registration",
+          "detectType",
+          "columns mapping"
+        ],
+        "tags": [
+          "widget",
+          "dashboard",
+          "registry",
+          "grid",
+          "checklist"
+        ],
+        "category": "frontend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "widget-is-frozen-group-snapshot.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/widget-is-frozen-group-snapshot.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Widgets are snapshots of a group at save time; later edits to the source group do not propagate",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "write-a-prd",
+      "category": "workflow",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/workflow/write-a-prd/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. Use when user wants to write a PRD, create a product requirements document, or plan a new feature.",
+        "triggers": [],
+        "tags": [
+          "prd",
+          "requirements",
+          "interview",
+          "planning"
+        ],
+        "category": "workflow"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "write-a-skill",
+      "category": "misc",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/misc/write-a-skill/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, or build a new skill.",
+        "triggers": [],
+        "tags": [
+          "skills",
+          "meta",
+          "authoring",
+          "progressive-disclosure"
+        ],
+        "category": "misc"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "x-filterable-fields-extraction",
+      "category": "workflow",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/workflow/x-filterable-fields-extraction/SKILL.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "OpenAPI 스펙에 x-filterable-fields 확장을 자동 생성하는 파이프라인. lucida-ui gridColumnDefs + lucida-meta i18n properties를 조합하여 필드명/한국어 title/operators를 추출",
+        "triggers": [
+          "x-filterable-fields",
+          "필터 가능 필드 추출",
+          "gridFilters 메타데이터",
+          "tagFilters 메타데이터",
+          "리소스 키 추출",
+          "GridFilter 정확도 개선"
+        ],
+        "tags": [],
+        "category": "workflow"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "xlog-extended-transaction-trace-with-compression.md",
+      "category": "api",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/api/xlog-extended-transaction-trace-with-compression.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "",
+        "triggers": [],
+        "tags": [
+          "xlog",
+          "tracing",
+          "apm",
+          "format",
+          "scouter"
+        ],
+        "category": "api"
+      }
+    },
+    {
+      "kind": "skill",
+      "slug": "yorkie-crdt-sync-pattern",
+      "category": "backend",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "skills/backend/yorkie-crdt-sync-pattern/SKILL.md"
+        },
+        {
+          "s": "A",
+          "p": "skills/backend/yorkie-crdt-sync-pattern/content.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Apply a single doc.update callback for local mutations and pullRemoteChangesIntoLocal(WithNodeIds) for remote→local sync in Yorkie-backed apps",
+        "triggers": [],
+        "tags": [],
+        "category": "backend"
+      }
+    },
+    {
+      "kind": "knowledge",
+      "slug": "yorkie-team-server-split.md",
+      "category": "arch",
+      "status": "A",
+      "files": [
+        {
+          "s": "A",
+          "p": "knowledge/arch/yorkie-team-server-split.md"
+        }
+      ],
+      "before": null,
+      "after": {
+        "description": "Yorkie holds live canvas state; the team server holds metadata (projects, assets, datasources) — never mix",
+        "triggers": [],
+        "tags": [],
+        "category": "arch"
+      }
+    }
+  ],
+  "modified": [
+    {
+      "kind": "bootstrap",
+      "slug": "commands/skills_bootstrap_publish.md",
+      "status": "M",
+      "files": [
+        {
+          "s": "M",
+          "p": "bootstrap/commands/skills_bootstrap_publish.md"
+        }
+      ]
+    },
+    {
+      "kind": "bootstrap",
+      "slug": "commands/skills_bootstrap_update.md",
+      "status": "M",
+      "files": [
+        {
+          "s": "M",
+          "p": "bootstrap/commands/skills_bootstrap_update.md"
+        }
+      ]
+    },
+    {
+      "kind": "skill",
+      "slug": "parallel-bulk-annotation",
+      "category": "workflow",
+      "status": "M",
+      "files": [
+        {
+          "s": "M",
+          "p": "skills/workflow/parallel-bulk-annotation/SKILL.md"
+        }
+      ],
+      "before": {
+        "description": "수십~수백 개 Java 파일에 어노테이션(@Schema, @Operation, @ApiResponse 등)을 대량 추가할 때 병렬 에이전트로 분산 실행하는 패턴",
+        "triggers": [
+          "대량 어노테이션 추가",
+          "@Schema 전수 부여",
+          "operationId 전수 부여",
+          "200개 메서드 어노테이션",
+          "bulk annotation"
+        ],
+        "tags": [],
+        "category": "workflow"
+      },
+      "after": {
+        "description": "수십~수백 개 Java 파일에 어노테이션(@Schema, @Operation, @ApiResponse 등)을 대량 추가할 때 병렬 에이전트로 분산 실행하는 패턴",
+        "triggers": [
+          "대량 어노테이션 추가",
+          "@Schema 전수 부여",
+          "operationId 전수 부여",
+          "200개 메서드 어노테이션",
+          "bulk annotation"
+        ],
+        "tags": [],
+        "category": "workflow"
+      }
+    },
+    {
+      "kind": "bootstrap",
+      "slug": "skills/skills-hub/SKILL.md",
+      "status": "M",
+      "files": [
+        {
+          "s": "M",
+          "p": "bootstrap/skills/skills-hub/SKILL.md"
+        }
+      ]
+    },
+    {
+      "kind": "skill",
+      "slug": "swagger-ai-optimization",
+      "category": "workflow",
+      "status": "M",
+      "files": [
+        {
+          "s": "M",
+          "p": "skills/workflow/swagger-ai-optimization/SKILL.md"
+        }
+      ],
+      "before": {
+        "description": "Spring Boot + springdoc 프로젝트의 Swagger/OpenAPI 스펙을 AI Agent용으로 최적화 (operationId, @Schema, @ApiResponse, x-filterable-fields 전수 적용)",
+        "triggers": [
+          "swagger ai 최적화",
+          "openapi ai optimization",
+          "MCP 연동 준비",
+          "swagger operationId 전수 부여",
+          "AI 이해도 테스트"
+        ],
+        "tags": [],
+        "category": "workflow"
+      },
+      "after": {
+        "description": "Spring Boot + springdoc 프로젝트의 Swagger/OpenAPI 스펙을 AI Agent용으로 최적화 (operationId, @Schema, @ApiResponse, x-filterable-fields 전수 적용)",
+        "triggers": [
+          "swagger ai 최적화",
+          "openapi ai optimization",
+          "MCP 연동 준비",
+          "swagger operationId 전수 부여",
+          "AI 이해도 테스트"
+        ],
+        "tags": [],
+        "category": "workflow"
+      }
+    }
+  ],
+  "removed": [],
+  "tagDelta": {
+    "added": [
+      {
+        "k": "external-reference",
+        "v": 37
+      },
+      {
+        "k": "oh-my-claudecode",
+        "v": 37
+      },
+      {
+        "k": "omc",
+        "v": 37
+      },
+      {
+        "k": "workflow",
+        "v": 37
+      },
+      {
+        "k": "mongodb",
+        "v": 11
+      },
+      {
+        "k": "apm",
+        "v": 8
+      },
+      {
+        "k": "scouter",
+        "v": 7
+      },
+      {
+        "k": "cpp",
+        "v": 6
+      },
+      {
+        "k": "codegen",
+        "v": 6
+      },
+      {
+        "k": "aggregation",
+        "v": 5
+      },
+      {
+        "k": "planning",
+        "v": 5
+      },
+      {
+        "k": "hexagonal",
+        "v": 4
+      },
+      {
+        "k": "architecture",
+        "v": 4
+      },
+      {
+        "k": "kafka",
+        "v": 4
+      },
+      {
+        "k": "time-series",
+        "v": 4
+      },
+      {
+        "k": "openapi",
+        "v": 4
+      },
+      {
+        "k": "refactor",
+        "v": 4
+      },
+      {
+        "k": "decision",
+        "v": 4
+      },
+      {
+        "k": "spring-boot",
+        "v": 4
+      },
+      {
+        "k": "tracing",
+        "v": 3
+      }
+    ],
+    "removed": []
+  },
+  "otherSample": [
+    {
+      "status": "A",
+      "path": "LICENSE"
+    },
+    {
+      "status": "M",
+      "path": "README.md"
+    },
+    {
+      "status": "M",
+      "path": "index.json"
+    }
+  ]
+}

--- a/example/skill-diff/index.html
+++ b/example/skill-diff/index.html
@@ -1,0 +1,195 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Skill Diff</title>
+<style>
+:root {
+  --bg: #0b0d10; --bg-2: #11151a; --bg-3: #161b22;
+  --fg: #c9d1d9; --fg-dim: #7d8590; --border: #21262d;
+  --accent: #7ee787; --accent-2: #79c0ff; --amber: #ffa657;
+  --mag: #d2a8ff; --red: #ff7b72;
+  --add: #238636; --del: #da3633; --mod: #d29922;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; background: var(--bg); color: var(--fg);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px; line-height: 1.5; }
+.wrap { max-width: 1280px; margin: 0 auto; padding: 24px 28px 60px; }
+header { display: flex; align-items: baseline; gap: 14px; margin-bottom: 22px; padding-bottom: 14px; border-bottom: 1px solid var(--border); flex-wrap: wrap; }
+header h1 { font-family: system-ui, sans-serif; font-size: 22px; margin: 0; color: var(--accent); font-weight: 600; }
+header h1::before { content: "▶ "; color: var(--fg-dim); }
+header .sub { color: var(--fg-dim); font-size: 12px; }
+.kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 10px; margin-bottom: 20px; }
+.kpi { background: var(--bg-2); border: 1px solid var(--border); border-radius: 6px; padding: 12px 14px; }
+.kpi .label { color: var(--fg-dim); font-size: 10px; text-transform: uppercase; letter-spacing: 0.6px; margin-bottom: 4px; }
+.kpi .value { font-size: 22px; font-weight: 600; }
+.kpi.A .value { color: var(--accent); }
+.kpi.M .value { color: var(--amber); }
+.kpi.D .value { color: var(--red); }
+.filters { display: flex; gap: 8px; margin-bottom: 16px; flex-wrap: wrap; }
+.chip { border: 1px solid var(--border); background: var(--bg-2); color: var(--fg-dim); padding: 4px 12px; border-radius: 14px; font-size: 11px; cursor: pointer; user-select: none; }
+.chip.on { border-color: var(--accent-2); color: var(--accent-2); }
+.kindmix { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; margin-bottom: 18px; }
+.km { background: var(--bg-2); border: 1px solid var(--border); border-radius: 6px; padding: 10px 12px; }
+.km .k { color: var(--fg-dim); font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 4px; }
+.km .v { display: flex; gap: 8px; font-size: 12px; }
+.km .add { color: var(--accent); } .km .mod { color: var(--amber); } .km .del { color: var(--red); }
+.card { background: var(--bg-2); border: 1px solid var(--border); border-radius: 6px; padding: 10px 14px; margin-bottom: 6px; }
+.card .head { display: grid; grid-template-columns: 70px 1fr auto auto; gap: 10px; align-items: center; cursor: pointer; }
+.card .head .badge { border-radius: 3px; padding: 2px 8px; font-size: 10px; text-align: center; font-weight: 600; text-transform: uppercase; }
+.card[data-s="A"] .badge { background: var(--add); color: #fff; }
+.card[data-s="M"] .badge { background: var(--mod); color: #000; }
+.card[data-s="D"] .badge { background: var(--del); color: #fff; }
+.card .slug { font-weight: 600; color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.card .kind { color: var(--fg-dim); font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; }
+.card .fcount { color: var(--fg-dim); font-size: 10px; }
+.card.open .body { display: block; }
+.card .body { display: none; margin-top: 10px; padding-top: 10px; border-top: 1px dashed var(--border); font-size: 11px; }
+.card .body .lbl { color: var(--fg-dim); font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; margin-top: 8px; margin-bottom: 3px; }
+.card .body .before, .card .body .after { padding: 6px 8px; border-radius: 4px; white-space: pre-wrap; word-break: break-word; }
+.card .body .before { background: rgba(218, 54, 51, 0.08); border-left: 2px solid var(--red); }
+.card .body .after { background: rgba(35, 134, 54, 0.1); border-left: 2px solid var(--accent); }
+.card .body .eq { color: var(--fg-dim); font-style: italic; }
+.card .body ul.files { margin: 4px 0; padding-left: 18px; color: var(--fg-dim); font-size: 10px; }
+.card .body ul.files li { list-style: none; position: relative; }
+.card .body ul.files li::before { content: attr(data-s); position: absolute; left: -14px; width: 10px; font-weight: 600; }
+.card .body ul.files li[data-s="A"]::before { color: var(--accent); }
+.card .body ul.files li[data-s="M"]::before { color: var(--amber); }
+.card .body ul.files li[data-s="D"]::before { color: var(--red); }
+.section { margin-bottom: 22px; }
+.section h2 { font-family: system-ui, sans-serif; font-size: 14px; margin: 0 0 10px; color: var(--accent-2); font-weight: 600; display: flex; justify-content: space-between; }
+.section h2 .count { color: var(--fg-dim); font-size: 11px; font-weight: 400; }
+footer { color: var(--fg-dim); text-align: right; font-size: 10px; margin-top: 24px; }
+.empty { color: var(--fg-dim); font-style: italic; padding: 14px 0; text-align: center; }
+.tag { display: inline-block; background: var(--bg-3); border-radius: 10px; padding: 1px 8px; margin: 2px 3px 2px 0; font-size: 10px; color: var(--fg-dim); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>skill-diff</h1>
+    <span class="sub" id="sub">loading…</span>
+  </header>
+
+  <div class="kpis" id="kpis"></div>
+  <div class="kindmix" id="kindmix"></div>
+
+  <div class="filters">
+    <div class="chip on" data-k="all">all</div>
+    <div class="chip on" data-k="skill">skill</div>
+    <div class="chip on" data-k="knowledge">knowledge</div>
+    <div class="chip on" data-k="example">example</div>
+    <div class="chip on" data-k="bootstrap">bootstrap</div>
+  </div>
+
+  <div class="section" id="sec-added"><h2>added <span class="count" id="c-A"></span></h2><div id="list-A"></div></div>
+  <div class="section" id="sec-modified"><h2>modified <span class="count" id="c-M"></span></h2><div id="list-M"></div></div>
+  <div class="section" id="sec-removed"><h2>removed <span class="count" id="c-D"></span></h2><div id="list-D"></div></div>
+
+  <footer>generated <span id="gen"></span> · rebuild: <b>node build-diff.mjs --from=REF --to=REF</b></footer>
+</div>
+<script>
+const $ = (s) => document.querySelector(s);
+const $$ = (s) => document.querySelectorAll(s);
+let DATA = null;
+let FILTER = new Set(['skill', 'knowledge', 'example', 'bootstrap']);
+
+fetch('diff.json').then(r => r.json()).then(render).catch(e => {
+  $('#sub').textContent = 'error: ' + e.message;
+});
+
+function escapeHtml(s) { return (s || '').replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' })[c]); }
+
+function render(d) {
+  DATA = d;
+  const { range } = d;
+  $('#sub').textContent = `${range.from} (${range.fromSha}) → ${range.to} (${range.toSha}) · ${range.fromDate.slice(0, 10)} → ${range.toDate.slice(0, 10)}`;
+  $('#gen').textContent = d.generatedAt;
+  $('#kpis').innerHTML = [
+    ['A', 'added', d.totals.added],
+    ['M', 'modified', d.totals.modified],
+    ['D', 'removed', d.totals.removed],
+    ['', 'other files', d.totals.otherFiles],
+    ['', 'skills', d.totals.byKind.find(k => k.k === 'skill') ? d.totals.byKind.find(k => k.k === 'skill').added + d.totals.byKind.find(k => k.k === 'skill').modified + d.totals.byKind.find(k => k.k === 'skill').removed : 0],
+  ].map(([cls, l, v]) => `<div class="kpi ${cls}"><div class="label">${l}</div><div class="value">${v}</div></div>`).join('');
+  $('#kindmix').innerHTML = d.totals.byKind.map(k => `
+    <div class="km"><div class="k">${k.k}</div>
+      <div class="v"><span class="add">+${k.added}</span><span class="mod">~${k.modified}</span><span class="del">-${k.removed}</span></div>
+    </div>`).join('');
+
+  $$('.chip').forEach(c => c.addEventListener('click', () => {
+    const k = c.dataset.k;
+    if (k === 'all') {
+      const allOn = [...FILTER].length === 4;
+      FILTER = allOn ? new Set() : new Set(['skill', 'knowledge', 'example', 'bootstrap']);
+    } else {
+      FILTER.has(k) ? FILTER.delete(k) : FILTER.add(k);
+    }
+    $$('.chip').forEach(cc => {
+      const kk = cc.dataset.k;
+      const on = kk === 'all' ? FILTER.size === 4 : FILTER.has(kk);
+      cc.classList.toggle('on', on);
+    });
+    redraw();
+  }));
+  redraw();
+}
+
+function redraw() {
+  for (const [bucket, label] of [['added', 'A'], ['modified', 'M'], ['removed', 'D']]) {
+    const items = DATA[bucket].filter(e => FILTER.has(e.kind));
+    $('#c-' + label).textContent = `${items.length}`;
+    $('#list-' + label).innerHTML = items.length ? items.map(e => renderCard(e, label)).join('') : `<div class="empty">nothing</div>`;
+  }
+  $$('.card .head').forEach(h => h.addEventListener('click', () => h.parentElement.classList.toggle('open')));
+}
+
+function renderCard(e, s) {
+  const hasBody = (e.before || e.after) || e.files.length > 1;
+  return `<div class="card" data-s="${s}">
+    <div class="head">
+      <div class="badge">${s === 'A' ? 'added' : s === 'M' ? 'mod' : 'del'}</div>
+      <div><span class="slug">${escapeHtml(e.slug)}</span> <span class="kind">${e.kind}${e.category ? ' / ' + escapeHtml(e.category) : ''}</span></div>
+      <div class="fcount">${e.files.length} file${e.files.length === 1 ? '' : 's'}</div>
+      <div>${hasBody ? '▸' : ''}</div>
+    </div>
+    ${hasBody ? `<div class="body">${renderBody(e)}</div>` : ''}
+  </div>`;
+}
+
+function renderBody(e) {
+  let out = '';
+  if (e.before || e.after) {
+    const b = e.before || {};
+    const a = e.after || {};
+    out += `<div class="lbl">description</div>`;
+    if (!e.before) out += `<div class="after">${escapeHtml(a.description || '(empty)')}</div>`;
+    else if (!e.after) out += `<div class="before">${escapeHtml(b.description || '(empty)')}</div>`;
+    else if (b.description === a.description) out += `<div class="eq">(unchanged)</div>`;
+    else out += `<div class="before">- ${escapeHtml(b.description || '(empty)')}</div><div class="after">+ ${escapeHtml(a.description || '(empty)')}</div>`;
+
+    const tagsB = (b.tags || []).join(','); const tagsA = (a.tags || []).join(',');
+    if (tagsB !== tagsA) {
+      out += `<div class="lbl">tags</div>`;
+      if (b.tags && b.tags.length) out += `<div class="before">- ${b.tags.map(t => `<span class="tag">${escapeHtml(t)}</span>`).join('')}</div>`;
+      if (a.tags && a.tags.length) out += `<div class="after">+ ${a.tags.map(t => `<span class="tag">${escapeHtml(t)}</span>`).join('')}</div>`;
+    }
+
+    const trB = (b.triggers || []).join('|'); const trA = (a.triggers || []).join('|');
+    if (trB !== trA) {
+      out += `<div class="lbl">triggers</div>`;
+      if (b.triggers && b.triggers.length) out += `<div class="before">- ${escapeHtml(b.triggers.join(' · '))}</div>`;
+      if (a.triggers && a.triggers.length) out += `<div class="after">+ ${escapeHtml(a.triggers.join(' · '))}</div>`;
+    }
+  }
+  if (e.files.length > 1) {
+    out += `<div class="lbl">files (${e.files.length})</div>`;
+    out += `<ul class="files">${e.files.slice(0, 15).map(f => `<li data-s="${f.s}">${escapeHtml(f.p)}</li>`).join('')}${e.files.length > 15 ? `<li data-s="·">… ${e.files.length - 15} more</li>` : ''}</ul>`;
+  }
+  return out;
+}
+</script>
+</body>
+</html>

--- a/example/skill-diff/manifest.json
+++ b/example/skill-diff/manifest.json
@@ -1,0 +1,12 @@
+{
+  "slug": "skill-diff",
+  "title": "Skill Diff",
+  "summary": "Zero-dep diff viewer for two refs of a skills-hub working copy — added/removed/modified slugs with description/tag/trigger deltas.",
+  "stack": ["node", "html", "js"],
+  "tags": ["diff", "git", "audit", "release-notes", "skills-hub"],
+  "created_at": "2026-04-16",
+  "source_project": "getskills",
+  "runtime": "node >=18",
+  "entrypoint": "serve.mjs",
+  "author": "kjuhwa@nkia.co.kr"
+}

--- a/example/skill-diff/serve.mjs
+++ b/example/skill-diff/serve.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// Tiny zero-dep static server for skill-diff.
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PORT = Number(process.env.PORT || 4179);
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js':   'application/javascript; charset=utf-8',
+  '.mjs':  'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.css':  'text/css; charset=utf-8',
+};
+
+http.createServer((req, res) => {
+  const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
+  const rel = urlPath === '/' ? 'index.html' : urlPath.replace(/^\/+/, '');
+  const file = path.join(HERE, rel);
+  if (!file.startsWith(HERE)) { res.statusCode = 403; return res.end('forbidden'); }
+  fs.readFile(file, (err, buf) => {
+    if (err) { res.statusCode = 404; return res.end('not found'); }
+    res.setHeader('content-type', MIME[path.extname(file)] || 'application/octet-stream');
+    res.end(buf);
+  });
+}).listen(PORT, () => {
+  console.log(`▶ skill diff → http://localhost:${PORT}/`);
+});


### PR DESCRIPTION
## Why

The hub gains and loses skills constantly — but there is no release-notes surface. `git log` shows that *something* changed, but not *which slug* or *how its description/triggers/tags differ*. `skill-diff` fills that audit / curation gap.

## What it ships

- Range-selectable diff (`--from=REF --to=REF`, any `git rev-parse` target).
- Three sections — **added / modified / removed** — of collapsible slug cards.
- Per-card frontmatter delta on expand: description before→after, tags before→after, triggers before→after.
- File list for each slug (showing per-file A/M/D status).
- Kind filters (skill / knowledge / example / bootstrap) for narrowing scope.
- Totals + kind-mix KPIs for quick release-notes scanning.

## Stack

Zero-dep Node + HTML + JS. Uses `git show FROM:path` / `git show TO:path` to extract before/after frontmatter for modified `SKILL.md` files.

## Run

\`\`\`bash
node build-diff.mjs --root=~/.claude/skills-hub/remote --from=HEAD~20 --to=HEAD
node serve.mjs  # http://localhost:4179/
\`\`\`

Preview: https://github.com/kjuhwa/skills-hub/tree/example/skill-diff/example/skill-diff