### PR TITLE
Publish 5 skills + 8 knowledge entries (skills_research trend 2026-04-16)

### DIFF
--- a/index.json
+++ b/index.json
@@ -21,6 +21,16 @@
       "path": "ai/ai-call-with-mock-fallback"
     },
     {
+      "name": "ai-subagent-scope-narrowing",
+      "description": "Orchestrator-first pattern for multi-agent AI coding — humans triage and curate context per task, subagents execute in isolated worktrees with narrowly-scoped briefs. Trades parallel throughput for reduced hallucination.",
+      "category": "ai",
+      "tags": "[agents, subagents, orchestration, context-isolation, worktree, hallucination]",
+      "triggers": "[\"subagent\",\"multiple agents\",\"parallel agents\",\"worktree\",\"agent hallucination\",\"narrow scope\",\"orchestrator agent\",\"context engineering\"]",
+      "source_project": "skills_research:trend:2026-04-16",
+      "version": "1.0.0",
+      "path": "ai/ai-subagent-scope-narrowing"
+    },
+    {
       "name": "async-subagent-resume-on-missing-artifact",
       "description": "When an async subagent is reported \"completed\" but its final message hints at unfinished work (e.g., \"Now let me build…\"), verify the expected on-disk artifact before moving on; if missing, use SendMessage to the agent id to finalize rather than re-dispatching a fresh agent.",
       "category": "workflow",
@@ -802,6 +812,16 @@
       "path": "frontend/jest-test-file-naming-test-only"
     },
     {
+      "name": "jj-jujutsu-day-one-workflow",
+      "description": "Minimum viable jj (Jujutsu) workflow for a git user — init on top of an existing git repo, the five commands that cover 95% of day-1 usage, and the mental-model shift from git's staging area.",
+      "category": "git",
+      "tags": "[jj, jujutsu, version-control, git-compatible, workflow, onboarding]",
+      "triggers": "[\"jj\",\"jujutsu\",\"jj git init\",\"jj describe\",\"jj bookmark\",\"jj st\",\"jj new\",\"jj log\"]",
+      "source_project": "skills_research:trend:2026-04-16",
+      "version": "1.0.0",
+      "path": "git/jj-jujutsu-day-one-workflow"
+    },
+    {
       "name": "json-seeded-jpa-loader",
       "description": "Idempotent reference-data seeding for Spring Boot — Flyway owns DDL, CommandLineRunner reads `resources/data/*.json`, maps to JPA entities, and saves only if the table is empty. Keeps static content in editable JSON without bloating migrations.",
       "category": "backend",
@@ -979,6 +999,29 @@
       "source_project": "kis-java-bundle",
       "version": "0.1.0-draft",
       "path": "arch/layered-risk-gates"
+    },
+    {
+      "name": "lean-verified-code-threat-boundary",
+      "description": "When shipping formally-verified code (Lean 4, Coq, F*), explicitly map what is inside and outside the verification boundary — untrusted parsers, runtime, and TCB assumptions almost always harbor the real bugs.",
+      "category": "security",
+      "tags": "[formal-verification, lean, coq, threat-modeling, fuzzing, tcb, security]",
+      "triggers": "[\"formally verified\",\"lean 4\",\"formal proof\",\"Coq\",\"F-star\",\"lean_alloc_sarray\",\"trusted computing base\",\"TCB\",\"verified library\",\"CompCert\"]",
+      "source_project": "skills_research:trend:2026-04-16",
+      "version": "1.0.0",
+      "path": "security/lean-verified-code-threat-boundary",
+      "linked_knowledge": [
+        "lean-verification-spec-coverage-gap"
+      ]
+    },
+    {
+      "name": "llm-integration-test-failure-diagnosis",
+      "description": "Wire an LLM-based diagnosis step into your CI for integration-test failures — summarize noisy logs, identify probable root cause, post findings to the code-review/PR UI. Based on Google's Auto-Diagnose (90%+ accuracy on 71-case study, adopted across 52k tests).",
+      "category": "testing",
+      "tags": "[llm, ci, integration-tests, test-diagnosis, log-analysis, root-cause, auto-diagnose]",
+      "triggers": "[\"test failure diagnosis\",\"integration test flaky\",\"log summarization\",\"auto-diagnose\",\"test failure LLM\",\"root cause analysis\"]",
+      "source_project": "skills_research:trend:2026-04-16",
+      "version": "1.0.0",
+      "path": "testing/llm-integration-test-failure-diagnosis"
     },
     {
       "name": "llm-json-extraction",
@@ -1293,6 +1336,16 @@
       "source_project": "yamltomcp",
       "version": "0.1.0-draft",
       "path": "ai/openapi-to-mcp-tag-grouping"
+    },
+    {
+      "name": "openssl-4-migration-checklist",
+      "description": "Step-by-step migration checklist for upgrading a C/C++ codebase from OpenSSL 3.x to 4.0.0 — const-qualified APIs, removed SSLv3 support, opaque ASN1_STRING, engine removal, cleanup semantics.",
+      "category": "security",
+      "tags": "[openssl, tls, cryptography, migration, c-api, breaking-changes, upgrade]",
+      "triggers": "[\"openssl 4\",\"OpenSSL 4.0.0\",\"openssl upgrade\",\"SSLv3_method\",\"ENGINE_load\",\"ASN1_STRING opaque\",\"X509_cmp_time\",\"openssl deprecated\"]",
+      "source_project": "skills_research:trend:2026-04-16",
+      "version": "1.0.0",
+      "path": "security/openssl-4-migration-checklist"
     },
     {
       "name": "opentelemetry-java-bootstrap",
@@ -2221,69 +2274,6 @@
   ],
   "knowledge": [
     {
-      "slug": "Annotation-driven coarse-grained authorization via @FunctionId",
-      "category": "arch",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "arch/annotation-driven-authz-via-function-id",
-      "linked_skills": []
-    },
-    {
-      "slug": "Gate startup initialization on dependent-service readiness via @WaitForServices",
-      "category": "arch",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "arch/wait-for-services-eureka-startup-init",
-      "linked_skills": []
-    },
-    {
-      "slug": "Per-request tenant context via HandlerInterceptor",
-      "category": "arch",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "arch/tenant-context-per-request-interceptor",
-      "linked_skills": []
-    },
-    {
-      "slug": "Polymorphic metadata persisted as BSON via enum-switch deserialization",
-      "category": "arch",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "arch/polymorphic-metadata-via-enum-switch",
-      "linked_skills": []
-    },
-    {
-      "slug": "account-lockout-configurable-threshold",
-      "category": "domain",
-      "summary": "Failed-login counter locks the account after a configurable threshold (ACCOUNT_LOCKOUT, default 10).",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "domain/account-lockout-configurable-threshold",
-      "linked_skills": []
-    },
-    {
-      "slug": "actuator-endpoints-skip-auth-by-design",
-      "category": "decision",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/actuator-endpoints-skip-auth-by-design",
-      "linked_skills": []
-    },
-    {
-      "slug": "actuator-metric-call-aggressive-timeout",
-      "category": "pitfall",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "pitfall/actuator-metric-call-aggressive-timeout",
-      "linked_skills": []
-    },
-    {
       "slug": "actuator-path-dual-compatibility",
       "category": "api",
       "summary": "Actuator endpoints must respond at both /actuator/** and /actuator/{appName}/** for deployment compatibility.",
@@ -2293,261 +2283,12 @@
       "linked_skills": []
     },
     {
-      "slug": "additive-registry-schema-versioning",
-      "category": "arch",
-      "summary": "JSON registry 진화는 version bump + 새 키 empty container + 첫 쓰기 시 자동 마이그레이션으로 하라",
+      "slug": "Claude Code Routines: scheduled/API/GitHub-triggered cloud sessions",
+      "category": "api",
+      "summary": "Routines are saved cloud Claude Code sessions (prompt+repos+connectors+environment) triggered by schedule, HTTP POST to /fire, or GitHub events. One routine can combine all three; daily run cap; pushes restricted to claude/* by default.",
       "confidence": "high",
-      "source_project": "",
-      "path": "arch/additive-registry-schema-versioning",
-      "linked_skills": []
-    },
-    {
-      "slug": "admin-role-disabled-secretkey",
-      "category": "decision",
-      "summary": "Default `admins` role is disabled and the shared `SecretKey` was removed from `config.properties` — never re-enable without a per-install key",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/admin-role-disabled-secretkey",
-      "linked_skills": []
-    },
-    {
-      "slug": "ai-guess-mark-and-review-checklist",
-      "category": "pitfall",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "pitfall/ai-guess-mark-and-review-checklist",
-      "linked_skills": []
-    },
-    {
-      "slug": "alarm-raw-over-1min-aggregate",
-      "category": "decision",
-      "summary": "Alarm judgement reads raw metrics, not 1-minute aggregates — accuracy over storage cost",
-      "confidence": "high",
-      "source_project": "lucida-measurement",
-      "path": "decision/alarm-raw-over-1min-aggregate",
-      "linked_skills": [
-        "kafka-consumer-semaphore-chunking"
-      ]
-    },
-    {
-      "slug": "anonymize-examples-in-skill-docs",
-      "category": "pitfall",
-      "summary": "실사 티켓 번호·실명·프로젝트명이 예시에 들어가면 보안 감사에서 지적됨. 공용 repo 기준 모든 예시는 익명 더미여야 한다.",
-      "confidence": "high",
-      "source_project": "",
-      "path": "pitfall/anonymize-examples-in-skill-docs",
-      "linked_skills": []
-    },
-    {
-      "slug": "asm-based-classloader-instrumentation-caveats",
-      "category": "pitfall",
-      "summary": "ASM-based JVM agents miss Java 8+ lambda forms, annotation-processor classes, and Spring proxies unless explicitly handled; misses manifest as XLog gaps or skipped trace points",
-      "confidence": "high",
-      "source_project": "scouter",
-      "path": "pitfall/asm-based-classloader-instrumentation-caveats",
-      "linked_skills": []
-    },
-    {
-      "slug": "assume-semantics-for-compiler-hints",
-      "category": "decision",
-      "summary": "Three-tier assertion strategy (Assert / CHECK_NONFATAL / Assume) separates fatal invariants from recoverable logic bugs and pure compiler hints.",
-      "confidence": "high",
-      "source_project": "bitcoin",
-      "path": "decision/assume-semantics-for-compiler-hints",
-      "linked_skills": []
-    },
-    {
-      "slug": "assumeutxo-snapshot-chainstate-phases",
-      "category": "arch",
-      "summary": "(Blockchain-specific) Multi-chainstate snapshot validation — active chainstate syncs from a trusted-but-unverified UTXO snapshot while a background chainstate validates the snapshot's base, with a phased state machine for clean cutover.",
-      "confidence": "high",
-      "source_project": "bitcoin",
-      "path": "arch/assumeutxo-snapshot-chainstate-phases",
-      "linked_skills": []
-    },
-    {
-      "slug": "audit-changed-prev-after-field-swap-bug",
-      "category": "pitfall",
-      "summary": "Audit diff logic had before/after swapped — iterating the wrong doc and putting the wrong value into changedPrev corrupted the audit trail silently",
-      "confidence": "high",
-      "source_project": "lucida-audit",
-      "path": "pitfall/audit-changed-prev-after-field-swap-bug",
-      "linked_skills": [
-        "audit-change-data-capture-pattern"
-      ]
-    },
-    {
-      "slug": "auto-lock-must-not-bump-lastEditedTime",
-      "category": "pitfall",
-      "summary": "|",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "pitfall/auto-lock-must-not-bump-lastEditedTime",
-      "linked_skills": []
-    },
-    {
-      "slug": "avro-private-fields-no-setters",
-      "category": "decision",
-      "summary": "Avro-generated classes are configured with `fieldVisibility=PRIVATE` and `createSetters=false` to enforce immutability on event payloads",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/avro-private-fields-no-setters",
-      "linked_skills": []
-    },
-    {
-      "slug": "bilingual-user-facing-strings",
-      "category": "arch",
-      "summary": "A bilingual_str struct carrying both original and translated forms lets GUI show translated text while logs/stderr keep the original — no locale branching in business code.",
-      "confidence": "high",
-      "source_project": "bitcoin",
-      "path": "arch/bilingual-user-facing-strings",
-      "linked_skills": []
-    },
-    {
-      "slug": "binsize-zero-fallback-to-one",
-      "category": "pitfall",
-      "summary": "Substitute binSize=1 whenever the computed interval is 0 in MongoDB time-bucket aggregation",
-      "confidence": "high",
-      "source_project": "",
-      "path": "pitfall/binsize-zero-fallback-to-one",
-      "linked_skills": []
-    },
-    {
-      "slug": "boilerplate-generated-business-logic-manual",
-      "category": "arch",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "arch/boilerplate-generated-business-logic-manual",
-      "linked_skills": []
-    },
-    {
-      "slug": "build-gradle-secret-and-insecure-protocol",
-      "category": "pitfall",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "pitfall/sonar-token-hardcoded-build-gradle",
-      "linked_skills": []
-    },
-    {
-      "slug": "cache-even-when-enable-false",
-      "category": "decision",
-      "summary": "Notification configs with `enable=false` are still loaded into the cache manager rather than skipped, so toggling enable on/off doesn't require a cache reload",
-      "confidence": "high",
-      "source_project": "lucida-notification",
-      "path": "decision/cache-even-when-enable-false",
-      "linked_skills": []
-    },
-    {
-      "slug": "catalina-urlencoder-internal-api",
-      "category": "pitfall",
-      "summary": "org.apache.catalina.util.URLEncoder is Tomcat internal — use java.net.URLEncoder or Spring UriUtils",
-      "confidence": "medium",
-      "source_project": "lucida-domain-automation",
-      "path": "pitfall/catalina-urlencoder-internal-api",
-      "linked_skills": []
-    },
-    {
-      "slug": "caveats-absence-confidence-cap",
-      "category": "decision",
-      "summary": "반증 조건(Counter/Caveats)이 비어 있는 knowledge는 confidence 최대 medium으로 강등한다 — 미확인 = 과신 위험",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/caveats-absence-confidence-cap",
-      "linked_skills": []
-    },
-    {
-      "slug": "circular-dependency-detection-script",
-      "category": "decision",
-      "summary": "A small Python script that parses #include directives across the tree and reports the shortest cycle in the module graph — cheap CI gate against architectural decay.",
-      "confidence": "high",
-      "source_project": "bitcoin",
-      "path": "decision/circular-dependency-detection-script",
-      "linked_skills": []
-    },
-    {
-      "slug": "classifier-both-verdict-self-reference",
-      "category": "pitfall",
-      "summary": "LLM classifier의 both-verdict에 suggested_links를 허용하면 자기 자신을 가리키는 self-link가 나온다 — 링크는 post-process에서 붙일 것",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "pitfall/classifier-both-verdict-self-reference",
-      "linked_skills": []
-    },
-    {
-      "slug": "claude-plugin-marketplace-owner-required",
-      "category": "pitfall",
-      "summary": "플러그인 설치 스키마 오류: marketplace.json 최상위에 `owner` 객체 없으면 플러그인 설치가 실패.",
-      "confidence": "high",
-      "source_project": "",
-      "path": "pitfall/claude-plugin-marketplace-owner-required",
-      "linked_skills": []
-    },
-    {
-      "slug": "claude-plugin-skill-md-is-sufficient",
-      "category": "arch",
-      "summary": "스킬 = SKILL.md 하나. 코드, 빌드, 의존성, 스크립트 없이도 완전히 동작한다.",
-      "confidence": "high",
-      "source_project": "",
-      "path": "arch/claude-plugin-skill-md-is-sufficient",
-      "linked_skills": []
-    },
-    {
-      "slug": "common-alarm-policy-init-gotcha",
-      "category": "pitfall",
-      "summary": "",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "pitfall/common-alarm-policy-init-gotcha",
-      "linked_skills": [
-        "kafka-debounce-event-coalescing"
-      ]
-    },
-    {
-      "slug": "commons-logging-exclusion-strategy",
-      "category": "arch",
-      "summary": "Globally exclude commons-logging, log4j, and slf4j-log4j12 in Gradle so SLF4J+Logback is the only logging backend on the classpath",
-      "confidence": "high",
-      "source_project": "lucida-audit",
-      "path": "arch/commons-logging-exclusion-strategy",
-      "linked_skills": []
-    },
-    {
-      "slug": "compare-counts-exclude-added-deleted",
-      "category": "pitfall",
-      "summary": "An earlier query filtered change-count by `latest` / `added` / `deleted` flags, which silently dropped newly-added resources from the \"number of changes between two points in time\" metric.",
-      "confidence": "high",
-      "source_project": "",
-      "path": "pitfall/compare-counts-exclude-added-deleted",
-      "linked_skills": []
-    },
-    {
-      "slug": "composite-alarm-all-deleted-npe",
-      "category": "pitfall",
-      "summary": "Composite/aggregated monitors must validate their child set before reducing — empty aggregation throws NPE",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "pitfall/composite-alarm-all-deleted-npe",
-      "linked_skills": []
-    },
-    {
-      "slug": "conf-info-may-lack-resource-type",
-      "category": "pitfall",
-      "summary": "The `conf_info` collection is NOT guaranteed to carry `resourceType` for every metric; criteria builders must tolerate missing field",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "pitfall/conf-info-may-lack-resource-type",
-      "linked_skills": []
-    },
-    {
-      "slug": "confid-only-query-over-resource-tuple",
-      "category": "decision",
-      "summary": "Performance queries key off `confId` (config id) whenever available, falling back to (resourceType, resourceName) only when confId is absent",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/confid-only-query-over-resource-tuple",
+      "source_project": "skills_research:trend:2026-04-16",
+      "path": "api/claude-code-routines-cloud-automation-model",
       "linked_skills": []
     },
     {
@@ -2560,30 +2301,147 @@
       "linked_skills": []
     },
     {
-      "slug": "copy-naming-suffix-numbered",
-      "category": "decision",
-      "summary": "|",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/copy-naming-suffix-numbered",
-      "linked_skills": []
-    },
-    {
-      "slug": "cors-allow-credentials-star-origin",
-      "category": "decision",
-      "summary": "Service-level allowCredentials+allowedOriginPatterns(*) kept because edge proxy (Traefik/Istio) enforces CORS",
-      "confidence": "medium",
-      "source_project": "lucida-domain-automation",
-      "path": "decision/cors-allow-credentials-star-origin",
-      "linked_skills": []
-    },
-    {
-      "slug": "csp-frame-ancestors-required",
-      "category": "decision",
-      "summary": "Send a Content-Security-Policy header (including `frame-ancestors`) on every response to block clickjacking",
+      "slug": "es-xpack-transport-vs-rest-ssl",
+      "category": "api",
+      "summary": "Elasticsearch transport SSL and REST SSL are independent X-Pack configs; enabling one does not enable the other",
       "confidence": "high",
       "source_project": "",
-      "path": "decision/csp-frame-ancestors-required",
+      "path": "api/es-xpack-transport-vs-rest-ssl",
+      "linked_skills": []
+    },
+    {
+      "slug": "kafka-avro-change-flag-contract",
+      "category": "api",
+      "summary": "Every Configuration-domain Avro event carries an `actionType` enum (INSERT/UPDATE/DELETE) plus boolean change flags per mutable section (e.g. `parentChanged`, `tagFiltersChanged`, `configurationsChanged`) rather than full before/after payloads.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "api/kafka-avro-change-flag-contract",
+      "linked_skills": []
+    },
+    {
+      "slug": "kafka-organization-id-record-header",
+      "category": "api",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "api/kafka-organization-id-record-header",
+      "linked_skills": []
+    },
+    {
+      "slug": "live-chart-timestamp-normalization",
+      "category": "api",
+      "summary": "LIVE charts accept `normalizeTimestamp` + `normalizeIntervalMs` to align per-agent millisecond offsets into a single x-axis",
+      "confidence": "medium",
+      "source_project": "lucida-measurement",
+      "path": "api/live-chart-timestamp-normalization",
+      "linked_skills": []
+    },
+    {
+      "slug": "stomp-heartbeat-10s-bidirectional",
+      "category": "api",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "api/stomp-heartbeat-10s-bidirectional",
+      "linked_skills": []
+    },
+    {
+      "slug": "timeselector-mode-interval-range-mapping",
+      "category": "api",
+      "summary": "Clients send a `mode` enum (RAW..YEAR); the server maps it to a (bin-interval, query-range) pair and picks the right pre-aggregated collection",
+      "confidence": "high",
+      "source_project": "",
+      "path": "api/timeselector-mode-interval-range-mapping",
+      "linked_skills": []
+    },
+    {
+      "slug": "xlog-extended-transaction-trace-with-compression",
+      "category": "api",
+      "summary": "XLog is scouter's per-request transaction trace format — hierarchical typed steps stored as compressed binary, indexed by end-time, with flat metadata for server-side filtering",
+      "confidence": "high",
+      "source_project": "scouter",
+      "path": "api/xlog-extended-transaction-trace-with-compression",
+      "linked_skills": []
+    },
+    {
+      "slug": "additive-registry-schema-versioning",
+      "category": "arch",
+      "summary": "JSON registry 진화는 version bump + 새 키 empty container + 첫 쓰기 시 자동 마이그레이션으로 하라",
+      "confidence": "high",
+      "source_project": "",
+      "path": "arch/additive-registry-schema-versioning",
+      "linked_skills": []
+    },
+    {
+      "slug": "Agent memory: binding, not recall, is the real bottleneck",
+      "category": "arch",
+      "summary": "A 500-run OrKa benchmark showed 0/250 stored skills were used even though retrieval worked. Fix is a bundle (skill record + episode record + bidirectional link) returned together on recall.",
+      "confidence": "medium",
+      "source_project": "skills_research:trend:2026-04-16",
+      "path": "arch/agent-memory-binding-vs-recall",
+      "linked_skills": []
+    },
+    {
+      "slug": "Annotation-driven coarse-grained authorization via @FunctionId",
+      "category": "arch",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "arch/annotation-driven-authz-via-function-id",
+      "linked_skills": []
+    },
+    {
+      "slug": "Archon: deterministic AI coding via YAML workflow DAGs",
+      "category": "arch",
+      "summary": "Workflows as YAML DAGs in the repo; deterministic nodes (tests/git) bracket AI-driven nodes; each run isolated in its own git worktree. Pattern generalizes beyond Archon.",
+      "confidence": "medium",
+      "source_project": "skills_research:trend:2026-04-16",
+      "path": "arch/archon-deterministic-ai-coding-harness",
+      "linked_skills": []
+    },
+    {
+      "slug": "assumeutxo-snapshot-chainstate-phases",
+      "category": "arch",
+      "summary": "(Blockchain-specific) Multi-chainstate snapshot validation — active chainstate syncs from a trusted-but-unverified UTXO snapshot while a background chainstate validates the snapshot's base, with a phased state machine for clean cutover.",
+      "confidence": "high",
+      "source_project": "bitcoin",
+      "path": "arch/assumeutxo-snapshot-chainstate-phases",
+      "linked_skills": []
+    },
+    {
+      "slug": "bilingual-user-facing-strings",
+      "category": "arch",
+      "summary": "A bilingual_str struct carrying both original and translated forms lets GUI show translated text while logs/stderr keep the original — no locale branching in business code.",
+      "confidence": "high",
+      "source_project": "bitcoin",
+      "path": "arch/bilingual-user-facing-strings",
+      "linked_skills": []
+    },
+    {
+      "slug": "boilerplate-generated-business-logic-manual",
+      "category": "arch",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "arch/boilerplate-generated-business-logic-manual",
+      "linked_skills": []
+    },
+    {
+      "slug": "claude-plugin-skill-md-is-sufficient",
+      "category": "arch",
+      "summary": "스킬 = SKILL.md 하나. 코드, 빌드, 의존성, 스크립트 없이도 완전히 동작한다.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "arch/claude-plugin-skill-md-is-sufficient",
+      "linked_skills": []
+    },
+    {
+      "slug": "commons-logging-exclusion-strategy",
+      "category": "arch",
+      "summary": "Globally exclude commons-logging, log4j, and slf4j-log4j12 in Gradle so SLF4J+Logback is the only logging backend on the classpath",
+      "confidence": "high",
+      "source_project": "lucida-audit",
+      "path": "arch/commons-logging-exclusion-strategy",
       "linked_skills": []
     },
     {
@@ -2593,33 +2451,6 @@
       "confidence": "medium",
       "source_project": "",
       "path": "arch/data-patch-package-for-migrations",
-      "linked_skills": []
-    },
-    {
-      "slug": "dataavro-json-wrapper-pattern",
-      "category": "decision",
-      "summary": "Single DataAvro{jsonData,jsonDataClass} wrapper avoids per-event Avro schema proliferation (TCM pattern)",
-      "confidence": "medium",
-      "source_project": "lucida-domain-automation",
-      "path": "decision/dataavro-json-wrapper-pattern",
-      "linked_skills": []
-    },
-    {
-      "slug": "do-not-ask-planners-for-api-design",
-      "category": "decision",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/do-not-ask-planners-for-api-design",
-      "linked_skills": []
-    },
-    {
-      "slug": "docker-engine-29-requires-traefik-upgrade",
-      "category": "pitfall",
-      "summary": "Docker Engine 29.x raises the minimum client API to 1.44, breaking older Traefik versions that pin an older API",
-      "confidence": "high",
-      "source_project": "lucida-for-docker",
-      "path": "pitfall/docker-engine-29-requires-traefik-upgrade",
       "linked_skills": []
     },
     {
@@ -2641,30 +2472,12 @@
       "linked_skills": []
     },
     {
-      "slug": "encrypted-pii-decode-on-export",
-      "category": "domain",
-      "summary": "PII fields (phone, email) are stored encrypted; only decrypted for explicit export/API response, never for logs.",
+      "slug": "DuckDB's five architectural pillars for analytical execution",
+      "category": "arch",
+      "summary": "Vectorized execution, pipelined operators, explicit memory + grouped aggregation, ART indexing, and query rewriting as a dedicated phase — the pillars that separate embedded analytical engines from row-at-a-time OLTP.",
       "confidence": "medium",
-      "source_project": "",
-      "path": "domain/encrypted-pii-decode-on-export",
-      "linked_skills": []
-    },
-    {
-      "slug": "enum-notnull-comparison-pitfall",
-      "category": "pitfall",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "pitfall/enum-notnull-comparison-pitfall",
-      "linked_skills": []
-    },
-    {
-      "slug": "enum-whitelist-blocks-time-based-sqli",
-      "category": "pitfall",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "pitfall/enum-whitelist-blocks-time-based-sqli",
+      "source_project": "skills_research:trend:2026-04-16",
+      "path": "arch/duckdb-vectorized-analytical-execution",
       "linked_skills": []
     },
     {
@@ -2677,39 +2490,12 @@
       "linked_skills": []
     },
     {
-      "slug": "es-xpack-transport-vs-rest-ssl",
-      "category": "api",
-      "summary": "Elasticsearch transport SSL and REST SSL are independent X-Pack configs; enabling one does not enable the other",
-      "confidence": "high",
-      "source_project": "",
-      "path": "api/es-xpack-transport-vs-rest-ssl",
-      "linked_skills": []
-    },
-    {
       "slug": "event-driven-init-wait-for-services",
       "category": "arch",
       "summary": "Initialization work is deferred until leader status and dependent-service readiness are confirmed via a `@WaitForServices` event listener",
       "confidence": "high",
       "source_project": "",
       "path": "arch/event-driven-init-wait-for-services",
-      "linked_skills": []
-    },
-    {
-      "slug": "existing-code-patterns-over-standard-rules",
-      "category": "decision",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/existing-code-patterns-over-standard-rules",
-      "linked_skills": []
-    },
-    {
-      "slug": "god-controller-split-by-resource",
-      "category": "decision",
-      "summary": "",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/god-controller-split-by-resource",
       "linked_skills": []
     },
     {
@@ -2722,57 +2508,12 @@
       "linked_skills": []
     },
     {
-      "slug": "gridfs-template-upload-data-loss-pitfall",
-      "category": "pitfall",
-      "summary": "MongoDB GridFS uploads can silently drop file bytes if the bucket/db selection or stream flush is wrong - always verify metadata size equals input size",
-      "confidence": "medium",
-      "source_project": "lucida-report",
-      "path": "pitfall/gridfs-template-upload-data-loss-pitfall",
-      "linked_skills": []
-    },
-    {
-      "slug": "hibernate-date-format-lowercase",
-      "category": "pitfall",
-      "summary": "Use lowercase `yyyy` for calendar year — `YYYY` is ISO week-year and produces wrong values near Jan 1 / Dec 31",
-      "confidence": "high",
-      "source_project": "",
-      "path": "pitfall/hibernate-date-format-lowercase",
-      "linked_skills": []
-    },
-    {
       "slug": "hierarchical-agents-md-catalog",
       "category": "arch",
       "summary": "루트 AGENTS.md(프로젝트 개요) + `skills/AGENTS.md`(스킬 카탈로그) 2계층 구조. 하위는 상위를 `<!-- Parent: ../AGENTS.md -->` 주석으로 가리킨다.",
       "confidence": "medium",
       "source_project": "",
       "path": "arch/hierarchical-agents-md-catalog",
-      "linked_skills": []
-    },
-    {
-      "slug": "history-view-yearly-partition-pitfall",
-      "category": "pitfall",
-      "summary": "A history/reporting view or materialized collection created with a year-bounded clause silently stops returning rows when the calendar year rolls over",
-      "confidence": "high",
-      "source_project": "lucida-notification",
-      "path": "pitfall/history-view-yearly-partition-pitfall",
-      "linked_skills": []
-    },
-    {
-      "slug": "hyperloglog-for-unique-user-counting",
-      "category": "decision",
-      "summary": "Scouter uses HyperLogLog (Clearspring stream-lib) to estimate recent and daily unique user counts with ~100 bytes of memory and ~2% error, avoiding O(n) hash sets",
-      "confidence": "medium",
-      "source_project": "scouter",
-      "path": "decision/hyperloglog-for-unique-user-counting",
-      "linked_skills": []
-    },
-    {
-      "slug": "injectmocks-generics-type-erasure",
-      "category": "pitfall",
-      "summary": "@InjectMocks picks wrong mock for same raw-type generic fields due to type erasure — flaky test root cause",
-      "confidence": "high",
-      "source_project": "lucida-domain-automation",
-      "path": "pitfall/injectmocks-generics-type-erasure",
       "linked_skills": []
     },
     {
@@ -2785,88 +2526,12 @@
       "linked_skills": []
     },
     {
-      "slug": "ipv6-colon-detection-edge",
-      "category": "pitfall",
-      "summary": "Detecting IPv6 by colon count breaks on compressed notation — use a regex character class",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "pitfall/ipv6-colon-detection-edge",
-      "linked_skills": []
-    },
-    {
-      "slug": "jackson-version-pinning-2.17.1",
-      "category": "pitfall",
-      "summary": "Jackson must be pinned via Gradle resolutionStrategy across all com.fasterxml.jackson.* groups to avoid NoSuchMethodError from transitive version drift",
-      "confidence": "high",
-      "source_project": "lucida-audit",
-      "path": "pitfall/jackson-version-pinning-2.17.1",
-      "linked_skills": []
-    },
-    {
-      "slug": "jacoco-exclude-business-layers",
-      "category": "decision",
-      "summary": "In this project's Jacoco config, nearly every layer (service, repository, dto, entity, kafka, config, constants, helper, exception, schedule, provider) is excluded from coverage measurement — only controllers/business orchestration code is measured.",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/jacoco-exclude-business-layers",
-      "linked_skills": []
-    },
-    {
-      "slug": "jacoco-sonar-exclusion-policy",
-      "category": "decision",
-      "summary": "Single exclusion list drives Jacoco + Sonar + test excludes; generated/boilerplate code never counts toward coverage",
-      "confidence": "medium",
-      "source_project": "lucida-measurement",
-      "path": "decision/jacoco-sonar-exclusion-policy",
-      "linked_skills": [
-        "querydsl-q-class-exclusion-pattern"
-      ]
-    },
-    {
-      "slug": "jacoco-sonar-exclusion-rationale",
-      "category": "decision",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/jacoco-sonar-exclusion-rationale",
-      "linked_skills": []
-    },
-    {
       "slug": "jar-task-disabled-bootjar-only",
       "category": "arch",
       "summary": "Gradle `jar` task is disabled so only `bootJar` produces an artifact — CI/Docker consumers never receive an ambiguous plain JAR",
       "confidence": "medium",
       "source_project": "lucida-audit",
       "path": "arch/jar-task-disabled-bootjar-only",
-      "linked_skills": []
-    },
-    {
-      "slug": "java-21-upgrade-rationale",
-      "category": "decision",
-      "summary": "Java 17 → 21 + Spring Boot 3.5.x upgrade rationale and required Gradle/JVM flag adjustments",
-      "confidence": "high",
-      "source_project": "lucida-audit",
-      "path": "decision/java-21-upgrade-rationale",
-      "linked_skills": [
-        "java-21-upgrade-rationale"
-      ]
-    },
-    {
-      "slug": "jdbc-template-var-xml-escape-bypass",
-      "category": "pitfall",
-      "summary": "When the template engine XML-escapes values but the downstream channel is raw SQL / plain text, the escaped `&amp; &lt; &gt;` leaks into stored data",
-      "confidence": "medium",
-      "source_project": "lucida-notification",
-      "path": "pitfall/jdbc-template-var-xml-escape-bypass",
-      "linked_skills": []
-    },
-    {
-      "slug": "jest-coverage-80-threshold",
-      "category": "decision",
-      "summary": "Global Jest coverage threshold is 80% on branches, functions, lines, and statements",
-      "confidence": "medium",
-      "source_project": "lucida-builder-r3",
-      "path": "decision/jest-coverage-80-threshold",
       "linked_skills": []
     },
     {
@@ -2879,39 +2544,12 @@
       "linked_skills": []
     },
     {
-      "slug": "jwt-stateless-refresh-24h-default",
-      "category": "decision",
-      "summary": "JWT stateless auth with 1h access / 24h refresh token defaults, both env-tunable.",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/jwt-stateless-refresh-24h-default",
-      "linked_skills": []
-    },
-    {
       "slug": "k-git-tag-registry-versioning",
       "category": "arch",
       "summary": "Git tag를 semver registry로 쓰면 별도 version manifest 없이 rollback·pinning을 얻는다",
       "confidence": "high",
       "source_project": "",
       "path": "arch/k-git-tag-registry-versioning",
-      "linked_skills": []
-    },
-    {
-      "slug": "k-kafka-message-header-metadata",
-      "category": "decision",
-      "summary": "멀티테넌트 Kafka routing 메타는 payload 대신 RecordHeader에 두어 business schema 오염을 막는다",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/k-kafka-message-header-metadata",
-      "linked_skills": []
-    },
-    {
-      "slug": "k8s-clusterrole-aggregation-npe",
-      "category": "pitfall",
-      "summary": "ClusterRole `aggregationRule` and its `clusterRoleSelectors` are both nullable — iterate only after null-check",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "pitfall/k8s-clusterrole-aggregation-npe",
       "linked_skills": []
     },
     {
@@ -2924,15 +2562,6 @@
       "linked_skills": [
         "kafka-consumer-semaphore-chunking"
       ]
-    },
-    {
-      "slug": "kafka-avro-change-flag-contract",
-      "category": "api",
-      "summary": "Every Configuration-domain Avro event carries an `actionType` enum (INSERT/UPDATE/DELETE) plus boolean change flags per mutable section (e.g. `parentChanged`, `tagFiltersChanged`, `configurationsChanged`) rather than full before/after payloads.",
-      "confidence": "high",
-      "source_project": "",
-      "path": "api/kafka-avro-change-flag-contract",
-      "linked_skills": []
     },
     {
       "slug": "kafka-avro-schedule-event-chain",
@@ -2953,44 +2582,6 @@
       "linked_skills": []
     },
     {
-      "slug": "kafka-batch-size-timeout-tuning",
-      "category": "decision",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/kafka-batch-size-timeout-tuning",
-      "linked_skills": [
-        "kafka-batch-consumer-partition-tuning"
-      ]
-    },
-    {
-      "slug": "kafka-consumer-group-id-hostname-not-timezone",
-      "category": "pitfall",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "pitfall/kafka-consumer-group-id-hostname-not-timezone",
-      "linked_skills": []
-    },
-    {
-      "slug": "kafka-error-handling-deserializer-fallback",
-      "category": "pitfall",
-      "summary": "Wrap Avro/JSON deserializers in ErrorHandlingDeserializer so a single bad record doesn't poison the consumer and crash-loop the container",
-      "confidence": "high",
-      "source_project": "lucida-audit",
-      "path": "pitfall/kafka-error-handling-deserializer-fallback",
-      "linked_skills": []
-    },
-    {
-      "slug": "kafka-organization-id-record-header",
-      "category": "api",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "api/kafka-organization-id-record-header",
-      "linked_skills": []
-    },
-    {
       "slug": "kafka-partition-topology-design",
       "category": "arch",
       "summary": "",
@@ -3002,77 +2593,21 @@
       ]
     },
     {
-      "slug": "kafka-sticky-partitioner-key-null",
-      "category": "pitfall",
-      "summary": "Kafka Sticky Partitioner batches key=null messages into one partition — explains dev vs prod distribution gap",
-      "confidence": "high",
-      "source_project": "lucida-domain-automation",
-      "path": "pitfall/kafka-sticky-partitioner-key-null",
-      "linked_skills": []
-    },
-    {
-      "slug": "konva-center-coord-system",
-      "category": "pitfall",
-      "summary": "Konva node coordinates can be center-based; when converting to top-left boxes subtract half width/height",
-      "confidence": "medium",
-      "source_project": "lucida-builder-r3",
-      "path": "pitfall/konva-center-coord-system",
-      "linked_skills": []
-    },
-    {
-      "slug": "large-range-query-raw-collections",
-      "category": "decision",
-      "summary": "For long time-range queries over day-partitioned data, hit raw daily collections instead of aggregated views to avoid timeouts",
-      "confidence": "high",
-      "source_project": "lucida-domain-apm",
-      "path": "decision/large-range-query-raw-collections",
-      "linked_skills": []
-    },
-    {
-      "slug": "latest-availability-deletion-risk",
-      "category": "pitfall",
-      "summary": "Latest-availability collection can lose data when upstream source is stale but not actually missing",
-      "confidence": "high",
-      "source_project": "lucida-measurement",
-      "path": "pitfall/latest-availability-deletion-risk",
-      "linked_skills": [
-        "availability-ttl-punctuate-processor"
-      ]
-    },
-    {
-      "slug": "legacy-datasource-naming",
-      "category": "pitfall",
-      "summary": "`dataSource` / `dataSourceFilter` in the codebase actually mean data-pipeline-select and data-pipeline-filter — not datasource",
-      "confidence": "high",
-      "source_project": "lucida-builder-r3",
-      "path": "pitfall/legacy-datasource-naming",
-      "linked_skills": []
-    },
-    {
-      "slug": "license-apply-window-15d",
-      "category": "decision",
-      "summary": "Issued licenses must be applied within 15 days; expired licenses are immutable.",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/license-apply-window-15d",
-      "linked_skills": []
-    },
-    {
-      "slug": "live-chart-timestamp-normalization",
-      "category": "api",
-      "summary": "LIVE charts accept `normalizeTimestamp` + `normalizeIntervalMs` to align per-agent millisecond offsets into a single x-axis",
-      "confidence": "medium",
-      "source_project": "lucida-measurement",
-      "path": "api/live-chart-timestamp-normalization",
-      "linked_skills": []
-    },
-    {
       "slug": "live-mode-aggregation-exceptions",
       "category": "arch",
       "summary": "LIVE mode reads raw data by default, but equalizer / multi-resource / TopN charts still aggregate raw at query time",
       "confidence": "medium",
       "source_project": "lucida-measurement",
       "path": "arch/live-mode-aggregation-exceptions",
+      "linked_skills": []
+    },
+    {
+      "slug": "The MxN problem of LLM tool calling across open-source models",
+      "category": "arch",
+      "summary": "Each OSS LLM family encodes tool calls in a different wire format (special tokens, XML, channel notation, JSON blocks), forcing M inference apps x N models of parser duplication. Fix is declarative tool-call specs shipped with the model.",
+      "confidence": "medium",
+      "source_project": "skills_research:trend:2026-04-16",
+      "path": "arch/llm-tool-calling-mxn-wire-format-problem",
       "linked_skills": []
     },
     {
@@ -3085,122 +2620,12 @@
       "linked_skills": []
     },
     {
-      "slug": "measurement-batch-send-per-config",
-      "category": "decision",
-      "summary": "",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/measurement-batch-send-per-config",
-      "linked_skills": []
-    },
-    {
-      "slug": "mongo-direct-connection-flag",
-      "category": "pitfall",
-      "summary": "MongoDB datasource connectionString requires directConnection=true in this deployment",
-      "confidence": "medium",
-      "source_project": "lucida-builder-r3",
-      "path": "pitfall/mongo-direct-connection-flag",
-      "linked_skills": []
-    },
-    {
-      "slug": "mongo-timeseries-forced-hint-kills-pushdown",
-      "category": "pitfall",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "pitfall/mongo-timeseries-forced-hint-kills-pushdown",
-      "linked_skills": []
-    },
-    {
-      "slug": "mongo-timeseries-match-split-for-pushdown",
-      "category": "pitfall",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "pitfall/mongo-timeseries-match-split-for-pushdown",
-      "linked_skills": []
-    },
-    {
-      "slug": "mongo-timeseries-view-pushdown-broken-8_2_3",
-      "category": "pitfall",
-      "summary": "",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "pitfall/mongo-timeseries-view-pushdown-broken-8_2_3",
-      "linked_skills": []
-    },
-    {
       "slug": "mongodb-aggregated-stats-as-views",
       "category": "arch",
       "summary": "",
       "confidence": "high",
       "source_project": "",
       "path": "arch/mongodb-aggregated-stats-as-views",
-      "linked_skills": []
-    },
-    {
-      "slug": "mongodb-changestream-resubscribe",
-      "category": "pitfall",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "pitfall/mongodb-changestream-resubscribe",
-      "linked_skills": [
-        "mongodb-changestream-field-filter"
-      ]
-    },
-    {
-      "slug": "mongodb-compound-index-on-views",
-      "category": "pitfall",
-      "summary": "Spring Data @CompoundIndex annotations on a view-backed @Document are silently ignored — index the collection class",
-      "confidence": "high",
-      "source_project": "lucida-domain-apm",
-      "path": "pitfall/mongodb-compound-index-on-views",
-      "linked_skills": []
-    },
-    {
-      "slug": "mongodb-documentreference-lazy-removal",
-      "category": "pitfall",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "pitfall/mongodb-documentreference-lazy-removal",
-      "linked_skills": []
-    },
-    {
-      "slug": "mongodb-exclude-system-databases",
-      "category": "domain",
-      "summary": "When enumerating tenant databases in a shared MongoDB cluster, filter out admin/config/local plus third-party DBs (yorkie-meta, migration) to avoid touching shared state",
-      "confidence": "medium",
-      "source_project": "lucida-audit",
-      "path": "domain/mongodb-exclude-system-databases",
-      "linked_skills": []
-    },
-    {
-      "slug": "mongodb-field-name-underscore-to-dot",
-      "category": "pitfall",
-      "summary": "|",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "pitfall/mongodb-field-name-underscore-to-dot",
-      "linked_skills": []
-    },
-    {
-      "slug": "mongodb-single-node-directconnection",
-      "category": "pitfall",
-      "summary": "MongoDB clients must pass directConnection=true when connecting to a single-node replSet, otherwise they hang on primary discovery",
-      "confidence": "high",
-      "source_project": "lucida-for-docker",
-      "path": "pitfall/mongodb-single-node-directconnection",
-      "linked_skills": []
-    },
-    {
-      "slug": "mongodb-string-id-field-type-mapping",
-      "category": "pitfall",
-      "summary": "Spring Data MongoDB coerces 24-char-hex @Id String values to ObjectId unless @Field(targetType = FieldType.STRING) is set",
-      "confidence": "high",
-      "source_project": "lucida-domain-dpm",
-      "path": "pitfall/mongodb-string-id-field-type-mapping",
       "linked_skills": []
     },
     {
@@ -3222,30 +2647,12 @@
       "linked_skills": []
     },
     {
-      "slug": "mysql-mariadb-performance-schema-detection",
-      "category": "domain",
-      "summary": "MySQL/MariaDB metric availability depends on per-instance Performance Schema state; detect at runtime, don't assume",
-      "confidence": "medium",
-      "source_project": "lucida-domain-dpm",
-      "path": "domain/mysql-mariadb-performance-schema-detection",
-      "linked_skills": []
-    },
-    {
       "slug": "nfs-backed-volumes-for-docker-swarm",
       "category": "arch",
       "summary": "Cross-node Docker Swarm persistence via a single NFS share mounted at the same host path on every swarm node",
       "confidence": "high",
       "source_project": "lucida-for-docker",
       "path": "arch/nfs-backed-volumes-for-docker-swarm",
-      "linked_skills": []
-    },
-    {
-      "slug": "node-npm-pin-matches-jenkins",
-      "category": "decision",
-      "summary": "UI build is pinned to Node 24.6.0 + npm 11.5.1 to match the Jenkins build environment",
-      "confidence": "high",
-      "source_project": "lucida-builder-r3",
-      "path": "decision/node-npm-pin-matches-jenkins",
       "linked_skills": []
     },
     {
@@ -3582,77 +2989,12 @@
       "linked_skills": []
     },
     {
-      "slug": "one-default-template-per-type-rule",
-      "category": "domain",
-      "summary": "Exactly one default message template may exist per notification type; creating a second default is rejected, but editing the existing default is allowed",
-      "confidence": "high",
-      "source_project": "lucida-notification",
-      "path": "domain/one-default-template-per-type-rule",
-      "linked_skills": []
-    },
-    {
       "slug": "openapi-as-single-fe-be-contract",
       "category": "arch",
       "summary": "",
       "confidence": "high",
       "source_project": "",
       "path": "arch/openapi-as-single-fe-be-contract",
-      "linked_skills": []
-    },
-    {
-      "slug": "organization-soft-delete-grace-period",
-      "category": "decision",
-      "summary": "Organization deletion uses a 30-day grace period before permanent removal (DELETE_ORGANIZATION_INTERVAL_DAYS).",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/organization-soft-delete-grace-period",
-      "linked_skills": []
-    },
-    {
-      "slug": "oz-license-file-placement-flip-flop",
-      "category": "pitfall",
-      "summary": "Vendor engines (OZ Report, Crystal, Jasper-Pro) often hard-code license file search paths - pin the path in the image and document it, or you will ship it broken repeatedly",
-      "confidence": "medium",
-      "source_project": "lucida-report",
-      "path": "pitfall/oz-license-file-placement-flip-flop",
-      "linked_skills": []
-    },
-    {
-      "slug": "page-map-returns-new-instance",
-      "category": "pitfall",
-      "summary": "Spring Data Page is immutable — Page.map() returns a new instance; forgetting to reassign silently loses the mapping",
-      "confidence": "high",
-      "source_project": "lucida-domain-automation",
-      "path": "pitfall/page-map-returns-new-instance",
-      "linked_skills": []
-    },
-    {
-      "slug": "period-interval-naming-convention",
-      "category": "domain",
-      "summary": "Period.Mode names encode both unit and multiplier (MIN_15, MONTH_2); monthly modes densify at 24h, not the unit itself",
-      "confidence": "medium",
-      "source_project": "lucida-measurement",
-      "path": "domain/period-interval-naming-convention",
-      "linked_skills": [
-        "period-mode-enum-config"
-      ]
-    },
-    {
-      "slug": "pims-write-requires-dryrun-confirm",
-      "category": "domain",
-      "summary": "PIMS 시간 기록/제출/일괄 갱신 등 모든 쓰기 API는 미리보기 → 사용자 확인 → 재시도 가능한 실행 플로우를 반드시 거친다. `--dry-run`은 API 쓰기 호출 자체가 금지.",
-      "confidence": "high",
-      "source_project": "",
-      "path": "domain/pims-write-requires-dryrun-confirm",
-      "linked_skills": []
-    },
-    {
-      "slug": "planning-doc-in-issue-description",
-      "category": "decision",
-      "summary": "",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/planning-doc-in-issue-description",
       "linked_skills": []
     },
     {
@@ -3665,24 +3007,13 @@
       "linked_skills": []
     },
     {
-      "slug": "plugin-repo-scope-generic-skills-only",
-      "category": "decision",
-      "summary": "nkia-skills 같은 공용 플러그인에는 범용 스킬만. 프로젝트 특화 스킬은 각 프로젝트의 `.claude/skills/`에 둔다.",
+      "slug": "Polymorphic metadata persisted as BSON via enum-switch deserialization",
+      "category": "arch",
+      "summary": "",
       "confidence": "high",
       "source_project": "",
-      "path": "decision/plugin-repo-scope-generic-skills-only",
+      "path": "arch/polymorphic-metadata-via-enum-switch",
       "linked_skills": []
-    },
-    {
-      "slug": "policy-edit-saveraw-loss",
-      "category": "pitfall",
-      "summary": "Editing a common collection policy can silently drop individual `saveRaw`/interval settings if not re-applied",
-      "confidence": "high",
-      "source_project": "lucida-measurement",
-      "path": "pitfall/policy-edit-saveraw-loss",
-      "linked_skills": [
-        "non-metric-saveraw-null-rule"
-      ]
     },
     {
       "slug": "port-out-no-optional-raise-in-adapter",
@@ -3691,6 +3022,383 @@
       "confidence": "medium",
       "source_project": "",
       "path": "arch/port-out-no-optional-raise-in-adapter",
+      "linked_skills": []
+    },
+    {
+      "slug": "published-vs-realtime-view-pages",
+      "category": "arch",
+      "summary": "PublishedViewPage renders a frozen deploy snapshot; RealTimeViewPage renders the live editable dashboard",
+      "confidence": "high",
+      "source_project": "lucida-builder-r3",
+      "path": "arch/published-vs-realtime-view-pages",
+      "linked_skills": []
+    },
+    {
+      "slug": "redis-change-counter-for-versioning-trigger",
+      "category": "arch",
+      "summary": "|",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "arch/redis-change-counter-for-versioning-trigger",
+      "linked_skills": []
+    },
+    {
+      "slug": "scouter-three-tier-architecture",
+      "category": "arch",
+      "summary": "Scouter APM enforces strict agent → server → client separation, with an optional standalone HTTP webapp for horizontal scaling of query load",
+      "confidence": "high",
+      "source_project": "scouter",
+      "path": "arch/scouter-three-tier-architecture",
+      "linked_skills": []
+    },
+    {
+      "slug": "shallow-clone-mktemp-cleanup-pattern",
+      "category": "arch",
+      "summary": "publish/install/원격 목록 조회처럼 원격 git repo를 만질 때는 `mktemp -d → git clone --depth 1 → 작업 → rm -rf`. 작업 디렉토리를 오염시키지 않는다.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "arch/shallow-clone-mktemp-cleanup-pattern",
+      "linked_skills": []
+    },
+    {
+      "slug": "Per-request tenant context via HandlerInterceptor",
+      "category": "arch",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "arch/tenant-context-per-request-interceptor",
+      "linked_skills": []
+    },
+    {
+      "slug": "Gate startup initialization on dependent-service readiness via @WaitForServices",
+      "category": "arch",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "arch/wait-for-services-eureka-startup-init",
+      "linked_skills": []
+    },
+    {
+      "slug": "widget-is-frozen-group-snapshot",
+      "category": "arch",
+      "summary": "Widgets are snapshots of a group at save time; later edits to the source group do not propagate",
+      "confidence": "high",
+      "source_project": "lucida-builder-r3",
+      "path": "arch/widget-is-frozen-group-snapshot",
+      "linked_skills": []
+    },
+    {
+      "slug": "yorkie-team-server-split",
+      "category": "arch",
+      "summary": "Yorkie holds live canvas state; the team server holds metadata (projects, assets, datasources) — never mix",
+      "confidence": "high",
+      "source_project": "lucida-builder-r3",
+      "path": "arch/yorkie-team-server-split",
+      "linked_skills": []
+    },
+    {
+      "slug": "actuator-endpoints-skip-auth-by-design",
+      "category": "decision",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "decision/actuator-endpoints-skip-auth-by-design",
+      "linked_skills": []
+    },
+    {
+      "slug": "admin-role-disabled-secretkey",
+      "category": "decision",
+      "summary": "Default `admins` role is disabled and the shared `SecretKey` was removed from `config.properties` — never re-enable without a per-install key",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "decision/admin-role-disabled-secretkey",
+      "linked_skills": []
+    },
+    {
+      "slug": "alarm-raw-over-1min-aggregate",
+      "category": "decision",
+      "summary": "Alarm judgement reads raw metrics, not 1-minute aggregates — accuracy over storage cost",
+      "confidence": "high",
+      "source_project": "lucida-measurement",
+      "path": "decision/alarm-raw-over-1min-aggregate",
+      "linked_skills": [
+        "kafka-consumer-semaphore-chunking"
+      ]
+    },
+    {
+      "slug": "assume-semantics-for-compiler-hints",
+      "category": "decision",
+      "summary": "Three-tier assertion strategy (Assert / CHECK_NONFATAL / Assume) separates fatal invariants from recoverable logic bugs and pure compiler hints.",
+      "confidence": "high",
+      "source_project": "bitcoin",
+      "path": "decision/assume-semantics-for-compiler-hints",
+      "linked_skills": []
+    },
+    {
+      "slug": "avro-private-fields-no-setters",
+      "category": "decision",
+      "summary": "Avro-generated classes are configured with `fieldVisibility=PRIVATE` and `createSetters=false` to enforce immutability on event payloads",
+      "confidence": "high",
+      "source_project": "",
+      "path": "decision/avro-private-fields-no-setters",
+      "linked_skills": []
+    },
+    {
+      "slug": "cache-even-when-enable-false",
+      "category": "decision",
+      "summary": "Notification configs with `enable=false` are still loaded into the cache manager rather than skipped, so toggling enable on/off doesn't require a cache reload",
+      "confidence": "high",
+      "source_project": "lucida-notification",
+      "path": "decision/cache-even-when-enable-false",
+      "linked_skills": []
+    },
+    {
+      "slug": "caveats-absence-confidence-cap",
+      "category": "decision",
+      "summary": "반증 조건(Counter/Caveats)이 비어 있는 knowledge는 confidence 최대 medium으로 강등한다 — 미확인 = 과신 위험",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "decision/caveats-absence-confidence-cap",
+      "linked_skills": []
+    },
+    {
+      "slug": "circular-dependency-detection-script",
+      "category": "decision",
+      "summary": "A small Python script that parses #include directives across the tree and reports the shortest cycle in the module graph — cheap CI gate against architectural decay.",
+      "confidence": "high",
+      "source_project": "bitcoin",
+      "path": "decision/circular-dependency-detection-script",
+      "linked_skills": []
+    },
+    {
+      "slug": "confid-only-query-over-resource-tuple",
+      "category": "decision",
+      "summary": "Performance queries key off `confId` (config id) whenever available, falling back to (resourceType, resourceName) only when confId is absent",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "decision/confid-only-query-over-resource-tuple",
+      "linked_skills": []
+    },
+    {
+      "slug": "copy-naming-suffix-numbered",
+      "category": "decision",
+      "summary": "|",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "decision/copy-naming-suffix-numbered",
+      "linked_skills": []
+    },
+    {
+      "slug": "cors-allow-credentials-star-origin",
+      "category": "decision",
+      "summary": "Service-level allowCredentials+allowedOriginPatterns(*) kept because edge proxy (Traefik/Istio) enforces CORS",
+      "confidence": "medium",
+      "source_project": "lucida-domain-automation",
+      "path": "decision/cors-allow-credentials-star-origin",
+      "linked_skills": []
+    },
+    {
+      "slug": "csp-frame-ancestors-required",
+      "category": "decision",
+      "summary": "Send a Content-Security-Policy header (including `frame-ancestors`) on every response to block clickjacking",
+      "confidence": "high",
+      "source_project": "",
+      "path": "decision/csp-frame-ancestors-required",
+      "linked_skills": []
+    },
+    {
+      "slug": "dataavro-json-wrapper-pattern",
+      "category": "decision",
+      "summary": "Single DataAvro{jsonData,jsonDataClass} wrapper avoids per-event Avro schema proliferation (TCM pattern)",
+      "confidence": "medium",
+      "source_project": "lucida-domain-automation",
+      "path": "decision/dataavro-json-wrapper-pattern",
+      "linked_skills": []
+    },
+    {
+      "slug": "do-not-ask-planners-for-api-design",
+      "category": "decision",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "decision/do-not-ask-planners-for-api-design",
+      "linked_skills": []
+    },
+    {
+      "slug": "existing-code-patterns-over-standard-rules",
+      "category": "decision",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "decision/existing-code-patterns-over-standard-rules",
+      "linked_skills": []
+    },
+    {
+      "slug": "5NF applies when AB-BC-AC triangles or ABC+D stars appear; otherwise stop at 4NF",
+      "category": "decision",
+      "summary": "5NF catches join dependencies that 4NF/BCNF miss, but in practice you rarely reason about it directly. Design from business entities and recognize the two patterns that force 5NF.",
+      "confidence": "medium",
+      "source_project": "skills_research:trend:2026-04-16",
+      "path": "decision/fifth-normal-form-join-dependency-tradeoff",
+      "linked_skills": []
+    },
+    {
+      "slug": "god-controller-split-by-resource",
+      "category": "decision",
+      "summary": "",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "decision/god-controller-split-by-resource",
+      "linked_skills": []
+    },
+    {
+      "slug": "hyperloglog-for-unique-user-counting",
+      "category": "decision",
+      "summary": "Scouter uses HyperLogLog (Clearspring stream-lib) to estimate recent and daily unique user counts with ~100 bytes of memory and ~2% error, avoiding O(n) hash sets",
+      "confidence": "medium",
+      "source_project": "scouter",
+      "path": "decision/hyperloglog-for-unique-user-counting",
+      "linked_skills": []
+    },
+    {
+      "slug": "jacoco-exclude-business-layers",
+      "category": "decision",
+      "summary": "In this project's Jacoco config, nearly every layer (service, repository, dto, entity, kafka, config, constants, helper, exception, schedule, provider) is excluded from coverage measurement — only controllers/business orchestration code is measured.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "decision/jacoco-exclude-business-layers",
+      "linked_skills": []
+    },
+    {
+      "slug": "jacoco-sonar-exclusion-policy",
+      "category": "decision",
+      "summary": "Single exclusion list drives Jacoco + Sonar + test excludes; generated/boilerplate code never counts toward coverage",
+      "confidence": "medium",
+      "source_project": "lucida-measurement",
+      "path": "decision/jacoco-sonar-exclusion-policy",
+      "linked_skills": [
+        "querydsl-q-class-exclusion-pattern"
+      ]
+    },
+    {
+      "slug": "jacoco-sonar-exclusion-rationale",
+      "category": "decision",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "decision/jacoco-sonar-exclusion-rationale",
+      "linked_skills": []
+    },
+    {
+      "slug": "java-21-upgrade-rationale",
+      "category": "decision",
+      "summary": "Java 17 → 21 + Spring Boot 3.5.x upgrade rationale and required Gradle/JVM flag adjustments",
+      "confidence": "high",
+      "source_project": "lucida-audit",
+      "path": "decision/java-21-upgrade-rationale",
+      "linked_skills": [
+        "java-21-upgrade-rationale"
+      ]
+    },
+    {
+      "slug": "jest-coverage-80-threshold",
+      "category": "decision",
+      "summary": "Global Jest coverage threshold is 80% on branches, functions, lines, and statements",
+      "confidence": "medium",
+      "source_project": "lucida-builder-r3",
+      "path": "decision/jest-coverage-80-threshold",
+      "linked_skills": []
+    },
+    {
+      "slug": "jwt-stateless-refresh-24h-default",
+      "category": "decision",
+      "summary": "JWT stateless auth with 1h access / 24h refresh token defaults, both env-tunable.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "decision/jwt-stateless-refresh-24h-default",
+      "linked_skills": []
+    },
+    {
+      "slug": "k-kafka-message-header-metadata",
+      "category": "decision",
+      "summary": "멀티테넌트 Kafka routing 메타는 payload 대신 RecordHeader에 두어 business schema 오염을 막는다",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "decision/k-kafka-message-header-metadata",
+      "linked_skills": []
+    },
+    {
+      "slug": "kafka-batch-size-timeout-tuning",
+      "category": "decision",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "decision/kafka-batch-size-timeout-tuning",
+      "linked_skills": [
+        "kafka-batch-consumer-partition-tuning"
+      ]
+    },
+    {
+      "slug": "large-range-query-raw-collections",
+      "category": "decision",
+      "summary": "For long time-range queries over day-partitioned data, hit raw daily collections instead of aggregated views to avoid timeouts",
+      "confidence": "high",
+      "source_project": "lucida-domain-apm",
+      "path": "decision/large-range-query-raw-collections",
+      "linked_skills": []
+    },
+    {
+      "slug": "license-apply-window-15d",
+      "category": "decision",
+      "summary": "Issued licenses must be applied within 15 days; expired licenses are immutable.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "decision/license-apply-window-15d",
+      "linked_skills": []
+    },
+    {
+      "slug": "measurement-batch-send-per-config",
+      "category": "decision",
+      "summary": "",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "decision/measurement-batch-send-per-config",
+      "linked_skills": []
+    },
+    {
+      "slug": "node-npm-pin-matches-jenkins",
+      "category": "decision",
+      "summary": "UI build is pinned to Node 24.6.0 + npm 11.5.1 to match the Jenkins build environment",
+      "confidence": "high",
+      "source_project": "lucida-builder-r3",
+      "path": "decision/node-npm-pin-matches-jenkins",
+      "linked_skills": []
+    },
+    {
+      "slug": "organization-soft-delete-grace-period",
+      "category": "decision",
+      "summary": "Organization deletion uses a 30-day grace period before permanent removal (DELETE_ORGANIZATION_INTERVAL_DAYS).",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "decision/organization-soft-delete-grace-period",
+      "linked_skills": []
+    },
+    {
+      "slug": "planning-doc-in-issue-description",
+      "category": "decision",
+      "summary": "",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "decision/planning-doc-in-issue-description",
+      "linked_skills": []
+    },
+    {
+      "slug": "plugin-repo-scope-generic-skills-only",
+      "category": "decision",
+      "summary": "nkia-skills 같은 공용 플러그인에는 범용 스킬만. 프로젝트 특화 스킬은 각 프로젝트의 `.claude/skills/`에 둔다.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "decision/plugin-repo-scope-generic-skills-only",
       "linked_skills": []
     },
     {
@@ -3709,15 +3417,6 @@
       "confidence": "high",
       "source_project": "",
       "path": "decision/prefer-static-import-over-constant-inheritance",
-      "linked_skills": []
-    },
-    {
-      "slug": "published-vs-realtime-view-pages",
-      "category": "arch",
-      "summary": "PublishedViewPage renders a frozen deploy snapshot; RealTimeViewPage renders the live editable dashboard",
-      "confidence": "high",
-      "source_project": "lucida-builder-r3",
-      "path": "arch/published-vs-realtime-view-pages",
       "linked_skills": []
     },
     {
@@ -3748,39 +3447,12 @@
       "linked_skills": []
     },
     {
-      "slug": "redis-change-counter-for-versioning-trigger",
-      "category": "arch",
-      "summary": "|",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/redis-change-counter-for-versioning-trigger",
-      "linked_skills": []
-    },
-    {
-      "slug": "refresh-token-do-not-regenerate",
-      "category": "pitfall",
-      "summary": "A refresh call must issue a new ACCESS token only, never a new refresh token.",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "pitfall/refresh-token-do-not-regenerate",
-      "linked_skills": []
-    },
-    {
       "slug": "resource-mount-unmount-use-jar-defaults",
       "category": "decision",
       "summary": "Don't bind-mount i18n/exception/menu resource files into Spring Boot containers; let the jar ship its own defaults",
       "confidence": "high",
       "source_project": "lucida-for-docker",
       "path": "decision/resource-mount-unmount-use-jar-defaults",
-      "linked_skills": []
-    },
-    {
-      "slug": "root-span-error-propagation",
-      "category": "domain",
-      "summary": "Root span isError must aggregate descendant errors; otherwise scatter and list views disagree on a trace's error state",
-      "confidence": "medium",
-      "source_project": "lucida-domain-apm",
-      "path": "domain/root-span-error-propagation",
       "linked_skills": []
     },
     {
@@ -3802,12 +3474,602 @@
       "linked_skills": []
     },
     {
-      "slug": "scouter-three-tier-architecture",
-      "category": "arch",
-      "summary": "Scouter APM enforces strict agent → server → client separation, with an optional standalone HTTP webapp for horizontal scaling of query load",
+      "slug": "skill-registry-vs-skill-config-split",
+      "category": "decision",
+      "summary": "원격 저장소 정보는 `.claude/skill-registry.yaml`, 스킬별 런타임 옵션(출력 경로 등)은 `.claude/skill-config.yaml`. 파일 단위로 관심사 분리.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "decision/skill-registry-vs-skill-config-split",
+      "linked_skills": []
+    },
+    {
+      "slug": "stub-in-service-unblocks-fe-parallelism",
+      "category": "decision",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "decision/stub-in-service-unblocks-fe-parallelism",
+      "linked_skills": []
+    },
+    {
+      "slug": "system-notification-shared-with-2fa-and-password-find",
+      "category": "decision",
+      "summary": "The `system_notification` config (SMTP/SMS credentials) is intentionally shared between 2FA and password-find flows rather than duplicated per flow",
+      "confidence": "medium",
+      "source_project": "lucida-notification",
+      "path": "decision/system-notification-shared-with-2fa-and-password-find",
+      "linked_skills": []
+    },
+    {
+      "slug": "tabular-metric-excluded-from-list",
+      "category": "decision",
+      "summary": "TABULAR measurement type is intentionally excluded from searchable metric-definition list endpoints",
+      "confidence": "high",
+      "source_project": "",
+      "path": "decision/tabular-metric-excluded-from-list",
+      "linked_skills": []
+    },
+    {
+      "slug": "tag-values-separate-collection",
+      "category": "decision",
+      "summary": "TagValueInfo's `values` array was extracted from the parent tag document into a separate `tag_value_detail` collection to bound document size and index cost.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "decision/tag-values-separate-collection",
+      "linked_skills": []
+    },
+    {
+      "slug": "tomcat-request-timeout-1h-for-oz-report",
+      "category": "decision",
+      "summary": "Report-generation services should raise Tomcat connection/read timeout to ~1 hour because export of large OZ/Jasper reports is genuinely long-running",
+      "confidence": "high",
+      "source_project": "lucida-report",
+      "path": "decision/tomcat-request-timeout-1h-for-oz-report",
+      "linked_skills": []
+    },
+    {
+      "slug": "Typed wikilinks for an LLM-facing knowledge base",
+      "category": "decision",
+      "summary": "Flat [[wikilinks]] carry one bit of information. Tag each link with a relationship type (supersedes, contradicts, causes, supports) so the graph becomes queryable, and sync types into frontmatter for external tools.",
+      "confidence": "medium",
+      "source_project": "skills_research:trend:2026-04-16",
+      "path": "decision/typed-wikilinks-for-llm-knowledge-base",
+      "linked_skills": []
+    },
+    {
+      "slug": "udp-for-throughput-tcp-for-reliability",
+      "category": "decision",
+      "summary": "Scouter streams periodic metrics over UDP (lossy but cheap) and reserves TCP for config fetch, agent registration, and XLog profile uploads that demand delivery guarantees",
       "confidence": "high",
       "source_project": "scouter",
-      "path": "arch/scouter-three-tier-architecture",
+      "path": "decision/udp-for-throughput-tcp-for-reliability",
+      "linked_skills": []
+    },
+    {
+      "slug": "variable-length-integer-encoding-for-metrics-bandwidth",
+      "category": "decision",
+      "summary": "Scouter's DataOutputX uses 3-byte (INT3) and 5-byte (LONG5) integer encodings to shrink UDP metric packs by 20-40% when most values fit within 24 / 40 bits",
+      "confidence": "medium",
+      "source_project": "scouter",
+      "path": "decision/variable-length-integer-encoding-for-metrics-bandwidth",
+      "linked_skills": []
+    },
+    {
+      "slug": "vllm-kv-cache-fp8-with-mtp",
+      "category": "decision",
+      "summary": "vLLM serving chose fp8_e4m3 KV cache + prefix caching + MTP speculative decoding for Qwen3.5 throughput",
+      "confidence": "medium",
+      "source_project": "lucida-for-docker",
+      "path": "decision/vllm-kv-cache-fp8-with-mtp",
+      "linked_skills": []
+    },
+    {
+      "slug": "account-lockout-configurable-threshold",
+      "category": "domain",
+      "summary": "Failed-login counter locks the account after a configurable threshold (ACCOUNT_LOCKOUT, default 10).",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "domain/account-lockout-configurable-threshold",
+      "linked_skills": []
+    },
+    {
+      "slug": "encrypted-pii-decode-on-export",
+      "category": "domain",
+      "summary": "PII fields (phone, email) are stored encrypted; only decrypted for explicit export/API response, never for logs.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "domain/encrypted-pii-decode-on-export",
+      "linked_skills": []
+    },
+    {
+      "slug": "mongodb-exclude-system-databases",
+      "category": "domain",
+      "summary": "When enumerating tenant databases in a shared MongoDB cluster, filter out admin/config/local plus third-party DBs (yorkie-meta, migration) to avoid touching shared state",
+      "confidence": "medium",
+      "source_project": "lucida-audit",
+      "path": "domain/mongodb-exclude-system-databases",
+      "linked_skills": []
+    },
+    {
+      "slug": "mysql-mariadb-performance-schema-detection",
+      "category": "domain",
+      "summary": "MySQL/MariaDB metric availability depends on per-instance Performance Schema state; detect at runtime, don't assume",
+      "confidence": "medium",
+      "source_project": "lucida-domain-dpm",
+      "path": "domain/mysql-mariadb-performance-schema-detection",
+      "linked_skills": []
+    },
+    {
+      "slug": "one-default-template-per-type-rule",
+      "category": "domain",
+      "summary": "Exactly one default message template may exist per notification type; creating a second default is rejected, but editing the existing default is allowed",
+      "confidence": "high",
+      "source_project": "lucida-notification",
+      "path": "domain/one-default-template-per-type-rule",
+      "linked_skills": []
+    },
+    {
+      "slug": "period-interval-naming-convention",
+      "category": "domain",
+      "summary": "Period.Mode names encode both unit and multiplier (MIN_15, MONTH_2); monthly modes densify at 24h, not the unit itself",
+      "confidence": "medium",
+      "source_project": "lucida-measurement",
+      "path": "domain/period-interval-naming-convention",
+      "linked_skills": [
+        "period-mode-enum-config"
+      ]
+    },
+    {
+      "slug": "pims-write-requires-dryrun-confirm",
+      "category": "domain",
+      "summary": "PIMS 시간 기록/제출/일괄 갱신 등 모든 쓰기 API는 미리보기 → 사용자 확인 → 재시도 가능한 실행 플로우를 반드시 거친다. `--dry-run`은 API 쓰기 호출 자체가 금지.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "domain/pims-write-requires-dryrun-confirm",
+      "linked_skills": []
+    },
+    {
+      "slug": "root-span-error-propagation",
+      "category": "domain",
+      "summary": "Root span isError must aggregate descendant errors; otherwise scatter and list views disagree on a trace's error state",
+      "confidence": "medium",
+      "source_project": "lucida-domain-apm",
+      "path": "domain/root-span-error-propagation",
+      "linked_skills": []
+    },
+    {
+      "slug": "topresource-immediate-generation-invariant",
+      "category": "domain",
+      "summary": "In report immediate-generation, the topResource flag decides whether to query by resource-id (fast path) or the full conf-id set (slow path)",
+      "confidence": "medium",
+      "source_project": "lucida-report",
+      "path": "domain/topresource-immediate-generation-invariant",
+      "linked_skills": []
+    },
+    {
+      "slug": "actuator-metric-call-aggressive-timeout",
+      "category": "pitfall",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "pitfall/actuator-metric-call-aggressive-timeout",
+      "linked_skills": []
+    },
+    {
+      "slug": "ai-guess-mark-and-review-checklist",
+      "category": "pitfall",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "pitfall/ai-guess-mark-and-review-checklist",
+      "linked_skills": []
+    },
+    {
+      "slug": "anonymize-examples-in-skill-docs",
+      "category": "pitfall",
+      "summary": "실사 티켓 번호·실명·프로젝트명이 예시에 들어가면 보안 감사에서 지적됨. 공용 repo 기준 모든 예시는 익명 더미여야 한다.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "pitfall/anonymize-examples-in-skill-docs",
+      "linked_skills": []
+    },
+    {
+      "slug": "asm-based-classloader-instrumentation-caveats",
+      "category": "pitfall",
+      "summary": "ASM-based JVM agents miss Java 8+ lambda forms, annotation-processor classes, and Spring proxies unless explicitly handled; misses manifest as XLog gaps or skipped trace points",
+      "confidence": "high",
+      "source_project": "scouter",
+      "path": "pitfall/asm-based-classloader-instrumentation-caveats",
+      "linked_skills": []
+    },
+    {
+      "slug": "audit-changed-prev-after-field-swap-bug",
+      "category": "pitfall",
+      "summary": "Audit diff logic had before/after swapped — iterating the wrong doc and putting the wrong value into changedPrev corrupted the audit trail silently",
+      "confidence": "high",
+      "source_project": "lucida-audit",
+      "path": "pitfall/audit-changed-prev-after-field-swap-bug",
+      "linked_skills": [
+        "audit-change-data-capture-pattern"
+      ]
+    },
+    {
+      "slug": "auto-lock-must-not-bump-lastEditedTime",
+      "category": "pitfall",
+      "summary": "|",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "pitfall/auto-lock-must-not-bump-lastEditedTime",
+      "linked_skills": []
+    },
+    {
+      "slug": "binsize-zero-fallback-to-one",
+      "category": "pitfall",
+      "summary": "Substitute binSize=1 whenever the computed interval is 0 in MongoDB time-bucket aggregation",
+      "confidence": "high",
+      "source_project": "",
+      "path": "pitfall/binsize-zero-fallback-to-one",
+      "linked_skills": []
+    },
+    {
+      "slug": "catalina-urlencoder-internal-api",
+      "category": "pitfall",
+      "summary": "org.apache.catalina.util.URLEncoder is Tomcat internal — use java.net.URLEncoder or Spring UriUtils",
+      "confidence": "medium",
+      "source_project": "lucida-domain-automation",
+      "path": "pitfall/catalina-urlencoder-internal-api",
+      "linked_skills": []
+    },
+    {
+      "slug": "classifier-both-verdict-self-reference",
+      "category": "pitfall",
+      "summary": "LLM classifier의 both-verdict에 suggested_links를 허용하면 자기 자신을 가리키는 self-link가 나온다 — 링크는 post-process에서 붙일 것",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "pitfall/classifier-both-verdict-self-reference",
+      "linked_skills": []
+    },
+    {
+      "slug": "claude-plugin-marketplace-owner-required",
+      "category": "pitfall",
+      "summary": "플러그인 설치 스키마 오류: marketplace.json 최상위에 `owner` 객체 없으면 플러그인 설치가 실패.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "pitfall/claude-plugin-marketplace-owner-required",
+      "linked_skills": []
+    },
+    {
+      "slug": "common-alarm-policy-init-gotcha",
+      "category": "pitfall",
+      "summary": "",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "pitfall/common-alarm-policy-init-gotcha",
+      "linked_skills": [
+        "kafka-debounce-event-coalescing"
+      ]
+    },
+    {
+      "slug": "compare-counts-exclude-added-deleted",
+      "category": "pitfall",
+      "summary": "An earlier query filtered change-count by `latest` / `added` / `deleted` flags, which silently dropped newly-added resources from the \"number of changes between two points in time\" metric.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "pitfall/compare-counts-exclude-added-deleted",
+      "linked_skills": []
+    },
+    {
+      "slug": "composite-alarm-all-deleted-npe",
+      "category": "pitfall",
+      "summary": "Composite/aggregated monitors must validate their child set before reducing — empty aggregation throws NPE",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "pitfall/composite-alarm-all-deleted-npe",
+      "linked_skills": []
+    },
+    {
+      "slug": "conf-info-may-lack-resource-type",
+      "category": "pitfall",
+      "summary": "The `conf_info` collection is NOT guaranteed to carry `resourceType` for every metric; criteria builders must tolerate missing field",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "pitfall/conf-info-may-lack-resource-type",
+      "linked_skills": []
+    },
+    {
+      "slug": "docker-engine-29-requires-traefik-upgrade",
+      "category": "pitfall",
+      "summary": "Docker Engine 29.x raises the minimum client API to 1.44, breaking older Traefik versions that pin an older API",
+      "confidence": "high",
+      "source_project": "lucida-for-docker",
+      "path": "pitfall/docker-engine-29-requires-traefik-upgrade",
+      "linked_skills": []
+    },
+    {
+      "slug": "enum-notnull-comparison-pitfall",
+      "category": "pitfall",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "pitfall/enum-notnull-comparison-pitfall",
+      "linked_skills": []
+    },
+    {
+      "slug": "enum-whitelist-blocks-time-based-sqli",
+      "category": "pitfall",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "pitfall/enum-whitelist-blocks-time-based-sqli",
+      "linked_skills": []
+    },
+    {
+      "slug": "gridfs-template-upload-data-loss-pitfall",
+      "category": "pitfall",
+      "summary": "MongoDB GridFS uploads can silently drop file bytes if the bucket/db selection or stream flush is wrong - always verify metadata size equals input size",
+      "confidence": "medium",
+      "source_project": "lucida-report",
+      "path": "pitfall/gridfs-template-upload-data-loss-pitfall",
+      "linked_skills": []
+    },
+    {
+      "slug": "hibernate-date-format-lowercase",
+      "category": "pitfall",
+      "summary": "Use lowercase `yyyy` for calendar year — `YYYY` is ISO week-year and produces wrong values near Jan 1 / Dec 31",
+      "confidence": "high",
+      "source_project": "",
+      "path": "pitfall/hibernate-date-format-lowercase",
+      "linked_skills": []
+    },
+    {
+      "slug": "history-view-yearly-partition-pitfall",
+      "category": "pitfall",
+      "summary": "A history/reporting view or materialized collection created with a year-bounded clause silently stops returning rows when the calendar year rolls over",
+      "confidence": "high",
+      "source_project": "lucida-notification",
+      "path": "pitfall/history-view-yearly-partition-pitfall",
+      "linked_skills": []
+    },
+    {
+      "slug": "injectmocks-generics-type-erasure",
+      "category": "pitfall",
+      "summary": "@InjectMocks picks wrong mock for same raw-type generic fields due to type erasure — flaky test root cause",
+      "confidence": "high",
+      "source_project": "lucida-domain-automation",
+      "path": "pitfall/injectmocks-generics-type-erasure",
+      "linked_skills": []
+    },
+    {
+      "slug": "ipv6-colon-detection-edge",
+      "category": "pitfall",
+      "summary": "Detecting IPv6 by colon count breaks on compressed notation — use a regex character class",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "pitfall/ipv6-colon-detection-edge",
+      "linked_skills": []
+    },
+    {
+      "slug": "jackson-version-pinning-2.17.1",
+      "category": "pitfall",
+      "summary": "Jackson must be pinned via Gradle resolutionStrategy across all com.fasterxml.jackson.* groups to avoid NoSuchMethodError from transitive version drift",
+      "confidence": "high",
+      "source_project": "lucida-audit",
+      "path": "pitfall/jackson-version-pinning-2.17.1",
+      "linked_skills": []
+    },
+    {
+      "slug": "jdbc-template-var-xml-escape-bypass",
+      "category": "pitfall",
+      "summary": "When the template engine XML-escapes values but the downstream channel is raw SQL / plain text, the escaped `&amp; &lt; &gt;` leaks into stored data",
+      "confidence": "medium",
+      "source_project": "lucida-notification",
+      "path": "pitfall/jdbc-template-var-xml-escape-bypass",
+      "linked_skills": []
+    },
+    {
+      "slug": "k8s-clusterrole-aggregation-npe",
+      "category": "pitfall",
+      "summary": "ClusterRole `aggregationRule` and its `clusterRoleSelectors` are both nullable — iterate only after null-check",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "pitfall/k8s-clusterrole-aggregation-npe",
+      "linked_skills": []
+    },
+    {
+      "slug": "kafka-consumer-group-id-hostname-not-timezone",
+      "category": "pitfall",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "pitfall/kafka-consumer-group-id-hostname-not-timezone",
+      "linked_skills": []
+    },
+    {
+      "slug": "kafka-error-handling-deserializer-fallback",
+      "category": "pitfall",
+      "summary": "Wrap Avro/JSON deserializers in ErrorHandlingDeserializer so a single bad record doesn't poison the consumer and crash-loop the container",
+      "confidence": "high",
+      "source_project": "lucida-audit",
+      "path": "pitfall/kafka-error-handling-deserializer-fallback",
+      "linked_skills": []
+    },
+    {
+      "slug": "kafka-sticky-partitioner-key-null",
+      "category": "pitfall",
+      "summary": "Kafka Sticky Partitioner batches key=null messages into one partition — explains dev vs prod distribution gap",
+      "confidence": "high",
+      "source_project": "lucida-domain-automation",
+      "path": "pitfall/kafka-sticky-partitioner-key-null",
+      "linked_skills": []
+    },
+    {
+      "slug": "konva-center-coord-system",
+      "category": "pitfall",
+      "summary": "Konva node coordinates can be center-based; when converting to top-left boxes subtract half width/height",
+      "confidence": "medium",
+      "source_project": "lucida-builder-r3",
+      "path": "pitfall/konva-center-coord-system",
+      "linked_skills": []
+    },
+    {
+      "slug": "latest-availability-deletion-risk",
+      "category": "pitfall",
+      "summary": "Latest-availability collection can lose data when upstream source is stale but not actually missing",
+      "confidence": "high",
+      "source_project": "lucida-measurement",
+      "path": "pitfall/latest-availability-deletion-risk",
+      "linked_skills": [
+        "availability-ttl-punctuate-processor"
+      ]
+    },
+    {
+      "slug": "Formal verification only covers what the spec formalizes",
+      "category": "pitfall",
+      "summary": "Proofs bound what the spec covers, not what the system does. Fuzzing lean-zip found runtime and parser bugs outside the verified surface; ship a verified-surface / unverified-surface / TCB decomposition with any 'proven correct' claim.",
+      "confidence": "medium",
+      "source_project": "skills_research:trend:2026-04-16",
+      "path": "pitfall/lean-verification-spec-coverage-gap",
+      "linked_skills": [
+        "lean-verified-code-threat-boundary"
+      ]
+    },
+    {
+      "slug": "legacy-datasource-naming",
+      "category": "pitfall",
+      "summary": "`dataSource` / `dataSourceFilter` in the codebase actually mean data-pipeline-select and data-pipeline-filter — not datasource",
+      "confidence": "high",
+      "source_project": "lucida-builder-r3",
+      "path": "pitfall/legacy-datasource-naming",
+      "linked_skills": []
+    },
+    {
+      "slug": "mongo-direct-connection-flag",
+      "category": "pitfall",
+      "summary": "MongoDB datasource connectionString requires directConnection=true in this deployment",
+      "confidence": "medium",
+      "source_project": "lucida-builder-r3",
+      "path": "pitfall/mongo-direct-connection-flag",
+      "linked_skills": []
+    },
+    {
+      "slug": "mongo-timeseries-forced-hint-kills-pushdown",
+      "category": "pitfall",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "pitfall/mongo-timeseries-forced-hint-kills-pushdown",
+      "linked_skills": []
+    },
+    {
+      "slug": "mongo-timeseries-match-split-for-pushdown",
+      "category": "pitfall",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "pitfall/mongo-timeseries-match-split-for-pushdown",
+      "linked_skills": []
+    },
+    {
+      "slug": "mongo-timeseries-view-pushdown-broken-8_2_3",
+      "category": "pitfall",
+      "summary": "",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "pitfall/mongo-timeseries-view-pushdown-broken-8_2_3",
+      "linked_skills": []
+    },
+    {
+      "slug": "mongodb-changestream-resubscribe",
+      "category": "pitfall",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "pitfall/mongodb-changestream-resubscribe",
+      "linked_skills": [
+        "mongodb-changestream-field-filter"
+      ]
+    },
+    {
+      "slug": "mongodb-compound-index-on-views",
+      "category": "pitfall",
+      "summary": "Spring Data @CompoundIndex annotations on a view-backed @Document are silently ignored — index the collection class",
+      "confidence": "high",
+      "source_project": "lucida-domain-apm",
+      "path": "pitfall/mongodb-compound-index-on-views",
+      "linked_skills": []
+    },
+    {
+      "slug": "mongodb-documentreference-lazy-removal",
+      "category": "pitfall",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "pitfall/mongodb-documentreference-lazy-removal",
+      "linked_skills": []
+    },
+    {
+      "slug": "mongodb-field-name-underscore-to-dot",
+      "category": "pitfall",
+      "summary": "|",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "pitfall/mongodb-field-name-underscore-to-dot",
+      "linked_skills": []
+    },
+    {
+      "slug": "mongodb-single-node-directconnection",
+      "category": "pitfall",
+      "summary": "MongoDB clients must pass directConnection=true when connecting to a single-node replSet, otherwise they hang on primary discovery",
+      "confidence": "high",
+      "source_project": "lucida-for-docker",
+      "path": "pitfall/mongodb-single-node-directconnection",
+      "linked_skills": []
+    },
+    {
+      "slug": "mongodb-string-id-field-type-mapping",
+      "category": "pitfall",
+      "summary": "Spring Data MongoDB coerces 24-char-hex @Id String values to ObjectId unless @Field(targetType = FieldType.STRING) is set",
+      "confidence": "high",
+      "source_project": "lucida-domain-dpm",
+      "path": "pitfall/mongodb-string-id-field-type-mapping",
+      "linked_skills": []
+    },
+    {
+      "slug": "oz-license-file-placement-flip-flop",
+      "category": "pitfall",
+      "summary": "Vendor engines (OZ Report, Crystal, Jasper-Pro) often hard-code license file search paths - pin the path in the image and document it, or you will ship it broken repeatedly",
+      "confidence": "medium",
+      "source_project": "lucida-report",
+      "path": "pitfall/oz-license-file-placement-flip-flop",
+      "linked_skills": []
+    },
+    {
+      "slug": "page-map-returns-new-instance",
+      "category": "pitfall",
+      "summary": "Spring Data Page is immutable — Page.map() returns a new instance; forgetting to reassign silently loses the mapping",
+      "confidence": "high",
+      "source_project": "lucida-domain-automation",
+      "path": "pitfall/page-map-returns-new-instance",
+      "linked_skills": []
+    },
+    {
+      "slug": "policy-edit-saveraw-loss",
+      "category": "pitfall",
+      "summary": "Editing a common collection policy can silently drop individual `saveRaw`/interval settings if not re-applied",
+      "confidence": "high",
+      "source_project": "lucida-measurement",
+      "path": "pitfall/policy-edit-saveraw-loss",
+      "linked_skills": [
+        "non-metric-saveraw-null-rule"
+      ]
+    },
+    {
+      "slug": "refresh-token-do-not-regenerate",
+      "category": "pitfall",
+      "summary": "A refresh call must issue a new ACCESS token only, never a new refresh token.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "pitfall/refresh-token-do-not-regenerate",
       "linked_skills": []
     },
     {
@@ -3817,15 +4079,6 @@
       "confidence": "high",
       "source_project": "",
       "path": "pitfall/serial-pipeline-failure-compounding",
-      "linked_skills": []
-    },
-    {
-      "slug": "shallow-clone-mktemp-cleanup-pattern",
-      "category": "arch",
-      "summary": "publish/install/원격 목록 조회처럼 원격 git repo를 만질 때는 `mktemp -d → git clone --depth 1 → 작업 → rm -rf`. 작업 디렉토리를 오염시키지 않는다.",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/shallow-clone-mktemp-cleanup-pattern",
       "linked_skills": []
     },
     {
@@ -3847,15 +4100,6 @@
       "linked_skills": []
     },
     {
-      "slug": "skill-registry-vs-skill-config-split",
-      "category": "decision",
-      "summary": "원격 저장소 정보는 `.claude/skill-registry.yaml`, 스킬별 런타임 옵션(출력 경로 등)은 `.claude/skill-config.yaml`. 파일 단위로 관심사 분리.",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/skill-registry-vs-skill-config-split",
-      "linked_skills": []
-    },
-    {
       "slug": "skip-schedule-if-previous-running",
       "category": "pitfall",
       "summary": "",
@@ -3871,6 +4115,15 @@
       "confidence": "high",
       "source_project": "",
       "path": "pitfall/snmp-ifindex-not-stable",
+      "linked_skills": []
+    },
+    {
+      "slug": "build-gradle-secret-and-insecure-protocol",
+      "category": "pitfall",
+      "summary": "",
+      "confidence": "high",
+      "source_project": "",
+      "path": "pitfall/sonar-token-hardcoded-build-gradle",
       "linked_skills": []
     },
     {
@@ -3937,51 +4190,6 @@
       "linked_skills": []
     },
     {
-      "slug": "stomp-heartbeat-10s-bidirectional",
-      "category": "api",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "api/stomp-heartbeat-10s-bidirectional",
-      "linked_skills": []
-    },
-    {
-      "slug": "stub-in-service-unblocks-fe-parallelism",
-      "category": "decision",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/stub-in-service-unblocks-fe-parallelism",
-      "linked_skills": []
-    },
-    {
-      "slug": "system-notification-shared-with-2fa-and-password-find",
-      "category": "decision",
-      "summary": "The `system_notification` config (SMTP/SMS credentials) is intentionally shared between 2FA and password-find flows rather than duplicated per flow",
-      "confidence": "medium",
-      "source_project": "lucida-notification",
-      "path": "decision/system-notification-shared-with-2fa-and-password-find",
-      "linked_skills": []
-    },
-    {
-      "slug": "tabular-metric-excluded-from-list",
-      "category": "decision",
-      "summary": "TABULAR measurement type is intentionally excluded from searchable metric-definition list endpoints",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/tabular-metric-excluded-from-list",
-      "linked_skills": []
-    },
-    {
-      "slug": "tag-values-separate-collection",
-      "category": "decision",
-      "summary": "TagValueInfo's `values` array was extracted from the parent tag document into a separate `tag_value_detail` collection to bound document size and index cost.",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/tag-values-separate-collection",
-      "linked_skills": []
-    },
-    {
       "slug": "tenant-context-clear-after-completion",
       "category": "pitfall",
       "summary": "Multi-tenant thread-locals must be cleared in a HandlerInterceptor `afterCompletion`, regardless of request outcome",
@@ -4018,24 +4226,6 @@
       "linked_skills": []
     },
     {
-      "slug": "timeselector-mode-interval-range-mapping",
-      "category": "api",
-      "summary": "Clients send a `mode` enum (RAW..YEAR); the server maps it to a (bin-interval, query-range) pair and picks the right pre-aggregated collection",
-      "confidence": "high",
-      "source_project": "",
-      "path": "api/timeselector-mode-interval-range-mapping",
-      "linked_skills": []
-    },
-    {
-      "slug": "tomcat-request-timeout-1h-for-oz-report",
-      "category": "decision",
-      "summary": "Report-generation services should raise Tomcat connection/read timeout to ~1 hour because export of large OZ/Jasper reports is genuinely long-running",
-      "confidence": "high",
-      "source_project": "lucida-report",
-      "path": "decision/tomcat-request-timeout-1h-for-oz-report",
-      "linked_skills": []
-    },
-    {
       "slug": "top-bottom-widest-collection-range",
       "category": "pitfall",
       "summary": "For Top/Bottom selection queries, pick the collection whose bin granularity covers the widest range, not the finest-grained one",
@@ -4056,15 +4246,6 @@
       ]
     },
     {
-      "slug": "topresource-immediate-generation-invariant",
-      "category": "domain",
-      "summary": "In report immediate-generation, the topResource flag decides whether to query by resource-id (fast path) or the full conf-id set (slow path)",
-      "confidence": "medium",
-      "source_project": "lucida-report",
-      "path": "domain/topresource-immediate-generation-invariant",
-      "linked_skills": []
-    },
-    {
       "slug": "trace-context-async-execution-propagation",
       "category": "pitfall",
       "summary": "Thread-local trace context is lost across executor.submit / reactor.flatMap boundaries; scouter injects bytecode wrappers around async entry points to capture and restore it",
@@ -4080,15 +4261,6 @@
       "confidence": "high",
       "source_project": "lucida-for-docker",
       "path": "pitfall/traefik-2.11-requires-explicit-idletimeout",
-      "linked_skills": []
-    },
-    {
-      "slug": "udp-for-throughput-tcp-for-reliability",
-      "category": "decision",
-      "summary": "Scouter streams periodic metrics over UDP (lossy but cheap) and reserves TCP for config fetch, agent registration, and XLog profile uploads that demand delivery guarantees",
-      "confidence": "high",
-      "source_project": "scouter",
-      "path": "decision/udp-for-throughput-tcp-for-reliability",
       "linked_skills": []
     },
     {
@@ -4116,51 +4288,6 @@
       "confidence": "medium",
       "source_project": "",
       "path": "pitfall/user-sql-source-requires-select-only-and-readonly",
-      "linked_skills": []
-    },
-    {
-      "slug": "variable-length-integer-encoding-for-metrics-bandwidth",
-      "category": "decision",
-      "summary": "Scouter's DataOutputX uses 3-byte (INT3) and 5-byte (LONG5) integer encodings to shrink UDP metric packs by 20-40% when most values fit within 24 / 40 bits",
-      "confidence": "medium",
-      "source_project": "scouter",
-      "path": "decision/variable-length-integer-encoding-for-metrics-bandwidth",
-      "linked_skills": []
-    },
-    {
-      "slug": "vllm-kv-cache-fp8-with-mtp",
-      "category": "decision",
-      "summary": "vLLM serving chose fp8_e4m3 KV cache + prefix caching + MTP speculative decoding for Qwen3.5 throughput",
-      "confidence": "medium",
-      "source_project": "lucida-for-docker",
-      "path": "decision/vllm-kv-cache-fp8-with-mtp",
-      "linked_skills": []
-    },
-    {
-      "slug": "widget-is-frozen-group-snapshot",
-      "category": "arch",
-      "summary": "Widgets are snapshots of a group at save time; later edits to the source group do not propagate",
-      "confidence": "high",
-      "source_project": "lucida-builder-r3",
-      "path": "arch/widget-is-frozen-group-snapshot",
-      "linked_skills": []
-    },
-    {
-      "slug": "xlog-extended-transaction-trace-with-compression",
-      "category": "api",
-      "summary": "XLog is scouter's per-request transaction trace format — hierarchical typed steps stored as compressed binary, indexed by end-time, with flat metadata for server-side filtering",
-      "confidence": "high",
-      "source_project": "scouter",
-      "path": "api/xlog-extended-transaction-trace-with-compression",
-      "linked_skills": []
-    },
-    {
-      "slug": "yorkie-team-server-split",
-      "category": "arch",
-      "summary": "Yorkie holds live canvas state; the team server holds metadata (projects, assets, datasources) — never mix",
-      "confidence": "high",
-      "source_project": "lucida-builder-r3",
-      "path": "arch/yorkie-team-server-split",
       "linked_skills": []
     }
   ]

--- a/knowledge/api/claude-code-routines-cloud-automation-model.md
+++ b/knowledge/api/claude-code-routines-cloud-automation-model.md
@@ -1,0 +1,27 @@
+---
+name: claude-code-routines-cloud-automation-model
+category: api
+summary: Claude Code Routines (research preview) are saved cloud sessions — prompt + repos + connectors + environment — triggered by schedule, HTTP POST, or GitHub events. One routine can combine all three. Daily run cap per account; branch pushes restricted to `claude/*` by default.
+source:
+  kind: web-research
+  ref: skills_research:trend:2026-04-16
+---
+
+# Claude Code Routines: trigger model
+
+**Fact.** A *routine* is a saved Claude Code configuration (prompt, repositories, environment, connectors) that runs autonomously on Anthropic-managed cloud infrastructure. Manage them at `claude.ai/code/routines` or with `/schedule` in the CLI. Three trigger types, combinable on a single routine:
+- **Scheduled** — hourly / daily / weekdays / weekly presets; arbitrary cron via `/schedule update`. Minimum interval 1 hour.
+- **API** — per-routine HTTPS endpoint `POST https://api.anthropic.com/v1/claude_code/routines/{routine_id}/fire`. Per-routine bearer token, shown once. Optional `text` field in the body is passed as freeform context (not parsed). Required headers: `Authorization: Bearer <token>`, `anthropic-beta: experimental-cc-routine-2026-04-01`, `anthropic-version: 2023-06-01`, `Content-Type: application/json`. Response: `{claude_code_session_id, claude_code_session_url}`.
+- **GitHub** — webhook-triggered on `pull_request` or `release` events. Requires the Claude GitHub App installed separately from `/web-setup`. Filters: author, title, body, base/head branch, labels, draft/merged/fork; regex matches the whole field.
+
+Runtime properties: routines run autonomously (no permission prompts); repos are cloned on every run from the default branch; branch pushes restricted to `claude/*` unless "Allow unrestricted branch pushes" is on per repo; routines are per-user (not team-shared); daily run cap per account with overage under "extra usage" billing. Plan requirement: Pro, Max, Team, or Enterprise with Claude Code on the web enabled.
+
+**Why.** Routines solve "want Claude to do this unattended" — scheduled maintenance, CI-adjacent code generation, alert triage, deploy verification. Cloud execution means runs survive laptop sleep/close; GitHub-event triggers keep them in the repo's flow.
+
+**How to apply.** Scope each routine tightly — one prompt with explicit success criteria, since there's no human to course-correct mid-run. Use filters on GitHub triggers to avoid burning the daily cap on PR noise. Rotate API tokens when developers leave, or store them per-environment in your alerting tool's secret store. Routine actions (commits, PRs, Slack messages via connectors) appear under *your* identity — remember this when wiring shared workflows. Don't expect GitHub-trigger event reuse: two PR updates produce two independent sessions.
+
+**Counter / caveats.** Research preview: API surface, rate limits, and token semantics may change; breaking changes ship under new dated beta headers with the two most recent versions still accepted. GitHub webhook events are subject to per-routine and per-account hourly caps during preview. `/web-setup` grants clone access but does *not* install the Claude GitHub App needed for webhook delivery — a common setup gotcha.
+
+## Sources
+
+- https://code.claude.com/docs/en/routines — canonical Claude Code docs (2026-04). High confidence as vendor-canonical reference; behavior may drift while the feature is in preview.

--- a/knowledge/arch/agent-memory-binding-vs-recall.md
+++ b/knowledge/arch/agent-memory-binding-vs-recall.md
@@ -1,0 +1,22 @@
+---
+name: agent-memory-binding-vs-recall
+category: arch
+summary: Agent memory systems that ace retrieval benchmarks still fail operationally because stored skills aren't *bound* to the episodes that validated them. Fix is a memory bundle — skill record + episode record + bidirectional link — returned together on recall.
+source:
+  kind: web-research
+  ref: skills_research:trend:2026-04-16
+---
+
+# Agent memory: binding, not recall, is the bottleneck
+
+**Fact.** A 500-run benchmark of an agent skill-memory system (OrKa, 250 tasks × 5 tracks) showed: aggregate rubric improvement from skill memory was **+0.06** on a 9.3/10 baseline; **0 of 250** stored skills were actually invoked by the agent despite successful retrieval; retrieved skills oscillated between over-specific paraphrases and vacuous generics ("implement [target]"); only Track C (complex routing, baseline 8.12) saw meaningful lift: **+0.40**. The recall layer worked — the skills were retrievable. They just weren't *bindable* — the retrieved text had no connection to the episodic evidence about when, why, and with what outcome it had been used.
+
+**Why.** Borrowing from cognitive-neuroscience language: the hippocampus doesn't store memories, it stores **bindings** between procedural, episodic, emotional, and semantic records. Agent frameworks that split skills and episodes into separate stores without a relational link reproduce the failure mode — the skill is findable but operationally inert. Memory helps where the model is weak (complex routing); where the model is already strong, extra memory is noise the model correctly ignores.
+
+**How to apply.** Stop evaluating agent memory by retrieval metrics alone (precision@k, MRR) — measure *downstream task lift*; if the skill doesn't change behavior, recall is vanity. Structure memory as *bundles*: a skill record plus one or more episode records plus a bidirectional link. On recall, return both. Schema hint: `skills.episode_ids[]` + `episodes.skill_id`. Include episode outcome, what worked, what failed, causal lessons — not just "skill X was used at time T." Score skill transferability by episode quality + recency — skills must prove continued utility under current conditions to survive. Deploy memory preferentially on hard tasks, not ones the base model already handles.
+
+**Counter / caveats.** Single-author, single-framework (OrKa) study. The binding hypothesis is intuitive but the quantitative claims come from one benchmark. Generalizability to other agent architectures (ReAct, tool-use loops without explicit skill stores) isn't established.
+
+## Sources
+
+- https://dev.to/marcosomma/i-ran-500-more-agent-memory-experiments-the-real-problem-wasnt-recall-it-was-binding-24kc — "I Ran 500 More Agent Memory Experiments..." (2026). Medium confidence; concrete numbers but one researcher's data.

--- a/knowledge/arch/archon-deterministic-ai-coding-harness.md
+++ b/knowledge/arch/archon-deterministic-ai-coding-harness.md
@@ -1,0 +1,22 @@
+---
+name: archon-deterministic-ai-coding-harness
+category: arch
+summary: Archon enforces deterministic AI-assisted coding by encoding workflows as YAML DAGs — deterministic nodes (tests, git ops) bracket AI-driven nodes (plan, implement, review), each run isolated in its own git worktree. The pattern generalizes beyond Archon itself.
+source:
+  kind: web-research
+  ref: skills_research:trend:2026-04-16
+---
+
+# Archon: deterministic AI coding via workflow DAGs
+
+**Fact.** Archon is an open-source harness that makes AI-assisted coding reproducible by separating the deterministic process skeleton from the AI-driven execution nodes inside it. Core elements: *workflows* are YAML DAGs checked into the repo under `.archon/workflows/`; each node is either deterministic (bash, tests, git) or AI-driven (plan, generate, review with a prompt); runs are isolated in dedicated git worktrees so concurrent fixes don't corrupt each other; loop nodes iterate until a stop condition with fresh AI context between iterations; human gates pause on interactive nodes; 17 default workflows ship (fix-issue, new-feature, PR-review, refactor) and teams override by committing same-named files. Stack: platform adapters (Web/CLI/Telegram/Slack) → orchestrator → three executors (command handler, workflow executor, AI assistant clients like Claude/Codex) → SQLite or Postgres for state. Configuration via YAML workflows, markdown commands, `~/.archon/config.yaml`, and env vars like `CLAUDE_BIN_PATH`.
+
+**Why.** Ad-hoc AI coding is variable by design — same prompt, different answers. That's fine for exploration, poison for CI-adjacent automation. Five mechanisms give determinism back: (1) explicit DAG dependencies prevent out-of-order execution; (2) isolated worktrees eliminate environmental cross-talk; (3) deterministic validation gates (tests) break the AI loop with a ground-truth signal; (4) human checkpoints keep a reviewer in the loop for high-stakes steps; (5) portable YAML definitions mean every teammate runs the same process. Positioning: Archon is to AI coding what Dockerfiles were to infra and GitHub Actions was to CI/CD — a standardized wrapper around an otherwise variable substrate.
+
+**How to apply.** Even if you don't adopt Archon itself, steal the pattern: plan → implement loop → validate → human gate → PR creation, nodes typed as deterministic or AI, each run in a fresh worktree. Put the process definition in the repo (`.<tool>/workflows/`), not in prompts — reproducibility requires the process to travel with the code. Bracket every AI node with deterministic nodes on both sides (curated input context and tests/schema validation on output). When AI nodes drift, shorten the loop and add a stricter gate rather than tuning the prompt.
+
+**Counter / caveats.** "Deterministic" here means *process-deterministic*, not output-deterministic — the AI nodes still produce varying text; what's deterministic is the surrounding phase structure and validation. Source is the project's own README, no independent benchmarks fetched — treat specifics (17 workflows, exact stack layers) as point-in-time. Worktree-per-run works for small/medium repos; monorepos with large checkout overhead need a different isolation strategy (containers, sparse checkouts).
+
+## Sources
+
+- https://github.com/coleam00/Archon — project README (2026-04). Medium confidence; project-authored description, useful primarily for the reusable pattern rather than a product endorsement.

--- a/knowledge/arch/duckdb-vectorized-analytical-execution.md
+++ b/knowledge/arch/duckdb-vectorized-analytical-execution.md
@@ -1,0 +1,22 @@
+---
+name: duckdb-vectorized-analytical-execution
+category: arch
+summary: DuckDB's design has five separable pillars — vectorized execution, pipelined operators, explicit memory + grouped aggregation, ART indexing, and a dedicated query rewriter — distinguishing it from row-at-a-time OLTP engines.
+source:
+  kind: web-research
+  ref: skills_research:trend:2026-04-16
+---
+
+# DuckDB architectural pillars
+
+**Fact.** DuckDB's internal design treats five concerns as distinct engineering problems: (1) *vectorized execution* — operators consume and produce batches of values rather than one row at a time (better CPU-cache locality, enables SIMD); (2) *pipelined operators* — query plans stream downstream without intermediate materialization where possible; (3) *explicit memory + grouped aggregation* — memory management coupled tightly to aggregation since group-by is where analytical queries pressure memory; (4) *ART (Adaptive Radix Tree) indexing* — preferred over B-trees for in-process mixed workloads; (5) *query rewriting / optimization as a phase* — transformations before execution, optimizer is a separable component rather than smeared across the runtime.
+
+**Why.** The row-at-a-time OLTP model is the wrong default for analytical workloads — per-tuple dispatch dominates on million-row scans, intermediate materialization blows out memory, and B-trees favor small updates over fast scans. Vectorized execution + pipelining is the well-established answer from column-store research (VectorWise / MonetDB lineage).
+
+**How to apply.** When choosing an embedded analytical engine, look for vectorized execution, pipelined operators, explicit memory config, and columnar storage — DuckDB, Polars, and Arrow-based engines satisfy these; SQLite intentionally does not. When profiling, hot paths are inside vector kernels (SIMD loops), not per-row dispatch — use CPU profiling tools that understand vectorized loops. When designing your own analytical plugin, separate rewriting, planning, and execution from day one — bundling them is technical debt you'll hit by the second major feature.
+
+**Counter / caveats.** Vectorized engines pay a latency tax on single-row lookups — they're tuned for scans. Don't front an OLTP API with DuckDB. The primary source consulted was the course-announcement page, not the full internals doc — specific constants (vector size, memory thresholds) are not cited here; the canonical details live in the VLDB/SIGMOD DuckDB papers.
+
+## Sources
+
+- https://duckdb.org/library/design-and-implementation-of-duckdb-internals/ — course-outline for "Design and Implementation of DuckDB Internals" (2026). Medium confidence.

--- a/knowledge/arch/llm-tool-calling-mxn-wire-format-problem.md
+++ b/knowledge/arch/llm-tool-calling-mxn-wire-format-problem.md
@@ -1,0 +1,22 @@
+---
+name: llm-tool-calling-mxn-wire-format-problem
+category: arch
+summary: Open-source LLMs each encode tool calls in a different wire format (special tokens, XML, channel notation, JSON blocks), so M inference apps × N models = M×N parsers. Fix is declarative tool-call specs shipped with the model and consumed by both grammar engines and parsers.
+source:
+  kind: web-research
+  ref: skills_research:trend:2026-04-16
+---
+
+# The M×N problem of LLM tool calling
+
+**Fact.** Open-source LLMs each define their own tool-calling wire format, chosen at training time: GPT-OSS uses `<|channel|>` notation; DeepSeek uses special-token markers with JSON blocks inside; GLM5 uses XML-style `<arg_key>` / `<arg_value>` pairs with no JSON at all. Every inference application (vLLM, SGLang, TensorRT-LLM, llama.cpp, etc.) implements a custom parser for each model — M applications × N models of duplicated parser code. The problem hits at two stages: generation (grammar engines like Outlines/XGrammar must constrain output to the model's format) and parsing (inference engines must extract the call back out). Both stages require identical format knowledge; today both reverse-engineer it independently.
+
+**Why.** Wire formats are training-time decisions, and nothing constrains them to a shared convention. When a new model drops, every inference-engine team debugs its quirks in parallel. Recent example: Gemma 4 leaked reasoning tokens into tool arguments, and the decoder stripped special tokens before the parser saw them. The ecosystem already converged on shared *chat templates*; tool calling hasn't had that convergence moment yet.
+
+**How to apply.** When adding tool calling to an inference server, budget real engineering per model — not "one generic parser." Track the wire format as a first-class artifact (boundary tokens, argument serialization, reasoning-token behavior) separately from the prompt template. Advocate for and consume declarative tool-call specs shipped alongside a model in the same slot as `chat_template.jinja`, so both grammar engines and parsers read the same source of truth. Don't assume a new OSS model will "just work" with your existing parser — add a fixture pass per model before enabling tool mode.
+
+**Counter / caveats.** Some shops standardize on one model family to sidestep the problem entirely — viable if model choice isn't a strategic lever. Closed-source APIs hide the wire format; you pay the same cost inside the vendor, you just don't see it.
+
+## Sources
+
+- https://www.thetypicalset.com/blog/grammar-parser-maintenance-contract — "The M×N problem of tool calling and open-source models" (2026). Single essay; medium confidence — well-aligned with vLLM/SGLang issue-tracker discussion but one author's framing.

--- a/knowledge/decision/fifth-normal-form-join-dependency-tradeoff.md
+++ b/knowledge/decision/fifth-normal-form-join-dependency-tradeoff.md
@@ -1,0 +1,22 @@
+---
+name: fifth-normal-form-join-dependency-tradeoff
+category: decision
+summary: 5NF catches join dependencies that 4NF/BCNF miss, but in practice you rarely reason about it directly — design from business entities, recognize AB-BC-AC triangles vs ABC+D stars, and let 5NF fall out.
+source:
+  kind: web-research
+  ref: skills_research:trend:2026-04-16
+---
+
+# 5NF: when it matters and when to stop normalizing earlier
+
+**Fact.** Fifth Normal Form says a record type is in 5NF when its information content *cannot* be reconstructed from several smaller record types via joins. Two real-world patterns force 5NF reasoning: (1) **AB-BC-AC triangle** — three many-to-many relationships between three entities (e.g., `brand↔flavor`, `brand↔friend`, `flavor↔friend`). Three distinct junction tables are required; collapsing two pairs can invent tuples that never existed. (2) **ABC+D star** — three entities linked through a central fourth entity (e.g., `musician`, `instrument`, `concert` connected through `Performance`). One three-column table with a composite key suffices. 4NF and BCNF handle functional and multivalued dependencies but can't detect these join-dependency cases.
+
+**Why.** In pattern 1, the three pairwise relationships are semantically independent ("this brand makes this flavor", "this friend prefers this brand", "this friend likes this flavor"), so projecting onto pairs and rejoining fabricates tuples. Keeping three junction tables preserves independence. In pattern 2, what looks like three relationships is actually one ternary relationship — collapsing to a junction *is* the right answer.
+
+**How to apply.** Design from business entities and their relationships, not from normal-form theory. When you see three entities with pairwise many-to-many links, ask: "three independent relationships (triangle) or one ternary (star)?" — the answer picks the schema. Don't normalize past the point your queries need; 4NF is usually enough for OLTP, and 5NF matters most in modelling-heavy domains (financial instruments, scheduling, multi-party contracts) where "did X-Y-Z really co-occur?" is a business question.
+
+**Counter / caveats.** In analytical workloads, denormalization wins; 5NF is an OLTP-correctness concept, not an OLAP-performance one. The source author's position: "you don't really need to involve 5NF to design your table schema" — if you structure from requirements, you'll naturally hit the right shape.
+
+## Sources
+
+- https://kb.databasedesignbook.com/posts/5nf/ — "5NF and Database Design." Medium confidence; single focused primer, consistent with Date/Darwen treatment of join dependencies.

--- a/knowledge/decision/typed-wikilinks-for-llm-knowledge-base.md
+++ b/knowledge/decision/typed-wikilinks-for-llm-knowledge-base.md
@@ -1,0 +1,22 @@
+---
+name: typed-wikilinks-for-llm-knowledge-base
+category: decision
+summary: Flat `[[wikilinks]]` carry one bit of information. For an LLM-facing knowledge base, tag every link with a relationship type (supersedes, contradicts, causes, supports) so the graph is queryable rather than just traversable.
+source:
+  kind: web-research
+  ref: skills_research:trend:2026-04-16
+---
+
+# Typed wikilinks for an LLM knowledge base
+
+**Fact.** In a Karpathy-style LLM wiki (sources → LLM-processed markdown → Obsidian-style graph), plain `[[wikilinks]]` flatten every relationship into an undifferentiated edge — the graph view becomes a hairball and you cannot query "which notes supersede this one?" or "which notes contradict each other?" A practical response is **typed wikilinks**: prefix or tag each link with a relationship type from a small closed vocabulary (~20-30 types: *supersedes, contradicts, causes, supports, depends-on, example-of, refines*, etc.). The syntax (e.g., `[[Note @supersedes previous analysis]]`) gets reflected into YAML frontmatter so it's queryable by scripts and LLM tools. Related gaps: manual relationship discovery doesn't scale past a few hundred notes; no persistent knowledge graph across sessions means every LLM session re-parses the flat index.
+
+**Why.** A knowledge base for LLM consumption has different requirements than a human note vault: humans tolerate browsing, LLMs need retrieval by relation. A typed graph lets you ask structured queries ("every note that contradicts X, created after 2026-01-01") — untyped wikilinks force full-text search instead. When the graph is typed, the LLM can reason about conflicts and supersession rather than emitting outdated and current information side-by-side.
+
+**How to apply.** Define a small, *closed* link-type vocabulary up front — three types used consistently beat thirty used arbitrarily. Pick a syntax that survives plaintext grep (`[[target @type context]]`); avoid anything that requires an editor plugin to be readable. Sync link types into YAML frontmatter so external tools (scripts, MCP servers, vector indexes) can query without parsing wikilink syntax. Treat relationship discovery as an ongoing task, not a one-shot import — a periodic automated + human-approved "vault linker" pass scales better than asking authors to get it right the first time.
+
+**Counter / caveats.** The source is vendor-adjacent (Penfield Labs, which sells a product that solves this). Treat the proposed product as one implementation, not "the" answer; the underlying claims about typed-link benefits stand on their own. For small vaults (<200 notes), untyped wikilinks are usually fine; typed links pay off at a scale bigger than most personal wikis.
+
+## Sources
+
+- https://dev.to/penfieldlabs/what-karpathys-llm-wiki-is-missing-and-how-to-fix-it-1988 — "What Karpathy's LLM Wiki Is Missing (And How to Fix It)" (2026). Medium confidence; single vendor-adjacent source.

--- a/knowledge/pitfall/lean-verification-spec-coverage-gap.md
+++ b/knowledge/pitfall/lean-verification-spec-coverage-gap.md
@@ -1,0 +1,23 @@
+---
+name: lean-verification-spec-coverage-gap
+category: pitfall
+summary: Formal proofs cover exactly what the spec formalizes — untrusted parsers and the language runtime, which are usually *not* in the spec, routinely contain the bugs a "proven correct" library claims to have eliminated.
+source:
+  kind: web-research
+  ref: skills_research:trend:2026-04-16
+linked_skills: [lean-verified-code-threat-boundary]
+---
+
+# Formal verification only covers what the spec formalizes
+
+**Fact.** Fuzzing a Lean 4 DEFLATE library (`lean-zip`) whose core decompression was proved correct — `decompress(compress(x)) = x` — still found two critical bugs: (1) a heap buffer overflow in the Lean runtime's `lean_alloc_sarray` (integer overflow in allocation math caused `SIZE_MAX`-byte requests to allocate ~23 bytes, with later writes overflowing; affects every Lean 4 program); (2) a DoS in the ZIP archive parser that piped attacker-controlled `compressedSize` to allocation without bounds. The proofs were valid. The bugs lived outside the verified surface — the untrusted parser and the C++ runtime supporting every Lean program.
+
+**Why.** Verification certifies that a specification holds. Two things are almost always *not* in the specification: (a) untrusted-input handling — parsers of ZIP/PE/ELF/TLS handshakes are the highest-value attack surface and the hardest to formalize; (b) the trusted computing base — compilers, runtimes, FFI glue, primitive allocators. Every theorem implicitly trusts these. CompCert's precedent is identical: Csmith found zero bugs in the verified passes, multiple bugs in the unverified C front end.
+
+**How to apply.** When adopting a "formally verified" library, ask for its *verified surface* (what theorems), its *unverified surface* (what parsers/readers), and its *TCB* (what runtime/compiler). Demand fuzzing results for the unverified surface before treating the library as hardened. When shipping verified code, publish the same three lists in the README — "formally verified" without that decomposition is marketing, not a security property.
+
+**Counter / caveats.** Verification isn't worthless — on the verified surface, `lean-zip` posted 105M crash-free fuzz runs. Some projects *do* formalize parsers (HACL*, some TLS stacks); check whether your library does.
+
+## Sources
+
+- https://kirancodes.me/posts/log-who-watches-the-watchers.html — "Who Watches The Watchers" (2026). Single detailed case study; medium confidence pending independent corroboration.

--- a/skills/ai/ai-subagent-scope-narrowing/SKILL.md
+++ b/skills/ai/ai-subagent-scope-narrowing/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: ai-subagent-scope-narrowing
+description: Orchestrator-first pattern for multi-agent AI coding — humans triage and curate context per task, subagents execute in isolated worktrees with narrowly-scoped briefs. Trades parallel throughput for reduced hallucination.
+category: ai
+tags: [agents, subagents, orchestration, context-isolation, worktree, hallucination]
+triggers: ["subagent", "multiple agents", "parallel agents", "worktree", "agent hallucination", "narrow scope", "orchestrator agent", "context engineering"]
+source_project: skills_research:trend:2026-04-16
+version: 1.0.0
+---

--- a/skills/ai/ai-subagent-scope-narrowing/content.md
+++ b/skills/ai/ai-subagent-scope-narrowing/content.md
@@ -1,0 +1,51 @@
+# Scope-narrowing pattern for AI subagents
+
+Parallel AI coding agents fabricate when under-specified. This pattern puts an experienced human at the front as orchestrator, so each subagent receives a tightly-bounded brief and operates in its own filesystem.
+
+## When to use
+
+- You're running multiple AI coding agents in parallel against the same repo.
+- Agents drift off-task or fabricate connections to unrelated code.
+- You want to keep senior judgment in the loop without it being a throughput bottleneck on the execution side.
+
+## Steps
+
+1. **Triage synchronously before dispatch.** Read each issue/ticket yourself, decide accept/defer/close. If you can't make that call from the existing data, you don't have enough context to brief a subagent.
+2. **Curate the subagent brief.** Include: the specific failure, relevant file paths, acceptance tests, non-goals. Exclude project history, unrelated tickets, opinions.
+3. **Isolate the filesystem.** Each subagent runs in its own git worktree (`git worktree add ../agent-N`) so parallel runs don't collide on branch, index, or working tree.
+4. **Grant a scoped credential.** `gh auth` or a PAT with just the permissions the subagent needs (e.g., PR creation on one repo). No org-wide tokens.
+5. **Run tests inside the worktree.** The subagent's "done" criterion is green tests in its worktree — not a passing CI on another branch.
+6. **Review before merge.** Orchestrator reads the diff, not the agent's narration. The narration is optimized for the model, the diff is the ground truth.
+7. **Kill and restart on drift.** If an agent starts asking meta questions, exploring unrelated code, or re-deriving the brief, terminate that worker rather than "negotiating" it back on task.
+
+## Success criteria
+
+- Each subagent session stays under a defined context budget (e.g., 50k tokens).
+- Merged PRs hit the acceptance tests supplied in the brief — no scope creep.
+- Two parallel agents modifying adjacent files never corrupt each other's worktree.
+- The orchestrator's time-per-issue (triage + review) is lower than the time it would take to implement it themselves.
+
+## Gotchas
+
+- **The orchestrator is the bottleneck, not the LLM.** Throughput is capped by how fast the human can triage and review.
+- **Context isolation beats "smart" prompts.** A small brief with exact file paths beats a long rich prompt with "read the codebase and figure it out."
+- **No institutional learning between runs.** Subagents start fresh each time. Codify repeat lessons as check-lists the orchestrator applies during triage, not as growing per-agent prompts.
+- **Senior skill erosion.** Over-delegating decomposition to the model eventually eats the skill that makes this pattern work in the first place. Junior devs need to practice triage, not just review.
+- **The `gh` CLI is a leak point.** A subagent with `gh` can open issues, push branches, and comment on PRs in your name. Scope the token.
+
+## Division of labor
+
+Orchestrator (human):
+- Issue analysis and triage
+- Context curation per task
+- Diff review before merge
+
+Subagents (AI):
+- Bounded implementation
+- Tests and validation
+- Commit and PR creation
+
+## Source
+
+- https://dev.to/nfrankel/experimenting-with-ai-subagents-pc7 — Nicolas Frankel, "Experimenting with AI subagents."
+- Research lane: skills_research trend survey, 2026-04-16 window.

--- a/skills/git/jj-jujutsu-day-one-workflow/SKILL.md
+++ b/skills/git/jj-jujutsu-day-one-workflow/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: jj-jujutsu-day-one-workflow
+description: Minimum viable jj (Jujutsu) workflow for a git user — init on top of an existing git repo, the five commands that cover 95% of day-1 usage, and the mental-model shift from git's staging area.
+category: git
+tags: [jj, jujutsu, version-control, git-compatible, workflow, onboarding]
+triggers: ["jj", "jujutsu", "jj git init", "jj describe", "jj bookmark", "jj st", "jj new", "jj log"]
+source_project: skills_research:trend:2026-04-16
+version: 1.0.0
+---

--- a/skills/git/jj-jujutsu-day-one-workflow/content.md
+++ b/skills/git/jj-jujutsu-day-one-workflow/content.md
@@ -1,0 +1,54 @@
+# jj day-1 workflow
+
+jj (Jujutsu) has a git-compatible backend: you can use it on a git repo without forcing collaborators to switch. This skill covers the minimum commands to get productive in a day without losing your git mental model.
+
+## When to use
+
+- You want to try jj on a personal branch without disrupting a team git workflow.
+- You're stuck on a multi-branch refactor and git's rebase/stash dance keeps breaking.
+- You want to stack changes where git's index/staging area makes it awkward.
+
+## Steps
+
+1. **Co-locate with git.** In an existing git repo: `jj git init --colocate`. Creates `.jj/` alongside `.git/`; pushes/pulls still go through the git backend.
+2. **Check state.** `jj st` — working copy + current change summary. No "staged vs unstaged" distinction: every change in the working copy is part of the current change.
+3. **Describe the current change.** `jj describe -m "..."` — edits the message of the change you're currently on. You can redescribe freely; there's no "amend vs rewrite history" tension.
+4. **Start a new change.** `jj new` — creates a fresh empty change on top. Conceptually like `git commit --allow-empty && new branch`, but without the branch.
+5. **View history.** `jj log` — shows your changes plus their relation to the git commits. Use `jj log -r @` to focus on the current chain.
+6. **Push to git.** Create a git bookmark (jj's named pointer): `jj bookmark set main -r @` then `jj git push --bookmark main`.
+
+## Success criteria
+
+- You can make, describe, split, and push a change without reaching for git commands.
+- Teammates see normal git commits; nothing signals jj was used.
+- You can abandon (`jj abandon`) a change without worrying about reflog gymnastics.
+
+## Gotchas
+
+- **No index.** Everything in the working copy is the change. Use `jj split` to carve one change into two; there's no `git add -p`.
+- **Change IDs vs commit IDs.** jj has stable change IDs that survive edits; git commits that correspond to them rotate. Refer to changes by change ID, not the git hash, within jj.
+- **Bookmarks ≠ branches.** A jj bookmark is just a pointer; it doesn't auto-advance when you commit. Move it explicitly before push, or set up auto-advance.
+- **Colocated mode keeps `.git/` writable.** If you run a git command inside a jj repo, jj will detect the drift and reconcile on the next jj command — but it's a source of confusion. Pick one.
+- **Conflicts are first-class.** jj keeps conflicts in the change rather than refusing to merge. This is powerful but surprising if you expect the git "abort and retry" loop.
+
+## Five-command cheat sheet
+
+- `jj git init --colocate` — init on top of an existing git repo.
+- `jj st` — working copy + current change.
+- `jj describe -m "..."` — edit current change's message.
+- `jj new` — start a new change on top.
+- `jj log` — history.
+
+Plus: `jj bookmark set <name> -r @`, `jj git push --bookmark <name>`, `jj split`, `jj abandon`.
+
+## Mental-model deltas from git
+
+- No staging area. Working copy = current change.
+- Change IDs are stable across edits; git commit hashes are derived and rotate.
+- Conflicts live inside a change rather than blocking the operation.
+- Bookmarks are passive pointers; they don't auto-follow new commits.
+
+## Source
+
+- https://steveklabnik.github.io/jujutsu-tutorial/introduction/what-is-jj-and-why-should-i-care.html — Steve Klabnik's jj tutorial (introduction).
+- Research lane: skills_research trend survey, 2026-04-16 window.

--- a/skills/security/lean-verified-code-threat-boundary/SKILL.md
+++ b/skills/security/lean-verified-code-threat-boundary/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: lean-verified-code-threat-boundary
+description: When shipping formally-verified code (Lean 4, Coq, F*), explicitly map what is inside and outside the verification boundary — untrusted parsers, runtime, and TCB assumptions almost always harbor the real bugs.
+category: security
+tags: [formal-verification, lean, coq, threat-modeling, fuzzing, tcb, security]
+triggers: ["formally verified", "lean 4", "formal proof", "Coq", "F-star", "lean_alloc_sarray", "trusted computing base", "TCB", "verified library", "CompCert"]
+source_project: skills_research:trend:2026-04-16
+version: 1.0.0
+---

--- a/skills/security/lean-verified-code-threat-boundary/content.md
+++ b/skills/security/lean-verified-code-threat-boundary/content.md
@@ -1,0 +1,48 @@
+# Ship verified code with an explicit threat boundary
+
+A formally-verified core doesn't make the whole system safe. The verification guarantees exactly what the specification covers; bugs migrate to untrusted parsers, the language runtime, and integer-overflow edges in the trusted computing base (TCB).
+
+## When to use
+
+- You or your team is about to claim "proven correct" in a README, paper, or security audit.
+- You're reviewing a formally-verified library before adopting it.
+- You're wiring a verified core into a larger product that also consumes untrusted input.
+
+## Steps
+
+1. **List the verified surface.** Enumerate every theorem and what it proves. Example: `decompress(compress(x)) = x`. Write this as a short "verified surface" section in the repo README.
+2. **List the unverified surface.** Anything that reads bytes from the network, filesystem, or user — parsers, archive-header readers, length-prefixed decoders. Every one of them is outside the proof.
+3. **List the TCB.** Language runtime (`lean_alloc_sarray`, GC, primitive allocators), FFI shims, C++ helpers, compiler itself. Assume bugs here until audited.
+4. **Fuzz the unverified surface.** Run libFuzzer / AFL on parsers and header readers with a deterministic corpus; the verified core won't crash — the unverified input path will.
+5. **Guard integer arithmetic crossing the FFI boundary.** Size/length values from untrusted input that get multiplied by `sizeof(T)` are a classic overflow path — check against a sane upper bound before allocation.
+6. **Document known assumptions.** `compressedSize` from a ZIP header is attacker-controlled; call it out next to the allocation site.
+7. **Threat-model each verified theorem.** Ask: "does this theorem still hold if inputs are adversarial?" — spec usually assumes well-formed inputs.
+
+## Success criteria
+
+- A reviewer can point at a specific line and say "this is inside / outside the proof" in under 10 seconds.
+- Fuzzing on the unverified surface produces zero crashes after N million executions (pick N; 100M+ is evidence).
+- TCB functions that do unchecked arithmetic on untrusted lengths have a regression test for `SIZE_MAX`-class inputs.
+
+## Gotchas
+
+- Theorems about "inverse of compress" say nothing about malicious compressed inputs with pathological dictionaries, exabyte-sized headers, or malformed CRCs.
+- The trusted runtime is usually implicit; contributors assume it's "part of the language" and skip auditing it.
+- Verification culture can bias toward proving what's already well-structured and away from the dirty parsing code that actually gets attacked.
+- "Zero bugs in CompCert's verified passes, all bugs in its unverified front-end" is the canonical cautionary tale.
+
+## Canonical cautionary cases
+
+- **CompCert**: verified C compiler; Csmith fuzzing found zero bugs in the verified middle/back end, but multiple bugs in the unverified front end.
+- **lean-zip (2026)**: proved `decompress(compress(x)) = x` over the DEFLATE pipeline plus Huffman and CRC32. Fuzzing still found:
+  1. Heap buffer overflow in Lean runtime's `lean_alloc_sarray` — integer overflow when requesting `SIZE_MAX` bytes allocated only ~23 bytes, with later writes clobbering the heap. Affects *all* Lean 4 programs.
+  2. DoS in the archive parser — the ZIP header's `compressedSize` field was piped to allocation without bounds, crashing on exabyte-claim inputs.
+
+## Linked knowledge
+
+- `knowledge/pitfall/lean-verification-spec-coverage-gap.md`
+
+## Source
+
+- https://kirancodes.me/posts/log-who-watches-the-watchers.html — "Who Watches The Watchers" (2026).
+- Research lane: skills_research trend survey, 2026-04-16 window.

--- a/skills/security/openssl-4-migration-checklist/SKILL.md
+++ b/skills/security/openssl-4-migration-checklist/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: openssl-4-migration-checklist
+description: Step-by-step migration checklist for upgrading a C/C++ codebase from OpenSSL 3.x to 4.0.0 — const-qualified APIs, removed SSLv3 support, opaque ASN1_STRING, engine removal, cleanup semantics.
+category: security
+tags: [openssl, tls, cryptography, migration, c-api, breaking-changes, upgrade]
+triggers: ["openssl 4", "OpenSSL 4.0.0", "openssl upgrade", "SSLv3_method", "ENGINE_load", "ASN1_STRING opaque", "X509_cmp_time", "openssl deprecated"]
+source_project: skills_research:trend:2026-04-16
+version: 1.0.0
+---

--- a/skills/security/openssl-4-migration-checklist/content.md
+++ b/skills/security/openssl-4-migration-checklist/content.md
@@ -1,0 +1,56 @@
+# OpenSSL 4.0.0 migration checklist
+
+Upstream OpenSSL 4.0.0 introduces breaking API changes, removed legacy protocols, and changed cleanup semantics. Follow this checklist when upgrading a 3.x-pinned project.
+
+## When to use
+
+- Bumping the OpenSSL dependency from 3.x to 4.0.0 in a C/C++ project.
+- Reviewing a build that started failing after an OpenSSL headers bump.
+- Auditing whether a library that wraps OpenSSL is ready for 4.0.
+
+## Steps
+
+1. **Audit const-qualifier adds.** Many X509 and related APIs gained `const` on arguments/returns. Compile against the new headers; treat every new const-mismatch warning as a real call site to patch (don't cast it away).
+2. **Replace removed error-state APIs.** `ERR_get_state`, `ERR_remove_state`, `ERR_remove_thread_state` are gone. Move callers to the current thread-error API.
+3. **Drop fixed SSL/TLS version method functions.** `SSLv3_method`, `TLSv1_method`, etc. are removed. Use `TLS_method()` and constrain versions via `SSL_CTX_set_min/max_proto_version`.
+4. **Remove custom EVP method registrations.** Custom `EVP_CIPHER`/`EVP_MD`/`EVP_PKEY`/`EVP_PKEY_ASN1` method-creation APIs no longer exist. Port to the provider API.
+5. **Stop direct `ASN1_STRING` field access.** The struct is opaque. Replace `->data`, `->length`, `->type` reads with `ASN1_STRING_get0_data`, `ASN1_STRING_length`, `ASN1_STRING_type`.
+6. **Delete engine glue.** ENGINE support is removed. `OPENSSL_NO_ENGINE` is always defined. Remove `ENGINE_load_*`, `ENGINE_by_id`, etc.
+7. **Audit TLS deprecated-EC usage.** Deprecated curves and explicit EC curves are off by default. If you still need them, rebuild with `enable-tls-deprecated-ec` and `enable-ec_explicit_curves` — otherwise delete the code.
+8. **Replace deprecated X509 time APIs.** `X509_cmp_time`, `X509_cmp_current_time`, `X509_cmp_timeframe` → `X509_check_certificate_times`.
+9. **Review cleanup assumptions.** libcrypto no longer registers an `atexit` cleanup. If you relied on automatic teardown (leak detectors, long-running daemons restarting), call `OPENSSL_cleanup()` explicitly.
+10. **Regenerate hex-parsing tests.** Hex dump widths standardized (24 bytes for signatures, 16 elsewhere) and leading `00:` bytes are stripped when the first significant byte ≥ 0x80. Golden files with OpenSSL hex output will drift.
+11. **Swap `c_rehash` callers.** The script is gone; use `openssl rehash`.
+12. **Remove SSLv3 / SSLv2 ClientHello paths.** Dead code now — the library refuses to negotiate these.
+13. **Check darwin build targets.** `darwin-i386*`, `darwin-ppc*` targets are removed; fail fast in CI on those runners.
+
+## Success criteria
+
+- Project compiles against 4.0.0 headers with `-Werror` and the original warning flags.
+- `openssl list -all-providers` shows the providers your code actually uses.
+- TLS smoke tests cover min/max proto version and any EC curves still enabled.
+- Integration tests with an external peer still pass (handshake, cert-validation boundaries).
+
+## Gotchas
+
+- Some code uses `const_cast`-style tricks to squash the new warnings. That hides call sites that genuinely mutate the input — track them down instead.
+- If a wrapper library (Python cryptography, Ruby openssl, Go x/crypto) hasn't released a 4.0.0-compatible build yet, you'll wedge consumers. Check compatibility matrices before upgrading shared infra.
+- FIPS provider gained stricter lower bounds on `PKCS5_PBKDF2_HMAC` — old short-password fixtures in tests may start failing.
+
+## Reference — removed / deprecated inventory
+
+- `ERR_get_state`, `ERR_remove_state`, `ERR_remove_thread_state` — removed.
+- Fixed-version method functions (`SSLv3_method`, `TLSv1_method`, etc.) — removed.
+- Custom `EVP_CIPHER`/`EVP_MD`/`EVP_PKEY`/`EVP_PKEY_ASN1` methods — no longer supported.
+- `BIO_f_reliable()` — removed with no replacement.
+- ENGINE framework — removed; `OPENSSL_NO_ENGINE` always defined.
+- `c_rehash` script — replaced by `openssl rehash`.
+- SSLv3 / SSLv2 ClientHello — removed.
+- Deprecated TLS elliptic curves and explicit EC curves — disabled by default (rebuild with `enable-tls-deprecated-ec` / `enable-ec_explicit_curves`).
+- `X509_cmp_time`, `X509_cmp_current_time`, `X509_cmp_timeframe` — deprecated in favor of `X509_check_certificate_times`.
+- darwin-i386, darwin-i386-cc, darwin-ppc, darwin-ppc64, darwin-ppc64-cc — removed build targets.
+
+## Source
+
+- https://github.com/openssl/openssl/releases/tag/openssl-4.0.0 — OpenSSL 4.0.0 release notes (vendor-canonical).
+- Research lane: skills_research trend survey, 2026-04-16 window.

--- a/skills/testing/llm-integration-test-failure-diagnosis/SKILL.md
+++ b/skills/testing/llm-integration-test-failure-diagnosis/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: llm-integration-test-failure-diagnosis
+description: Wire an LLM-based diagnosis step into your CI for integration-test failures — summarize noisy logs, identify probable root cause, post findings to the code-review/PR UI. Based on Google's Auto-Diagnose system (90%+ accuracy on 71-case study, adopted across 52k tests).
+category: testing
+tags: [llm, ci, integration-tests, test-diagnosis, log-analysis, root-cause, auto-diagnose]
+triggers: ["test failure diagnosis", "integration test flaky", "log summarization", "auto-diagnose", "test failure LLM", "root cause analysis"]
+source_project: skills_research:trend:2026-04-16
+version: 1.0.0
+---

--- a/skills/testing/llm-integration-test-failure-diagnosis/content.md
+++ b/skills/testing/llm-integration-test-failure-diagnosis/content.md
@@ -1,0 +1,46 @@
+# LLM-based integration-test failure diagnosis
+
+Integration-test logs are unstructured and high-volume, which makes manual triage the slow part of the loop. Google's Auto-Diagnose shows LLMs can summarize the log and propose a root cause well enough that developers adopt it in their review workflow. This skill describes how to build the equivalent.
+
+## When to use
+
+- Your integration test suite fails often enough that log triage is a measurable developer time sink.
+- You already have a structured code-review or PR UI where findings can be posted inline.
+- You can ship a per-failure payload (≤1–2MB) to an LLM without exfiltrating secrets.
+
+## Steps
+
+1. **Collect the failure payload.** Per failed test: final N log lines (or the last successful checkpoint → failure tail), stack trace, recent commits touching the changed files, test name and framework, and the test's assertion message.
+2. **Redact before sending.** Strip credentials, internal hostnames, customer PII, bearer tokens. This is the highest-blast-radius integration point; a pre-flight redactor is non-negotiable.
+3. **Structure the prompt.** Explicit sections: `CONTEXT`, `LOGS`, `FAILURE`, `RECENT_CHANGES`, `TASK`. Ask for a structured response (markdown with `summary`, `probable_root_cause`, `supporting_log_lines`).
+4. **Cap log volume.** Truncate to the most recent ~30KB of text; over-long logs dilute the signal without improving accuracy.
+5. **Post findings to the review UI.** At Google: inline into Critique. For GitHub: a PR review comment or a check-run annotation. Make the finding rejectable — "not helpful" is a first-class button.
+6. **Measure helpfulness explicitly.** Track a "not helpful" rate per failure type; a working system should stay under ~10% of negative feedback.
+7. **Bound the ranking claim.** Auto-Diagnose ranked #14 of 370 Critique finders. Your system is one voice among many — don't block merges on it.
+
+## Success criteria
+
+- ≥85% diagnosis accuracy on a manually-labeled holdout of ≥50 real failures before roll-out.
+- "Not helpful" rate below 10% once live.
+- End-to-end latency from test fail to posted finding under the developer's context-switch window (target: <1 minute).
+- Redaction layer has its own unit tests — any change to it blocks deploy.
+
+## Gotchas
+
+- **Logs aren't sanitized.** Internal tests leak stack traces with internal hostnames, DB schemas, user IDs. Budget real engineering for the redactor before the LLM call.
+- **Flaky tests pollute training signal.** If you fine-tune on past diagnoses, exclude flakes — their "root cause" is often "infra blip" and the model will overfit.
+- **Cost scales with failure rate.** A regression that takes out 500 tests fires 500 diagnoses. Deduplicate by stack-trace fingerprint before calling the LLM.
+- **Confidence calibration.** Ranking #14/370 means developers will still ignore findings they don't trust. Show the supporting log lines inline so they don't have to re-read the raw log.
+- **Don't auto-close bugs from LLM diagnosis.** It's an assistive finding, not a verdict.
+
+## Reference numbers from Auto-Diagnose (Google)
+
+- Manual case study: 90.14% root-cause accuracy across 71 real-world failures.
+- Production rollout: 52,635 distinct failing tests covered.
+- Helpfulness: "Not helpful" feedback in 5.8% of cases.
+- Ranking: #14 of 370 tools posting findings in Critique.
+
+## Source
+
+- https://arxiv.org/abs/2604.12108 — "LLM-Based Automated Diagnosis Of Integration Test Failures At Google" (2026).
+- Research lane: skills_research trend survey, 2026-04-16 window.


### PR DESCRIPTION
## Summary

Harvested from `/skills_research` trend run on 2026-04-16 (window: 30d). Sources: GitHub trending, HN front page, arxiv cs.SE, dev.to top week. 40 raw items → 12 shortlisted → 13 drafts (5 skills, 8 knowledge, 1 cross-linked pair).

## Skills

| Category | Skill | Version | Confidence |
|----------|-------|---------|------------|
| ai | `ai-subagent-scope-narrowing` | v1.0.0 | medium |
| git | `jj-jujutsu-day-one-workflow` | v1.0.0 | medium |
| security | `lean-verified-code-threat-boundary` | v1.0.0 | medium |
| security | `openssl-4-migration-checklist` | v1.0.0 | **high** |
| testing | `llm-integration-test-failure-diagnosis` | v1.0.0 | **high** |

## Knowledge

| Category | Entry | Confidence |
|----------|-------|------------|
| api | `claude-code-routines-cloud-automation-model` | **high** |
| arch | `agent-memory-binding-vs-recall` | medium |
| arch | `archon-deterministic-ai-coding-harness` | medium |
| arch | `duckdb-vectorized-analytical-execution` | medium |
| arch | `llm-tool-calling-mxn-wire-format-problem` | medium |
| decision | `fifth-normal-form-join-dependency-tradeoff` | medium |
| decision | `typed-wikilinks-for-llm-knowledge-base` | medium |
| pitfall | `lean-verification-spec-coverage-gap` | medium |

## Cross-links

- `lean-verified-code-threat-boundary` (skill, security) ↔ `lean-verification-spec-coverage-gap` (knowledge, pitfall)

## Source

- Research lane: `/skills_research` trend run, 2026-04-16
- Source channels: gh (10), hn (15), arxiv (5), devto (10); 12 unique URLs fetched after dedupe
- All drafts carry inline `## Source` sections linking to the originating URL
- Confidence rubric: "high" requires vendor-canonical docs or peer-reviewed source + corroboration. Single-source medium items are flagged accordingly in their draft bodies.

## Review notes

- Two skill categories remapped to canonical CATEGORIES.md during publish: `verification` → `security` (Lean threat boundary); `devtools` → `git` (jj workflow).
- Knowledge frontmatter follows the repo's `{name, category, summary, source: {kind, ref}}` shape; skill SKILL.md is frontmatter-only with body in `content.md`.
- Tags pushed: 5 annotated (`skills/<name>/v1.0.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)