### PR TITLE
Cleanup: design 카테고리 추가 + 인덱스 재생성

### DIFF
--- a/CATEGORIES.md
+++ b/CATEGORIES.md
@@ -22,6 +22,7 @@ Canonical list. Keep broad (target ≤20). Use tags for fine-grained attributes.
 | `docs` | Documentation writing, API docs, diagrams, changelog |
 | `workflow` | Process/team patterns, review protocols, release flows |
 | `game-dev` | Game engines, combat, RNG/gacha, progression, status effects, turn systems |
+| `design` | UI component patterns, styling, theming, design tokens, design-dev handoff |
 | `misc` | Doesn't fit above — revisit during `/skills_cleanup` |
 
 ## Proposing a New Category

--- a/index.json
+++ b/index.json
@@ -4,3106 +4,2447 @@
       "name": "adaptive-strategy-hot-swap",
       "description": "Periodically re-evaluate candidate strategies/policies against recent data, swap the active one only when a weighted composite score beats the incumbent by a hysteresis threshold — prevents flapping while staying adaptive.",
       "category": "arch",
-      "tags": "[strategy, adaptive, hot-swap, hysteresis, rebalance, composite-score, backtest]",
-      "triggers": "[\"shouldUpdateStrategy\", \"reanalyze\", \"strategy update\", \"hot swap\", \"policy rotation\", \"best strategy\", \"composite score\", \"hysteresis threshold\"]",
-      "source_project": "kis-java-bundle",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "arch/adaptive-strategy-hot-swap"
+      "path": "skills/arch/adaptive-strategy-hot-swap"
+    },
+    {
+      "name": "ag-grid-custom-filter-system",
+      "description": "ag-grid Enterprise wrapper with GridContext provider, custom filter components (Boolean, Number, DateRange, SelectMulti), and pagination state management",
+      "category": "design",
+      "tags": [],
+      "triggers": [],
+      "version": "1.0.0",
+      "path": "skills/design/ag-grid-custom-filter-system"
     },
     {
       "name": "ai-call-with-mock-fallback",
       "description": "Wrap unreliable LLM/AI calls with a deterministic mock fallback so the UI always receives a valid shape — annotate the response with a `mock: true` or `error:` field so the client can show a badge.",
       "category": "ai",
-      "tags": "[llm, resilience, fallback, mock, ux, error-handling]",
-      "triggers": "[\"AI 생성 실패\", \"mock data\", \"ANTHROPIC_API_KEY\", \"fallback response\", \"mock: true\", \"degraded mode\"]",
-      "source_project": "webtoon_ai_project_with_wrapper",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "ai/ai-call-with-mock-fallback"
+      "path": "skills/ai/ai-call-with-mock-fallback"
     },
     {
       "name": "ai-subagent-scope-narrowing",
       "description": "Orchestrator-first pattern for multi-agent AI coding — humans triage and curate context per task, subagents execute in isolated worktrees with narrowly-scoped briefs. Trades parallel throughput for reduced hallucination.",
       "category": "ai",
-      "tags": "[agents, subagents, orchestration, context-isolation, worktree, hallucination]",
-      "triggers": "[\"subagent\",\"multiple agents\",\"parallel agents\",\"worktree\",\"agent hallucination\",\"narrow scope\",\"orchestrator agent\",\"context engineering\"]",
-      "source_project": "skills_research:trend:2026-04-16",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "ai/ai-subagent-scope-narrowing"
+      "path": "skills/ai/ai-subagent-scope-narrowing"
+    },
+    {
+      "name": "antd-wrapper-component-pattern",
+      "description": "Wrap Ant Design components with a custom design system layer (Sirius pattern) that extends props, enforces standards, and maintains upgrade compatibility",
+      "category": "design",
+      "tags": [],
+      "triggers": [],
+      "version": "1.0.0",
+      "path": "skills/design/antd-wrapper-component-pattern"
     },
     {
       "name": "async-subagent-resume-on-missing-artifact",
       "description": "When an async subagent is reported \"completed\" but its final message hints at unfinished work (e.g., \"Now let me build…\"), verify the expected on-disk artifact before moving on; if missing, use SendMessage to the agent id to finalize rather than re-dispatching a fresh agent.",
       "category": "workflow",
-      "tags": "[agents, async, verification, send-message]",
-      "triggers": "[\"\\\"agent completed but artifact missing\\\"\", \"\\\"subagent incomplete output\\\"\"]",
-      "scope": "user",
-      "source_project": "",
+      "tags": [],
+      "triggers": [
+        "\"agent completed but artifact missing\"",
+        "\"subagent incomplete output\""
+      ],
       "version": "1.0.0",
-      "path": "workflow/async-subagent-resume-on-missing-artifact"
+      "path": "skills/workflow/async-subagent-resume-on-missing-artifact"
     },
     {
       "name": "audit-change-data-capture-pattern",
       "description": "Compute before/after diffs for audit logs by comparing two BSON/JSON documents field-by-field — always iterate the BEFORE doc and read from AFTER to avoid prev/after swap bugs",
       "category": "backend",
-      "tags": "",
-      "triggers": "Recording audit trail entries where UPDATE events need field-level before/after snapshots",
-      "source_project": "lucida-audit",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/audit-change-data-capture-pattern",
-      "linked_knowledge": [
-        "audit-changed-prev-after-field-swap-bug"
-      ]
+      "path": "skills/backend/audit-change-data-capture-pattern"
     },
     {
       "name": "availability-ttl-punctuate-processor",
       "description": "Kafka Streams processor schedules a wall-clock `punctuate` for TTL eviction of the state store, and emits downstream only on value change. Wall-clock (not stream-time) so idle inputs still trigger cleanup.",
       "category": "backend",
-      "tags": "[kafka-streams, punctuate, wall-clock, TTL, state-store, change-detection]",
-      "triggers": "[\"PunctuationType.WALL_CLOCK_TIME\", \"state store TTL\", \"latest materialized view\", \"change-only forward\"]",
-      "source_project": "lucida-measurement",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/availability-ttl-punctuate-processor",
-      "linked_knowledge": [
-        "latest-availability-deletion-risk"
-      ]
+      "path": "skills/backend/availability-ttl-punctuate-processor"
     },
     {
       "name": "avro-event-with-change-flags",
       "description": "Design Kafka Avro event schemas that carry an actionType enum plus boolean \"changed\" flags per mutable section so consumers can branch cheaply without diffing payloads.",
       "category": "backend",
-      "tags": "[kafka, avro, event-sourcing, schema, change-flag]",
-      "triggers": "[\"parentChanged\", \"tagFiltersChanged\", \"actionType INSERT UPDATE DELETE\", \"Avro event schema\"]",
-      "source_project": "lucida-cm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/avro-event-change-flags"
+      "path": "skills/backend/avro-event-change-flags"
     },
     {
       "name": "avro-gradle-kafka-schema-pipeline",
       "description": "Wire the davidmc24 Avro Gradle plugin so .avsc schemas generate Java sources consumed by Kafka producers/consumers with Confluent Schema Registry",
       "category": "backend",
-      "tags": "[avro, gradle, kafka, schema-registry, codegen]",
-      "triggers": "Spring Boot + Gradle service using Avro over Kafka with generated Java classes and a Schema Registry",
-      "source_project": "lucida-report",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/avro-gradle-kafka-schema-pipeline"
+      "path": "skills/backend/avro-gradle-kafka-schema-pipeline"
     },
     {
       "name": "axios-refresh-queue-zustand",
       "description": "Axios response interceptor that intercepts 401, queues concurrent failed requests, refreshes the token once, and replays queued requests with the new token. Prevents thundering-herd refresh calls.",
       "category": "frontend",
-      "tags": "[\"axios\", \"jwt\", \"refresh-token\", \"interceptor\", \"zustand\", \"auth\"]",
-      "triggers": "[\"axios 401 refresh\", \"token refresh queue\", \"isRefreshing flag\", \"axios interceptor zustand\", \"refresh thundering herd\", \"retry original request\"]",
-      "source_project": "veda-chronicles",
+      "tags": [
+        "axios",
+        "jwt",
+        "refresh-token",
+        "interceptor",
+        "zustand",
+        "auth"
+      ],
+      "triggers": [
+        "axios 401 refresh",
+        "token refresh queue",
+        "isRefreshing flag",
+        "axios interceptor zustand",
+        "refresh thundering herd",
+        "retry original request"
+      ],
       "version": "0.1.0-draft",
-      "path": "frontend/axios-refresh-queue-zustand"
+      "path": "skills/frontend/axios-refresh-queue-zustand"
     },
     {
       "name": "baseline-historical-comparison-threshold",
       "description": "Evaluate a current metric against a historical baseline (prev hour/day/week/month/year, with MIN/AVG/MAX aggregation) as a dynamic threshold; supports RATE or VALUE change modes and dampening.",
       "category": "backend",
-      "tags": "[baseline, threshold, anomaly-detection, seasonality, dampening, metric]",
-      "triggers": "[\"BaselineType\", \"baseline\", \"historical threshold\", \"YESTERDAY_SAME_HOUR\", \"RATE vs VALUE\", \"dynamic threshold\"]",
-      "source_project": "lucida-alarm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/baseline-historical-comparison-threshold"
+      "path": "skills/backend/baseline-historical-comparison-threshold"
     },
     {
       "name": "bootrun-jvmargs-jdwp-opens-java21",
       "description": "Bake JDWP debug port and required --add-opens flags into Gradle bootRun so every dev gets the same Java 17/21-compatible local runtime",
       "category": "backend",
-      "tags": "[gradle, spring-boot, java21, debug, jvm-args]",
-      "triggers": "Local bootRun needs IDE-attach debug and Java 17/21 reflective access without per-dev run configs",
-      "source_project": "lucida-account",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/bootrun-jvmargs-jdwp-opens-java21"
+      "path": "skills/backend/bootrun-jvmargs-jdwp-opens-java21"
     },
     {
       "name": "bucket-parallel-java-annotation-dispatch",
       "description": "For bulk Java annotation work (200+ @Operation methods across many controllers, or 500+ @Schema fields across many DTOs), dispatch N parallel executor subagents with disjoint file buckets. Leader runs a single compile at the end; agents never run gradle themselves.",
       "category": "workflow",
-      "tags": "[parallel-agents, java, annotation, spring, swagger, gradle]",
-      "triggers": "[\"\\\"bulk annotation\\\"\", \"\\\"전수 적용\\\"\", \"\\\"controller 전체 주석\\\"\", \"\\\"DTO @Schema 전수\\\"\"]",
-      "scope": "user",
-      "source_project": "",
+      "tags": [],
+      "triggers": [
+        "\"bulk annotation\"",
+        "\"전수 적용\"",
+        "\"controller 전체 주석\"",
+        "\"DTO @Schema 전수\""
+      ],
       "version": "1.0.0",
-      "path": "workflow/bucket-parallel-java-annotation-dispatch"
+      "path": "skills/workflow/bucket-parallel-java-annotation-dispatch"
     },
     {
       "name": "build-error-triage",
       "description": "Systematic triage workflow for build/compilation errors — classify by root cause (missing symbol, signature mismatch, instantiation failure), then isolate the first error before chasing cascades.",
       "category": "debug",
-      "tags": "[build, compilation, java, javac, errors, triage]",
-      "triggers": "[Unresolved compilation, Cannot instantiate, method is undefined, cannot find symbol, compilation error]",
-      "source_project": "manual",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "debug/build-error-triage"
+      "path": "skills/debug/build-error-triage"
     },
     {
       "name": "byte-aware-sms-truncation-with-ellipsis",
       "description": "Truncate SMS message body to a byte budget (not char count) per charset, appending '...' without exceeding the budget",
       "category": "backend",
-      "tags": "",
-      "triggers": "[\"writing to an SMS column / gateway with a hard byte limit where multibyte chars (Korean, emoji) overflow a naive char truncation\"]",
-      "source_project": "lucida-notification",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/byte-aware-sms-truncation-with-ellipsis"
+      "path": "skills/backend/byte-aware-sms-truncation-with-ellipsis"
     },
     {
       "name": "cache-variance-ttl-jitter",
       "description": "Add ±N% random jitter to cache TTLs so keys written together don't all expire in the same tick, avoiding synchronized recompute storms",
       "category": "backend",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-realtime",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/cache-variance-ttl-jitter"
+      "path": "skills/backend/cache-variance-ttl-jitter"
     },
     {
       "name": "calendar-cron-vs-spring-cron-migration",
       "description": "Convert between Spring 6-field cron and Quartz/calendar 7-field cron without DST/leap-year regressions",
       "category": "backend",
-      "tags": "[cron, quartz, spring-scheduler, migration]",
-      "triggers": "Scheduler migration from Spring @Scheduled(cron=...) to Quartz-style CronTrigger, or persisting user-authored cron that must survive both engines",
-      "source_project": "lucida-report",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/calendar-cron-vs-spring-cron-migration"
+      "path": "skills/backend/calendar-cron-vs-spring-cron-migration"
     },
     {
       "name": "challenge-response-auth-redis-ttl",
       "description": "Replay-resistant two-step login — server issues a short-lived random challenge stored in Redis with TTL, client signs/hashes response, bounded attempts per key",
       "category": "backend",
-      "tags": "[authentication, redis, challenge-response, security, replay-protection]",
-      "triggers": "Login flow needs replay-resistant credential exchange without full TLS client-cert or OAuth2 overhead",
-      "source_project": "lucida-account",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/challenge-response-auth-redis-ttl"
+      "path": "skills/backend/challenge-response-auth-redis-ttl"
     },
     {
       "name": "character-sheet-multi-panel-consistency",
       "description": "Keep a consistent character across multiple diffusion-model image generations by emitting a reusable \"character sheet\" description string from the LLM and prefixing it into every panel's image prompt.",
       "category": "ai",
-      "tags": "[stable-diffusion, prompt-engineering, character-consistency, comic, storyboard, multi-panel]",
-      "triggers": "[\"character sheet\", \"characterSheet\", \"consistent character\", \"multi-panel\", \"storyboard\", \"comic\", \"same character in all panels\"]",
-      "source_project": "webtoon_ai_project_with_wrapper",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "ai/character-sheet-multi-panel-consistency"
+      "path": "skills/ai/character-sheet-multi-panel-consistency"
     },
     {
       "name": "chunked-resource-id-batch-fetch",
       "description": "Split large ID lists into ~1000-item chunks before querying DB or Elasticsearch to avoid bind-parameter limits (MSSQL 2100, Oracle 1000) and OOM on bulk responses",
       "category": "backend",
-      "tags": "[batch, chunk, jdbc, elasticsearch, terms-query, bind-parameter, oracle, mssql]",
-      "triggers": "[\"`WHERE id IN (?, ?, …)` with thousands of IDs\", \"ES `terms` query near 65536-item ceiling\", \"monitor/report accepts an unbounded target ID list\"]",
-      "source_project": "cygnus",
+      "tags": [],
+      "triggers": [
+        "`WHERE id IN (?, ?, …)` with thousands of IDs",
+        "ES `terms` query near 65536-item ceiling",
+        "monitor/report accepts an unbounded target ID list"
+      ],
       "version": "1.0.0",
-      "path": "backend/chunked-resource-id-batch-fetch"
+      "path": "skills/backend/chunked-resource-id-batch-fetch"
     },
     {
       "name": "clang-tidy-integration-workflow",
       "description": "Automated static analysis pipeline using clang-tidy with project-specific checks and suppression strategies for large multi-file C++ codebases.",
       "category": "devops",
-      "tags": "[cpp, static-analysis, clang-tidy, ci, linting]",
-      "triggers": "",
-      "source_project": "bitcoin",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "devops/clang-tidy-integration-workflow"
+      "path": "skills/devops/clang-tidy-integration-workflow"
     },
     {
       "name": "claude-cli-from-jvm-via-node-wrapper",
       "description": "Shell out to the `claude` CLI from a JVM / Spring Boot app by going through a tiny Node.js wrapper that supplies the required empty stdin — the CLI hangs when invoked with a directly-inherited TTY-less stdin from ProcessBuilder.",
       "category": "ai",
-      "tags": "[claude-cli, subprocess, spring-boot, processbuilder, node-wrapper, stdin, hang]",
-      "triggers": "[\"claude -p\", \"ProcessBuilder\", \"claude CLI\", \"node claude-runner\", \"execFileSync\", \"subprocess hang\", \"cli stdin\"]",
-      "source_project": "webtoon_ai_project_with_wrapper",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "ai/claude-cli-from-jvm-via-node-wrapper"
+      "path": "skills/ai/claude-cli-from-jvm-via-node-wrapper"
     },
     {
       "name": "claude-code-skill-scaffold",
-      "description": "[Tooling] Claude Code 스킬 표준 구조(SKILL.md + prompts/ + scripts/ + references/)를 자동 생성하는 스캐폴딩.",
+      "description": "\"[Tooling] Claude Code 스킬 표준 구조(SKILL.md + prompts/ + scripts/ + references/)를 자동 생성하는 스캐폴딩.\"",
       "category": "devops",
-      "tags": "[claude-code, skill, scaffold, plugin]",
-      "triggers": "[\"skill-create\", \"new skill\", \"scaffold skill\", \"SKILL.md boilerplate\"]",
-      "source_project": "nkia-skills",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "devops/claude-code-skill-scaffold"
+      "path": "skills/devops/claude-code-skill-scaffold"
     },
     {
       "name": "claude-plugin-catalog-publish",
-      "description": "[Tooling] 로컬 스킬을 원격 Git repo에 배포하고 AGENTS.md 카탈로그를 자동 갱신하는 publish 플로우.",
+      "description": "\"[Tooling] 로컬 스킬을 원격 Git repo에 배포하고 AGENTS.md 카탈로그를 자동 갱신하는 publish 플로우.\"",
       "category": "devops",
-      "tags": "[claude-code, plugin, publish, git, catalog, agents-md]",
-      "triggers": "[\"skill-publish\", \"publish plugin\", \"catalog update\", \"claude plugin deploy\"]",
-      "source_project": "nkia-skills",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "devops/claude-plugin-catalog-publish"
+      "path": "skills/devops/claude-plugin-catalog-publish"
     },
     {
       "name": "collection-routing-by-period",
       "description": "Single resolver maps `(Period.Mode, from, to)` → time-series collection (raw view / 1-min / hour-with-monthly-suffix / day). Callers never hardcode collection names.",
       "category": "backend",
-      "tags": "[mongodb, time-series, routing, period, view]",
-      "triggers": "[\"raw view\", \"hour collection\", \"time-series routing\", \"period mode\", \"collection suffix\"]",
-      "source_project": "lucida-measurement",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/collection-routing-by-period"
+      "path": "skills/backend/collection-routing-by-period"
     },
     {
       "name": "compact-binary-wire-protocol-with-variable-length-encoding",
       "description": "Define a custom binary wire format with variable-length integer encodings (e.g. 3-byte / 5-byte) to minimize UDP packet size for high-volume metric or telemetry streams",
       "category": "backend",
-      "tags": "[protocol, binary, varint, udp, telemetry, perf]",
-      "triggers": "",
-      "source_project": "scouter",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/compact-binary-wire-protocol-with-variable-length-encoding"
+      "path": "skills/backend/compact-binary-wire-protocol-with-variable-length-encoding"
     },
     {
       "name": "concurrent-jdbc-pool-datasource-lifecycle",
       "description": "Manage a pool of short-lived JDBC targets for monitoring agents with dual maps (active vs all) and periodic revalidation",
       "category": "backend",
-      "tags": "",
-      "triggers": "multi-tenant JDBC agent, per-target connection lifecycle, monitoring pool management",
-      "source_project": "lucida-domain-dpm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/concurrent-jdbc-pool-datasource-lifecycle"
+      "path": "skills/backend/concurrent-jdbc-pool-datasource-lifecycle"
     },
     {
       "name": "conditional-feature-flag-rollout",
       "description": "@ConditionalOnProperty로 구/신 구현을 공존시키고 런타임 속성 하나로 전환하는 점진적 롤아웃 패턴",
       "category": "backend",
-      "tags": "",
-      "triggers": "Large architecture swap (sync→event) needing gradual rollout + instant rollback",
-      "source_project": "lucida-domain-automation",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/conditional-feature-flag-rollout"
+      "path": "skills/backend/conditional-feature-flag-rollout"
     },
     {
       "name": "custom-actuator-command-whitelist",
       "description": "Expose safe remote OS command execution on a Spring Boot service via a custom Actuator endpoint, restricted by a command whitelist, an argument sanitizer, and an execution timeout.",
       "category": "backend",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-health",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/custom-actuator-command-whitelist"
+      "path": "skills/backend/custom-actuator-command-whitelist"
     },
     {
       "name": "debug-lockorder-detection-system",
       "description": "Runtime lock-order deadlock detection via a DEBUG_LOCKORDER compile flag that tracks lock acquisition order and reports circular dependencies.",
       "category": "debug",
-      "tags": "[cpp, threading, deadlock, debugging, instrumentation]",
-      "triggers": "",
-      "source_project": "bitcoin",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "debug/debug-lockorder-detection-system"
+      "path": "skills/debug/debug-lockorder-detection-system"
     },
     {
       "name": "definition-registry-helper-cache",
       "description": "Static helper class with ConcurrentHashMap caches populated at startup by @PostConstruct providers, enabling zero-allocation hot-path lookups via static getters",
       "category": "arch",
-      "tags": "[spring, cache, static, concurrenthashmap, performance]",
-      "triggers": "[\"static helper cache\", \"ConcurrentHashMap static cache\", \"PostConstruct populate static map\", \"definition helper lookup\", \"zero allocation hot path cache\"]",
-      "scope": "user",
-      "source_project": "lucida-domain-sms",
+      "tags": [],
+      "triggers": [
+        "static helper cache",
+        "ConcurrentHashMap static cache",
+        "PostConstruct populate static map",
+        "definition helper lookup",
+        "zero allocation hot path cache"
+      ],
       "version": "0.1.0-draft",
-      "path": "arch/definition-registry-helper-cache"
+      "path": "skills/arch/definition-registry-helper-cache"
     },
     {
       "name": "design-an-interface",
       "description": "Generate multiple radically different interface designs for a module using parallel sub-agents. Use when user wants to design an API, explore interface options, compare module shapes, or mentions \"design it twice\".",
       "category": "misc",
-      "tags": "[design, api-design, sub-agents, design-it-twice]",
-      "triggers": "",
-      "source_project": "mattpocock-skills",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "misc/design-an-interface"
+      "path": "skills/misc/design-an-interface"
     },
     {
       "name": "deterministic-coverage-verification",
       "description": "Run LLVM-instrumented tests multiple times and verify identical coverage reports — catches compiler/env non-determinism that can mask real bugs.",
       "category": "testing",
-      "tags": "[coverage, llvm, testing, determinism, ci]",
-      "triggers": "",
-      "source_project": "bitcoin",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "testing/deterministic-coverage-verification"
+      "path": "skills/testing/deterministic-coverage-verification"
     },
     {
       "name": "dev-controller-tenant-wrapping-helper",
       "description": "Dev/로컬 전용 컨트롤러의 테넌트+JWT 반복 래핑을 함수형 인터페이스 + 헬퍼 컴포넌트로 추출",
       "category": "backend",
-      "tags": "",
-      "triggers": "*ControllerDev.java files repeat TenantContextHolder.set + JWT + try-finally",
-      "source_project": "lucida-domain-automation",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/dev-controller-tenant-wrapping-helper"
+      "path": "skills/backend/dev-controller-tenant-wrapping-helper"
     },
     {
       "name": "distributed-lock-mongodb",
       "description": "MongoDB findAndModify-based distributed lock with TTL expiry, owner tagging, and retry loop for multi-instance Spring Boot services.",
       "category": "backend",
-      "tags": "[mongodb, distributed-lock, mutex, spring-boot, multi-instance, ttl]",
-      "triggers": "[\"distributed lock\", \"mutex\", \"mongo lock\", \"cross-instance lock\"]",
-      "source_project": "lucida-meta",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/distributed-lock-mongodb"
+      "path": "skills/backend/distributed-lock-mongodb"
     },
     {
       "name": "divide-by-zero-rate-guard",
       "description": "Guard rate/percentage calculations against zero denominators to prevent NaN from poisoning downstream metrics and serialization.",
       "category": "backend",
-      "tags": "",
-      "triggers": "errorRate / successRate / cacheHitRatio / any num/den metric; NaN in dashboards",
-      "source_project": "lucida-domain-apm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/divide-by-zero-rate-guard"
+      "path": "skills/backend/divide-by-zero-rate-guard"
+    },
+    {
+      "name": "dnd-kit-tab-reordering",
+      "description": "Implement horizontal tab drag reordering using @dnd-kit/core + @dnd-kit/sortable with PointerSensor and CSS.Transform",
+      "category": "design",
+      "tags": [],
+      "triggers": [],
+      "version": "1.0.0",
+      "path": "skills/design/dnd-kit-tab-reordering"
     },
     {
       "name": "docker-compose-service-inventory-files",
       "description": "Manage large Docker Compose service fleets using flat inventory files with '#' as an EX (exclude) marker",
       "category": "devops",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-for-docker",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "devops/docker-compose-service-inventory-files"
+      "path": "skills/devops/docker-compose-service-inventory-files"
     },
     {
       "name": "docker-compose-v1-v2-auto-detect",
       "description": "Shell helper that prefers `docker compose` (v2) over `docker-compose` (v1) with graceful fallback",
       "category": "devops",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-for-docker",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "devops/docker-compose-v1-v2-auto-detect"
+      "path": "skills/devops/docker-compose-v1-v2-auto-detect"
     },
     {
       "name": "domain-category-endpoint-registry",
       "description": "Organize a large vendor-API client (100s of endpoints) under a three-level `{domain}/{category}/{Action}{Entity}` package convention with a shared base class and a single `initializeEndpoints()` registry — scalable, greppable, and uniformly logged.",
       "category": "arch",
-      "tags": "[api-client, registry, code-organization, vendor-sdk, base-class, sdk-wrapping]",
-      "triggers": "[\"BaseApiEndpoint\", \"initializeEndpoints\", \"ApiEndpoint\", \"api registry\", \"vendor sdk\", \"many endpoints\", \"endpoint catalog\"]",
-      "source_project": "kis-java-bundle",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "arch/domain-category-endpoint-registry"
+      "path": "skills/arch/domain-category-endpoint-registry"
     },
     {
       "name": "dotenv-multi-env-routing",
       "description": "Single ENV variable flips an entire stack (REST base URL, WebSocket base, per-operation transaction IDs) between production and sandbox tiers, loaded via dotenv with OS-env precedence.",
       "category": "backend",
-      "tags": "[dotenv, config, environments, sandbox, production, routing]",
-      "triggers": "[\"KIS_ENV\", \"prod\", \"vts\", \"sandbox\", \"dotenv\", \"Dotenv.configure\", \"multi-environment\", \"openapi host\"]",
-      "source_project": "kis-java-bundle",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "backend/dotenv-multi-env-routing"
+      "path": "skills/backend/dotenv-multi-env-routing"
+    },
+    {
+      "name": "drawer-resizable-mouse-drag",
+      "description": "Make Ant Design Drawer resizable via mouse drag with styled-components handle, min/max width constraints, and transition suppression during drag",
+      "category": "design",
+      "tags": [],
+      "triggers": [],
+      "version": "1.0.0",
+      "path": "skills/design/drawer-resizable-mouse-drag"
     },
     {
       "name": "dry-run-confirm-retry-write-flow",
-      "description": "[Backend] 트래커/외부 API 쓰기 작업에 적용하는 공통 플로우: 미리보기 → 사용자 확인 → 쓰기 → 재시도.",
+      "description": "\"[Backend] 트래커/외부 API 쓰기 작업에 적용하는 공통 플로우: 미리보기 → 사용자 확인 → 쓰기 → 재시도.\"",
       "category": "backend",
-      "tags": "[api, write-flow, dry-run, retry, user-confirmation, tracker]",
-      "triggers": "[\"dry-run\", \"pims write\", \"external api write\", \"retry-with-confirmation\", \"tracker submit\"]",
-      "source_project": "nkia-skills",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/dry-run-confirm-retry-write-flow"
+      "path": "skills/backend/dry-run-confirm-retry-write-flow"
     },
     {
       "name": "dual-jre-docker-oz-report",
       "description": "Package a Java 21 Spring Boot app that bundles a legacy JRE 8 + sidecar Tomcat (OZ Report engine) in one Alpine container",
       "category": "devops",
-      "tags": "[docker, alpine, jre, legacy, oz-report, tomcat]",
-      "triggers": "User is containerizing an app that must run both a modern Spring Boot JAR and a legacy JRE-bound reporting/servlet engine side-by-side",
-      "source_project": "lucida-report",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "devops/dual-jre-docker-oz-report"
+      "path": "skills/devops/dual-jre-docker-oz-report"
     },
     {
       "name": "dynamic-gridfs-template-multi-tenant",
       "description": "Resolve MongoDB GridFsTemplate per (tenant-db, bucket) pair with lazy caching, for storing large binary assets per tenant",
       "category": "backend",
-      "tags": "[mongodb, gridfs, multi-tenant, spring-data]",
-      "triggers": "Multi-tenant Spring service storing uploaded files/templates in MongoDB GridFS where each tenant has its own database or bucket",
-      "source_project": "lucida-report",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/dynamic-gridfs-template-multi-tenant"
+      "path": "skills/backend/dynamic-gridfs-template-multi-tenant"
+    },
+    {
+      "name": "echarts-svg-worker-chart",
+      "description": "High-performance chart component using ECharts with custom SVG overlays (markLine/markArea/markPoint), worker thread data processing, and brush selection interaction",
+      "category": "design",
+      "tags": [],
+      "triggers": [],
+      "version": "1.0.0",
+      "path": "skills/design/echarts-svg-worker-chart"
     },
     {
       "name": "eclipse-rcp-rich-client-for-apm-ui",
       "description": "Build a desktop-class APM / observability client on Eclipse RCP + ZEST/GEF for high-throughput real-time visualization that HTTP + JSON browsers struggle with",
       "category": "apm",
-      "tags": "[rcp, eclipse, desktop, apm, visualization]",
-      "triggers": "",
-      "source_project": "scouter",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "apm/eclipse-rcp-rich-client-for-apm-ui"
+      "path": "skills/apm/eclipse-rcp-rich-client-for-apm-ui"
     },
     {
       "name": "edit-article",
       "description": "Edit and improve articles by restructuring sections, improving clarity, and tightening prose. Use when user wants to edit, revise, or improve an article draft.",
       "category": "docs",
-      "tags": "[writing, editing, clarity]",
-      "triggers": "",
-      "source_project": "mattpocock-skills",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "docs/edit-article"
+      "path": "skills/docs/edit-article"
     },
     {
       "name": "elasticsearch-xpack-ssl-transport",
       "description": "Gate `PreBuiltXPackTransportClient` vs `PreBuiltTransportClient` on auth flag (not SSL flag) and configure keystore/truststore as independent ES X-Pack settings",
       "category": "backend",
-      "tags": "[elasticsearch, xpack, ssl, transport-client, keystore, truststore]",
-      "triggers": "[\"connect Java client to X-Pack-secured Elasticsearch cluster\", \"production ES requires auth and optional transport TLS\"]",
-      "source_project": "cygnus",
+      "tags": [],
+      "triggers": [
+        "connect Java client to X-Pack-secured Elasticsearch cluster",
+        "production ES requires auth and optional transport TLS"
+      ],
       "version": "1.0.0",
-      "path": "backend/elasticsearch-xpack-ssl-transport"
+      "path": "skills/backend/elasticsearch-xpack-ssl-transport"
     },
     {
       "name": "enable-async-tenant-aware",
       "description": "Place @EnableAsync on a dedicated @Configuration that extends a tenant-aware AsyncConfigurer, so tenant/MDC context propagates across the executor boundary",
       "category": "backend",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-realtime",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/enable-async-tenant-aware"
+      "path": "skills/backend/enable-async-tenant-aware"
     },
     {
       "name": "encrypted-pii-decrypt-before-send",
       "description": "Store user email/phone encrypted at rest; decrypt only inside the sender, never in cache/DTO/log boundaries",
       "category": "backend",
-      "tags": "",
-      "triggers": "[\"any notification service whose user directory stores PII encrypted (GDPR/K-privacy) and which must deliver to plaintext recipient addresses\"]",
-      "source_project": "lucida-notification",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/encrypted-pii-decrypt-before-send"
+      "path": "skills/backend/encrypted-pii-decrypt-before-send"
     },
     {
       "name": "eureka-service-discovery-wait-annotation",
       "description": "Declarative @WaitForServices annotation on @EventListener methods — blocks initialization until named Eureka services are healthy, with optional leader-only execution",
       "category": "backend",
-      "tags": "",
-      "triggers": "Service startup must wait for other microservices (metadata, auth, config) to be registered AND healthy in Eureka before running initialization logic",
-      "source_project": "lucida-audit",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/eureka-service-discovery-wait-annotation"
+      "path": "skills/backend/eureka-service-discovery-wait-annotation"
     },
     {
       "name": "event-driven-kafka-scheduling",
       "description": "Replace Spring @Scheduled with a Kafka-delivered JobExecuteNotice so a central scheduler service fans out tick events — with a skip-if-previous-still-running guard to prevent pile-up.",
       "category": "backend",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-health",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/event-driven-kafka-scheduling"
+      "path": "skills/backend/event-driven-kafka-scheduling"
     },
     {
       "name": "excel-download-null-date-range-handling",
       "description": "Defensive pattern for grid/list excel-export endpoints — null-check every filter value and normalize field names before querying",
       "category": "backend",
-      "tags": "",
-      "triggers": "Building an excel-export endpoint that reuses a grid/list filter DTO where date ranges or text filters may be absent",
-      "source_project": "lucida-audit",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/excel-download-null-date-range-handling"
+      "path": "skills/backend/excel-download-null-date-range-handling"
     },
     {
       "name": "excel-export-enum-replacer",
       "description": "Use DataToBeReplace.builder() to map enum/code values to display labels before passing content to ExcelExportManager.objectToExcelAndDownload()",
       "category": "backend",
-      "tags": "[spring, excel, export, enum, controller]",
-      "triggers": "[\"excel export enum replace\", \"DataToBeReplace\", \"ExcelExportManager\", \"objectToExcelAndDownload\", \"excel download controller\"]",
-      "scope": "user",
-      "source_project": "lucida-domain-sms",
+      "tags": [],
+      "triggers": [
+        "excel export enum replace",
+        "DataToBeReplace",
+        "ExcelExportManager",
+        "objectToExcelAndDownload",
+        "excel download controller"
+      ],
       "version": "0.1.0-draft",
-      "path": "backend/excel-export-enum-replacer"
+      "path": "skills/backend/excel-export-enum-replacer"
     },
     {
       "name": "feed-envelope-frame",
       "description": "Uniform WebSocket payload wrapper with Type (ACK/SNAPSHOT/DELTA/ERROR), PayloadKind, and correlation requestId, including null-safe factory methods",
       "category": "backend",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-realtime",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/feed-envelope-frame"
+      "path": "skills/backend/feed-envelope-frame"
+    },
+    {
+      "name": "figma-code-connect-react",
+      "description": "Map Figma component variants to React props using @figma/code-connect with co-located *.figma.tsx files",
+      "category": "frontend",
+      "tags": [],
+      "triggers": [],
+      "version": "0.1.0-draft",
+      "path": "skills/frontend/figma-code-connect-react"
+    },
+    {
+      "name": "figma-token-scss-style-dictionary-v3",
+      "description": "Figma Tokens Studio JSON → split files → Style Dictionary v3 → SCSS variables, typography classes, and composition classes",
+      "category": "frontend",
+      "tags": [],
+      "triggers": [],
+      "version": "0.1.0-draft",
+      "path": "skills/frontend/figma-token-scss-style-dictionary-v3"
+    },
+    {
+      "name": "figma-token-to-tailwind-theme",
+      "description": "Pipeline from Figma Token Studio JSON exports through Style Dictionary v5 to Tailwind v4 @theme CSS custom properties, with dark/light/contrast mode support and breaking change detection",
+      "category": "design",
+      "tags": [],
+      "triggers": [],
+      "version": "1.1.0",
+      "path": "skills/design/figma-token-to-tailwind-theme"
     },
     {
       "name": "folder-coloc-style-types",
       "description": "Keep component, style, and types files at the same depth; never split into styles/ or types/ subfolders",
       "category": "frontend",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-builder-r3",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "frontend/folder-coloc-style-types"
+      "path": "skills/frontend/folder-coloc-style-types"
     },
     {
       "name": "font-cache-alpine-locale-docker",
       "description": "Make CJK/custom fonts usable inside an Alpine container by copying TTF/OTF and rebuilding the fontconfig cache",
       "category": "devops",
-      "tags": "[docker, alpine, fonts, fontconfig, cjk, locale]",
-      "triggers": "Report/PDF/image-rendering containers on Alpine produce tofu (squares) or missing glyphs for CJK or custom-branded fonts",
-      "source_project": "lucida-report",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "devops/font-cache-alpine-locale-docker"
+      "path": "skills/devops/font-cache-alpine-locale-docker"
     },
     {
       "name": "freemarker-two-phase-expression-subst",
       "description": "Render templates by first replacing raw ${var} placeholders via string-replace, then running FreeMarker for expression-object binding, avoiding double-evaluation and escape conflicts",
       "category": "backend",
-      "tags": "",
-      "triggers": "[\"using FreeMarker (or similar) for user-authored templates that mix literal variable placeholders with model-bound expressions\"]",
-      "source_project": "lucida-notification",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/freemarker-two-phase-expression-subst"
+      "path": "skills/backend/freemarker-two-phase-expression-subst"
     },
     {
       "name": "frozen-detection-consecutive-count",
       "description": "Detect a stuck/frozen metric (identical value for N consecutive samples) by CONSECUTIVE-dampening equality check; catches sensor/collector failures that threshold alarms miss.",
       "category": "backend",
-      "tags": "[monitoring, frozen, stuck-metric, dampening, consecutive, sensor-failure]",
-      "triggers": "[\"FrozenCondition\", \"stuck metric\", \"flatline\", \"consecutive equality\", \"AlarmDampeningType.CONSECUTIVE\"]",
-      "source_project": "lucida-alarm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/frozen-detection-consecutive-count"
+      "path": "skills/backend/frozen-detection-consecutive-count"
     },
     {
       "name": "fuzz-corpus-seed-management",
       "description": "Structured libFuzzer workflow — seed corpora in a separate asset repo, determinism verification, and reproducible crash workflows.",
       "category": "testing",
-      "tags": "[fuzzing, libfuzzer, llvm, testing, corpus]",
-      "triggers": "",
-      "source_project": "bitcoin",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "testing/fuzz-corpus-seed-management"
+      "path": "skills/testing/fuzz-corpus-seed-management"
     },
     {
       "name": "gacha-soft-hard-pity",
       "description": "Server-authoritative gacha with soft pity (rate ramp after N pulls), hard pity (guaranteed top rarity at M pulls), and 50/50 guarantee carryover. Split rate calculation from result resolution so probability is testable.",
       "category": "game-dev",
-      "tags": "[\"gacha\", \"pity\", \"probability\", \"securerandom\", \"loot\", \"rng-fairness\"]",
-      "triggers": "[\"gacha pity system\", \"soft pity hard pity\", \"50/50 pity\", \"banner rate up\", \"rate calculator\"]",
-      "source_project": "veda-chronicles",
+      "tags": [
+        "gacha",
+        "pity",
+        "probability",
+        "securerandom",
+        "loot",
+        "rng-fairness"
+      ],
+      "triggers": [
+        "gacha pity system",
+        "soft pity hard pity",
+        "50/50 pity",
+        "banner rate up",
+        "rate calculator"
+      ],
       "version": "0.1.0-draft",
-      "path": "game-dev/gacha-soft-hard-pity"
+      "path": "skills/game-dev/gacha-soft-hard-pity"
     },
     {
       "name": "git-guardrails-claude-code",
       "description": "Set up Claude Code hooks to block dangerous git commands (push, reset --hard, clean, branch -D, etc.) before they execute. Use when user wants to prevent destructive git operations, add git safety hooks, or block git push/reset in Claude Code.",
       "category": "cli",
-      "tags": "[git, hooks, claude-code, guardrails, safety]",
-      "triggers": "",
-      "source_project": "mattpocock-skills",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "cli/git-guardrails-claude-code"
+      "path": "skills/cli/git-guardrails-claude-code"
     },
     {
       "name": "git-tag-registry-versioning",
       "description": "Add semver rollback and pinning to any git-backed asset registry (skills, prompts, commands, snippets) using namespaced annotated tags per item and per-release bundle.",
       "category": "arch",
-      "tags": "[git, versioning, semver, registry, rollback, tags]",
-      "triggers": "[version pin, rollback, git tag, registry versioning, skill versioning, prompt versioning, \"install specific version\"]",
-      "source_project": "skills-hub",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "arch/git-tag-registry-versioning"
+      "path": "skills/arch/git-tag-registry-versioning"
     },
     {
       "name": "github-triage",
       "description": "Triage GitHub issues through a label-based state machine with interactive grilling sessions. Use when user wants to triage issues, review incoming bugs or feature requests, prepare issues for an AFK agent, or manage issue workflow.",
       "category": "workflow",
-      "tags": "[github, triage, issues, labels, state-machine]",
-      "triggers": "",
-      "source_project": "mattpocock-skills",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "workflow/github-triage"
+      "path": "skills/workflow/github-triage"
     },
     {
       "name": "gradle-bootjar-conditional-archive-bundle",
       "description": "Gradle Spring Boot build that conditionally bundles the fat JAR plus externalized resources into a dated zip/tar for on-prem delivery, gated by a flag",
       "category": "arch",
-      "tags": "",
-      "triggers": "[\"a Spring Boot service that ships to a cloud registry AND to on-prem customers who need a tarball with jar + config + libs\"]",
-      "source_project": "lucida-notification",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "arch/gradle-bootjar-conditional-archive-bundle"
+      "path": "skills/arch/gradle-bootjar-conditional-archive-bundle"
     },
     {
       "name": "gradle-bootrun-local-dev-env",
       "description": "Gradle bootRun task recipe that wires local MongoDB/Kafka/Redis/MQTT/Eureka/Quartz via environment variables — no docker-compose needed",
       "category": "devops",
-      "tags": "",
-      "triggers": "Running a Spring Boot microservice locally against existing infra containers without building a separate profile YAML",
-      "source_project": "lucida-audit",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "devops/gradle-bootrun-local-dev-env"
+      "path": "skills/devops/gradle-bootrun-local-dev-env"
     },
     {
       "name": "gradle-jacoco-exclusion-strategy",
       "description": "Curated Jacoco/Sonar exclusion patterns for Spring Boot projects — skips config/DAO/entity/generated layers and Querydsl Q-classes",
       "category": "devops",
-      "tags": "",
-      "triggers": "Setting up Jacoco coverage rules on a Spring Boot + Gradle project where generated code and infrastructure layers bloat coverage metrics",
-      "source_project": "lucida-audit",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "devops/gradle-jacoco-exclusion-strategy"
+      "path": "skills/devops/gradle-jacoco-exclusion-strategy"
     },
     {
       "name": "gradle-shared-exclusions-jacoco-sonar",
       "description": "Keep Jacoco report, Jacoco coverage verification, and SonarQube exclusions in sync by defining one `exclusionPatterns` list in Gradle ext",
       "category": "devops",
-      "tags": "[gradle, jacoco, sonarqube, coverage, exclusions]",
-      "triggers": "[\"jacoco and sonarqube exclusion lists drift apart\", \"adding a new package to coverage exclusions requires editing multiple blocks\", \"querydsl Q-classes / generated code leaking into coverage reports\"]",
-      "source_project": "lucida-performance",
+      "tags": [],
+      "triggers": [
+        "jacoco and sonarqube exclusion lists drift apart",
+        "adding a new package to coverage exclusions requires editing multiple blocks",
+        "querydsl Q-classes / generated code leaking into coverage reports"
+      ],
       "version": "1.0.0",
-      "path": "devops/gradle-shared-exclusions-jacoco-sonar"
+      "path": "skills/devops/gradle-shared-exclusions-jacoco-sonar"
     },
     {
       "name": "grid-filter-to-criteria-converter",
       "description": "Convert a UI grid filter DTO (gridFilters + tagFilters + pageable) to MongoDB Criteria using CriteriaMakeHelper, supporting equals/contains/greaterThan/inRange operators",
       "category": "backend",
-      "tags": "[spring, mongodb, filter, criteria, pagination, grid]",
-      "triggers": "[\"grid filter to criteria\", \"FiltersPageableDto\", \"CriteriaMakeHelper\", \"mongodb dynamic filter\", \"UI filter to query\"]",
-      "scope": "user",
-      "source_project": "lucida-domain-sms",
+      "tags": [],
+      "triggers": [
+        "grid filter to criteria",
+        "FiltersPageableDto",
+        "CriteriaMakeHelper",
+        "mongodb dynamic filter",
+        "UI filter to query"
+      ],
       "version": "0.1.0-draft",
-      "path": "backend/grid-filter-to-criteria-converter"
+      "path": "skills/backend/grid-filter-to-criteria-converter"
     },
     {
       "name": "grill-me",
       "description": "Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions \"grill me\".",
       "category": "workflow",
-      "tags": "[interview, planning, clarification, socratic]",
-      "triggers": "",
-      "source_project": "mattpocock-skills",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "workflow/grill-me"
+      "path": "skills/workflow/grill-me"
     },
     {
       "name": "hibernate-multi-dialect-swap",
       "description": "Ship one WAR that connects to Oracle, PostgreSQL, MSSQL, Tibero, DB2, or MariaDB based on Spring profile — all JDBC drivers bundled, dialect and datasource resolved from externalized config",
       "category": "backend",
-      "tags": "[hibernate, jdbc, spring, multi-tenant, dialect, oracle, postgres, mssql, tibero, db2, mariadb]",
-      "triggers": "[\"one deployable must support multiple RDBMS vendors without rebuild\", \"hibernate dialect chosen at startup, not compile time\", \"customer deployments dictate DB vendor\"]",
-      "source_project": "cygnus",
+      "tags": [],
+      "triggers": [
+        "one deployable must support multiple RDBMS vendors without rebuild",
+        "hibernate dialect chosen at startup, not compile time",
+        "customer deployments dictate DB vendor"
+      ],
       "version": "1.0.0",
-      "path": "backend/hibernate-multi-dialect-swap"
+      "path": "skills/backend/hibernate-multi-dialect-swap"
     },
     {
       "name": "hierarchical-group-entity-mongo",
       "description": "Model a tree-structured group entity in MongoDB with parentId + path + pathIds + level, plus recursive child-path update on move and cycle detection.",
       "category": "backend",
-      "tags": "[mongodb, tree, hierarchy, breadcrumb, cycle-detection, move-reorder]",
-      "triggers": "[\"pathIds level parentId\", \"group tree move\", \"recursive child path update\", \"cycle detection hierarchy\"]",
-      "source_project": "lucida-cm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/hierarchical-group-entity"
+      "path": "skills/backend/hierarchical-group-entity"
     },
     {
       "name": "identifier-truncate-with-hash-suffix",
       "description": "Deterministically shrink any identifier to a length cap while preserving uniqueness by appending a short hash of the original.",
       "category": "backend",
-      "tags": "[identifiers, hashing, naming, collision-avoidance]",
-      "triggers": "[\"\\\"name too long\\\"\", \"\\\"identifier length limit\\\"\", \"\\\"shorten tool name\\\"\", \"\\\"truncate unique\\\"\"]",
-      "source_project": "yamltomcp",
+      "tags": [],
+      "triggers": [
+        "\"name too long\"",
+        "\"identifier length limit\"",
+        "\"shorten tool name\"",
+        "\"truncate unique\""
+      ],
       "version": "0.1.0-draft",
-      "path": "backend/identifier-truncate-with-hash-suffix"
+      "path": "skills/backend/identifier-truncate-with-hash-suffix"
     },
     {
       "name": "immutable-action-event-log",
       "description": "Model state transitions as `(state, action) → (newState, List<Event>)` where the event list is an append-only, serializable log. Enables deterministic replay, audit trails, cheat detection, and UI choreography without coupling engine to presentation.",
       "category": "arch",
-      "tags": "[\"event-sourcing\", \"immutable-state\", \"action-log\", \"deterministic\", \"replay\", \"audit\"]",
-      "triggers": "[\"action result log\", \"state transition events\", \"replay log\", \"deterministic engine\", \"audit trail events\"]",
-      "source_project": "veda-chronicles",
+      "tags": [
+        "event-sourcing",
+        "immutable-state",
+        "action-log",
+        "deterministic",
+        "replay",
+        "audit"
+      ],
+      "triggers": [
+        "action result log",
+        "state transition events",
+        "replay log",
+        "deterministic engine",
+        "audit trail events"
+      ],
       "version": "0.1.0-draft",
-      "path": "arch/immutable-action-event-log"
+      "path": "skills/arch/immutable-action-event-log"
     },
     {
       "name": "improve-codebase-architecture",
       "description": "Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. Use when user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more AI-navigable.",
       "category": "refactor",
-      "tags": "[architecture, codebase, exploration]",
-      "triggers": "",
-      "source_project": "mattpocock-skills",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "refactor/improve-codebase-architecture"
+      "path": "skills/refactor/improve-codebase-architecture"
     },
     {
       "name": "init-deadline-guard",
       "description": "Watchdog that force-exits a Spring Boot service if startup initialization (external discovery, topic creation, warmup) does not complete within a deadline",
       "category": "backend",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-realtime",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/init-deadline-guard"
+      "path": "skills/backend/init-deadline-guard"
     },
     {
       "name": "ip-allowlist-cidr-validator",
       "description": "Validate client IPs against user-supplied allow-lists accepting mixed notations — plain IPv4, CIDR, octet wildcards (192.168.*.*), and octet ranges (192.168.10-20.*)",
       "category": "backend",
-      "tags": "[security, cidr, ip-allowlist, authentication, commons-net]",
-      "triggers": "Per-user or per-tenant IP allow-list supporting CIDR, plain IPs, octet wildcards, and ranges",
-      "source_project": "lucida-account",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/ip-allowlist-cidr-validator"
+      "path": "skills/backend/ip-allowlist-cidr-validator"
     },
     {
       "name": "jacoco-exclude-boilerplate-layers",
       "description": "Configure JaCoCo + SonarQube to exclude generated/boilerplate layers (avro, config, dto, entity, kafka, *Dev) from coverage so coverage % reflects business logic only",
       "category": "backend",
-      "tags": "[jacoco, sonarqube, coverage, gradle, spring-boot, test, boilerplate]",
-      "triggers": "[\"jacoco\", \"sonarqube coverage\", \"jacocoTestReport\", \"coverage exclusion\", \"sonar.coverage.exclusions\", \"boilerplate coverage\"]",
-      "source_project": "lucida-topology",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/jacoco-exclude-boilerplate-layers"
+      "path": "skills/backend/jacoco-exclude-boilerplate-layers"
     },
     {
       "name": "jacoco-sonar-shared-exclusion-list",
       "description": "Define coverage/quality exclusions once in ext.exclusionPatterns and reuse across jacoco, sonar, and packaging tasks to prevent report drift",
       "category": "backend",
-      "tags": "[gradle, jacoco, sonarqube, coverage, quality-gate]",
-      "triggers": "Gradle build has diverging exclusion lists across jacoco, sonar, and packaging tasks",
-      "source_project": "lucida-account",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/jacoco-sonar-shared-exclusion-list"
+      "path": "skills/backend/jacoco-sonar-shared-exclusion-list"
     },
     {
       "name": "java-agent-bytecode-instrumentation-with-asm",
       "description": "Build a JVM agent using ASM's ClassFileTransformer to inject profiling/monitoring hooks into application classes via pluggable visitor chains",
       "category": "backend",
-      "tags": "[java, jvm, apm, instrumentation, asm, bytecode]",
-      "triggers": "",
-      "source_project": "scouter",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/java-agent-bytecode-instrumentation-with-asm"
+      "path": "skills/backend/java-agent-bytecode-instrumentation-with-asm"
     },
     {
       "name": "jdbc-configurable-sql-insert-sender",
       "description": "Ship a notification/integration channel that writes to a user-configured external DB via user-supplied INSERT SQL with ${var} placeholders",
       "category": "backend",
-      "tags": "",
-      "triggers": "[\"integrating with a third-party SMS gateway / ticketing system whose API is \"insert into our table\"\"]",
-      "source_project": "lucida-notification",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/jdbc-configurable-sql-insert-sender"
+      "path": "skills/backend/jdbc-configurable-sql-insert-sender"
     },
     {
       "name": "jenkins-dual-registry-docker-push",
       "description": "Jenkins pipeline that builds one image and tags+pushes it to two registries (SaaS + on-prem) with both build-specific and rolling-latest tags",
       "category": "devops",
-      "tags": "[jenkins, docker, registry, ci-cd]",
-      "triggers": "Release pipeline where the same artifact must land in an internal on-prem registry and an external SaaS/cloud registry, each with current and latest tags",
-      "source_project": "lucida-report",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "devops/jenkins-dual-registry-docker-push"
+      "path": "skills/devops/jenkins-dual-registry-docker-push"
     },
     {
       "name": "jest-test-file-naming-test-only",
       "description": "Use .test.ts naming (not .spec.ts) and explicitly import jest globals; .spec.ts is excluded from the runner",
       "category": "frontend",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-builder-r3",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "frontend/jest-test-file-naming-test-only"
+      "path": "skills/frontend/jest-test-file-naming-test-only"
     },
     {
       "name": "jj-jujutsu-day-one-workflow",
       "description": "Minimum viable jj (Jujutsu) workflow for a git user — init on top of an existing git repo, the five commands that cover 95% of day-1 usage, and the mental-model shift from git's staging area.",
       "category": "git",
-      "tags": "[jj, jujutsu, version-control, git-compatible, workflow, onboarding]",
-      "triggers": "[\"jj\",\"jujutsu\",\"jj git init\",\"jj describe\",\"jj bookmark\",\"jj st\",\"jj new\",\"jj log\"]",
-      "source_project": "skills_research:trend:2026-04-16",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "git/jj-jujutsu-day-one-workflow"
+      "path": "skills/git/jj-jujutsu-day-one-workflow"
     },
     {
       "name": "json-seeded-jpa-loader",
       "description": "Idempotent reference-data seeding for Spring Boot — Flyway owns DDL, CommandLineRunner reads `resources/data/*.json`, maps to JPA entities, and saves only if the table is empty. Keeps static content in editable JSON without bloating migrations.",
       "category": "backend",
-      "tags": "[\"spring-boot\", \"jpa\", \"seeding\", \"flyway\", \"commandlinerunner\", \"jackson\", \"reference-data\"]",
-      "triggers": "[\"seed reference data spring\", \"CommandLineRunner JSON\", \"populate static content\", \"data initializer spring\", \"load catalog JSON\"]",
-      "source_project": "veda-chronicles",
+      "tags": [
+        "spring-boot",
+        "jpa",
+        "seeding",
+        "flyway",
+        "commandlinerunner",
+        "jackson",
+        "reference-data"
+      ],
+      "triggers": [
+        "seed reference data spring",
+        "CommandLineRunner JSON",
+        "populate static content",
+        "data initializer spring",
+        "load catalog JSON"
+      ],
       "version": "0.1.0-draft",
-      "path": "backend/json-seeded-jpa-loader"
+      "path": "skills/backend/json-seeded-jpa-loader"
     },
     {
       "name": "jwt-extraction-via-base-controller",
       "description": "Consolidate repeated `JwtTokenService.getXxxFromBearerToken(headerAuthorization)` calls across Spring controllers by moving the service and helper methods onto a shared `BaseController`. Subclass controllers call `getOrganizationId(h)` / `getLoginId(h)` / `getRoleIds(h)` directly.",
       "category": "backend",
-      "tags": "[spring-boot, jwt, controller, refactor, base-class]",
-      "triggers": "[\"\\\"jwt extraction controller duplication\\\"\", \"\\\"base controller jwt\\\"\", \"\\\"getXxxFromBearerToken 중복 제거\\\"\"]",
-      "scope": "user",
-      "source_project": "lucida-widget",
+      "tags": [],
+      "triggers": [
+        "\"jwt extraction controller duplication\"",
+        "\"base controller jwt\"",
+        "\"getXxxFromBearerToken 중복 제거\""
+      ],
       "version": "1.0.0",
-      "path": "backend/jwt-extraction-via-base-controller"
+      "path": "skills/backend/jwt-extraction-via-base-controller"
     },
     {
       "name": "jwt-refresh-rotation-spring",
       "description": "Spring Boot 3 JWT with short-lived access token + long-lived refresh token, filter-chain integration, and stateless session config. Avoids common mistakes that silently break refresh flows.",
       "category": "security",
-      "tags": "[\"jwt\", \"spring-boot\", \"auth\", \"refresh-token\", \"jjwt\", \"security-filter\"]",
-      "triggers": "[\"jwt spring boot\", \"refresh token rotation\", \"JwtAuthenticationFilter\", \"jjwt 0.12\", \"SessionCreationPolicy.STATELESS\", \"access token refresh token\"]",
-      "source_project": "veda-chronicles",
+      "tags": [
+        "jwt",
+        "spring-boot",
+        "auth",
+        "refresh-token",
+        "jjwt",
+        "security-filter"
+      ],
+      "triggers": [
+        "jwt spring boot",
+        "refresh token rotation",
+        "JwtAuthenticationFilter",
+        "jjwt 0.12",
+        "SessionCreationPolicy.STATELESS",
+        "access token refresh token"
+      ],
       "version": "0.1.0-draft",
-      "path": "security/jwt-refresh-rotation-spring"
+      "path": "skills/security/jwt-refresh-rotation-spring"
     },
     {
       "name": "k8s-health-via-getnodelist",
       "description": "Use `listNode()` with readiness check for Kubernetes cluster health — `getVersion()` succeeds on degraded clusters that will fail real work",
       "category": "backend",
-      "tags": "[kubernetes, openshift, health-check, liveness, coreV1Api, listNode]",
-      "triggers": "[\"cluster liveness probe before running a collector pass\", \"guard against API-server flaps\"]",
-      "source_project": "cygnus",
+      "tags": [],
+      "triggers": [
+        "cluster liveness probe before running a collector pass",
+        "guard against API-server flaps"
+      ],
       "version": "1.0.0",
-      "path": "backend/k8s-health-via-getnodelist"
+      "path": "skills/backend/k8s-health-via-getnodelist"
     },
     {
       "name": "kafka-avro-producer-gzip-30mb",
       "description": "Spring Kafka producer config for Avro values with gzip compression and a raised 30MB max.request.size for schema-registry payloads",
       "category": "backend",
-      "tags": "[kafka, avro, spring-kafka, schema-registry, producer]",
-      "triggers": "[\"KafkaAvroSerializer\", \"max.request.size\", \"schema.registry.url\", \"compression.type gzip\", \"RecordTooLargeException\"]",
-      "source_project": "lucida-performance",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/kafka-avro-producer-gzip-30mb"
+      "path": "skills/backend/kafka-avro-producer-gzip-30mb"
     },
     {
       "name": "kafka-avro-topic-auto-create-config",
       "description": "Spring Boot Kafka config bean that auto-creates topics on startup via ApplicationRunner, with Avro serde, manual-ack listener, and bounded concurrency",
       "category": "arch",
-      "tags": "",
-      "triggers": "[\"greenfield Spring Boot service that consumes Avro events from Kafka and must not fail hard when the topic is missing in a fresh environment\"]",
-      "source_project": "lucida-notification",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "arch/kafka-avro-topic-auto-create-config"
+      "path": "skills/arch/kafka-avro-topic-auto-create-config"
     },
     {
       "name": "kafka-batch-consumer-partition-tuning",
       "description": "Size Kafka partition count + max-poll-records per topic volume so heavy-processing batch consumers avoid max.poll.interval.ms breaches and maintain throughput via per-partition concurrency.",
       "category": "backend",
-      "tags": "[kafka, spring-kafka, partition, max-poll-records, batch-listener, concurrency]",
-      "triggers": "[\"max.poll.interval.ms\", \"rebalance storm\", \"setBatchListener\", \"setConcurrency\", \"partition count\", \"AckMode.BATCH\"]",
-      "source_project": "lucida-alarm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/kafka-batch-consumer-partition-tuning",
-      "linked_knowledge": [
-        "kafka-batch-size-timeout-tuning",
-        "kafka-partition-topology-design"
-      ]
+      "path": "skills/backend/kafka-batch-consumer-partition-tuning"
     },
     {
       "name": "kafka-consumer-config-3-factories",
       "description": "Spring Kafka consumer setup with three ListenerContainerFactory variants (standard / batch / UUID-group) and autoStartup=false to allow topic bootstrap before listeners attach",
       "category": "backend",
-      "tags": "",
-      "triggers": "Building a Spring Kafka consumer that must wait for an ApplicationRunner to create topics before listeners start, or needs both single-record and batch listeners in the same app",
-      "source_project": "lucida-audit",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/kafka-consumer-config-3-factories"
+      "path": "skills/backend/kafka-consumer-config-3-factories"
     },
     {
       "name": "kafka-consumer-errorhandling-wrapper",
       "description": "Wrap key/value deserializers in Spring Kafka's ErrorHandlingDeserializer so a single poison record doesn't halt the consumer",
       "category": "backend",
-      "tags": "[kafka, spring-kafka, avro, poison-pill, resilience]",
-      "triggers": "[\"ErrorHandlingDeserializer\", \"poison pill\", \"DeserializationException\", \"DeadLetterPublishingRecoverer\", \"stuck consumer\"]",
-      "source_project": "lucida-performance",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/kafka-consumer-errorhandling-wrapper"
+      "path": "skills/backend/kafka-consumer-errorhandling-wrapper"
     },
     {
       "name": "kafka-consumer-semaphore-chunking",
       "description": "Bound in-flight async work from a Kafka consumer with `Semaphore(poolSize + queueCapacity - 2)` plus fixed-size chunks; release in `whenComplete` on both success and failure.",
       "category": "backend",
-      "tags": "[kafka, backpressure, semaphore, async, executor, chunk]",
-      "triggers": "[\"kafka backpressure\", \"consumer OOM\", \"executor queue overflow\", \"semaphore acquireUninterruptibly\", \"rebalance storm\"]",
-      "source_project": "lucida-measurement",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/kafka-consumer-semaphore-chunking",
-      "linked_knowledge": [
-        "kafka-1h-topic-and-nonmetric-pool"
-      ]
+      "path": "skills/backend/kafka-consumer-semaphore-chunking"
     },
     {
       "name": "kafka-consumer-tenant-fan-out",
       "description": "@KafkaListener pattern consuming a topicPattern across tenants, using a record header for tenant identity and routing to per-tenant downstream streams",
       "category": "backend",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-realtime",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/kafka-consumer-tenant-fan-out"
+      "path": "skills/backend/kafka-consumer-tenant-fan-out"
     },
     {
       "name": "kafka-debounce-event-coalescing",
       "description": "Coalesce bursts of change events into one Kafka event per tenant per debounce window using Redis state (first/last change time + changed-tenant SET), with a MAX_WAIT fallback so a never-quiet stream still fires.",
       "category": "backend",
-      "tags": "[kafka, redis, debounce, coalesce, multi-tenant, event-driven]",
-      "triggers": "[\"debounce\", \"coalesce events\", \"first_change_time\", \"changed_tenants\", \"burst to single event\"]",
-      "source_project": "lucida-alarm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/kafka-debounce-event-coalescing"
+      "path": "skills/backend/kafka-debounce-event-coalescing"
     },
     {
       "name": "kafka-engine-distributed-job-framework",
       "description": "Kafka 이벤트 기반 분산 작업 실행 프레임워크 스켈레톤 — Publisher→Topic→Consumer→Queue→Worker + Admission Control + Strategy SPI",
       "category": "arch",
-      "tags": "",
-      "triggers": "invokeAll-based Pod bottleneck, long-blocking device timeouts, need for multi-Pod Consumer Group distribution",
-      "source_project": "lucida-domain-automation",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "arch/kafka-engine-distributed-job-framework"
+      "path": "skills/arch/kafka-engine-distributed-job-framework"
     },
     {
       "name": "kafka-message-header-metadata",
       "description": "Attach org-id, user-id, and timestamp as RecordHeader[] on a ProducerRecord to enable multi-tenant event routing without polluting the Avro payload",
       "category": "backend",
-      "tags": "[kafka, avro, multi-tenant, headers, spring]",
-      "triggers": "[\"kafka record headers\", \"ProducerRecord headers\", \"organization-id header kafka\", \"multi-tenant kafka routing\", \"RecordHeader metadata\"]",
-      "scope": "user",
-      "source_project": "lucida-domain-sms",
+      "tags": [],
+      "triggers": [
+        "kafka record headers",
+        "ProducerRecord headers",
+        "organization-id header kafka",
+        "multi-tenant kafka routing",
+        "RecordHeader metadata"
+      ],
       "version": "0.1.0-draft",
-      "path": "backend/kafka-message-header-metadata"
+      "path": "skills/backend/kafka-message-header-metadata"
     },
     {
       "name": "kafka-producer-async-callback",
       "description": "Fire-and-log Kafka send pattern using CompletableFuture.whenComplete() for audit/event topics where the caller should not block",
       "category": "backend",
-      "tags": "[kafka, async, callback, producer, completablefuture]",
-      "triggers": "Service needs to emit audit or event messages to Kafka without blocking the user request, but still log delivery failures",
-      "source_project": "lucida-report",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/kafka-producer-async-callback"
+      "path": "skills/backend/kafka-producer-async-callback"
     },
     {
       "name": "kafka-producer-config-avro-schema-registry",
       "description": "Kafka producer config template for Avro + Confluent Schema Registry with LZ4 compression, 30MB max request size, and acks=1",
       "category": "backend",
-      "tags": "",
-      "triggers": "Setting up a Spring Kafka producer that publishes Avro-serialized events against a Confluent Schema Registry",
-      "source_project": "lucida-audit",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/kafka-producer-config-avro-schema-registry"
+      "path": "skills/backend/kafka-producer-config-avro-schema-registry"
     },
     {
       "name": "layered-risk-gates",
       "description": "Three-layer safety pattern for autonomous action loops — pre-action admission gate, in-flight monitor (stop/target thresholds), and a consecutive-failure circuit breaker — so a single runaway loop can't clear out the account before a human sees it.",
       "category": "arch",
-      "tags": "[risk, circuit-breaker, safety, autonomous, limits, guardrails]",
-      "triggers": "[\"risk management\", \"position sizing\", \"max daily loss\", \"consecutive losses\", \"stop loss\", \"take profit\", \"kill switch\", \"circuit breaker\"]",
-      "source_project": "kis-java-bundle",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "arch/layered-risk-gates"
+      "path": "skills/arch/layered-risk-gates"
     },
     {
       "name": "lean-verified-code-threat-boundary",
       "description": "When shipping formally-verified code (Lean 4, Coq, F*), explicitly map what is inside and outside the verification boundary — untrusted parsers, runtime, and TCB assumptions almost always harbor the real bugs.",
       "category": "security",
-      "tags": "[formal-verification, lean, coq, threat-modeling, fuzzing, tcb, security]",
-      "triggers": "[\"formally verified\",\"lean 4\",\"formal proof\",\"Coq\",\"F-star\",\"lean_alloc_sarray\",\"trusted computing base\",\"TCB\",\"verified library\",\"CompCert\"]",
-      "source_project": "skills_research:trend:2026-04-16",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "security/lean-verified-code-threat-boundary",
-      "linked_knowledge": [
-        "lean-verification-spec-coverage-gap"
-      ]
+      "path": "skills/security/lean-verified-code-threat-boundary"
     },
     {
       "name": "llm-integration-test-failure-diagnosis",
-      "description": "Wire an LLM-based diagnosis step into your CI for integration-test failures — summarize noisy logs, identify probable root cause, post findings to the code-review/PR UI. Based on Google's Auto-Diagnose (90%+ accuracy on 71-case study, adopted across 52k tests).",
+      "description": "Wire an LLM-based diagnosis step into your CI for integration-test failures — summarize noisy logs, identify probable root cause, post findings to the code-review/PR UI. Based on Google's Auto-Diagnose system (90%+ accuracy on 71-case study, adopted across 52k tests).",
       "category": "testing",
-      "tags": "[llm, ci, integration-tests, test-diagnosis, log-analysis, root-cause, auto-diagnose]",
-      "triggers": "[\"test failure diagnosis\",\"integration test flaky\",\"log summarization\",\"auto-diagnose\",\"test failure LLM\",\"root cause analysis\"]",
-      "source_project": "skills_research:trend:2026-04-16",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "testing/llm-integration-test-failure-diagnosis"
+      "path": "skills/testing/llm-integration-test-failure-diagnosis"
     },
     {
       "name": "llm-json-extraction",
       "description": "Robustly extract a JSON object from free-form LLM text output — strip markdown fences, locate outermost braces, tolerate prelude/postlude prose.",
       "category": "ai",
-      "tags": "[llm, json, parsing, prompt-engineering, robustness]",
-      "triggers": "[\"extract JSON\", \"parse LLM response\", \"strip code fence\", \"ObjectMapper.readValue\", \"JSON from model\", \"```json\"]",
-      "source_project": "webtoon_ai_project_with_wrapper",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "ai/llm-json-extraction"
+      "path": "skills/ai/llm-json-extraction"
     },
     {
       "name": "mcp-capability-negotiated-initialize",
       "description": "In MCP `initialize`, advertise optional server capabilities (prompts, resources, sampling) only when the client declared matching support — avoids clients rejecting the handshake or spamming unsupported methods.",
       "category": "backend",
-      "tags": "[mcp, json-rpc, capability-negotiation, handshake]",
-      "triggers": "[\"\\\"mcp initialize\\\"\", \"\\\"capability negotiation\\\"\", \"\\\"server capabilities\\\"\", \"\\\"prompts/resources not showing\\\"\"]",
-      "source_project": "yamltomcp",
+      "tags": [],
+      "triggers": [
+        "\"mcp initialize\"",
+        "\"capability negotiation\"",
+        "\"server capabilities\"",
+        "\"prompts/resources not showing\""
+      ],
       "version": "0.1.0-draft",
-      "path": "backend/mcp-capability-negotiated-initialize"
+      "path": "skills/backend/mcp-capability-negotiated-initialize"
     },
     {
       "name": "mcp-runtime-prompt-refresh",
       "description": "Expose a built-in MCP tool that hot-swaps the server's prompt set at runtime, persists it to disk, and emits notifications/prompts/list_changed so clients pick it up without reconnecting.",
       "category": "ai",
-      "tags": "[mcp, prompts, hot-reload, json-rpc, tool-design]",
-      "triggers": "[\"\\\"refresh prompts\\\"\", \"\\\"update mcp prompts at runtime\\\"\", \"\\\"prompts list_changed\\\"\", \"\\\"mcp hot reload\\\"\"]",
-      "source_project": "yamltomcp",
+      "tags": [],
+      "triggers": [
+        "\"refresh prompts\"",
+        "\"update mcp prompts at runtime\"",
+        "\"prompts list_changed\"",
+        "\"mcp hot reload\""
+      ],
       "version": "0.1.0-draft",
-      "path": "ai/mcp-runtime-prompt-refresh"
+      "path": "skills/ai/mcp-runtime-prompt-refresh"
     },
     {
       "name": "measurement-grouping-combiner",
       "description": "Group rows by `(resourceId, metricId, bucketTs)` into `Map<K, List<T>>`, then a per-granularity pure `combine…ByKey` merges each list into one composite record. One combiner per granularity (raw/1m/5m/hour/day).",
       "category": "backend",
-      "tags": "[java, stream, grouping, rollup, combiner]",
-      "triggers": "[\"combineByKey\", \"groupingBy\", \"metric rollup\", \"per-granularity merge\"]",
-      "source_project": "lucida-measurement",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/measurement-grouping-combiner"
+      "path": "skills/backend/measurement-grouping-combiner"
     },
     {
       "name": "menu-key-config-registry",
       "description": "Centralize sidebar/drawer menu keys as a union type + config object per domain, so menu rendering, drawer view switches, and default-expand state all reference the same source of truth. Eliminates string-key drift across the three places a menu key appears.",
       "category": "frontend",
-      "tags": "[react, menu, drawer, registry, typescript, union-type, configuration]",
-      "triggers": "[\"menu key drift\", \"Drawer case switch\", \"selectedSubMenu\", \"DetailMenuList\", \"sidebar menu config\"]",
-      "source_project": "lucida-ui",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "frontend/menu-key-config-registry"
+      "path": "skills/frontend/menu-key-config-registry"
     },
     {
       "name": "mermaid-gitlab-mr-size-rules",
       "description": "Keep Mermaid diagrams in GitLab MRs readable — cap nodes, avoid nested subgraphs, quote IDs with special chars, connect all subgraphs",
       "category": "workflow",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-builder-r3",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "workflow/mermaid-gitlab-mr-size-rules"
+      "path": "skills/workflow/mermaid-gitlab-mr-size-rules"
     },
     {
       "name": "message-loader-gated-on-database-ready",
       "description": "Gate i18n/seed loading on database readiness + per-tenant distributed lock so the first instance wins initialization in a multi-replica rollout.",
       "category": "backend",
-      "tags": "[multi-tenant, bootstrap, distributed-lock, readiness, seeding, kafka]",
-      "triggers": "[\"seed race\", \"multi-replica init\", \"tenant bootstrap\", \"first instance wins\"]",
-      "source_project": "lucida-meta",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/message-loader-gated-on-database-ready"
+      "path": "skills/backend/message-loader-gated-on-database-ready"
     },
     {
       "name": "mfa-memoryrouter-isolation",
       "description": "Wrap Module Federation-exposed React components in `MemoryRouter` so they own a private router context instead of inheriting the host's — avoids cross-origin router errors in dev and keeps the remote's routes from leaking into the host URL bar.",
       "category": "frontend",
-      "tags": "[module-federation, react-router, memoryrouter, micro-frontend, cross-origin]",
-      "triggers": "[\"MemoryRouter\", \"Router context\", \"cross-origin\", \"useNavigate outside Router\", \"MFA expose router\"]",
-      "source_project": "lucida-ui",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "frontend/mfa-memoryrouter-isolation"
+      "path": "skills/frontend/mfa-memoryrouter-isolation"
     },
     {
       "name": "mfa-plain-html-dropdown-escape-hatch",
       "description": "When a library Dropdown component infinite-loops or cross-origin-fails inside a Module Federation remote, replace it with a plain HTML `<button>` + absolutely-positioned menu `<ul>`. Cheaper than debugging the library's portal/context assumptions.",
       "category": "frontend",
-      "tags": "[module-federation, dropdown, antd, infinite-loop, cross-origin, react]",
-      "triggers": "[\"Dropdown infinite loop\", \"options useMemo\", \"MFA dropdown\", \"portal cross-origin\", \"library dropdown broken in remote\"]",
-      "source_project": "lucida-ui",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "frontend/mfa-plain-html-dropdown-escape-hatch"
+      "path": "skills/frontend/mfa-plain-html-dropdown-escape-hatch"
+    },
+    {
+      "name": "mfa-portal-css-isolation",
+      "description": "Isolate Tailwind CSS in Module Federation portals using lazyStyleTag injection, postcss-prefix-selector with :where() specificity control, scoped root elements, and Headless UI PortalGroup",
+      "category": "design",
+      "tags": [],
+      "triggers": [],
+      "version": "1.1.0",
+      "path": "skills/design/mfa-portal-css-isolation"
     },
     {
       "name": "migrate-to-shoehorn",
       "description": "Migrate test files from `as` type assertions to @total-typescript/shoehorn. Use when user mentions shoehorn, wants to replace `as` in tests, or needs partial test data.",
       "category": "refactor",
-      "tags": "[typescript, shoehorn, type-assertions, migration]",
-      "triggers": "",
-      "source_project": "mattpocock-skills",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "refactor/migrate-to-shoehorn"
+      "path": "skills/refactor/migrate-to-shoehorn"
     },
     {
       "name": "migration-processor-pipeline",
       "description": "Abstract migration processor template — validate → load → transform → emit Kafka Avro event with org-id header → audit log, multi-tenant safe",
       "category": "backend",
-      "tags": "[spring, kafka, avro, migration, multi-tenant, mongodb]",
-      "triggers": "[\"migration processor\", \"data migration pipeline\", \"legacy data import\", \"migration with kafka\"]",
-      "scope": "user",
-      "source_project": "lucida-domain-sms",
+      "tags": [],
+      "triggers": [
+        "migration processor",
+        "data migration pipeline",
+        "legacy data import",
+        "migration with kafka"
+      ],
       "version": "0.1.0-draft",
-      "path": "backend/migration-processor-pipeline"
+      "path": "skills/backend/migration-processor-pipeline"
     },
     {
       "name": "module-federation-expose-react-component",
       "description": "Expose a React component from one MF remote to be consumed by other remotes via a stable 6-step pipeline (implementation → expose wrapper → config → MF constant → RemoteApp wrapper → consumer import).",
       "category": "frontend",
-      "tags": "[module-federation, micro-frontend, react, webpack, expose, monorepo]",
-      "triggers": "[\"expose a component across module federation remotes\", \"share React component between MFA remotes\", \"MFA expose pipeline\", \"cross-remote import forbidden\"]",
-      "source_project": "lucida-ui",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "frontend/module-federation-expose-react-component"
+      "path": "skills/frontend/module-federation-expose-react-component"
     },
     {
       "name": "module-federation-expose-wrapper",
       "description": "Six-step pattern for exposing a component from one Module Federation remote and consuming it from another via a shared library — implementation → expose wrapper → MF config → MF name constant → RemoteApp wrapper in shared → consumer import. Prevents direct cross-remote imports and webpack alias collisions.",
       "category": "arch",
-      "tags": "[module-federation, micro-frontend, webpack, react, remote, expose, mfa]",
-      "triggers": "[\"module federation\", \"MFA\", \"cross-remote import\", \"exposes\", \"RemoteApp\", \"webpack alias collision\"]",
-      "source_project": "lucida-ui",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "arch/module-federation-expose-wrapper"
+      "path": "skills/arch/module-federation-expose-wrapper"
     },
     {
       "name": "mongo-aggregation-filter-optimization",
       "description": "Replace `$unwind`+`$match` on array sub-documents with inline `$filter` so array elements are pruned before any downstream stage — avoids N× document explosion.",
       "category": "backend",
-      "tags": "[mongodb, aggregation, performance, $filter, $unwind, topn]",
-      "triggers": "[\"$unwind $match\", \"aggregation pipeline slow\", \"topn query\", \"array filter\", \"mongo pipeline memory\"]",
-      "source_project": "lucida-measurement",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/mongo-aggregation-filter-optimization",
-      "linked_knowledge": [
-        "topn-unwind-match-to-filter"
-      ]
+      "path": "skills/backend/mongo-aggregation-filter-optimization"
     },
     {
       "name": "mongo-criteria-maker-elemmatch-and-or",
       "description": "Compose dynamic MongoDB Criteria with mixed AND/OR groups and elemMatch on tag-array fields using a stack-based builder",
       "category": "backend",
-      "tags": "[mongodb, spring-data, criteria, elemmatch, query-builder, and-or]",
-      "triggers": "[\"building MongoDB queries with user-defined AND/OR filter rows\", \"matching key/value pairs inside an array field (tags, labels, attributes)\", \"replacing string-concatenated Mongo queries with type-safe Criteria\"]",
-      "source_project": "lucida-performance",
+      "tags": [],
+      "triggers": [
+        "building MongoDB queries with user-defined AND/OR filter rows",
+        "matching key/value pairs inside an array field (tags, labels, attributes)",
+        "replacing string-concatenated Mongo queries with type-safe Criteria"
+      ],
       "version": "1.0.0",
-      "path": "backend/mongo-criteria-maker-elemmatch-and-or"
+      "path": "skills/backend/mongo-criteria-maker-elemmatch-and-or"
     },
     {
       "name": "mongo-timestamp-densification",
       "description": "Fill sparse time-series gaps with `$dateTrunc` + `$densify` in Mongo, then a residual Java gap-fill loop for LIVE windows. Partition by series to keep multi-line charts aligned.",
       "category": "backend",
-      "tags": "[mongodb, $densify, $dateTrunc, time-series, chart, gap-fill]",
-      "triggers": "[\"densify\", \"sparse chart\", \"missing buckets\", \"$dateTrunc binSize\", \"partitionByFields\"]",
-      "source_project": "lucida-measurement",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/mongo-timestamp-densification"
+      "path": "skills/backend/mongo-timestamp-densification"
     },
     {
       "name": "mongo-ttl-with-aggregation-delta",
       "description": "Store short-lived counter snapshots in MongoDB with a TTL index for auto-expiry and compute delta-from-previous at read time via an aggregation $subtract pipeline.",
       "category": "backend",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-health",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/mongo-ttl-with-aggregation-delta"
+      "path": "skills/backend/mongo-ttl-with-aggregation-delta"
     },
     {
       "name": "mongodb-changestream-field-filter",
       "description": "Filter MongoDB change stream UPDATE events by inspecting updateDescription.updatedFields so irrelevant mutations do not trigger downstream work; INSERT/DELETE fall through as always-relevant.",
       "category": "backend",
-      "tags": "[mongodb, changestream, cdc, field-filter, updateDescription]",
-      "triggers": "[\"updateDescription.updatedFields\", \"change stream filter\", \"ChangeStreamDocument\", \"policy-relevant field\", \"CDC\"]",
-      "source_project": "lucida-alarm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/mongodb-changestream-field-filter",
-      "linked_knowledge": [
-        "mongodb-changestream-resubscribe"
-      ]
+      "path": "skills/backend/mongodb-changestream-field-filter"
     },
     {
       "name": "mongodb-compound-index-esr-rule",
       "description": "Order MongoDB compound-index fields as Equality → Sort → Range so the query planner keeps a tight IXSCAN and avoids in-memory sorts.",
       "category": "backend",
-      "tags": "",
-      "triggers": "Designing or reviewing MongoDB compound indexes; slow queries with COLLSCAN or in-memory sort",
-      "source_project": "lucida-domain-apm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/mongodb-compound-index-esr-rule"
+      "path": "skills/backend/mongodb-compound-index-esr-rule"
     },
     {
       "name": "mongodb-datetrunc-binsize-zero-guard",
       "description": "Guard MongoDB $dateTrunc binSize against 0 when your interval may be auto/unset; coerce to 1 to avoid runtime error",
       "category": "backend",
-      "tags": "[mongodb, aggregation, dateTrunc, pitfall]",
-      "triggers": "[\"binSize must be >= 1\", \"$dateTrunc\", \"interval=0\", \"dateTrunc binSize\"]",
-      "source_project": "lucida-performance",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/mongodb-datetrunc-binsize-zero-guard",
-      "linked_knowledge": [
-        "binsize-zero-fallback-to-one"
-      ]
+      "path": "skills/backend/mongodb-datetrunc-binsize-zero-guard"
     },
     {
       "name": "mongodb-volume-copy-backup",
       "description": "Back up and restore MongoDB Docker volumes via rsync volume-copy instead of mongodump/tar.gz",
       "category": "devops",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-for-docker",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "devops/mongodb-volume-copy-backup"
+      "path": "skills/devops/mongodb-volume-copy-backup"
     },
     {
       "name": "multi-dbms-resource-provider-pattern",
       "description": "Structure a polyglot RDBMS monitoring agent with one ResourceProvider + entity/dto/service per DBMS, sharing a common base",
       "category": "backend",
-      "tags": "",
-      "triggers": "multi-DBMS instrumentation, per-product measurement definitions, polyglot collectors",
-      "source_project": "lucida-domain-dpm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/multi-dbms-resource-provider-pattern"
+      "path": "skills/backend/multi-dbms-resource-provider-pattern"
     },
     {
       "name": "multi-resource-or-batch-query",
       "description": "Collapse N per-resource Mongo queries into one pipeline using `Criteria.orOperator` (or `$in`) over resourceId, projecting a synthetic `key` field for service-side de-multiplexing. Chunk at ~200 for index-friendly `$or`.",
       "category": "backend",
-      "tags": "[mongodb, batch, $or, $in, multi-resource, projection]",
-      "triggers": "[\"multi-resource chart\", \"Criteria.orOperator\", \"batch aggregation\", \"resourceId $in\"]",
-      "source_project": "lucida-measurement",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/multi-resource-or-batch-query"
+      "path": "skills/backend/multi-resource-or-batch-query"
     },
     {
       "name": "multi-tenant-kafka-header-organization-context",
       "description": "Propagate tenant/organization id from Kafka headers through async handler threads via a ThreadLocal context holder",
       "category": "backend",
-      "tags": "",
-      "triggers": "multi-tenant kafka consumer, tenant context propagation, async handler thread-local",
-      "source_project": "lucida-domain-dpm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/multi-tenant-kafka-header-organization-context"
+      "path": "skills/backend/multi-tenant-kafka-header-organization-context"
     },
     {
       "name": "multi-tenant-scheduler-iteration",
       "description": "|",
       "category": "backend",
-      "tags": "[spring-boot, mongodb, multi-tenant, scheduled-job, tenant-context]",
-      "triggers": "[\"scheduled job multi tenant mongodb\", \"TenantContextHolder 스케줄러\", \"iterate every tenant database\"]",
-      "scope": "user",
-      "source_project": "lucida-snote",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "backend/multi-tenant-scheduler-iteration"
+      "path": "skills/backend/multi-tenant-scheduler-iteration"
     },
     {
       "name": "netty-tcp-reconnect-backoff",
       "description": "On Netty `channelInactive`/EOF/read-timeout, reconnect with exponential backoff (100ms → 30s cap), reset on success, keep SO_KEEPALIVE + TCP_NODELAY",
       "category": "backend",
-      "tags": "[netty, tcp, reconnect, backoff, keepalive, eof]",
-      "triggers": "[\"long-lived TCP client to a device or broker that drops silently\", \"need to survive peer restarts without crashing the collector\"]",
-      "source_project": "cygnus",
+      "tags": [],
+      "triggers": [
+        "long-lived TCP client to a device or broker that drops silently",
+        "need to survive peer restarts without crashing the collector"
+      ],
       "version": "1.0.0",
-      "path": "backend/netty-tcp-reconnect-backoff"
+      "path": "skills/backend/netty-tcp-reconnect-backoff"
     },
     {
       "name": "non-metric-saveraw-null-rule",
       "description": "Treat `saveRaw` as tri-state `Boolean` — `null` for non-METRIC types (Availability/Trait), `true`/`false` only for METRIC. Re-apply the rule on every policy mutation path.",
       "category": "backend",
-      "tags": "[domain, tri-state, Boolean, measurement-type, policy]",
-      "triggers": "[\"saveRaw null\", \"non-METRIC\", \"policy update\", \"MeasurementType\", \"tri-state boolean\"]",
-      "source_project": "lucida-measurement",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/non-metric-saveraw-null-rule",
-      "linked_knowledge": [
-        "policy-edit-saveraw-loss"
-      ]
+      "path": "skills/backend/non-metric-saveraw-null-rule"
     },
     {
       "name": "oauth-token-env-persistence",
       "description": "Persist OAuth access tokens to a sidecar env file (token + refresh + issue_time), refresh N minutes before expiry with a thread-safe guard, auto-inject into outgoing API calls — survives process restart without re-login.",
       "category": "security",
-      "tags": "[oauth, token, refresh, dotenv, persistence, auth, thread-safety]",
-      "triggers": "[\"access_token\", \"refresh_token\", \"token refresh\", \"access_token.env\", \"token issue time\", \"bearer auto inject\", \"token expiry\"]",
-      "source_project": "kis-java-bundle",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "security/oauth-token-env-persistence"
+      "path": "skills/security/oauth-token-env-persistence"
     },
     {
       "name": "obsidian-vault",
       "description": "Search, create, and manage notes in the Obsidian vault with wikilinks and index notes. Use when user wants to find, create, or organize notes in Obsidian.",
       "category": "docs",
-      "tags": "[obsidian, notes, wikilinks, vault]",
-      "triggers": "",
-      "source_project": "mattpocock-skills",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "docs/obsidian-vault"
+      "path": "skills/docs/obsidian-vault"
     },
     {
       "name": "openapi-to-mcp-tag-grouping",
       "description": "Convert OpenAPI specs into MCP tools by grouping operations under their OpenAPI tag, exposing one tool per tag with an operation selector and per-operation arguments.",
       "category": "ai",
-      "tags": "[mcp, openapi, tool-design, schema, json-schema]",
-      "triggers": "[\"\\\"openapi to mcp\\\"\", \"\\\"swagger to mcp\\\"\", \"\\\"generate mcp tools\\\"\", \"\\\"tag based tool grouping\\\"\"]",
-      "source_project": "yamltomcp",
+      "tags": [],
+      "triggers": [
+        "\"openapi to mcp\"",
+        "\"swagger to mcp\"",
+        "\"generate mcp tools\"",
+        "\"tag based tool grouping\""
+      ],
       "version": "0.1.0-draft",
-      "path": "ai/openapi-to-mcp-tag-grouping"
+      "path": "skills/ai/openapi-to-mcp-tag-grouping"
     },
     {
       "name": "openssl-4-migration-checklist",
       "description": "Step-by-step migration checklist for upgrading a C/C++ codebase from OpenSSL 3.x to 4.0.0 — const-qualified APIs, removed SSLv3 support, opaque ASN1_STRING, engine removal, cleanup semantics.",
       "category": "security",
-      "tags": "[openssl, tls, cryptography, migration, c-api, breaking-changes, upgrade]",
-      "triggers": "[\"openssl 4\",\"OpenSSL 4.0.0\",\"openssl upgrade\",\"SSLv3_method\",\"ENGINE_load\",\"ASN1_STRING opaque\",\"X509_cmp_time\",\"openssl deprecated\"]",
-      "source_project": "skills_research:trend:2026-04-16",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "security/openssl-4-migration-checklist"
+      "path": "skills/security/openssl-4-migration-checklist"
     },
     {
       "name": "opentelemetry-java-bootstrap",
       "description": "Minimal OpenTelemetry bootstrap for a Java service — OTLP exporter, resource attributes, auto-instrumentation agent, and graceful shutdown. Covers the common setup mistakes that cause spans to silently drop.",
       "category": "apm",
-      "tags": "[opentelemetry, otel, java, tracing, otlp, observability]",
-      "triggers": "[OpenTelemetry, OTEL, otel-javaagent, otlp, tracing setup, service.name, span exporter]",
-      "source_project": "manual",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "apm/opentelemetry-java-bootstrap"
+      "path": "skills/apm/opentelemetry-java-bootstrap"
     },
     {
       "name": "optional-outbound-adapter-no-op-port",
       "description": "Register a No-Op implementation of an optional outbound port with @ConditionalOnMissingBean so services boot when the real adapter (Kafka audit, tracing, notifications) is absent.",
       "category": "arch",
-      "tags": "",
-      "triggers": "Hexagonal outbound port whose backing infrastructure is optional; service fails to boot without audit/tracing adapter",
-      "source_project": "lucida-domain-apm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "arch/optional-outbound-adapter-no-op-port"
+      "path": "skills/arch/optional-outbound-adapter-no-op-port"
     },
     {
       "name": "org-scoped-kafka-topic-bootstrap",
       "description": "On-startup and on-event creation of per-tenant Kafka topics, with retention overrides per topic class and a service-readiness gate",
       "category": "backend",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-realtime",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/org-scoped-kafka-topic-bootstrap"
+      "path": "skills/backend/org-scoped-kafka-topic-bootstrap"
     },
     {
       "name": "paired-flag-multi-instance-registration",
       "description": "CLI pattern for registering N instances of a composite config (e.g. spec+baseUrl pairs) using repeated paired flags and a pending-state parser.",
       "category": "cli",
-      "tags": "[argparse, cli-design, multi-instance, config]",
-      "triggers": "[\"\\\"multiple config pairs\\\"\", \"\\\"repeated flag\\\"\", \"\\\"paired cli args\\\"\", \"\\\"multi-spec cli\\\"\"]",
-      "source_project": "yamltomcp",
+      "tags": [],
+      "triggers": [
+        "\"multiple config pairs\"",
+        "\"repeated flag\"",
+        "\"paired cli args\"",
+        "\"multi-spec cli\""
+      ],
       "version": "0.1.0-draft",
-      "path": "cli/paired-flag-multi-instance-registration"
+      "path": "skills/cli/paired-flag-multi-instance-registration"
     },
     {
       "name": "parallel-bulk-annotation",
       "description": "수십~수백 개 Java 파일에 어노테이션(@Schema, @Operation, @ApiResponse 등)을 대량 추가할 때 병렬 에이전트로 분산 실행하는 패턴",
       "category": "workflow",
-      "tags": "",
-      "triggers": "[\"대량 어노테이션 추가\", \"@Schema 전수 부여\", \"operationId 전수 부여\", \"200개 메서드 어노테이션\", \"bulk annotation\"]",
-      "scope": "user",
-      "source_project": "",
+      "tags": [],
+      "triggers": [
+        "대량 어노테이션 추가",
+        "@Schema 전수 부여",
+        "operationId 전수 부여",
+        "200개 메서드 어노테이션",
+        "bulk annotation"
+      ],
       "version": "1.0.0",
-      "path": "workflow/parallel-bulk-annotation"
+      "path": "skills/workflow/parallel-bulk-annotation"
     },
     {
       "name": "parallel-tasks-generic-extraction",
       "description": "invokeAll + Callable 반복 패턴을 제네릭 executeParallelTasks + TaskFactory로 추출",
       "category": "backend",
-      "tags": "",
-      "triggers": "Same invokeAll + Future result-splitting block appears 2+ times in one service",
-      "source_project": "lucida-domain-automation",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/parallel-tasks-generic-extraction"
+      "path": "skills/backend/parallel-tasks-generic-extraction"
     },
     {
       "name": "period-mode-enum-config",
       "description": "One enum `Mode` holds all (intervalMs, isFullData, dateFormat, retention, chartFormat) tuples for every time-series granularity — single source of truth across repository/service/chart layers.",
       "category": "backend",
-      "tags": "[enum, time-series, domain, period, config]",
-      "triggers": "[\"Period.Mode\", \"MIN_15\", \"MONTH_2\", \"interval retention enum\", \"chart format\"]",
-      "source_project": "lucida-measurement",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/period-mode-enum-config",
-      "linked_knowledge": [
-        "period-interval-naming-convention"
-      ]
+      "path": "skills/backend/period-mode-enum-config"
     },
     {
       "name": "playwright-exception-advice",
       "description": "Map PlaywrightException to a structured JSON error in Spring @ControllerAdvice, detecting common cases (cert errors, timeouts) and attaching actionable suggestions",
       "category": "backend",
-      "tags": "[spring-boot, exception-handling, playwright, controller-advice]",
-      "triggers": "[\"ControllerAdvice playwright\", \"PlaywrightException spring\", \"ERR_CERT_AUTHORITY_INVALID\"]",
-      "source_project": "url-screenshot-java",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "backend/playwright-exception-advice"
+      "path": "skills/backend/playwright-exception-advice"
     },
     {
       "name": "playwright-inspector-codegen",
       "description": "Enable Playwright Inspector / codegen from a running Java app by setting PWDEBUG env vars before Playwright.create() and exposing an mvn codegen invocation for the user",
       "category": "debug",
-      "tags": "[playwright, inspector, codegen, debugging, java]",
-      "triggers": "[\"PWDEBUG\", \"playwright inspector\", \"playwright codegen\", \"record selectors\"]",
-      "source_project": "url-screenshot-java",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "debug/playwright-inspector-codegen"
+      "path": "skills/debug/playwright-inspector-codegen"
     },
     {
       "name": "playwright-java-dockerfile",
       "description": "Multi-stage Dockerfile that builds a Java/Maven app in a JDK image and runs it on the official Playwright Java runtime image, avoiding manual browser installation",
       "category": "devops",
-      "tags": "[docker, playwright, java, maven, multi-stage]",
-      "triggers": "[\"dockerfile playwright java\", \"mcr.microsoft.com/playwright/java\", \"playwright container\"]",
-      "source_project": "url-screenshot-java",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "devops/playwright-java-dockerfile"
+      "path": "skills/devops/playwright-java-dockerfile"
     },
     {
       "name": "playwright-java-spring-lifecycle",
       "description": "Share one Playwright+Browser instance across a Spring Boot app and create per-request BrowserContext/Page, cleaning up with try-with-resources and @PreDestroy",
       "category": "backend",
-      "tags": "[playwright, spring-boot, java, lifecycle, browser]",
-      "triggers": "[\"playwright\", \"BrowserManager\", \"BrowserContext\", \"headless browser spring\"]",
-      "source_project": "url-screenshot-java",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "backend/playwright-java-spring-lifecycle"
+      "path": "skills/backend/playwright-java-spring-lifecycle"
     },
     {
       "name": "pluggable-sender-factory-pattern",
       "description": "Register multiple notification/transport backends (SMS, EMAIL, SMTP, JDBC, REST, SLACK, SOCKET) behind a single FactoryBean that dispatches by enum type",
       "category": "arch",
-      "tags": "",
-      "triggers": "[\"adding a new notification channel / transport sender to a service that already has 2+ channels\"]",
-      "source_project": "lucida-notification",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "arch/pluggable-sender-factory-pattern"
+      "path": "skills/arch/pluggable-sender-factory-pattern"
     },
     {
       "name": "plugin-resource-provider-architecture",
       "description": "Stable `ResourceProvider` SPI loaded via Spring component scan; each new device/resource type is a separate Gradle-module JAR packaged into the WAR — zero core edits",
       "category": "arch",
-      "tags": "[plugin, spi, spring, component-scan, gradle, war, extensibility]",
-      "triggers": "[\"extensible monitoring/management platform\", \"vendor support must be pluggable per deployment\"]",
-      "source_project": "cygnus",
+      "tags": [],
+      "triggers": [
+        "extensible monitoring/management platform",
+        "vendor support must be pluggable per deployment"
+      ],
       "version": "1.0.0",
-      "path": "arch/plugin-resource-provider-architecture"
+      "path": "skills/arch/plugin-resource-provider-architecture"
     },
     {
       "name": "policy-target-evaluation-with-groups-tags",
       "description": "Evaluate whether a resource matches a policy via direct IDs + static/dynamic groups + tag filters, with explicit exclusion rules that take precedence over includes.",
       "category": "backend",
-      "tags": "[policy, targeting, groups, tag-filter, smart-group, exclusion]",
-      "triggers": "[\"target allocation\", \"smart group\", \"tag filter\", \"exclusion wins\", \"policy membership\"]",
-      "source_project": "lucida-alarm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/policy-target-evaluation-with-groups-tags"
+      "path": "skills/backend/policy-target-evaluation-with-groups-tags"
     },
     {
       "name": "polymorphic-command-entities",
       "description": "Expose a list of typed commands over JSON using Jackson @JsonTypeInfo + @JsonSubTypes so clients can submit executable scripts to a REST endpoint",
       "category": "backend",
-      "tags": "[jackson, polymorphism, command-pattern, rest, java]",
-      "triggers": "[\"JsonTypeInfo\", \"JsonSubTypes\", \"command pattern json\", \"polymorphic deserialization\"]",
-      "source_project": "url-screenshot-java",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "backend/polymorphic-command-entities"
+      "path": "skills/backend/polymorphic-command-entities"
     },
     {
       "name": "prd-to-issues",
       "description": "Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. Use when user wants to convert a PRD to issues, create implementation tickets, or break down a PRD into work items.",
       "category": "workflow",
-      "tags": "[prd, github, issues, tracer-bullet, planning]",
-      "triggers": "",
-      "source_project": "mattpocock-skills",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "workflow/prd-to-issues"
+      "path": "skills/workflow/prd-to-issues"
     },
     {
       "name": "prd-to-plan",
       "description": "Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in ./plans/. Use when user wants to break down a PRD, create an implementation plan, plan phases from a PRD, or mentions \"tracer bullets\".",
       "category": "workflow",
-      "tags": "[prd, planning, phased, tracer-bullet]",
-      "triggers": "",
-      "source_project": "mattpocock-skills",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "workflow/prd-to-plan"
+      "path": "skills/workflow/prd-to-plan"
     },
     {
       "name": "qa",
       "description": "Interactive QA session where user reports bugs or issues conversationally, and the agent files GitHub issues. Explores the codebase in the background for context and domain language. Use when user wants to report bugs, do QA, file issues conversationally, or mentions \"QA session\".",
       "category": "testing",
-      "tags": "[qa, interactive, bug-reports]",
-      "triggers": "",
-      "source_project": "mattpocock-skills",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "testing/qa"
+      "path": "skills/testing/qa"
     },
     {
       "name": "querydsl-q-class-exclusion-pattern",
       "description": "One `exclusionPatterns` list drives Jacoco report + verification + Sonar exclusions; catches generated Querydsl Q-classes via `('A'..'Z').collect { \"**/**/Q${it}*\" }`.",
       "category": "devops",
-      "tags": "[gradle, jacoco, sonar, querydsl, coverage, exclusion]",
-      "triggers": "[\"jacoco exclusion\", \"sonar exclusion\", \"Q class\", \"querydsl generated\", \"coverage inflation\"]",
-      "source_project": "lucida-measurement",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "devops/querydsl-q-class-exclusion-pattern",
-      "linked_knowledge": [
-        "jacoco-sonar-exclusion-policy"
-      ]
+      "path": "skills/devops/querydsl-q-class-exclusion-pattern"
     },
     {
       "name": "react-native-android-emulator-localhost",
       "description": "Use Platform.select to pick the right loopback host when a React Native dev build talks to a backend on the host machine — Android emulator needs 10.0.2.2, iOS simulator uses localhost.",
       "category": "mobile",
-      "tags": "[react-native, android, emulator, localhost, 10.0.2.2, networking, dev-environment]",
-      "triggers": "[\"10.0.2.2\", \"Platform.select\", \"localhost:8080\", \"android emulator network\", \"React Native API base\", \"fetch failed\", \"Network request failed\"]",
-      "source_project": "webtoon_ai_project_with_wrapper",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "mobile/react-native-android-emulator-localhost"
+      "path": "skills/mobile/react-native-android-emulator-localhost"
     },
     {
       "name": "reactive-webclient-ssl-jdk",
       "description": "Force reactor-netty WebClient to SslProvider.JDK so SSL works in slim containers that lack netty-tcnative native libraries.",
       "category": "backend",
-      "tags": "",
-      "triggers": "Spring WebFlux WebClient SSL failures in containers; UnsatisfiedLinkError for netty-tcnative",
-      "source_project": "lucida-domain-apm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/reactive-webclient-ssl-jdk"
+      "path": "skills/backend/reactive-webclient-ssl-jdk"
     },
     {
       "name": "reactor-subscription-router-backpressure",
       "description": "Per-session, per-destination Reactor Flux router with bounded buffer + DROP_LATEST backpressure and automatic cleanup on session disconnect",
       "category": "backend",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-realtime",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/reactor-subscription-router-backpressure"
+      "path": "skills/backend/reactor-subscription-router-backpressure"
     },
     {
       "name": "realtime-vs-polling-fallback",
       "description": "Let each resource type declare `supportsRealtime`; scheduler runs push-mode at the realtime interval and falls back to a safe polling interval (e.g., 60s) otherwise",
       "category": "backend",
-      "tags": "[scheduler, realtime, polling, collector, fallback]",
-      "triggers": "[\"mixed collection pipeline (some resources push, some pull)\", \"avoid hammering APIs that do not support realtime\"]",
-      "source_project": "cygnus",
+      "tags": [],
+      "triggers": [
+        "mixed collection pipeline (some resources push, some pull)",
+        "avoid hammering APIs that do not support realtime"
+      ],
       "version": "1.0.0",
-      "path": "backend/realtime-vs-polling-fallback"
+      "path": "skills/backend/realtime-vs-polling-fallback"
     },
     {
       "name": "redis-lock-recheck-flag-pattern",
       "description": "Distributed Redis lock with a \"recheck\" flag so concurrent events arriving while the lock is held force the holder to run a second pass, instead of being silently dropped.",
       "category": "backend",
-      "tags": "[redis, distributed-lock, recheck, concurrency, lua]",
-      "triggers": "[\"distributed lock\", \"recheck flag\", \"concurrent event lost\", \"SET NX EX\", \"lua release\"]",
-      "source_project": "lucida-alarm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/redis-lock-recheck-flag-pattern"
+      "path": "skills/backend/redis-lock-recheck-flag-pattern"
     },
     {
       "name": "request-refactor-plan",
       "description": "Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.",
       "category": "refactor",
-      "tags": "[planning, commits, interview]",
-      "triggers": "",
-      "source_project": "mattpocock-skills",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "refactor/request-refactor-plan"
+      "path": "skills/refactor/request-refactor-plan"
     },
     {
       "name": "resource-provider-registry",
       "description": "Spring DI plugin registry where @Component implementations of a typed interface are auto-discovered and looked up at runtime by a string type key",
       "category": "arch",
-      "tags": "[spring, plugin, registry, interface, component]",
-      "triggers": "[\"plugin registry\", \"provider lookup by type\", \"auto-discovered handlers\", \"resource provider pattern\"]",
-      "scope": "user",
-      "source_project": "lucida-domain-sms",
+      "tags": [],
+      "triggers": [
+        "plugin registry",
+        "provider lookup by type",
+        "auto-discovered handlers",
+        "resource provider pattern"
+      ],
       "version": "0.1.0-draft",
-      "path": "arch/resource-provider-registry"
+      "path": "skills/arch/resource-provider-registry"
     },
     {
       "name": "resource-summary-resolve-override-template",
       "description": "리소스 상세 화면의 \"요약\" 탭에서 `OVERRIDE → TEMPLATE → NONE` 순으로 대시보드를 결정하는 서버-클라이언트 패턴. 오버라이드 엔티티, resolve API, 상태별 UI 드롭다운 규칙까지 포함.",
       "category": "arch",
-      "tags": "[resource-detail, dashboard, override, template, resolve, widget, summary]",
-      "triggers": "[\"resource summary\", \"리소스 요약\", \"resolve override template\", \"dashboard override\", \"resourceSummary\", \"composition override\"]",
-      "source_project": "lucida-domain-sms",
+      "tags": [],
+      "triggers": [
+        "resource summary",
+        "리소스 요약",
+        "resolve override template",
+        "dashboard override",
+        "resourceSummary",
+        "composition override"
+      ],
       "version": "1.0.0",
-      "path": "arch/resource-summary-resolve-override-template"
+      "path": "skills/arch/resource-summary-resolve-override-template"
     },
     {
       "name": "scaffold-exercises",
       "description": "Create exercise directory structures with sections, problems, solutions, and explainers that pass linting. Use when user wants to scaffold exercises, create exercise stubs, or set up a new course section.",
       "category": "misc",
-      "tags": "[scaffolding, exercises, template]",
-      "triggers": "",
-      "source_project": "mattpocock-skills",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "misc/scaffold-exercises"
+      "path": "skills/misc/scaffold-exercises"
     },
     {
       "name": "second-aggregation-snapshot-merge",
       "description": "Per-second metric aggregation using in-memory counters + Flux.interval snapshot-and-reset + bounded parallel publish, to decouple request latency from downstream health.",
       "category": "backend",
-      "tags": "",
-      "triggers": "1-second-resolution metrics (TPS, error counts) without hitting Kafka/DB per event",
-      "source_project": "lucida-domain-apm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/second-aggregation-snapshot-merge"
+      "path": "skills/backend/second-aggregation-snapshot-merge"
     },
     {
       "name": "server-plugin-scripting-and-builtin-extensibility",
       "description": "Dual plugin system for a monitoring server — hot-reload script plugins (alert rules, filters) plus compiled JAR plugins for stateful, performance-critical data handlers",
       "category": "backend",
-      "tags": "[plugin, extensibility, scripting, hot-reload, monitoring]",
-      "triggers": "",
-      "source_project": "scouter",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/server-plugin-scripting-and-builtin-extensibility"
+      "path": "skills/backend/server-plugin-scripting-and-builtin-extensibility"
     },
     {
       "name": "service-discovery-replica-leader-tracking",
       "description": "Track Eureka replica UP/DOWN events and emit ServiceLeaderElected / ServiceReplicaAllDown Spring events for cluster-aware init",
       "category": "backend",
-      "tags": "[eureka, discovery, leader-election, spring-events]",
-      "triggers": "Microservice needs to react when the cluster gains its first live peer, loses its last peer, or the leader changes - not just on startup",
-      "source_project": "lucida-report",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/service-discovery-replica-leader-tracking"
+      "path": "skills/backend/service-discovery-replica-leader-tracking"
     },
     {
       "name": "service-readiness-event-listener-pattern",
       "description": "Two-phase startup where each instance initializes locally, but only the leader runs global one-time work (seed data, default report creation)",
       "category": "backend",
-      "tags": "[spring, startup, leader-election, seed-data]",
-      "triggers": "Spring Boot microservice running 2+ replicas where some init work must happen once across the cluster (seeds, schema migrations, default rows)",
-      "source_project": "lucida-report",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/service-readiness-event-listener-pattern"
+      "path": "skills/backend/service-readiness-event-listener-pattern"
     },
     {
       "name": "service-status-provider-actuator",
       "description": "Spring Boot 3.5 ServiceStatusProvider that reports RUNNING vs READY based on MongoDB ping + Kafka listener container liveness",
       "category": "backend",
-      "tags": "",
-      "triggers": "Exposing a richer readiness signal than HealthIndicator for a service whose \"ready\" state depends on both DB reachability and Kafka consumers being attached",
-      "source_project": "lucida-audit",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/service-status-provider-actuator"
+      "path": "skills/backend/service-status-provider-actuator"
     },
     {
       "name": "servicejar-embeddable-library-task",
       "description": "Gradle task that builds a library JAR alongside bootJar for embedding inside a host Spring Boot app — excludes Application class, web/OpenAPI configs, and bundled resources",
       "category": "backend",
-      "tags": "[gradle, spring-boot, packaging, saas, on-prem, embedding]",
-      "triggers": "Same Spring Boot service must run both standalone and embedded inside a host app",
-      "source_project": "lucida-account",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/servicejar-embeddable-library-task"
+      "path": "skills/backend/servicejar-embeddable-library-task"
     },
     {
       "name": "session-lock-tree-blocking-chain-modeling",
       "description": "Model RDBMS blocking sessions as a directed graph and persist the resolved lock tree alongside the session snapshot",
       "category": "backend",
-      "tags": "",
-      "triggers": "lock contention monitoring, blocking session analysis, RDBMS session graph",
-      "source_project": "lucida-domain-dpm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/session-lock-tree-blocking-chain-modeling"
+      "path": "skills/backend/session-lock-tree-blocking-chain-modeling"
     },
     {
       "name": "setup-pre-commit",
       "description": "Set up Husky pre-commit hooks with lint-staged (Prettier), type checking, and tests in the current repo. Use when user wants to add pre-commit hooks, set up Husky, configure lint-staged, or add commit-time formatting/typechecking/testing.",
       "category": "cli",
-      "tags": "[husky, lint-staged, pre-commit, prettier, typescript]",
-      "triggers": "",
-      "source_project": "mattpocock-skills",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "cli/setup-pre-commit"
+      "path": "skills/cli/setup-pre-commit"
     },
     {
       "name": "shared-apis-endpoint-service-pattern",
       "description": "Module Federation 모노레포에서 REST 엔드포인트를 추가할 때 `endpoint 상수 → services 메서드 → commonApiService 호출` 3계층 레이어링으로 도메인 일관성을 유지하는 패턴.",
       "category": "frontend",
-      "tags": "[api, services, endpoint, module-federation, monorepo, layering]",
-      "triggers": "[\"엔드포인트 추가\", \"widgetEndPoint\", \"shared/apis\", \"commonApiService\", \"API 레이어 추가\", \"endpoint constant\"]",
-      "source_project": "lucida-domain-sms",
+      "tags": [],
+      "triggers": [
+        "엔드포인트 추가",
+        "widgetEndPoint",
+        "shared/apis",
+        "commonApiService",
+        "API 레이어 추가",
+        "endpoint constant"
+      ],
       "version": "1.0.0",
-      "path": "frontend/shared-apis-endpoint-service-pattern"
+      "path": "skills/frontend/shared-apis-endpoint-service-pattern"
     },
     {
       "name": "shared-package-only-cross-module",
       "description": "Enforce a one-way dependency graph in a multi-module repo — sibling modules may only import from a single `shared/` package, never from each other. Prevents webpack alias collisions, keeps module boundaries enforceable, and makes build/deploy units independent.",
       "category": "arch",
-      "tags": "[monorepo, module-boundaries, webpack, alias, micro-frontend, dependency-direction]",
-      "triggers": "[\"cross-module import\", \"cannot resolve @/\", \"alias collision\", \"webpack root\", \"monorepo boundaries\"]",
-      "source_project": "lucida-ui",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "arch/shared-package-only-cross-module"
+      "path": "skills/arch/shared-package-only-cross-module"
     },
     {
       "name": "site-per-customer-override-modules",
       "description": "One Gradle module per customer (`<product>-site-<customer>`) overrides core beans, auth, notification channels, and assets — keeps core customer-agnostic and scales to dozens of deployments",
       "category": "arch",
-      "tags": "[b2b, customization, gradle-module, spring, bean-override, multi-tenant]",
-      "triggers": "[\"B2B product delivered to many customers with bespoke requirements\", \"feature-flag soup is polluting core\"]",
-      "source_project": "cygnus",
+      "tags": [],
+      "triggers": [
+        "B2B product delivered to many customers with bespoke requirements",
+        "feature-flag soup is polluting core"
+      ],
       "version": "1.0.0",
-      "path": "arch/site-per-customer-override-modules"
+      "path": "skills/arch/site-per-customer-override-modules"
     },
     {
       "name": "skill-md-validator",
-      "description": "[Tooling] SKILL.md frontmatter + 필수 섹션을 CRITICAL/WARNING 등급으로 검증하는 품질 게이트.",
+      "description": "\"[Tooling] SKILL.md frontmatter + 필수 섹션을 CRITICAL/WARNING 등급으로 검증하는 품질 게이트.\"",
       "category": "devops",
-      "tags": "[claude-code, skill, validation, quality-gate]",
-      "triggers": "[\"skill-validate\", \"validate skill\", \"SKILL.md check\", \"publish gate\"]",
-      "source_project": "nkia-skills",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "devops/skill-md-validator"
+      "path": "skills/devops/skill-md-validator"
     },
     {
       "name": "skill-repo-bootstrap-architecture",
       "description": "Lay out a shared skill/knowledge git repo so it is simultaneously a catalog and a self-installer — separate bootstrap (commands + umbrella skill + installers) from skills (category/name/SKILL.md). Covers repo layout, safety gates, registry pinning, and skill deprecation lifecycle.",
       "category": "workflow",
-      "tags": "[skill-hub, repo-layout, bootstrap, claude-code, cursor, git, architecture, deprecation]",
-      "triggers": "[skill repo, skill hub, bootstrap install, category-separated, skills registry, skill deprecation, umbrella skill]",
-      "source_project": "skills-hub-setup-session",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "workflow/skill-repo-bootstrap-architecture"
+      "path": "skills/workflow/skill-repo-bootstrap-architecture"
     },
     {
       "name": "slack-webhook-notify",
       "description": "Slack Incoming Webhook으로 메시지를 전송한다. 빌드/테스트/배포 결과, 작업 완료 알림 등을 Slack 채널에 보낼 때 사용.",
       "category": "devops",
-      "tags": "",
-      "triggers": "[\"slack\", \"슬랙\", \"slack notify\", \"webhook 알림\", \"빌드 알림\", \"작업 완료 알림\"]",
-      "source_project": "lucida-domain-sms",
+      "tags": [],
+      "triggers": [
+        "slack",
+        "슬랙",
+        "slack notify",
+        "webhook 알림",
+        "빌드 알림",
+        "작업 완료 알림"
+      ],
       "version": "1.0.0",
-      "path": "devops/slack-webhook-notify"
+      "path": "skills/devops/slack-webhook-notify"
     },
     {
       "name": "slash-command-authoring",
       "description": "Author Claude Code slash commands that read cleanly, include safety rules, and compose with OMC skills — frontmatter, argument-hint, step ordering, and dry-run patterns.",
       "category": "workflow",
-      "tags": "[claude-code, slash-command, skill, authoring, frontmatter]",
-      "triggers": "[slash command, /skills_, /init_, .claude/commands, argument-hint, command frontmatter]",
-      "source_project": "manual",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "workflow/slash-command-authoring"
+      "path": "skills/workflow/slash-command-authoring"
     },
     {
       "name": "spring-actuator-health-collector",
       "description": "Poll remote Spring Boot services via Actuator (/health + /metrics/{name}) using OkHttp with per-target timeouts and a configurable metric whitelist, publishing results to a downstream bus.",
       "category": "backend",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-health",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/spring-actuator-health-collector"
+      "path": "skills/backend/spring-actuator-health-collector"
     },
     {
       "name": "spring-applicationrunner-system-seed",
       "description": "Use ApplicationRunner to seed required system/root records on startup, guarded by an exists-check and marked with a systemFlag so they can't be deleted or moved by users.",
       "category": "backend",
-      "tags": "[spring-boot, ApplicationRunner, bootstrap, seed, system-record]",
-      "triggers": "[\"ApplicationRunner seed\", \"root default group auto create\", \"system record cannot delete\", \"startup initializer\"]",
-      "source_project": "lucida-cm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/system-data-initializer-runner"
+      "path": "skills/backend/system-data-initializer-runner"
     },
     {
       "name": "spring-bootrun-local-dev-env-block",
       "description": "Gradle `bootRun` env block that wires local Redis/Mongo/Kafka/Eureka/MQTT for zero-config `./gradlew bootRun` developer experience",
       "category": "devops",
-      "tags": "[spring-boot, gradle, bootrun, local-dev, eureka, testcontainers]",
-      "triggers": "[\"new engineer asks \\\"how do I run this locally?\\\"\", \"application-local.yaml is gitignored and no-one knows the defaults\", \"Spring Cloud service refuses to start locally because Eureka client is enabled\"]",
-      "source_project": "lucida-performance",
+      "tags": [],
+      "triggers": [
+        "new engineer asks \"how do I run this locally?\"",
+        "application-local.yaml is gitignored and no-one knows the defaults",
+        "Spring Cloud service refuses to start locally because Eureka client is enabled"
+      ],
       "version": "1.0.0",
-      "path": "devops/spring-bootrun-local-dev-env-block"
+      "path": "skills/devops/spring-bootrun-local-dev-env-block"
     },
     {
       "name": "spring-data-mongo-repository-custom-split",
       "description": "Standard 3-file split for MongoRepository — the base interface, a *Custom interface for handwritten queries, and a *Impl class that uses MongoTemplate — so complex queries live beside the CRUD without breaking derived-query inference.",
       "category": "backend",
-      "tags": "[spring-data-mongo, repository, custom-impl, MongoTemplate]",
-      "triggers": "[\"RepositoryCustom Impl split\", \"MongoTemplate complex query\", \"derived query plus aggregation\"]",
-      "source_project": "lucida-cm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/mongo-repository-custom-impl-split"
+      "path": "skills/backend/mongo-repository-custom-impl-split"
     },
     {
       "name": "spring-dual-profile-flyway",
       "description": "Spring Boot dual-profile setup — H2 file-mode for dev (zero install, console enabled), PostgreSQL for prod — with Flyway managing DDL and JPA set to validate-only. The profile split that keeps local dev fast without drifting from prod schema.",
       "category": "backend",
-      "tags": "[\"spring-boot\", \"flyway\", \"h2\", \"postgresql\", \"profiles\", \"migrations\", \"jpa\"]",
-      "triggers": "[\"spring profiles dev prod\", \"flyway migrations spring\", \"h2 file mode dev\", \"ddl-auto validate\", \"postgresql production profile\"]",
-      "source_project": "veda-chronicles",
+      "tags": [
+        "spring-boot",
+        "flyway",
+        "h2",
+        "postgresql",
+        "profiles",
+        "migrations",
+        "jpa"
+      ],
+      "triggers": [
+        "spring profiles dev prod",
+        "flyway migrations spring",
+        "h2 file mode dev",
+        "ddl-auto validate",
+        "postgresql production profile"
+      ],
       "version": "0.1.0-draft",
-      "path": "backend/spring-dual-profile-flyway"
+      "path": "skills/backend/spring-dual-profile-flyway"
     },
     {
       "name": "spring-mongo-lightweight-migration",
       "description": "Annotation-driven MongoDB migration runner for Spring Boot — `@MongoMigration` methods on `MigrationScript` beans execute in order at startup, with history in `{prefix}_migrations` collection. No Mongock dependency.",
       "category": "backend",
-      "tags": "[spring-boot, mongodb, migration, annotation-driven, idempotent]",
-      "triggers": "[\"\\\"mongo migration spring boot\\\"\", \"\\\"mongock 없이 마이그레이션\\\"\", \"\\\"annotation-based mongo migration\\\"\"]",
-      "scope": "user",
-      "source_project": "lucida-widget",
+      "tags": [],
+      "triggers": [
+        "\"mongo migration spring boot\"",
+        "\"mongock 없이 마이그레이션\"",
+        "\"annotation-based mongo migration\""
+      ],
       "version": "1.0.0",
-      "path": "backend/spring-mongo-lightweight-migration"
+      "path": "skills/backend/spring-mongo-lightweight-migration"
     },
     {
       "name": "spring-profile-datasource-activation",
       "description": "Select DB/Hibernate/logging config at JVM startup via `spring.profiles.active` so one build ships to dev, test, and prod without branching in code",
       "category": "backend",
-      "tags": "[spring, profile, datasource, config.properties, jetty, tapestry]",
-      "triggers": "[\"same WAR goes to multiple environments\", \"Spring profile chooses datasource and credentials\"]",
-      "source_project": "cygnus",
+      "tags": [],
+      "triggers": [
+        "same WAR goes to multiple environments",
+        "Spring profile chooses datasource and credentials"
+      ],
       "version": "1.0.0",
-      "path": "backend/spring-profile-datasource-activation"
+      "path": "skills/backend/spring-profile-datasource-activation"
     },
     {
       "name": "spring-testcontainers-multitenant-base",
       "description": "Base test class that boots Testcontainers (Mongo + Kafka), pre-sets tenant/auth context, and forces JVM halt in AfterAll to avoid leaked containers.",
       "category": "testing",
-      "tags": "[spring-boot, testcontainers, junit5, multi-tenant, tenant-context, mockitobean]",
-      "triggers": "[\"testcontainers\", \"base test\", \"tenant context test\", \"spring integration test\"]",
-      "source_project": "lucida-meta",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "testing/spring-testcontainers-multitenant-base"
+      "path": "skills/testing/spring-testcontainers-multitenant-base"
     },
     {
       "name": "spring-typed-config-properties",
       "description": "Type-safe, nested `@ConfigurationProperties` pattern for Spring Boot — centralizes tunable constants (rate limits, formula coefficients, balance numbers) in YAML with a single injected POJO tree. Beats scattered `@Value` strings.",
       "category": "backend",
-      "tags": "[\"spring-boot\", \"configuration-properties\", \"yaml\", \"typed-config\", \"constructor-binding\"]",
-      "triggers": "[\"ConfigurationProperties nested\", \"centralize tunable constants\", \"spring typed config\", \"balance config\", \"constructor binding yaml\"]",
-      "source_project": "veda-chronicles",
+      "tags": [
+        "spring-boot",
+        "configuration-properties",
+        "yaml",
+        "typed-config",
+        "constructor-binding"
+      ],
+      "triggers": [
+        "ConfigurationProperties nested",
+        "centralize tunable constants",
+        "spring typed config",
+        "balance config",
+        "constructor binding yaml"
+      ],
       "version": "0.1.0-draft",
-      "path": "backend/spring-typed-config-properties"
+      "path": "skills/backend/spring-typed-config-properties"
     },
     {
       "name": "springdoc-yaml-externalization",
       "description": "Move long `@Operation description` and `@RequestBody examples` text out of Spring controllers into per-controller YAML files under `resources/api-docs/`, injected at runtime via a single `OperationCustomizer` bean. Swagger UI output unchanged.",
       "category": "backend",
-      "tags": "[spring-boot, springdoc, openapi, swagger, yaml, refactor]",
-      "triggers": "[\"\\\"swagger externalize annotations\\\"\", \"\\\"move swagger description to yaml\\\"\", \"\\\"OperationCustomizer\\\"\"]",
-      "scope": "user",
-      "source_project": "lucida-widget",
+      "tags": [],
+      "triggers": [
+        "\"swagger externalize annotations\"",
+        "\"move swagger description to yaml\"",
+        "\"OperationCustomizer\""
+      ],
       "version": "1.0.0",
-      "path": "backend/springdoc-yaml-externalization"
+      "path": "skills/backend/springdoc-yaml-externalization"
     },
     {
       "name": "stable-horde-async-poll",
       "description": "Submit-then-poll integration pattern for Stable Horde image generation — anonymous apikey, model fallback list, negative-prompt separator, bounded poll loop.",
       "category": "ai",
-      "tags": "[stable-horde, image-generation, stable-diffusion, async, polling, anonymous-api]",
-      "triggers": "[\"stablehorde.net\", \"generate/async\", \"generate/status\", \"apikey 0000000000\", \"image generation\", \"Stable Horde\", \"horde\"]",
-      "source_project": "webtoon_ai_project_with_wrapper",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "ai/stable-horde-async-poll"
+      "path": "skills/ai/stable-horde-async-poll"
     },
     {
       "name": "stack-parse-tag-filter-to-mongo-criteria",
       "description": "Parse a tokenized boolean filter expression (key=value, AND, OR, parens) into a MongoDB Criteria tree using a shunting-yard/stack algorithm, with elemMatch for array-of-tag subdocs.",
       "category": "backend",
-      "tags": "[mongodb, criteria, shunting-yard, parser, elemMatch, smart-group]",
-      "triggers": "[\"tag filter expression\", \"smart group criteria\", \"AND OR parens token\", \"elemMatch tag key value\"]",
-      "source_project": "lucida-cm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/stack-tag-filter-to-mongo-criteria"
+      "path": "skills/backend/stack-tag-filter-to-mongo-criteria"
     },
     {
       "name": "stale-persistent-context-detection",
       "description": "Detect and remove stale error snapshots that LLM tools inject via persistent-context files (CLAUDE.md, AGENTS.md, system prompts, memory) before chasing a fix. If the current source already compiles, the injected error is a ghost from a previous session, not a real bug.",
       "category": "workflow",
-      "tags": "[llm, context, claude-code, cursor, agents-md, memory, stale, debugging, hygiene]",
-      "triggers": "[CLAUDE.md, AGENTS.md, persistent context, stale error, system-reminder, injected error, claudeMd context, system prompt, agent instructions, injected context]",
-      "source_project": "skills-hub-setup-session",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "workflow/stale-persistent-context-detection"
+      "path": "skills/workflow/stale-persistent-context-detection"
     },
     {
       "name": "stateless-turn-combat-engine",
       "description": "Turn-based combat as a pure function — `(state, action) → newState + events`. Speed-based turn order, deterministic damage, no hidden mutation. Makes combat unit-testable, replayable, and server-authoritative.",
       "category": "game-dev",
-      "tags": "[\"combat-engine\", \"turn-based\", \"rpg\", \"pure-function\", \"deterministic\", \"server-authoritative\"]",
-      "triggers": "[\"turn based combat\", \"combat engine design\", \"speed based turn order\", \"server authoritative combat\", \"stateless combat\"]",
-      "source_project": "veda-chronicles",
+      "tags": [
+        "combat-engine",
+        "turn-based",
+        "rpg",
+        "pure-function",
+        "deterministic",
+        "server-authoritative"
+      ],
+      "triggers": [
+        "turn based combat",
+        "combat engine design",
+        "speed based turn order",
+        "server authoritative combat",
+        "stateless combat"
+      ],
       "version": "0.1.0-draft",
-      "path": "game-dev/stateless-turn-combat-engine"
+      "path": "skills/game-dev/stateless-turn-combat-engine"
     },
     {
       "name": "status-effect-enum-system",
       "description": "Model status effects (burn, stun, buff, debuff) as enum-tagged records attached to units, with per-turn tick logic split between application, duration decay, and removal. Keeps damage-over-time and crowd control uniform and testable.",
       "category": "game-dev",
-      "tags": "[\"status-effect\", \"buff-debuff\", \"dot\", \"cc\", \"enum\", \"turn-based\"]",
-      "triggers": "[\"status effect system\", \"buff debuff\", \"damage over time\", \"burn stun freeze\", \"crowd control turn based\"]",
-      "source_project": "veda-chronicles",
+      "tags": [
+        "status-effect",
+        "buff-debuff",
+        "dot",
+        "cc",
+        "enum",
+        "turn-based"
+      ],
+      "triggers": [
+        "status effect system",
+        "buff debuff",
+        "damage over time",
+        "burn stun freeze",
+        "crowd control turn based"
+      ],
       "version": "0.1.0-draft",
-      "path": "game-dev/status-effect-enum-system"
+      "path": "skills/game-dev/status-effect-enum-system"
     },
     {
       "name": "stomp-cookie-auth-handshake",
       "description": "Authenticate STOMP WebSocket upgrade using an HttpOnly cookie extracted during the handshake, then bind identity to the STOMP session",
       "category": "backend",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-realtime",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/stomp-cookie-auth-handshake"
+      "path": "skills/backend/stomp-cookie-auth-handshake"
     },
     {
       "name": "stomp-principal-jwt-channel",
       "description": "STOMP ChannelInterceptor that validates a JWT on CONNECT and binds a multi-tenant Principal (orgId + userId + sessionId) for downstream routing",
       "category": "backend",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-realtime",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/stomp-principal-jwt-channel"
+      "path": "skills/backend/stomp-principal-jwt-channel"
     },
     {
       "name": "strategy-spi-list-to-map-autoinject",
       "description": "Spring이 자동 주입하는 List<T>를 생성자에서 Map<Key,T>로 변환해 Strategy를 enum 키로 O(1) 디스패치하는 패턴",
       "category": "backend",
-      "tags": "",
-      "triggers": "Many enum-keyed job types / event types with one implementation each — replace switch/if chains",
-      "source_project": "lucida-domain-automation",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/strategy-spi-list-to-map-autoinject"
+      "path": "skills/backend/strategy-spi-list-to-map-autoinject"
     },
     {
       "name": "swagger-ai-optimization",
       "description": "Spring Boot + springdoc 프로젝트의 Swagger/OpenAPI 스펙을 AI Agent용으로 최적화 (operationId, @Schema, @ApiResponse, x-filterable-fields 전수 적용)",
       "category": "workflow",
-      "tags": "",
-      "triggers": "[\"swagger ai 최적화\", \"openapi ai optimization\", \"MCP 연동 준비\", \"swagger operationId 전수 부여\", \"AI 이해도 테스트\"]",
-      "scope": "user",
-      "source_project": "",
-      "version": "1.1.0",
-      "path": "workflow/swagger-ai-optimization"
+      "tags": [],
+      "triggers": [
+        "swagger ai 최적화",
+        "openapi ai optimization",
+        "MCP 연동 준비",
+        "swagger operationId 전수 부여",
+        "AI 이해도 테스트"
+      ],
+      "version": "1.0.0",
+      "path": "skills/workflow/swagger-ai-optimization"
     },
     {
       "name": "swagger-spec-baseline-from-git",
       "description": "Re-run spec-based optimization workflow on a clean branch without running the Spring Boot app — restore prior baseline artifacts (swagger-before.json + scripts) via `git show <sha>:<path>` from the commit on another branch that already captured them.",
       "category": "workflow",
-      "tags": "[swagger, openapi, git, baseline, spring-boot]",
-      "triggers": "[\"\\\"swagger 전체 재실행\\\"\", \"\\\"rerun swagger optimization\\\"\", \"\\\"baseline 없이 시작\\\"\"]",
-      "scope": "user",
-      "source_project": "",
+      "tags": [],
+      "triggers": [
+        "\"swagger 전체 재실행\"",
+        "\"rerun swagger optimization\"",
+        "\"baseline 없이 시작\""
+      ],
       "version": "1.0.0",
-      "path": "workflow/swagger-spec-baseline-from-git"
+      "path": "skills/workflow/swagger-spec-baseline-from-git"
     },
     {
       "name": "tdd",
       "description": "Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions \"red-green-refactor\", wants integration tests, or asks for test-first development.",
       "category": "testing",
-      "tags": "[tdd, red-green-refactor]",
-      "triggers": "",
-      "source_project": "mattpocock-skills",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "testing/tdd"
+      "path": "skills/testing/tdd"
     },
     {
       "name": "tenant-context-holder-propagation",
       "description": "Set TenantContextHolder.INSTANCE.setTenantId(orgId) on the current thread so MongoDB tenant-isolated templates route queries correctly, always clearing in a finally block",
       "category": "arch",
-      "tags": "[spring, multi-tenant, threadlocal, mongodb, isolation]",
-      "triggers": "[\"TenantContextHolder\", \"tenant context propagation\", \"multi-tenant thread local\", \"MONGODB_TEMPLATE_ISOLATION\", \"tenant isolation mongodb\"]",
-      "scope": "user",
-      "source_project": "lucida-domain-sms",
+      "tags": [],
+      "triggers": [
+        "TenantContextHolder",
+        "tenant context propagation",
+        "multi-tenant thread local",
+        "MONGODB_TEMPLATE_ISOLATION",
+        "tenant isolation mongodb"
+      ],
       "version": "0.1.0-draft",
-      "path": "arch/tenant-context-holder-propagation"
+      "path": "skills/arch/tenant-context-holder-propagation"
     },
     {
       "name": "tenant-context-try-finally-on-worker",
       "description": "Kafka/Queue Worker에서 멀티테넌트 ThreadLocal 컨텍스트를 try-finally로 안전하게 세팅/정리하는 패턴",
       "category": "backend",
-      "tags": "",
-      "triggers": "@KafkaListener or ThreadPool worker touching ThreadLocal TenantContext — pool reuse leaks",
-      "source_project": "lucida-domain-automation",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/tenant-context-try-finally-on-worker"
+      "path": "skills/backend/tenant-context-try-finally-on-worker"
     },
     {
       "name": "tenant-db-initialization-on-startup",
       "description": "On leader startup, fetch tenant/org list from metadata service and provision per-tenant MongoDB databases — idempotent, leader-only",
       "category": "backend",
-      "tags": "",
-      "triggers": "Multi-tenant service that creates one MongoDB database (or schema) per organization and must ensure all tenants are bootstrapped before serving traffic",
-      "source_project": "lucida-audit",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/tenant-db-initialization-on-startup"
+      "path": "skills/backend/tenant-db-initialization-on-startup"
     },
     {
       "name": "tenant-isolated-mongo-collection",
       "description": "Route each tenant to its own MongoDB collection (or collection-name suffix) via a custom annotation resolved at repository/template layer, so application code stays tenant-agnostic.",
       "category": "backend",
-      "tags": "[multi-tenant, mongodb, isolation, annotation, organizationId]",
-      "triggers": "[\"MongoDBIsolationCollection\", \"tenant collection routing\", \"organizationId per-method\", \"logical isolation mongo\"]",
-      "source_project": "lucida-cm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/tenant-isolated-mongo-collection"
+      "path": "skills/backend/tenant-isolated-mongo-collection"
     },
     {
       "name": "tenant-per-database-mongo-routing",
       "description": "Route Spring Data Mongo operations to per-tenant databases via a ThreadLocal tenant holder and two MongoTemplate beans (isolated vs shared collections).",
       "category": "backend",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-health",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/tenant-per-database-mongo-routing"
+      "path": "skills/backend/tenant-per-database-mongo-routing"
     },
     {
       "name": "testcontainers-mongo-kafka-abstract-base",
       "description": "Abstract test base classes that spin up MongoDB + Kafka via Testcontainers with static start() and reuse=true, exposing mapped ports via System.setProperty",
       "category": "backend",
-      "tags": "",
-      "triggers": "[\"Spring Boot integration tests that need real Kafka + MongoDB (no mocks), running locally and in CI without per-test container churn\"]",
-      "source_project": "lucida-notification",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/testcontainers-mongo-kafka-abstract-base"
+      "path": "skills/backend/testcontainers-mongo-kafka-abstract-base"
     },
     {
       "name": "testcontainers-reuse-disabled",
       "description": "Set TESTCONTAINERS_REUSE_ENABLE=false on the Gradle test task so CI and shared dev machines never inherit stale container state across suites",
       "category": "backend",
-      "tags": "[testcontainers, gradle, flaky-tests, ci]",
-      "triggers": "CI or shared dev box has Testcontainers runs leaking state between suites",
-      "source_project": "lucida-account",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/testcontainers-reuse-disabled"
+      "path": "skills/backend/testcontainers-reuse-disabled"
     },
     {
       "name": "thread-pool-config-tenant-aware",
       "description": "Property-driven ThreadPoolTaskExecutor + Scheduler config that extends TenantAsyncConfigurerSupport so @Async tasks inherit tenant context",
       "category": "backend",
-      "tags": "",
-      "triggers": "Multi-tenant Spring Boot service where @Async tasks must preserve tenant/org context across thread boundaries",
-      "source_project": "lucida-audit",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/thread-pool-config-tenant-aware"
+      "path": "skills/backend/thread-pool-config-tenant-aware"
     },
     {
       "name": "thread-pool-queue-backpressure",
       "description": "Bounded in-memory queue between Kafka consumer and async thread pool, with hysteretic pause/resume thresholds driving Spring Kafka container pause()/resume() so bursts do not OOM the JVM.",
       "category": "backend",
-      "tags": "[kafka, backpressure, blocking-queue, thread-pool, hysteresis, pause-resume]",
-      "triggers": "[\"pause-threshold\", \"resume-threshold\", \"BlockingQueue\", \"KafkaListenerEndpointRegistry.pause\", \"backpressure\"]",
-      "source_project": "lucida-alarm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/thread-pool-queue-backpressure"
+      "path": "skills/backend/thread-pool-queue-backpressure"
     },
     {
       "name": "tiered-rebalance-schedule",
       "description": "Run three cadences against the same managed set — fast performance review, mid-frequency policy re-analysis, slow portfolio rebalance — each with its own trigger interval and mutation budget, so urgency scales with cost.",
       "category": "arch",
-      "tags": "[scheduler, rebalance, tiers, cadence, cron, portfolio, lifecycle]",
-      "triggers": "[\"scheduleWithFixedDelay\", \"periodic review\", \"rebalance\", \"reanalysis interval\", \"tiered schedule\", \"performance review\", \"portfolio rebalance\"]",
-      "source_project": "kis-java-bundle",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "arch/tiered-rebalance-schedule"
+      "path": "skills/arch/tiered-rebalance-schedule"
     },
     {
       "name": "transaction-trace-pack-serialization-with-step-hierarchy",
       "description": "Encode per-request distributed traces as a hierarchical list of typed steps (method, DB, external call, error) in a compressed binary pack, indexed by request end-time",
       "category": "apm",
-      "tags": "[tracing, apm, xlog, serialization, perf]",
-      "triggers": "",
-      "source_project": "scouter",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "apm/transaction-trace-pack-serialization-with-step-hierarchy"
+      "path": "skills/apm/transaction-trace-pack-serialization-with-step-hierarchy"
     },
     {
       "name": "triage-issue",
       "description": "Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. Use when user reports a bug, wants to file an issue, mentions \"triage\", or wants to investigate and plan a fix for a problem.",
       "category": "debug",
-      "tags": "[bug, triage, root-cause, investigation]",
-      "triggers": "",
-      "source_project": "mattpocock-skills",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "debug/triage-issue"
+      "path": "skills/debug/triage-issue"
     },
     {
       "name": "triple-env-file-split-loader",
       "description": "Split operator-facing env into three files (.env / .version / .memory) and load them in a fixed order",
       "category": "devops",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-for-docker",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "devops/triple-env-file-split-loader"
+      "path": "skills/devops/triple-env-file-split-loader"
     },
     {
       "name": "ts-type-prefix-convention",
       "description": "Prefix interfaces with I and type aliases with T; use type for unions/literals and interface for inheritable shapes",
       "category": "frontend",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-builder-r3",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "frontend/ts-type-prefix-convention"
+      "path": "skills/frontend/ts-type-prefix-convention"
     },
     {
       "name": "tsv-driven-permission-bootstrap",
       "description": "Treat a version-controlled TSV file as source of truth for the Function/Permission/Menu catalog; the service reconciles the DB against it on startup",
       "category": "backend",
-      "tags": "[authorization, permissions, bootstrap, tsv, reconciliation]",
-      "triggers": "Permission/menu/function catalog needs to be version-controlled and diff-reviewable instead of DB rows",
-      "source_project": "lucida-account",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/tsv-driven-permission-bootstrap"
+      "path": "skills/backend/tsv-driven-permission-bootstrap"
     },
     {
       "name": "ubiquitous-language",
       "description": "Extract a DDD-style ubiquitous language glossary from the current conversation, flagging ambiguities and proposing canonical terms. Saves to UBIQUITOUS_LANGUAGE.md. Use when user wants to define domain terms, build a glossary, harden terminology, create a ubiquitous language, or mentions \"domain model\" or \"DDD\".",
       "category": "docs",
-      "tags": "[ddd, glossary, language, domain]",
-      "triggers": "",
-      "source_project": "mattpocock-skills",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "docs/ubiquitous-language"
+      "path": "skills/docs/ubiquitous-language"
     },
     {
       "name": "udp-with-tcp-fallback-metrics-transport",
       "description": "Transport telemetry via UDP for low-latency fire-and-forget streams, and fall back to TCP for critical request/response and bulk uploads that require delivery guarantees",
       "category": "backend",
-      "tags": "[network, udp, tcp, apm, telemetry]",
-      "triggers": "",
-      "source_project": "scouter",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/udp-with-tcp-fallback-metrics-transport"
+      "path": "skills/backend/udp-with-tcp-fallback-metrics-transport"
     },
     {
       "name": "version-specific-sql-map-selection",
       "description": "Select MyBatis-style SQL maps at runtime by DBMS + version with graceful fallback to a default supported version",
       "category": "backend",
-      "tags": "",
-      "triggers": "multi-version RDBMS query routing, versioned SQL XML maps, per-DBMS query dispatch",
-      "source_project": "lucida-domain-dpm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/version-specific-sql-map-selection"
+      "path": "skills/backend/version-specific-sql-map-selection"
     },
     {
       "name": "vllm-nginx-tls-single-port-routing",
       "description": "Serve multiple vLLM OpenAI-API backends behind one Nginx TLS proxy on 443 using path-based routing",
       "category": "ai",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-for-docker",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "ai/vllm-nginx-tls-single-port-routing"
+      "path": "skills/ai/vllm-nginx-tls-single-port-routing"
     },
     {
       "name": "websocket-stomp-channel-pool-config",
       "description": "Spring WebSocket STOMP config with separate inbound/outbound task executors and raised transport buffer limits, sized for burst notification fan-out to many role-filtered subscribers.",
       "category": "backend",
-      "tags": "[websocket, stomp, spring, channel-pool, fan-out, real-time]",
-      "triggers": "[\"configureClientInboundChannel\", \"configureClientOutboundChannel\", \"StompChannelInterceptor\", \"sendBufferSizeLimit\", \"messageSizeLimit\"]",
-      "source_project": "lucida-alarm",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/websocket-stomp-channel-pool-config"
+      "path": "skills/backend/websocket-stomp-channel-pool-config"
+    },
+    {
+      "name": "widget-card-composition",
+      "description": "Dashboard widget composition pattern using a CardWidget chrome wrapper with domain-specific Card* content components, resize tracking, and popover menus",
+      "category": "design",
+      "tags": [],
+      "triggers": [],
+      "version": "1.0.0",
+      "path": "skills/design/widget-card-composition"
     },
     {
       "name": "widget-confid-injection-sweep",
       "description": "리소스 상세 대시보드에서 모든 위젯 데이터 요청에 `confId` 를 일관되게 주입하기 위한 위젯 fetch 지점 전수 스윕(sweep) 패턴 — 일부만 주입하면 같은 대시보드 안에서 위젯별 필터 동작이 갈라지는 버그를 방지한다.",
       "category": "frontend",
-      "tags": "[widget, dashboard, resource-detail, data-fetch, scope-injection]",
-      "triggers": "[\"confId 주입\", \"selectCondition confId\", \"위젯 필터링\", \"widget scope injection\", \"resource-scoped widget\"]",
-      "source_project": "lucida-domain-sms",
+      "tags": [],
+      "triggers": [
+        "confId 주입",
+        "selectCondition confId",
+        "위젯 필터링",
+        "widget scope injection",
+        "resource-scoped widget"
+      ],
       "version": "1.0.0",
-      "path": "frontend/widget-confid-injection-sweep"
+      "path": "skills/frontend/widget-confid-injection-sweep"
     },
     {
       "name": "widget-grid-type-registration-checklist",
       "description": "대시보드의 TableGrid/차트 위젯에 새로운 타입을 추가할 때 드리프트 없이 5곳(columns 매핑, fetch hook, 에디터 폼, detectType, 모델 DTO) 모두 반영하게 하는 체크리스트 스킬.",
       "category": "frontend",
-      "tags": "[widget, dashboard, registry, grid, checklist]",
-      "triggers": "[\"TableGridType\", \"위젯 타입 추가\", \"tableGridType\", \"widget type registration\", \"detectType\", \"columns mapping\"]",
-      "source_project": "lucida-domain-sms",
+      "tags": [],
+      "triggers": [
+        "TableGridType",
+        "위젯 타입 추가",
+        "tableGridType",
+        "widget type registration",
+        "detectType",
+        "columns mapping"
+      ],
       "version": "1.0.0",
-      "path": "frontend/widget-grid-type-registration-checklist"
+      "path": "skills/frontend/widget-grid-type-registration-checklist"
     },
     {
       "name": "write-a-prd",
       "description": "Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. Use when user wants to write a PRD, create a product requirements document, or plan a new feature.",
       "category": "workflow",
-      "tags": "[prd, requirements, interview, planning]",
-      "triggers": "",
-      "source_project": "mattpocock-skills",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "workflow/write-a-prd"
+      "path": "skills/workflow/write-a-prd"
     },
     {
       "name": "write-a-skill",
       "description": "Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, or build a new skill.",
       "category": "misc",
-      "tags": "[skills, meta, authoring, progressive-disclosure]",
-      "triggers": "",
-      "source_project": "mattpocock-skills",
+      "tags": [],
+      "triggers": [],
       "version": "0.1.0-draft",
-      "path": "misc/write-a-skill"
+      "path": "skills/misc/write-a-skill"
     },
     {
       "name": "x-filterable-fields-extraction",
       "description": "OpenAPI 스펙에 x-filterable-fields 확장을 자동 생성하는 파이프라인. lucida-ui gridColumnDefs + lucida-meta i18n properties를 조합하여 필드명/한국어 title/operators를 추출",
       "category": "workflow",
-      "tags": "",
-      "triggers": "[\"x-filterable-fields\", \"필터 가능 필드 추출\", \"gridFilters 메타데이터\", \"tagFilters 메타데이터\", \"리소스 키 추출\", \"GridFilter 정확도 개선\"]",
-      "scope": "user",
-      "source_project": "",
+      "tags": [],
+      "triggers": [
+        "x-filterable-fields",
+        "필터 가능 필드 추출",
+        "gridFilters 메타데이터",
+        "tagFilters 메타데이터",
+        "리소스 키 추출",
+        "GridFilter 정확도 개선"
+      ],
       "version": "1.0.0",
-      "path": "workflow/x-filterable-fields-extraction"
+      "path": "skills/workflow/x-filterable-fields-extraction"
     },
     {
       "name": "yorkie-crdt-sync-pattern",
       "description": "Apply a single doc.update callback for local mutations and pullRemoteChangesIntoLocal(WithNodeIds) for remote→local sync in Yorkie-backed apps",
       "category": "backend",
-      "tags": "",
-      "triggers": "",
-      "source_project": "lucida-builder-r3",
+      "tags": [],
+      "triggers": [],
       "version": "1.0.0",
-      "path": "backend/yorkie-crdt-sync-pattern"
+      "path": "skills/backend/yorkie-crdt-sync-pattern"
     },
     {
       "name": "zustand-preset-manager",
       "description": "Zustand + persist middleware pattern for managing N named presets (team comps, saved filters, dashboard layouts) with active-selection, max-count guard, and auto-reselect on delete.",
       "category": "frontend",
-      "tags": "[\"zustand\", \"localstorage\", \"preset\", \"state-management\", \"persist-middleware\"]",
-      "triggers": "[\"zustand persist\", \"saved presets\", \"team presets\", \"named configurations\", \"localStorage preset\", \"multi-preset selector\"]",
-      "source_project": "veda-chronicles",
+      "tags": [
+        "zustand",
+        "localstorage",
+        "preset",
+        "state-management",
+        "persist-middleware"
+      ],
+      "triggers": [
+        "zustand persist",
+        "saved presets",
+        "team presets",
+        "named configurations",
+        "localStorage preset",
+        "multi-preset selector"
+      ],
       "version": "0.1.0-draft",
-      "path": "frontend/zustand-preset-manager"
+      "path": "skills/frontend/zustand-preset-manager"
     }
   ],
   "knowledge": [
+    {
+      "slug": "account-lockout-configurable-threshold",
+      "category": "domain",
+      "summary": "Failed-login counter locks the account after a configurable threshold (ACCOUNT_LOCKOUT, default 10).",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/domain/account-lockout-configurable-threshold.md"
+    },
+    {
+      "slug": "actuator-endpoints-skip-auth-by-design",
+      "category": "decision",
+      "summary": "In a monitoring collector, target-level BASIC/BEARER auth is stored but intentionally NOT applied when calling /actuator/health and /actuator/metrics.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/actuator-endpoints-skip-auth-by-design.md"
+    },
+    {
+      "slug": "actuator-metric-call-aggressive-timeout",
+      "category": "pitfall",
+      "summary": "Use aggressive HTTP timeouts (100ms–1s) for /actuator/health and /actuator/metrics polling, but keep long timeouts for /actuator/threaddump and /actuator/heapdump — mixing them stalls the collector.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/pitfall/actuator-metric-call-aggressive-timeout.md"
+    },
     {
       "slug": "actuator-path-dual-compatibility",
       "category": "api",
       "summary": "Actuator endpoints must respond at both /actuator/** and /actuator/{appName}/** for deployment compatibility.",
       "confidence": "medium",
       "source_project": "",
-      "path": "api/actuator-path-dual-compatibility",
-      "linked_skills": []
-    },
-    {
-      "slug": "Claude Code Routines: scheduled/API/GitHub-triggered cloud sessions",
-      "category": "api",
-      "summary": "Routines are saved cloud Claude Code sessions (prompt+repos+connectors+environment) triggered by schedule, HTTP POST to /fire, or GitHub events. One routine can combine all three; daily run cap; pushes restricted to claude/* by default.",
-      "confidence": "high",
-      "source_project": "skills_research:trend:2026-04-16",
-      "path": "api/claude-code-routines-cloud-automation-model",
-      "linked_skills": []
-    },
-    {
-      "slug": "confid-vs-resourceid-routing",
-      "category": "api",
-      "summary": "Queries support both `configIds` (tenant/policy scope) and `resourceId` (agent scope); filter routes to different Mongo match fields",
-      "confidence": "medium",
-      "source_project": "lucida-measurement",
-      "path": "api/confid-vs-resourceid-routing",
-      "linked_skills": []
-    },
-    {
-      "slug": "es-xpack-transport-vs-rest-ssl",
-      "category": "api",
-      "summary": "Elasticsearch transport SSL and REST SSL are independent X-Pack configs; enabling one does not enable the other",
-      "confidence": "high",
-      "source_project": "",
-      "path": "api/es-xpack-transport-vs-rest-ssl",
-      "linked_skills": []
-    },
-    {
-      "slug": "kafka-avro-change-flag-contract",
-      "category": "api",
-      "summary": "Every Configuration-domain Avro event carries an `actionType` enum (INSERT/UPDATE/DELETE) plus boolean change flags per mutable section (e.g. `parentChanged`, `tagFiltersChanged`, `configurationsChanged`) rather than full before/after payloads.",
-      "confidence": "high",
-      "source_project": "",
-      "path": "api/kafka-avro-change-flag-contract",
-      "linked_skills": []
-    },
-    {
-      "slug": "kafka-organization-id-record-header",
-      "category": "api",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "api/kafka-organization-id-record-header",
-      "linked_skills": []
-    },
-    {
-      "slug": "live-chart-timestamp-normalization",
-      "category": "api",
-      "summary": "LIVE charts accept `normalizeTimestamp` + `normalizeIntervalMs` to align per-agent millisecond offsets into a single x-axis",
-      "confidence": "medium",
-      "source_project": "lucida-measurement",
-      "path": "api/live-chart-timestamp-normalization",
-      "linked_skills": []
-    },
-    {
-      "slug": "stomp-heartbeat-10s-bidirectional",
-      "category": "api",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "api/stomp-heartbeat-10s-bidirectional",
-      "linked_skills": []
-    },
-    {
-      "slug": "timeselector-mode-interval-range-mapping",
-      "category": "api",
-      "summary": "Clients send a `mode` enum (RAW..YEAR); the server maps it to a (bin-interval, query-range) pair and picks the right pre-aggregated collection",
-      "confidence": "high",
-      "source_project": "",
-      "path": "api/timeselector-mode-interval-range-mapping",
-      "linked_skills": []
-    },
-    {
-      "slug": "xlog-extended-transaction-trace-with-compression",
-      "category": "api",
-      "summary": "XLog is scouter's per-request transaction trace format — hierarchical typed steps stored as compressed binary, indexed by end-time, with flat metadata for server-side filtering",
-      "confidence": "high",
-      "source_project": "scouter",
-      "path": "api/xlog-extended-transaction-trace-with-compression",
-      "linked_skills": []
+      "path": "knowledge/api/actuator-path-dual-compatibility.md"
     },
     {
       "slug": "additive-registry-schema-versioning",
       "category": "arch",
-      "summary": "JSON registry 진화는 version bump + 새 키 empty container + 첫 쓰기 시 자동 마이그레이션으로 하라",
+      "summary": "\"JSON registry 진화는 version bump + 새 키 empty container + 첫 쓰기 시 자동 마이그레이션으로 하라\"",
       "confidence": "high",
       "source_project": "",
-      "path": "arch/additive-registry-schema-versioning",
-      "linked_skills": []
-    },
-    {
-      "slug": "Agent memory: binding, not recall, is the real bottleneck",
-      "category": "arch",
-      "summary": "A 500-run OrKa benchmark showed 0/250 stored skills were used even though retrieval worked. Fix is a bundle (skill record + episode record + bidirectional link) returned together on recall.",
-      "confidence": "medium",
-      "source_project": "skills_research:trend:2026-04-16",
-      "path": "arch/agent-memory-binding-vs-recall",
-      "linked_skills": []
-    },
-    {
-      "slug": "Annotation-driven coarse-grained authorization via @FunctionId",
-      "category": "arch",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "arch/annotation-driven-authz-via-function-id",
-      "linked_skills": []
-    },
-    {
-      "slug": "Archon: deterministic AI coding via YAML workflow DAGs",
-      "category": "arch",
-      "summary": "Workflows as YAML DAGs in the repo; deterministic nodes (tests/git) bracket AI-driven nodes; each run isolated in its own git worktree. Pattern generalizes beyond Archon.",
-      "confidence": "medium",
-      "source_project": "skills_research:trend:2026-04-16",
-      "path": "arch/archon-deterministic-ai-coding-harness",
-      "linked_skills": []
-    },
-    {
-      "slug": "assumeutxo-snapshot-chainstate-phases",
-      "category": "arch",
-      "summary": "(Blockchain-specific) Multi-chainstate snapshot validation — active chainstate syncs from a trusted-but-unverified UTXO snapshot while a background chainstate validates the snapshot's base, with a phased state machine for clean cutover.",
-      "confidence": "high",
-      "source_project": "bitcoin",
-      "path": "arch/assumeutxo-snapshot-chainstate-phases",
-      "linked_skills": []
-    },
-    {
-      "slug": "bilingual-user-facing-strings",
-      "category": "arch",
-      "summary": "A bilingual_str struct carrying both original and translated forms lets GUI show translated text while logs/stderr keep the original — no locale branching in business code.",
-      "confidence": "high",
-      "source_project": "bitcoin",
-      "path": "arch/bilingual-user-facing-strings",
-      "linked_skills": []
-    },
-    {
-      "slug": "boilerplate-generated-business-logic-manual",
-      "category": "arch",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "arch/boilerplate-generated-business-logic-manual",
-      "linked_skills": []
-    },
-    {
-      "slug": "claude-plugin-skill-md-is-sufficient",
-      "category": "arch",
-      "summary": "스킬 = SKILL.md 하나. 코드, 빌드, 의존성, 스크립트 없이도 완전히 동작한다.",
-      "confidence": "high",
-      "source_project": "",
-      "path": "arch/claude-plugin-skill-md-is-sufficient",
-      "linked_skills": []
-    },
-    {
-      "slug": "commons-logging-exclusion-strategy",
-      "category": "arch",
-      "summary": "Globally exclude commons-logging, log4j, and slf4j-log4j12 in Gradle so SLF4J+Logback is the only logging backend on the classpath",
-      "confidence": "high",
-      "source_project": "lucida-audit",
-      "path": "arch/commons-logging-exclusion-strategy",
-      "linked_skills": []
-    },
-    {
-      "slug": "data-patch-package-for-migrations",
-      "category": "arch",
-      "summary": "One-off data patches (backfills, embedded→referenced splits, field additions) are grouped under a `patch` package so they're isolated from day-to-day service code and easy to audit/remove after a release.",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/data-patch-package-for-migrations",
-      "linked_skills": []
-    },
-    {
-      "slug": "domain-registry-plus-projects-yaml",
-      "category": "arch",
-      "summary": "",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/domain-registry-plus-projects-yaml",
-      "linked_skills": []
-    },
-    {
-      "slug": "dual-redis-lock-vs-access-control",
-      "category": "arch",
-      "summary": "The service connects to two separate Redis instances: Lock Control (default port 6399) and Access Control (default port 6389). They are not interchangeable.",
-      "confidence": "high",
-      "source_project": "",
-      "path": "arch/dual-redis-lock-vs-access-control",
-      "linked_skills": []
-    },
-    {
-      "slug": "DuckDB's five architectural pillars for analytical execution",
-      "category": "arch",
-      "summary": "Vectorized execution, pipelined operators, explicit memory + grouped aggregation, ART indexing, and query rewriting as a dedicated phase — the pillars that separate embedded analytical engines from row-at-a-time OLTP.",
-      "confidence": "medium",
-      "source_project": "skills_research:trend:2026-04-16",
-      "path": "arch/duckdb-vectorized-analytical-execution",
-      "linked_skills": []
-    },
-    {
-      "slug": "env-override-last-wins-chain",
-      "category": "arch",
-      "summary": "Environment variables resolve across four sources with \"last wins\" precedence.",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/env-override-last-wins-chain",
-      "linked_skills": []
-    },
-    {
-      "slug": "event-driven-init-wait-for-services",
-      "category": "arch",
-      "summary": "Initialization work is deferred until leader status and dependent-service readiness are confirmed via a `@WaitForServices` event listener",
-      "confidence": "high",
-      "source_project": "",
-      "path": "arch/event-driven-init-wait-for-services",
-      "linked_skills": []
-    },
-    {
-      "slug": "gradle-avro-plugin-config",
-      "category": "arch",
-      "summary": "davidmc24 avro-gradle-plugin config — createSetters=false + fieldVisibility=PRIVATE enforces immutable generated event schemas",
-      "confidence": "medium",
-      "source_project": "lucida-audit",
-      "path": "arch/gradle-avro-plugin-config",
-      "linked_skills": []
-    },
-    {
-      "slug": "hierarchical-agents-md-catalog",
-      "category": "arch",
-      "summary": "루트 AGENTS.md(프로젝트 개요) + `skills/AGENTS.md`(스킬 카탈로그) 2계층 구조. 하위는 상위를 `<!-- Parent: ../AGENTS.md -->` 주석으로 가리킨다.",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/hierarchical-agents-md-catalog",
-      "linked_skills": []
-    },
-    {
-      "slug": "interface-abstraction-for-modularity",
-      "category": "arch",
-      "summary": "Pure-virtual C++ interfaces in a dedicated src/interfaces/ directory decouple modules without symbol-level coupling, and enable IPC code generation later.",
-      "confidence": "high",
-      "source_project": "bitcoin",
-      "path": "arch/interface-abstraction-for-modularity",
-      "linked_skills": []
-    },
-    {
-      "slug": "jar-task-disabled-bootjar-only",
-      "category": "arch",
-      "summary": "Gradle `jar` task is disabled so only `bootJar` produces an artifact — CI/Docker consumers never receive an ambiguous plain JAR",
-      "confidence": "medium",
-      "source_project": "lucida-audit",
-      "path": "arch/jar-task-disabled-bootjar-only",
-      "linked_skills": []
-    },
-    {
-      "slug": "jvm-module-opens-java21-spring-kafka",
-      "category": "arch",
-      "summary": "",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/jvm-module-opens-java21-spring-kafka",
-      "linked_skills": []
-    },
-    {
-      "slug": "k-git-tag-registry-versioning",
-      "category": "arch",
-      "summary": "Git tag를 semver registry로 쓰면 별도 version manifest 없이 rollback·pinning을 얻는다",
-      "confidence": "high",
-      "source_project": "",
-      "path": "arch/k-git-tag-registry-versioning",
-      "linked_skills": []
-    },
-    {
-      "slug": "kafka-1h-topic-and-nonmetric-pool",
-      "category": "arch",
-      "summary": "Raw alarm path uses a 1-hour-retention Kafka topic and a dedicated non-metric thread pool — isolates alarm latency from batch ingest",
-      "confidence": "medium",
-      "source_project": "lucida-measurement",
-      "path": "arch/kafka-1h-topic-and-nonmetric-pool",
-      "linked_skills": [
-        "kafka-consumer-semaphore-chunking"
-      ]
-    },
-    {
-      "slug": "kafka-avro-schedule-event-chain",
-      "category": "arch",
-      "summary": "Collection scheduling decouples Kafka ingress from per-DBMS handlers via four typed BlockingQueues",
-      "confidence": "high",
-      "source_project": "lucida-domain-dpm",
-      "path": "arch/kafka-avro-schedule-event-chain",
-      "linked_skills": []
-    },
-    {
-      "slug": "kafka-avro-schema-registry-env-topology",
-      "category": "arch",
-      "summary": "Kafka uses Avro + Confluent Schema Registry; partition and replication counts are environment-driven.",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/kafka-avro-schema-registry-env-topology",
-      "linked_skills": []
-    },
-    {
-      "slug": "kafka-partition-topology-design",
-      "category": "arch",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "arch/kafka-partition-topology-design",
-      "linked_skills": [
-        "kafka-batch-consumer-partition-tuning"
-      ]
-    },
-    {
-      "slug": "live-mode-aggregation-exceptions",
-      "category": "arch",
-      "summary": "LIVE mode reads raw data by default, but equalizer / multi-resource / TopN charts still aggregate raw at query time",
-      "confidence": "medium",
-      "source_project": "lucida-measurement",
-      "path": "arch/live-mode-aggregation-exceptions",
-      "linked_skills": []
-    },
-    {
-      "slug": "The MxN problem of LLM tool calling across open-source models",
-      "category": "arch",
-      "summary": "Each OSS LLM family encodes tool calls in a different wire format (special tokens, XML, channel notation, JSON blocks), forcing M inference apps x N models of parser duplication. Fix is declarative tool-call specs shipped with the model.",
-      "confidence": "medium",
-      "source_project": "skills_research:trend:2026-04-16",
-      "path": "arch/llm-tool-calling-mxn-wire-format-problem",
-      "linked_skills": []
-    },
-    {
-      "slug": "lucida-framework-gate-annotations",
-      "category": "arch",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "arch/lucida-framework-gate-annotations",
-      "linked_skills": []
-    },
-    {
-      "slug": "mongodb-aggregated-stats-as-views",
-      "category": "arch",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "arch/mongodb-aggregated-stats-as-views",
-      "linked_skills": []
-    },
-    {
-      "slug": "multi-domain-split-via-domain-mapping",
-      "category": "arch",
-      "summary": "",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/multi-domain-split-via-domain-mapping",
-      "linked_skills": []
-    },
-    {
-      "slug": "multiprocess-architecture-via-ipc",
-      "category": "arch",
-      "summary": "Decompose a monolith into cooperating processes by defining interfaces in a neutral schema language (Cap'n Proto), then codegen client/server proxies that preserve the original C++ interface shape.",
-      "confidence": "high",
-      "source_project": "bitcoin",
-      "path": "arch/multiprocess-architecture-via-ipc",
-      "linked_skills": []
-    },
-    {
-      "slug": "nfs-backed-volumes-for-docker-swarm",
-      "category": "arch",
-      "summary": "Cross-node Docker Swarm persistence via a single NFS share mounted at the same host path on every swarm node",
-      "confidence": "high",
-      "source_project": "lucida-for-docker",
-      "path": "arch/nfs-backed-volumes-for-docker-swarm",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-ai-slop-cleaner",
-      "category": "arch",
-      "summary": "OMC implements \\\"ai-slop-cleaner\\\" as: Clean AI-generated code slop with a regression-safe, deletion-first workflow and optional reviewer-only mode",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-ai-slop-cleaner",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-ask",
-      "category": "arch",
-      "summary": "OMC implements \\\"ask\\\" as: Process-first advisor routing for Claude, Codex, or Gemini via `omc ask`, with artifact capture and no raw CLI assembly",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-ask",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-autopilot",
-      "category": "arch",
-      "summary": "OMC implements \\\"autopilot\\\" as: Full autonomous execution from idea to working code",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-autopilot",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-cancel",
-      "category": "arch",
-      "summary": "OMC implements \\\"cancel\\\" as: Cancel any active OMC mode (autopilot, ralph, ultrawork, ultraqa, swarm, ultrapilot, pipeline, team)",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-cancel",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-ccg",
-      "category": "arch",
-      "summary": "OMC implements \\\"ccg\\\" as: Claude-Codex-Gemini tri-model orchestration via /ask codex + /ask gemini, then Claude synthesizes results",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-ccg",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-configure-notifications",
-      "category": "arch",
-      "summary": "OMC implements \\\"configure-notifications\\\" as: Configure notification integrations (Telegram, Discord, Slack) via natural language",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-configure-notifications",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-debug",
-      "category": "arch",
-      "summary": "OMC implements \\\"debug\\\" as: Diagnose the current OMC session or repo state using logs, traces, state, and focused reproduction",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-debug",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-deep-dive",
-      "category": "arch",
-      "summary": "OMC implements \\\"deep-dive\\\" as: 2-stage pipeline: trace (causal investigation) -> deep-interview (requirements crystallization) with 3-point injection",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-deep-dive",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-deep-interview",
-      "category": "arch",
-      "summary": "OMC implements \\\"deep-interview\\\" as: Socratic deep interview with mathematical ambiguity gating before autonomous execution",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-deep-interview",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-deepinit",
-      "category": "arch",
-      "summary": "OMC implements \\\"deepinit\\\" as: Deep codebase initialization with hierarchical AGENTS.md documentation",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-deepinit",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-external-context",
-      "category": "arch",
-      "summary": "OMC implements \\\"external-context\\\" as: Invoke parallel document-specialist agents for external web searches and documentation lookup",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-external-context",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-hud",
-      "category": "arch",
-      "summary": "OMC implements \\\"hud\\\" as: Configure HUD display options (layout, presets, display elements)",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-hud",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-learner",
-      "category": "arch",
-      "summary": "OMC implements \\\"learner\\\" as: Extract a learned skill from the current conversation",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-learner",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-mcp-setup",
-      "category": "arch",
-      "summary": "OMC implements \\\"mcp-setup\\\" as: Configure popular MCP servers for enhanced agent capabilities",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-mcp-setup",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-omc-doctor",
-      "category": "arch",
-      "summary": "OMC implements \\\"omc-doctor\\\" as: Diagnose and fix oh-my-claudecode installation issues",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-omc-doctor",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-omc-reference",
-      "category": "arch",
-      "summary": "OMC implements \\\"omc-reference\\\" as: OMC agent catalog, available tools, team pipeline routing, commit protocol, and skills registry. Auto-loads when delegating to agents, using OMC tools, orchestrating teams, making commits, or invoking skills.",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-omc-reference",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-omc-setup",
-      "category": "arch",
-      "summary": "OMC implements \\\"omc-setup\\\" as: Install or refresh oh-my-claudecode for plugin, npm, and local-dev setups from the canonical setup flow",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-omc-setup",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-omc-teams",
-      "category": "arch",
-      "summary": "OMC implements \\\"omc-teams\\\" as: CLI-team runtime for claude, codex, or gemini workers in tmux panes when you need process-based parallel execution",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-omc-teams",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-plan",
-      "category": "arch",
-      "summary": "OMC implements \\\"plan\\\" as: Strategic planning with optional interview workflow",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-plan",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-project-session-manager",
-      "category": "arch",
-      "summary": "OMC implements \\\"project-session-manager\\\" as: Worktree-first dev environment manager for issues, PRs, and features with optional tmux sessions",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-project-session-manager",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-ralph",
-      "category": "arch",
-      "summary": "OMC implements \\\"ralph\\\" as: Self-referential loop until task completion with configurable verification reviewer",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-ralph",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-ralplan",
-      "category": "arch",
-      "summary": "OMC implements \\\"ralplan\\\" as: Consensus planning entrypoint that auto-gates vague ralph/autopilot/team requests before execution",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-ralplan",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-release",
-      "category": "arch",
-      "summary": "OMC implements \\\"release\\\" as: Generic release assistant — analyzes repo release rules, caches them in .omc/RELEASE_RULE.md, then guides the release",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-release",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-remember",
-      "category": "arch",
-      "summary": "OMC implements \\\"remember\\\" as: Review reusable project knowledge and decide what belongs in project memory, notepad, or durable docs",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-remember",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-sciomc",
-      "category": "arch",
-      "summary": "OMC implements \\\"sciomc\\\" as: Orchestrate parallel scientist agents for comprehensive analysis with AUTO mode",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-sciomc",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-self-improve",
-      "category": "arch",
-      "summary": "OMC implements \\\"self-improve\\\" as: Autonomous evolutionary code improvement engine with tournament selection",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-self-improve",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-setup",
-      "category": "arch",
-      "summary": "OMC implements \\\"setup\\\" as: Use first for install/update routing — sends setup, doctor, or MCP requests to the correct OMC setup flow",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-setup",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-skill",
-      "category": "arch",
-      "summary": "OMC implements \\\"skill\\\" as: Manage local skills - list, add, remove, search, edit, setup wizard",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-skill",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-skillify",
-      "category": "arch",
-      "summary": "OMC implements \\\"skillify\\\" as: Turn a repeatable workflow from the current session into a reusable OMC skill draft",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-skillify",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-team",
-      "category": "arch",
-      "summary": "OMC implements \\\"team\\\" as: N coordinated agents on shared task list using Claude Code native teams",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-team",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-trace",
-      "category": "arch",
-      "summary": "OMC implements \\\"trace\\\" as: Evidence-driven tracing lane that orchestrates competing tracer hypotheses in Claude built-in team mode",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-trace",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-ultraqa",
-      "category": "arch",
-      "summary": "OMC implements \\\"ultraqa\\\" as: QA cycling workflow - test, verify, fix, repeat until goal met",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-ultraqa",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-ultrawork",
-      "category": "arch",
-      "summary": "OMC implements \\\"ultrawork\\\" as: Parallel execution engine for high-throughput task completion",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-ultrawork",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-verify",
-      "category": "arch",
-      "summary": "OMC implements \\\"verify\\\" as: Verify that a change really works before you claim completion",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-verify",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-visual-verdict",
-      "category": "arch",
-      "summary": "OMC implements \\\"visual-verdict\\\" as: Structured visual QA verdict for screenshot-to-reference comparisons",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-visual-verdict",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-wiki",
-      "category": "arch",
-      "summary": "OMC implements \\\"wiki\\\" as: LLM Wiki — persistent markdown knowledge base that compounds across sessions (Karpathy model)",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-wiki",
-      "linked_skills": []
-    },
-    {
-      "slug": "oh-my-claudecode-writer-memory",
-      "category": "arch",
-      "summary": "OMC implements \\\"writer-memory\\\" as: Agentic memory system for writers - track characters, relationships, scenes, and themes",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/oh-my-claudecode-writer-memory",
-      "linked_skills": []
-    },
-    {
-      "slug": "openapi-as-single-fe-be-contract",
-      "category": "arch",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "arch/openapi-as-single-fe-be-contract",
-      "linked_skills": []
-    },
-    {
-      "slug": "plugin-architecture-runtime-vs-startup-loading",
-      "category": "arch",
-      "summary": "Scouter server loads hot-reloadable script plugins (.plug files) for alerts/filters and compiled JAR plugins for stateful data handlers (sinks, connection-pool-heavy integrations)",
-      "confidence": "medium",
-      "source_project": "scouter",
-      "path": "arch/plugin-architecture-runtime-vs-startup-loading",
-      "linked_skills": []
-    },
-    {
-      "slug": "Polymorphic metadata persisted as BSON via enum-switch deserialization",
-      "category": "arch",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "arch/polymorphic-metadata-via-enum-switch",
-      "linked_skills": []
-    },
-    {
-      "slug": "port-out-no-optional-raise-in-adapter",
-      "category": "arch",
-      "summary": "",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/port-out-no-optional-raise-in-adapter",
-      "linked_skills": []
-    },
-    {
-      "slug": "published-vs-realtime-view-pages",
-      "category": "arch",
-      "summary": "PublishedViewPage renders a frozen deploy snapshot; RealTimeViewPage renders the live editable dashboard",
-      "confidence": "high",
-      "source_project": "lucida-builder-r3",
-      "path": "arch/published-vs-realtime-view-pages",
-      "linked_skills": []
-    },
-    {
-      "slug": "redis-change-counter-for-versioning-trigger",
-      "category": "arch",
-      "summary": "|",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/redis-change-counter-for-versioning-trigger",
-      "linked_skills": []
-    },
-    {
-      "slug": "scouter-three-tier-architecture",
-      "category": "arch",
-      "summary": "Scouter APM enforces strict agent → server → client separation, with an optional standalone HTTP webapp for horizontal scaling of query load",
-      "confidence": "high",
-      "source_project": "scouter",
-      "path": "arch/scouter-three-tier-architecture",
-      "linked_skills": []
-    },
-    {
-      "slug": "shallow-clone-mktemp-cleanup-pattern",
-      "category": "arch",
-      "summary": "publish/install/원격 목록 조회처럼 원격 git repo를 만질 때는 `mktemp -d → git clone --depth 1 → 작업 → rm -rf`. 작업 디렉토리를 오염시키지 않는다.",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "arch/shallow-clone-mktemp-cleanup-pattern",
-      "linked_skills": []
-    },
-    {
-      "slug": "Per-request tenant context via HandlerInterceptor",
-      "category": "arch",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "arch/tenant-context-per-request-interceptor",
-      "linked_skills": []
-    },
-    {
-      "slug": "Gate startup initialization on dependent-service readiness via @WaitForServices",
-      "category": "arch",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "arch/wait-for-services-eureka-startup-init",
-      "linked_skills": []
-    },
-    {
-      "slug": "widget-is-frozen-group-snapshot",
-      "category": "arch",
-      "summary": "Widgets are snapshots of a group at save time; later edits to the source group do not propagate",
-      "confidence": "high",
-      "source_project": "lucida-builder-r3",
-      "path": "arch/widget-is-frozen-group-snapshot",
-      "linked_skills": []
-    },
-    {
-      "slug": "yorkie-team-server-split",
-      "category": "arch",
-      "summary": "Yorkie holds live canvas state; the team server holds metadata (projects, assets, datasources) — never mix",
-      "confidence": "high",
-      "source_project": "lucida-builder-r3",
-      "path": "arch/yorkie-team-server-split",
-      "linked_skills": []
-    },
-    {
-      "slug": "actuator-endpoints-skip-auth-by-design",
-      "category": "decision",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/actuator-endpoints-skip-auth-by-design",
-      "linked_skills": []
+      "path": "knowledge/arch/additive-registry-schema-versioning.md"
     },
     {
       "slug": "admin-role-disabled-secretkey",
@@ -3111,567 +2452,55 @@
       "summary": "Default `admins` role is disabled and the shared `SecretKey` was removed from `config.properties` — never re-enable without a per-install key",
       "confidence": "medium",
       "source_project": "",
-      "path": "decision/admin-role-disabled-secretkey",
-      "linked_skills": []
+      "path": "knowledge/decision/admin-role-disabled-secretkey.md"
+    },
+    {
+      "slug": "agent-memory-binding-vs-recall",
+      "category": "arch",
+      "summary": "Agent memory systems that ace retrieval benchmarks still fail operationally because stored skills aren't *bound* to the episodes that validated them. Fix is a memory bundle — skill record + episode record + bidirectional link — returned together on recall.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/agent-memory-binding-vs-recall.md"
+    },
+    {
+      "slug": "ai-guess-mark-and-review-checklist",
+      "category": "pitfall",
+      "summary": "When AI fills gaps the source doc doesn't specify, annotate the guess inline and output a review checklist alongside the artifact",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/pitfall/ai-guess-mark-and-review-checklist.md"
     },
     {
       "slug": "alarm-raw-over-1min-aggregate",
       "category": "decision",
       "summary": "Alarm judgement reads raw metrics, not 1-minute aggregates — accuracy over storage cost",
       "confidence": "high",
-      "source_project": "lucida-measurement",
-      "path": "decision/alarm-raw-over-1min-aggregate",
-      "linked_skills": [
-        "kafka-consumer-semaphore-chunking"
-      ]
+      "source_project": "",
+      "path": "knowledge/decision/alarm-raw-over-1min-aggregate.md"
     },
     {
-      "slug": "assume-semantics-for-compiler-hints",
-      "category": "decision",
-      "summary": "Three-tier assertion strategy (Assert / CHECK_NONFATAL / Assume) separates fatal invariants from recoverable logic bugs and pure compiler hints.",
-      "confidence": "high",
-      "source_project": "bitcoin",
-      "path": "decision/assume-semantics-for-compiler-hints",
-      "linked_skills": []
-    },
-    {
-      "slug": "avro-private-fields-no-setters",
-      "category": "decision",
-      "summary": "Avro-generated classes are configured with `fieldVisibility=PRIVATE` and `createSetters=false` to enforce immutability on event payloads",
+      "slug": "annotation-driven-authz-via-function-id",
+      "category": "arch",
+      "summary": "Controllers declare required capability with a method-level enum annotation; an interceptor enforces it against JWT-derived roles",
       "confidence": "high",
       "source_project": "",
-      "path": "decision/avro-private-fields-no-setters",
-      "linked_skills": []
-    },
-    {
-      "slug": "cache-even-when-enable-false",
-      "category": "decision",
-      "summary": "Notification configs with `enable=false` are still loaded into the cache manager rather than skipped, so toggling enable on/off doesn't require a cache reload",
-      "confidence": "high",
-      "source_project": "lucida-notification",
-      "path": "decision/cache-even-when-enable-false",
-      "linked_skills": []
-    },
-    {
-      "slug": "caveats-absence-confidence-cap",
-      "category": "decision",
-      "summary": "반증 조건(Counter/Caveats)이 비어 있는 knowledge는 confidence 최대 medium으로 강등한다 — 미확인 = 과신 위험",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/caveats-absence-confidence-cap",
-      "linked_skills": []
-    },
-    {
-      "slug": "circular-dependency-detection-script",
-      "category": "decision",
-      "summary": "A small Python script that parses #include directives across the tree and reports the shortest cycle in the module graph — cheap CI gate against architectural decay.",
-      "confidence": "high",
-      "source_project": "bitcoin",
-      "path": "decision/circular-dependency-detection-script",
-      "linked_skills": []
-    },
-    {
-      "slug": "confid-only-query-over-resource-tuple",
-      "category": "decision",
-      "summary": "Performance queries key off `confId` (config id) whenever available, falling back to (resourceType, resourceName) only when confId is absent",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/confid-only-query-over-resource-tuple",
-      "linked_skills": []
-    },
-    {
-      "slug": "copy-naming-suffix-numbered",
-      "category": "decision",
-      "summary": "|",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/copy-naming-suffix-numbered",
-      "linked_skills": []
-    },
-    {
-      "slug": "cors-allow-credentials-star-origin",
-      "category": "decision",
-      "summary": "Service-level allowCredentials+allowedOriginPatterns(*) kept because edge proxy (Traefik/Istio) enforces CORS",
-      "confidence": "medium",
-      "source_project": "lucida-domain-automation",
-      "path": "decision/cors-allow-credentials-star-origin",
-      "linked_skills": []
-    },
-    {
-      "slug": "csp-frame-ancestors-required",
-      "category": "decision",
-      "summary": "Send a Content-Security-Policy header (including `frame-ancestors`) on every response to block clickjacking",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/csp-frame-ancestors-required",
-      "linked_skills": []
-    },
-    {
-      "slug": "dataavro-json-wrapper-pattern",
-      "category": "decision",
-      "summary": "Single DataAvro{jsonData,jsonDataClass} wrapper avoids per-event Avro schema proliferation (TCM pattern)",
-      "confidence": "medium",
-      "source_project": "lucida-domain-automation",
-      "path": "decision/dataavro-json-wrapper-pattern",
-      "linked_skills": []
-    },
-    {
-      "slug": "do-not-ask-planners-for-api-design",
-      "category": "decision",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/do-not-ask-planners-for-api-design",
-      "linked_skills": []
-    },
-    {
-      "slug": "existing-code-patterns-over-standard-rules",
-      "category": "decision",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/existing-code-patterns-over-standard-rules",
-      "linked_skills": []
-    },
-    {
-      "slug": "5NF applies when AB-BC-AC triangles or ABC+D stars appear; otherwise stop at 4NF",
-      "category": "decision",
-      "summary": "5NF catches join dependencies that 4NF/BCNF miss, but in practice you rarely reason about it directly. Design from business entities and recognize the two patterns that force 5NF.",
-      "confidence": "medium",
-      "source_project": "skills_research:trend:2026-04-16",
-      "path": "decision/fifth-normal-form-join-dependency-tradeoff",
-      "linked_skills": []
-    },
-    {
-      "slug": "god-controller-split-by-resource",
-      "category": "decision",
-      "summary": "",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/god-controller-split-by-resource",
-      "linked_skills": []
-    },
-    {
-      "slug": "hyperloglog-for-unique-user-counting",
-      "category": "decision",
-      "summary": "Scouter uses HyperLogLog (Clearspring stream-lib) to estimate recent and daily unique user counts with ~100 bytes of memory and ~2% error, avoiding O(n) hash sets",
-      "confidence": "medium",
-      "source_project": "scouter",
-      "path": "decision/hyperloglog-for-unique-user-counting",
-      "linked_skills": []
-    },
-    {
-      "slug": "jacoco-exclude-business-layers",
-      "category": "decision",
-      "summary": "In this project's Jacoco config, nearly every layer (service, repository, dto, entity, kafka, config, constants, helper, exception, schedule, provider) is excluded from coverage measurement — only controllers/business orchestration code is measured.",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/jacoco-exclude-business-layers",
-      "linked_skills": []
-    },
-    {
-      "slug": "jacoco-sonar-exclusion-policy",
-      "category": "decision",
-      "summary": "Single exclusion list drives Jacoco + Sonar + test excludes; generated/boilerplate code never counts toward coverage",
-      "confidence": "medium",
-      "source_project": "lucida-measurement",
-      "path": "decision/jacoco-sonar-exclusion-policy",
-      "linked_skills": [
-        "querydsl-q-class-exclusion-pattern"
-      ]
-    },
-    {
-      "slug": "jacoco-sonar-exclusion-rationale",
-      "category": "decision",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/jacoco-sonar-exclusion-rationale",
-      "linked_skills": []
-    },
-    {
-      "slug": "java-21-upgrade-rationale",
-      "category": "decision",
-      "summary": "Java 17 → 21 + Spring Boot 3.5.x upgrade rationale and required Gradle/JVM flag adjustments",
-      "confidence": "high",
-      "source_project": "lucida-audit",
-      "path": "decision/java-21-upgrade-rationale",
-      "linked_skills": [
-        "java-21-upgrade-rationale"
-      ]
-    },
-    {
-      "slug": "jest-coverage-80-threshold",
-      "category": "decision",
-      "summary": "Global Jest coverage threshold is 80% on branches, functions, lines, and statements",
-      "confidence": "medium",
-      "source_project": "lucida-builder-r3",
-      "path": "decision/jest-coverage-80-threshold",
-      "linked_skills": []
-    },
-    {
-      "slug": "jwt-stateless-refresh-24h-default",
-      "category": "decision",
-      "summary": "JWT stateless auth with 1h access / 24h refresh token defaults, both env-tunable.",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/jwt-stateless-refresh-24h-default",
-      "linked_skills": []
-    },
-    {
-      "slug": "k-kafka-message-header-metadata",
-      "category": "decision",
-      "summary": "멀티테넌트 Kafka routing 메타는 payload 대신 RecordHeader에 두어 business schema 오염을 막는다",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/k-kafka-message-header-metadata",
-      "linked_skills": []
-    },
-    {
-      "slug": "kafka-batch-size-timeout-tuning",
-      "category": "decision",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/kafka-batch-size-timeout-tuning",
-      "linked_skills": [
-        "kafka-batch-consumer-partition-tuning"
-      ]
-    },
-    {
-      "slug": "large-range-query-raw-collections",
-      "category": "decision",
-      "summary": "For long time-range queries over day-partitioned data, hit raw daily collections instead of aggregated views to avoid timeouts",
-      "confidence": "high",
-      "source_project": "lucida-domain-apm",
-      "path": "decision/large-range-query-raw-collections",
-      "linked_skills": []
-    },
-    {
-      "slug": "license-apply-window-15d",
-      "category": "decision",
-      "summary": "Issued licenses must be applied within 15 days; expired licenses are immutable.",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/license-apply-window-15d",
-      "linked_skills": []
-    },
-    {
-      "slug": "measurement-batch-send-per-config",
-      "category": "decision",
-      "summary": "",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/measurement-batch-send-per-config",
-      "linked_skills": []
-    },
-    {
-      "slug": "node-npm-pin-matches-jenkins",
-      "category": "decision",
-      "summary": "UI build is pinned to Node 24.6.0 + npm 11.5.1 to match the Jenkins build environment",
-      "confidence": "high",
-      "source_project": "lucida-builder-r3",
-      "path": "decision/node-npm-pin-matches-jenkins",
-      "linked_skills": []
-    },
-    {
-      "slug": "organization-soft-delete-grace-period",
-      "category": "decision",
-      "summary": "Organization deletion uses a 30-day grace period before permanent removal (DELETE_ORGANIZATION_INTERVAL_DAYS).",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/organization-soft-delete-grace-period",
-      "linked_skills": []
-    },
-    {
-      "slug": "planning-doc-in-issue-description",
-      "category": "decision",
-      "summary": "",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "decision/planning-doc-in-issue-description",
-      "linked_skills": []
-    },
-    {
-      "slug": "plugin-repo-scope-generic-skills-only",
-      "category": "decision",
-      "summary": "nkia-skills 같은 공용 플러그인에는 범용 스킬만. 프로젝트 특화 스킬은 각 프로젝트의 `.claude/skills/`에 둔다.",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/plugin-repo-scope-generic-skills-only",
-      "linked_skills": []
-    },
-    {
-      "slug": "postgres-version-rolling-support",
-      "category": "decision",
-      "summary": "Roll PostgreSQL major-version support forward incrementally (9.x → 18) rather than pinning one LTS",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/postgres-version-rolling-support",
-      "linked_skills": []
-    },
-    {
-      "slug": "prefer-static-import-over-constant-inheritance",
-      "category": "decision",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/prefer-static-import-over-constant-inheritance",
-      "linked_skills": []
-    },
-    {
-      "slug": "push-local-removed-use-doc-update",
-      "category": "decision",
-      "summary": "pushLocalChangesIntoRemote and its action-mapping helpers were removed; mutate Yorkie via doc.update directly",
-      "confidence": "high",
-      "source_project": "lucida-builder-r3",
-      "path": "decision/push-local-removed-use-doc-update",
-      "linked_skills": []
-    },
-    {
-      "slug": "query-manager-version-conversion-fallback",
-      "category": "decision",
-      "summary": "Unknown target RDBMS versions fall back to a documented default bucket rather than erroring, keeping collection alive",
-      "confidence": "medium",
-      "source_project": "lucida-domain-dpm",
-      "path": "decision/query-manager-version-conversion-fallback",
-      "linked_skills": []
-    },
-    {
-      "slug": "rcp-desktop-client-design-rationale-vs-saas-web",
-      "category": "decision",
-      "summary": "Scouter chose an Eclipse RCP desktop client over a browser UI to enable high-throughput binary streams, local caching, and real-time drill-down without HTTP/JSON overhead",
-      "confidence": "high",
-      "source_project": "scouter",
-      "path": "decision/rcp-desktop-client-design-rationale-vs-saas-web",
-      "linked_skills": []
-    },
-    {
-      "slug": "resource-mount-unmount-use-jar-defaults",
-      "category": "decision",
-      "summary": "Don't bind-mount i18n/exception/menu resource files into Spring Boot containers; let the jar ship its own defaults",
-      "confidence": "high",
-      "source_project": "lucida-for-docker",
-      "path": "decision/resource-mount-unmount-use-jar-defaults",
-      "linked_skills": []
-    },
-    {
-      "slug": "save-child-only-when-changed",
-      "category": "decision",
-      "summary": "When reconciling parent→child configurations, persistence is conditional on \"new\" or \"resourceName/tags changed\". Unconditional save caused unnecessary write load and spurious change events.",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/save-child-only-when-changed",
-      "linked_skills": []
-    },
-    {
-      "slug": "scatter-topic-1min-retention",
-      "category": "decision",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/scatter-topic-1min-retention",
-      "linked_skills": []
-    },
-    {
-      "slug": "skill-registry-vs-skill-config-split",
-      "category": "decision",
-      "summary": "원격 저장소 정보는 `.claude/skill-registry.yaml`, 스킬별 런타임 옵션(출력 경로 등)은 `.claude/skill-config.yaml`. 파일 단위로 관심사 분리.",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/skill-registry-vs-skill-config-split",
-      "linked_skills": []
-    },
-    {
-      "slug": "stub-in-service-unblocks-fe-parallelism",
-      "category": "decision",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/stub-in-service-unblocks-fe-parallelism",
-      "linked_skills": []
-    },
-    {
-      "slug": "system-notification-shared-with-2fa-and-password-find",
-      "category": "decision",
-      "summary": "The `system_notification` config (SMTP/SMS credentials) is intentionally shared between 2FA and password-find flows rather than duplicated per flow",
-      "confidence": "medium",
-      "source_project": "lucida-notification",
-      "path": "decision/system-notification-shared-with-2fa-and-password-find",
-      "linked_skills": []
-    },
-    {
-      "slug": "tabular-metric-excluded-from-list",
-      "category": "decision",
-      "summary": "TABULAR measurement type is intentionally excluded from searchable metric-definition list endpoints",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/tabular-metric-excluded-from-list",
-      "linked_skills": []
-    },
-    {
-      "slug": "tag-values-separate-collection",
-      "category": "decision",
-      "summary": "TagValueInfo's `values` array was extracted from the parent tag document into a separate `tag_value_detail` collection to bound document size and index cost.",
-      "confidence": "high",
-      "source_project": "",
-      "path": "decision/tag-values-separate-collection",
-      "linked_skills": []
-    },
-    {
-      "slug": "tomcat-request-timeout-1h-for-oz-report",
-      "category": "decision",
-      "summary": "Report-generation services should raise Tomcat connection/read timeout to ~1 hour because export of large OZ/Jasper reports is genuinely long-running",
-      "confidence": "high",
-      "source_project": "lucida-report",
-      "path": "decision/tomcat-request-timeout-1h-for-oz-report",
-      "linked_skills": []
-    },
-    {
-      "slug": "Typed wikilinks for an LLM-facing knowledge base",
-      "category": "decision",
-      "summary": "Flat [[wikilinks]] carry one bit of information. Tag each link with a relationship type (supersedes, contradicts, causes, supports) so the graph becomes queryable, and sync types into frontmatter for external tools.",
-      "confidence": "medium",
-      "source_project": "skills_research:trend:2026-04-16",
-      "path": "decision/typed-wikilinks-for-llm-knowledge-base",
-      "linked_skills": []
-    },
-    {
-      "slug": "udp-for-throughput-tcp-for-reliability",
-      "category": "decision",
-      "summary": "Scouter streams periodic metrics over UDP (lossy but cheap) and reserves TCP for config fetch, agent registration, and XLog profile uploads that demand delivery guarantees",
-      "confidence": "high",
-      "source_project": "scouter",
-      "path": "decision/udp-for-throughput-tcp-for-reliability",
-      "linked_skills": []
-    },
-    {
-      "slug": "variable-length-integer-encoding-for-metrics-bandwidth",
-      "category": "decision",
-      "summary": "Scouter's DataOutputX uses 3-byte (INT3) and 5-byte (LONG5) integer encodings to shrink UDP metric packs by 20-40% when most values fit within 24 / 40 bits",
-      "confidence": "medium",
-      "source_project": "scouter",
-      "path": "decision/variable-length-integer-encoding-for-metrics-bandwidth",
-      "linked_skills": []
-    },
-    {
-      "slug": "vllm-kv-cache-fp8-with-mtp",
-      "category": "decision",
-      "summary": "vLLM serving chose fp8_e4m3 KV cache + prefix caching + MTP speculative decoding for Qwen3.5 throughput",
-      "confidence": "medium",
-      "source_project": "lucida-for-docker",
-      "path": "decision/vllm-kv-cache-fp8-with-mtp",
-      "linked_skills": []
-    },
-    {
-      "slug": "account-lockout-configurable-threshold",
-      "category": "domain",
-      "summary": "Failed-login counter locks the account after a configurable threshold (ACCOUNT_LOCKOUT, default 10).",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "domain/account-lockout-configurable-threshold",
-      "linked_skills": []
-    },
-    {
-      "slug": "encrypted-pii-decode-on-export",
-      "category": "domain",
-      "summary": "PII fields (phone, email) are stored encrypted; only decrypted for explicit export/API response, never for logs.",
-      "confidence": "medium",
-      "source_project": "",
-      "path": "domain/encrypted-pii-decode-on-export",
-      "linked_skills": []
-    },
-    {
-      "slug": "mongodb-exclude-system-databases",
-      "category": "domain",
-      "summary": "When enumerating tenant databases in a shared MongoDB cluster, filter out admin/config/local plus third-party DBs (yorkie-meta, migration) to avoid touching shared state",
-      "confidence": "medium",
-      "source_project": "lucida-audit",
-      "path": "domain/mongodb-exclude-system-databases",
-      "linked_skills": []
-    },
-    {
-      "slug": "mysql-mariadb-performance-schema-detection",
-      "category": "domain",
-      "summary": "MySQL/MariaDB metric availability depends on per-instance Performance Schema state; detect at runtime, don't assume",
-      "confidence": "medium",
-      "source_project": "lucida-domain-dpm",
-      "path": "domain/mysql-mariadb-performance-schema-detection",
-      "linked_skills": []
-    },
-    {
-      "slug": "one-default-template-per-type-rule",
-      "category": "domain",
-      "summary": "Exactly one default message template may exist per notification type; creating a second default is rejected, but editing the existing default is allowed",
-      "confidence": "high",
-      "source_project": "lucida-notification",
-      "path": "domain/one-default-template-per-type-rule",
-      "linked_skills": []
-    },
-    {
-      "slug": "period-interval-naming-convention",
-      "category": "domain",
-      "summary": "Period.Mode names encode both unit and multiplier (MIN_15, MONTH_2); monthly modes densify at 24h, not the unit itself",
-      "confidence": "medium",
-      "source_project": "lucida-measurement",
-      "path": "domain/period-interval-naming-convention",
-      "linked_skills": [
-        "period-mode-enum-config"
-      ]
-    },
-    {
-      "slug": "pims-write-requires-dryrun-confirm",
-      "category": "domain",
-      "summary": "PIMS 시간 기록/제출/일괄 갱신 등 모든 쓰기 API는 미리보기 → 사용자 확인 → 재시도 가능한 실행 플로우를 반드시 거친다. `--dry-run`은 API 쓰기 호출 자체가 금지.",
-      "confidence": "high",
-      "source_project": "",
-      "path": "domain/pims-write-requires-dryrun-confirm",
-      "linked_skills": []
-    },
-    {
-      "slug": "root-span-error-propagation",
-      "category": "domain",
-      "summary": "Root span isError must aggregate descendant errors; otherwise scatter and list views disagree on a trace's error state",
-      "confidence": "medium",
-      "source_project": "lucida-domain-apm",
-      "path": "domain/root-span-error-propagation",
-      "linked_skills": []
-    },
-    {
-      "slug": "topresource-immediate-generation-invariant",
-      "category": "domain",
-      "summary": "In report immediate-generation, the topResource flag decides whether to query by resource-id (fast path) or the full conf-id set (slow path)",
-      "confidence": "medium",
-      "source_project": "lucida-report",
-      "path": "domain/topresource-immediate-generation-invariant",
-      "linked_skills": []
-    },
-    {
-      "slug": "actuator-metric-call-aggressive-timeout",
-      "category": "pitfall",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "pitfall/actuator-metric-call-aggressive-timeout",
-      "linked_skills": []
-    },
-    {
-      "slug": "ai-guess-mark-and-review-checklist",
-      "category": "pitfall",
-      "summary": "",
-      "confidence": "high",
-      "source_project": "",
-      "path": "pitfall/ai-guess-mark-and-review-checklist",
-      "linked_skills": []
+      "path": "knowledge/arch/annotation-driven-authz-via-function-id.md"
     },
     {
       "slug": "anonymize-examples-in-skill-docs",
       "category": "pitfall",
-      "summary": "실사 티켓 번호·실명·프로젝트명이 예시에 들어가면 보안 감사에서 지적됨. 공용 repo 기준 모든 예시는 익명 더미여야 한다.",
+      "summary": "\"실사 티켓 번호·실명·프로젝트명이 예시에 들어가면 보안 감사에서 지적됨. 공용 repo 기준 모든 예시는 익명 더미여야 한다.\"",
       "confidence": "high",
       "source_project": "",
-      "path": "pitfall/anonymize-examples-in-skill-docs",
-      "linked_skills": []
+      "path": "knowledge/pitfall/anonymize-examples-in-skill-docs.md"
+    },
+    {
+      "slug": "archon-deterministic-ai-coding-harness",
+      "category": "arch",
+      "summary": "Archon enforces deterministic AI-assisted coding by encoding workflows as YAML DAGs — deterministic nodes (tests, git ops) bracket AI-driven nodes (plan, implement, review), each run isolated in its own git worktree. The pattern generalizes beyond Archon itself.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/archon-deterministic-ai-coding-harness.md"
     },
     {
       "slug": "asm-based-classloader-instrumentation-caveats",
@@ -3679,19 +2508,31 @@
       "summary": "ASM-based JVM agents miss Java 8+ lambda forms, annotation-processor classes, and Spring proxies unless explicitly handled; misses manifest as XLog gaps or skipped trace points",
       "confidence": "high",
       "source_project": "scouter",
-      "path": "pitfall/asm-based-classloader-instrumentation-caveats",
-      "linked_skills": []
+      "path": "knowledge/pitfall/asm-based-classloader-instrumentation-caveats.md"
+    },
+    {
+      "slug": "assume-semantics-for-compiler-hints",
+      "category": "decision",
+      "summary": "Three-tier assertion strategy (Assert / CHECK_NONFATAL / Assume) separates fatal invariants from recoverable logic bugs and pure compiler hints.",
+      "confidence": "high",
+      "source_project": "bitcoin",
+      "path": "knowledge/decision/assume-semantics-for-compiler-hints.md"
+    },
+    {
+      "slug": "assumeutxo-snapshot-chainstate-phases",
+      "category": "arch",
+      "summary": "(Blockchain-specific) Multi-chainstate snapshot validation — active chainstate syncs from a trusted-but-unverified UTXO snapshot while a background chainstate validates the snapshot's base, with a phased state machine for clean cutover.",
+      "confidence": "high",
+      "source_project": "bitcoin",
+      "path": "knowledge/arch/assumeutxo-snapshot-chainstate-phases.md"
     },
     {
       "slug": "audit-changed-prev-after-field-swap-bug",
       "category": "pitfall",
       "summary": "Audit diff logic had before/after swapped — iterating the wrong doc and putting the wrong value into changedPrev corrupted the audit trail silently",
       "confidence": "high",
-      "source_project": "lucida-audit",
-      "path": "pitfall/audit-changed-prev-after-field-swap-bug",
-      "linked_skills": [
-        "audit-change-data-capture-pattern"
-      ]
+      "source_project": "",
+      "path": "knowledge/pitfall/audit-changed-prev-after-field-swap-bug.md"
     },
     {
       "slug": "auto-lock-must-not-bump-lastEditedTime",
@@ -3699,8 +2540,23 @@
       "summary": "|",
       "confidence": "medium",
       "source_project": "",
-      "path": "pitfall/auto-lock-must-not-bump-lastEditedTime",
-      "linked_skills": []
+      "path": "knowledge/pitfall/auto-lock-must-not-bump-lastEditedTime.md"
+    },
+    {
+      "slug": "avro-private-fields-no-setters",
+      "category": "decision",
+      "summary": "Avro-generated classes are configured with `fieldVisibility=PRIVATE` and `createSetters=false` to enforce immutability on event payloads",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/avro-private-fields-no-setters.md"
+    },
+    {
+      "slug": "bilingual-user-facing-strings",
+      "category": "arch",
+      "summary": "A bilingual_str struct carrying both original and translated forms lets GUI show translated text while logs/stderr keep the original — no locale branching in business code.",
+      "confidence": "high",
+      "source_project": "bitcoin",
+      "path": "knowledge/arch/bilingual-user-facing-strings.md"
     },
     {
       "slug": "binsize-zero-fallback-to-one",
@@ -3708,46 +2564,95 @@
       "summary": "Substitute binSize=1 whenever the computed interval is 0 in MongoDB time-bucket aggregation",
       "confidence": "high",
       "source_project": "",
-      "path": "pitfall/binsize-zero-fallback-to-one",
-      "linked_skills": []
+      "path": "knowledge/pitfall/binsize-zero-fallback-to-one.md"
+    },
+    {
+      "slug": "boilerplate-generated-business-logic-manual",
+      "category": "arch",
+      "summary": "Split AI codegen scope along the boilerplate/business-logic line — AI produces skeletons, humans fill domain rules",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/arch/boilerplate-generated-business-logic-manual.md"
+    },
+    {
+      "slug": "cache-even-when-enable-false",
+      "category": "decision",
+      "summary": "Notification configs with `enable=false` are still loaded into the cache manager rather than skipped, so toggling enable on/off doesn't require a cache reload",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/cache-even-when-enable-false.md"
     },
     {
       "slug": "catalina-urlencoder-internal-api",
       "category": "pitfall",
-      "summary": "org.apache.catalina.util.URLEncoder is Tomcat internal — use java.net.URLEncoder or Spring UriUtils",
+      "summary": "org.apache.catalina.util.URLEncoder는 톰캣 내부 API — 컨테이너 교체/버전업에 깨지기 쉽다. java.net.URLEncoder 또는 Spring UriUtils 사용",
       "confidence": "medium",
-      "source_project": "lucida-domain-automation",
-      "path": "pitfall/catalina-urlencoder-internal-api",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/catalina-urlencoder-internal-api.md"
+    },
+    {
+      "slug": "caveats-absence-confidence-cap",
+      "category": "decision",
+      "summary": "\"반증 조건(Counter/Caveats)이 비어 있는 knowledge는 confidence 최대 medium으로 강등한다 — 미확인 = 과신 위험\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/caveats-absence-confidence-cap.md"
+    },
+    {
+      "slug": "circular-dependency-detection-script",
+      "category": "decision",
+      "summary": "A small Python script that parses #include directives across the tree and reports the shortest cycle in the module graph — cheap CI gate against architectural decay.",
+      "confidence": "high",
+      "source_project": "bitcoin",
+      "path": "knowledge/decision/circular-dependency-detection-script.md"
     },
     {
       "slug": "classifier-both-verdict-self-reference",
       "category": "pitfall",
-      "summary": "LLM classifier의 both-verdict에 suggested_links를 허용하면 자기 자신을 가리키는 self-link가 나온다 — 링크는 post-process에서 붙일 것",
+      "summary": "\"LLM classifier의 both-verdict에 suggested_links를 허용하면 자기 자신을 가리키는 self-link가 나온다 — 링크는 post-process에서 붙일 것\"",
       "confidence": "medium",
       "source_project": "",
-      "path": "pitfall/classifier-both-verdict-self-reference",
-      "linked_skills": []
+      "path": "knowledge/pitfall/classifier-both-verdict-self-reference.md"
+    },
+    {
+      "slug": "claude-code-routines-cloud-automation-model",
+      "category": "api",
+      "summary": "Claude Code Routines (research preview) are saved cloud sessions — prompt + repos + connectors + environment — triggered by schedule, HTTP POST, or GitHub events. One routine can combine all three. Daily run cap per account; branch pushes restricted to `claude/*` by default.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/api/claude-code-routines-cloud-automation-model.md"
     },
     {
       "slug": "claude-plugin-marketplace-owner-required",
       "category": "pitfall",
-      "summary": "플러그인 설치 스키마 오류: marketplace.json 최상위에 `owner` 객체 없으면 플러그인 설치가 실패.",
+      "summary": "\"플러그인 설치 스키마 오류: marketplace.json 최상위에 `owner` 객체 없으면 플러그인 설치가 실패.\"",
       "confidence": "high",
       "source_project": "",
-      "path": "pitfall/claude-plugin-marketplace-owner-required",
-      "linked_skills": []
+      "path": "knowledge/pitfall/claude-plugin-marketplace-owner-required.md"
+    },
+    {
+      "slug": "claude-plugin-skill-md-is-sufficient",
+      "category": "arch",
+      "summary": "\"스킬 = SKILL.md 하나. 코드, 빌드, 의존성, 스크립트 없이도 완전히 동작한다.\"",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/arch/claude-plugin-skill-md-is-sufficient.md"
     },
     {
       "slug": "common-alarm-policy-init-gotcha",
       "category": "pitfall",
-      "summary": "",
+      "summary": "Policy loader that \"only runs on first boot if records exist\" silently skips later-added policies for tenants that started empty",
       "confidence": "medium",
       "source_project": "",
-      "path": "pitfall/common-alarm-policy-init-gotcha",
-      "linked_skills": [
-        "kafka-debounce-event-coalescing"
-      ]
+      "path": "knowledge/pitfall/common-alarm-policy-init-gotcha.md"
+    },
+    {
+      "slug": "commons-logging-exclusion-strategy",
+      "category": "arch",
+      "summary": "Globally exclude commons-logging, log4j, and slf4j-log4j12 in Gradle so SLF4J+Logback is the only logging backend on the classpath",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/arch/commons-logging-exclusion-strategy.md"
     },
     {
       "slug": "compare-counts-exclude-added-deleted",
@@ -3755,8 +2660,7 @@
       "summary": "An earlier query filtered change-count by `latest` / `added` / `deleted` flags, which silently dropped newly-added resources from the \"number of changes between two points in time\" metric.",
       "confidence": "high",
       "source_project": "",
-      "path": "pitfall/compare-counts-exclude-added-deleted",
-      "linked_skills": []
+      "path": "knowledge/pitfall/compare-counts-exclude-added-deleted.md"
     },
     {
       "slug": "composite-alarm-all-deleted-npe",
@@ -3764,8 +2668,7 @@
       "summary": "Composite/aggregated monitors must validate their child set before reducing — empty aggregation throws NPE",
       "confidence": "medium",
       "source_project": "",
-      "path": "pitfall/composite-alarm-all-deleted-npe",
-      "linked_skills": []
+      "path": "knowledge/pitfall/composite-alarm-all-deleted-npe.md"
     },
     {
       "slug": "conf-info-may-lack-resource-type",
@@ -3773,44 +2676,207 @@
       "summary": "The `conf_info` collection is NOT guaranteed to carry `resourceType` for every metric; criteria builders must tolerate missing field",
       "confidence": "medium",
       "source_project": "",
-      "path": "pitfall/conf-info-may-lack-resource-type",
-      "linked_skills": []
+      "path": "knowledge/pitfall/conf-info-may-lack-resource-type.md"
+    },
+    {
+      "slug": "confid-only-query-over-resource-tuple",
+      "category": "decision",
+      "summary": "Performance queries key off `confId` (config id) whenever available, falling back to (resourceType, resourceName) only when confId is absent",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/confid-only-query-over-resource-tuple.md"
+    },
+    {
+      "slug": "confid-vs-resourceid-routing",
+      "category": "api",
+      "summary": "Queries support both `configIds` (tenant/policy scope) and `resourceId` (agent scope); filter routes to different Mongo match fields",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/api/confid-vs-resourceid-routing.md"
+    },
+    {
+      "slug": "copy-naming-suffix-numbered",
+      "category": "decision",
+      "summary": "|",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/copy-naming-suffix-numbered.md"
+    },
+    {
+      "slug": "cors-allow-credentials-star-origin",
+      "category": "decision",
+      "summary": "서비스 레벨 allowCredentials=true + allowedOriginPatterns(\"*\") 유지 — 엣지(Traefik/Istio)에서 CORS를 제어하는 아키텍처 전제",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/cors-allow-credentials-star-origin.md"
+    },
+    {
+      "slug": "crypto-randomuuid-requires-secure-context",
+      "category": "pitfall",
+      "summary": "\"`crypto.randomUUID()` is only defined in secure contexts (HTTPS or localhost); plain-HTTP dev or intranet deployments need an explicit UUID fallback.\"",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/pitfall/crypto-randomuuid-requires-secure-context.md"
+    },
+    {
+      "slug": "csp-frame-ancestors-required",
+      "category": "decision",
+      "summary": "Send a Content-Security-Policy header (including `frame-ancestors`) on every response to block clickjacking",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/csp-frame-ancestors-required.md"
+    },
+    {
+      "slug": "data-patch-package-for-migrations",
+      "category": "arch",
+      "summary": "One-off data patches (backfills, embedded→referenced splits, field additions) are grouped under a `patch` package so they're isolated from day-to-day service code and easy to audit/remove after a release.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/data-patch-package-for-migrations.md"
+    },
+    {
+      "slug": "dataavro-json-wrapper-pattern",
+      "category": "decision",
+      "summary": "여러 이벤트 타입마다 Avro 스키마를 만들지 않고 DataAvro{jsonData,jsonDataClass} 하나로 통일 — TCM 선례 채택",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/dataavro-json-wrapper-pattern.md"
+    },
+    {
+      "slug": "do-not-ask-planners-for-api-design",
+      "category": "decision",
+      "summary": "Product planners own screens and UX, not endpoint shapes — push API design to AI extraction + developer review instead of template-driven planner input",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/do-not-ask-planners-for-api-design.md"
     },
     {
       "slug": "docker-engine-29-requires-traefik-upgrade",
       "category": "pitfall",
       "summary": "Docker Engine 29.x raises the minimum client API to 1.44, breaking older Traefik versions that pin an older API",
       "confidence": "high",
-      "source_project": "lucida-for-docker",
-      "path": "pitfall/docker-engine-29-requires-traefik-upgrade",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/docker-engine-29-requires-traefik-upgrade.md"
+    },
+    {
+      "slug": "domain-registry-plus-projects-yaml",
+      "category": "arch",
+      "summary": "Central domain registry + per-user path map for multi-repo codegen",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/domain-registry-plus-projects-yaml.md"
+    },
+    {
+      "slug": "dual-design-token-pipeline-arch",
+      "category": "arch",
+      "summary": "Project runs two parallel design token pipelines — legacy SD v3→SCSS for sirius/Ant Design and modern SD v5→CSS @theme for AI Portal/Tailwind v4",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/dual-design-token-pipeline-arch.md"
+    },
+    {
+      "slug": "dual-redis-lock-vs-access-control",
+      "category": "arch",
+      "summary": "The service connects to two separate Redis instances: Lock Control (default port 6399) and Access Control (default port 6389). They are not interchangeable.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/arch/dual-redis-lock-vs-access-control.md"
+    },
+    {
+      "slug": "duckdb-vectorized-analytical-execution",
+      "category": "arch",
+      "summary": "DuckDB's design has five separable pillars — vectorized execution, pipelined operators, explicit memory + grouped aggregation, ART indexing, and a dedicated query rewriter — distinguishing it from row-at-a-time OLTP engines.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/duckdb-vectorized-analytical-execution.md"
+    },
+    {
+      "slug": "encrypted-pii-decode-on-export",
+      "category": "domain",
+      "summary": "PII fields (phone, email) are stored encrypted; only decrypted for explicit export/API response, never for logs.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/domain/encrypted-pii-decode-on-export.md"
     },
     {
       "slug": "enum-notnull-comparison-pitfall",
       "category": "pitfall",
-      "summary": "",
+      "summary": "In Java, comparing an enum field with `==` without a null guard NPEs on the left operand; prefer constant-on-the-left or an explicit @NotNull contract",
       "confidence": "high",
       "source_project": "",
-      "path": "pitfall/enum-notnull-comparison-pitfall",
-      "linked_skills": []
+      "path": "knowledge/pitfall/enum-notnull-comparison-pitfall.md"
     },
     {
       "slug": "enum-whitelist-blocks-time-based-sqli",
       "category": "pitfall",
-      "summary": "",
+      "summary": "Validate user-supplied identifiers (metric aliases, column names, value-type keys) against a known definition/enum before they reach any query builder — string-only sinks are still injectable",
       "confidence": "high",
       "source_project": "",
-      "path": "pitfall/enum-whitelist-blocks-time-based-sqli",
-      "linked_skills": []
+      "path": "knowledge/pitfall/enum-whitelist-blocks-time-based-sqli.md"
+    },
+    {
+      "slug": "env-override-last-wins-chain",
+      "category": "arch",
+      "summary": "Environment variables resolve across four sources with \"last wins\" precedence.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/env-override-last-wins-chain.md"
+    },
+    {
+      "slug": "es-xpack-transport-vs-rest-ssl",
+      "category": "api",
+      "summary": "Elasticsearch transport SSL and REST SSL are independent X-Pack configs; enabling one does not enable the other",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/api/es-xpack-transport-vs-rest-ssl.md"
+    },
+    {
+      "slug": "event-driven-init-wait-for-services",
+      "category": "arch",
+      "summary": "Initialization work is deferred until leader status and dependent-service readiness are confirmed via a `@WaitForServices` event listener",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/arch/event-driven-init-wait-for-services.md"
+    },
+    {
+      "slug": "existing-code-patterns-over-standard-rules",
+      "category": "decision",
+      "summary": "When generating into an established repo, mirror the repo's existing style first; apply the written standard only when the repo is empty or silent",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/existing-code-patterns-over-standard-rules.md"
+    },
+    {
+      "slug": "fifth-normal-form-join-dependency-tradeoff",
+      "category": "decision",
+      "summary": "5NF catches join dependencies that 4NF/BCNF miss, but in practice you rarely reason about it directly — design from business entities, recognize AB-BC-AC triangles vs ABC+D stars, and let 5NF fall out.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/fifth-normal-form-join-dependency-tradeoff.md"
+    },
+    {
+      "slug": "god-controller-split-by-resource",
+      "category": "decision",
+      "summary": "\"Split an oversized controller along URL sub-resource boundaries (one controller per sub-path like /page, /widget, /file) and keep the common @RequestMapping prefix — clearer per-class responsibility without breaking the external API surface.\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/god-controller-split-by-resource.md"
+    },
+    {
+      "slug": "gradle-avro-plugin-config",
+      "category": "arch",
+      "summary": "davidmc24 avro-gradle-plugin config — createSetters=false + fieldVisibility=PRIVATE enforces immutable generated event schemas",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/gradle-avro-plugin-config.md"
     },
     {
       "slug": "gridfs-template-upload-data-loss-pitfall",
       "category": "pitfall",
-      "summary": "MongoDB GridFS uploads can silently drop file bytes if the bucket/db selection or stream flush is wrong - always verify metadata size equals input size",
+      "summary": "MongoDB GridFS uploads can silently drop file bytes if the bucket/db selection or stream flush is wrong — always verify metadata size equals input size",
       "confidence": "medium",
-      "source_project": "lucida-report",
-      "path": "pitfall/gridfs-template-upload-data-loss-pitfall",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/gridfs-template-upload-data-loss-pitfall.md"
     },
     {
       "slug": "hibernate-date-format-lowercase",
@@ -3818,26 +2884,47 @@
       "summary": "Use lowercase `yyyy` for calendar year — `YYYY` is ISO week-year and produces wrong values near Jan 1 / Dec 31",
       "confidence": "high",
       "source_project": "",
-      "path": "pitfall/hibernate-date-format-lowercase",
-      "linked_skills": []
+      "path": "knowledge/pitfall/hibernate-date-format-lowercase.md"
+    },
+    {
+      "slug": "hierarchical-agents-md-catalog",
+      "category": "arch",
+      "summary": "\"루트 AGENTS.md(프로젝트 개요) + `skills/AGENTS.md`(스킬 카탈로그) 2계층 구조. 하위는 상위를 `<!-- Parent: ../AGENTS.md -->` 주석으로 가리킨다.\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/hierarchical-agents-md-catalog.md"
     },
     {
       "slug": "history-view-yearly-partition-pitfall",
       "category": "pitfall",
       "summary": "A history/reporting view or materialized collection created with a year-bounded clause silently stops returning rows when the calendar year rolls over",
       "confidence": "high",
-      "source_project": "lucida-notification",
-      "path": "pitfall/history-view-yearly-partition-pitfall",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/history-view-yearly-partition-pitfall.md"
+    },
+    {
+      "slug": "hyperloglog-for-unique-user-counting",
+      "category": "decision",
+      "summary": "Scouter uses HyperLogLog (Clearspring stream-lib) to estimate recent and daily unique user counts with ~100 bytes of memory and ~2% error, avoiding O(n) hash sets",
+      "confidence": "medium",
+      "source_project": "scouter",
+      "path": "knowledge/decision/hyperloglog-for-unique-user-counting.md"
     },
     {
       "slug": "injectmocks-generics-type-erasure",
       "category": "pitfall",
-      "summary": "@InjectMocks picks wrong mock for same raw-type generic fields due to type erasure — flaky test root cause",
+      "summary": "@InjectMocks가 제네릭 필드에 Mock을 주입할 때 타입 소거로 잘못된 후보를 고르는 flaky 원인",
       "confidence": "high",
-      "source_project": "lucida-domain-automation",
-      "path": "pitfall/injectmocks-generics-type-erasure",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/injectmocks-generics-type-erasure.md"
+    },
+    {
+      "slug": "interface-abstraction-for-modularity",
+      "category": "arch",
+      "summary": "Pure-virtual C++ interfaces in a dedicated src/interfaces/ directory decouple modules without symbol-level coupling, and enable IPC code generation later.",
+      "confidence": "high",
+      "source_project": "bitcoin",
+      "path": "knowledge/arch/interface-abstraction-for-modularity.md"
     },
     {
       "slug": "ipv6-colon-detection-edge",
@@ -3845,26 +2932,103 @@
       "summary": "Detecting IPv6 by colon count breaks on compressed notation — use a regex character class",
       "confidence": "medium",
       "source_project": "",
-      "path": "pitfall/ipv6-colon-detection-edge",
-      "linked_skills": []
+      "path": "knowledge/pitfall/ipv6-colon-detection-edge.md"
     },
     {
       "slug": "jackson-version-pinning-2.17.1",
       "category": "pitfall",
       "summary": "Jackson must be pinned via Gradle resolutionStrategy across all com.fasterxml.jackson.* groups to avoid NoSuchMethodError from transitive version drift",
       "confidence": "high",
-      "source_project": "lucida-audit",
-      "path": "pitfall/jackson-version-pinning-2.17.1",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/jackson-version-pinning-2.17.1.md"
+    },
+    {
+      "slug": "jacoco-exclude-business-layers",
+      "category": "decision",
+      "summary": "In this project's Jacoco config, nearly every layer (service, repository, dto, entity, kafka, config, constants, helper, exception, schedule, provider) is excluded from coverage measurement — only controllers/business orchestration code is measured.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/jacoco-exclude-business-layers.md"
+    },
+    {
+      "slug": "jacoco-sonar-exclusion-policy",
+      "category": "decision",
+      "summary": "Single exclusion list drives Jacoco + Sonar + test excludes; generated/boilerplate code never counts toward coverage",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/jacoco-sonar-exclusion-policy.md"
+    },
+    {
+      "slug": "jacoco-sonar-exclusion-rationale",
+      "category": "decision",
+      "summary": "Classes under config/, dto/, entity/, kafka/, avro/, exception/, advice/, schedule/, service/websocket/, and generated Q-classes are excluded from Jacoco coverage gates. Only business logic (routers, guards, services) is measured.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/jacoco-sonar-exclusion-rationale.md"
+    },
+    {
+      "slug": "jar-task-disabled-bootjar-only",
+      "category": "arch",
+      "summary": "Gradle `jar` task is disabled so only `bootJar` produces an artifact — CI/Docker consumers never receive an ambiguous plain JAR",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/jar-task-disabled-bootjar-only.md"
+    },
+    {
+      "slug": "java-21-upgrade-rationale",
+      "category": "decision",
+      "summary": "Java 17 → 21 + Spring Boot 3.5.x upgrade rationale and required Gradle/JVM flag adjustments",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/java-21-upgrade-rationale.md"
     },
     {
       "slug": "jdbc-template-var-xml-escape-bypass",
       "category": "pitfall",
       "summary": "When the template engine XML-escapes values but the downstream channel is raw SQL / plain text, the escaped `&amp; &lt; &gt;` leaks into stored data",
       "confidence": "medium",
-      "source_project": "lucida-notification",
-      "path": "pitfall/jdbc-template-var-xml-escape-bypass",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/jdbc-template-var-xml-escape-bypass.md"
+    },
+    {
+      "slug": "jest-coverage-80-threshold",
+      "category": "decision",
+      "summary": "Global Jest coverage threshold is 80% on branches, functions, lines, and statements",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/jest-coverage-80-threshold.md"
+    },
+    {
+      "slug": "jvm-module-opens-java21-spring-kafka",
+      "category": "arch",
+      "summary": "Java 21 runs Spring Boot + Kafka/MongoDB clients under strict module access; two --add-opens flags are required or reflective serializers fail at runtime.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/jvm-module-opens-java21-spring-kafka.md"
+    },
+    {
+      "slug": "jwt-stateless-refresh-24h-default",
+      "category": "decision",
+      "summary": "JWT stateless auth with 1h access / 24h refresh token defaults, both env-tunable.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/jwt-stateless-refresh-24h-default.md"
+    },
+    {
+      "slug": "k-git-tag-registry-versioning",
+      "category": "arch",
+      "summary": "\"Git tag를 semver registry로 쓰면 별도 version manifest 없이 rollback·pinning을 얻는다\"",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/arch/k-git-tag-registry-versioning.md"
+    },
+    {
+      "slug": "k-kafka-message-header-metadata",
+      "category": "decision",
+      "summary": "\"멀티테넌트 Kafka routing 메타는 payload 대신 RecordHeader에 두어 business schema 오염을 막는다\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/k-kafka-message-header-metadata.md"
     },
     {
       "slug": "k8s-clusterrole-aggregation-npe",
@@ -3872,140 +3036,279 @@
       "summary": "ClusterRole `aggregationRule` and its `clusterRoleSelectors` are both nullable — iterate only after null-check",
       "confidence": "medium",
       "source_project": "",
-      "path": "pitfall/k8s-clusterrole-aggregation-npe",
-      "linked_skills": []
+      "path": "knowledge/pitfall/k8s-clusterrole-aggregation-npe.md"
+    },
+    {
+      "slug": "kafka-1h-topic-and-nonmetric-pool",
+      "category": "arch",
+      "summary": "Raw alarm path uses a 1-hour-retention Kafka topic and a dedicated non-metric thread pool — isolates alarm latency from batch ingest",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/kafka-1h-topic-and-nonmetric-pool.md"
+    },
+    {
+      "slug": "kafka-avro-change-flag-contract",
+      "category": "api",
+      "summary": "Every Configuration-domain Avro event carries an `actionType` enum (INSERT/UPDATE/DELETE) plus boolean change flags per mutable section (e.g. `parentChanged`, `tagFiltersChanged`, `configurationsChanged`) rather than full before/after payloads.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/api/kafka-avro-change-flag-contract.md"
+    },
+    {
+      "slug": "kafka-avro-schedule-event-chain",
+      "category": "arch",
+      "summary": "Collection scheduling decouples Kafka ingress from per-DBMS handlers via four typed BlockingQueues",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/kafka-avro-schedule-event-chain.md"
+    },
+    {
+      "slug": "kafka-avro-schema-registry-env-topology",
+      "category": "arch",
+      "summary": "Kafka uses Avro + Confluent Schema Registry; partition and replication counts are environment-driven.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/kafka-avro-schema-registry-env-topology.md"
+    },
+    {
+      "slug": "kafka-batch-size-timeout-tuning",
+      "category": "decision",
+      "summary": "Lowering Spring Kafka max-poll-records (e.g. 200→10) on heavy-processing consumers prevents max.poll.interval.ms timeouts and rebalance storms",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/kafka-batch-size-timeout-tuning.md"
     },
     {
       "slug": "kafka-consumer-group-id-hostname-not-timezone",
       "category": "pitfall",
-      "summary": "",
+      "summary": "Kafka consumer group-id must derive from a stable node identifier (hostname), never from a timezone/locale string — a silent typo will split consumers into unintended groups.",
       "confidence": "high",
       "source_project": "",
-      "path": "pitfall/kafka-consumer-group-id-hostname-not-timezone",
-      "linked_skills": []
+      "path": "knowledge/pitfall/kafka-consumer-group-id-hostname-not-timezone.md"
     },
     {
       "slug": "kafka-error-handling-deserializer-fallback",
       "category": "pitfall",
       "summary": "Wrap Avro/JSON deserializers in ErrorHandlingDeserializer so a single bad record doesn't poison the consumer and crash-loop the container",
       "confidence": "high",
-      "source_project": "lucida-audit",
-      "path": "pitfall/kafka-error-handling-deserializer-fallback",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/kafka-error-handling-deserializer-fallback.md"
+    },
+    {
+      "slug": "kafka-organization-id-record-header",
+      "category": "api",
+      "summary": "Place organizationId (tenant) in the Kafka record header, not only in the payload — downstream consumers route by header before deserializing.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/api/kafka-organization-id-record-header.md"
+    },
+    {
+      "slug": "kafka-partition-topology-design",
+      "category": "arch",
+      "summary": "Asymmetric Kafka partition counts per topic (high for hot-path, default for admin topics) match volume and concurrency needs without over-provisioning",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/arch/kafka-partition-topology-design.md"
     },
     {
       "slug": "kafka-sticky-partitioner-key-null",
       "category": "pitfall",
-      "summary": "Kafka Sticky Partitioner batches key=null messages into one partition — explains dev vs prod distribution gap",
+      "summary": "ProducerRecord key=null일 때 Sticky Partitioner가 batch.size 동안 한 파티션에 몰리는 성질 — 소규모 환경에서 Pod 분산 안 보이는 원인",
       "confidence": "high",
-      "source_project": "lucida-domain-automation",
-      "path": "pitfall/kafka-sticky-partitioner-key-null",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/kafka-sticky-partitioner-key-null.md"
     },
     {
       "slug": "konva-center-coord-system",
       "category": "pitfall",
       "summary": "Konva node coordinates can be center-based; when converting to top-left boxes subtract half width/height",
       "confidence": "medium",
-      "source_project": "lucida-builder-r3",
-      "path": "pitfall/konva-center-coord-system",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/konva-center-coord-system.md"
+    },
+    {
+      "slug": "large-range-query-raw-collections",
+      "category": "decision",
+      "summary": "For long time-range analytics over day-partitioned data, query the daily raw collections directly rather than going through an aggregated view to avoid query timeouts.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/large-range-query-raw-collections.md"
     },
     {
       "slug": "latest-availability-deletion-risk",
       "category": "pitfall",
       "summary": "Latest-availability collection can lose data when upstream source is stale but not actually missing",
       "confidence": "high",
-      "source_project": "lucida-measurement",
-      "path": "pitfall/latest-availability-deletion-risk",
-      "linked_skills": [
-        "availability-ttl-punctuate-processor"
-      ]
+      "source_project": "",
+      "path": "knowledge/pitfall/latest-availability-deletion-risk.md"
     },
     {
-      "slug": "Formal verification only covers what the spec formalizes",
+      "slug": "lean-verification-spec-coverage-gap",
       "category": "pitfall",
-      "summary": "Proofs bound what the spec covers, not what the system does. Fuzzing lean-zip found runtime and parser bugs outside the verified surface; ship a verified-surface / unverified-surface / TCB decomposition with any 'proven correct' claim.",
+      "summary": "Formal proofs cover exactly what the spec formalizes — untrusted parsers and the language runtime, which are usually *not* in the spec, routinely contain the bugs a \"proven correct\" library claims to have eliminated.",
       "confidence": "medium",
-      "source_project": "skills_research:trend:2026-04-16",
-      "path": "pitfall/lean-verification-spec-coverage-gap",
-      "linked_skills": [
-        "lean-verified-code-threat-boundary"
-      ]
+      "source_project": "",
+      "path": "knowledge/pitfall/lean-verification-spec-coverage-gap.md"
     },
     {
       "slug": "legacy-datasource-naming",
       "category": "pitfall",
-      "summary": "`dataSource` / `dataSourceFilter` in the codebase actually mean data-pipeline-select and data-pipeline-filter — not datasource",
+      "summary": "\"`dataSource` / `dataSourceFilter` in the codebase actually mean data-pipeline-select and data-pipeline-filter — not datasource\"",
       "confidence": "high",
-      "source_project": "lucida-builder-r3",
-      "path": "pitfall/legacy-datasource-naming",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/legacy-datasource-naming.md"
+    },
+    {
+      "slug": "less-antd-theme-only",
+      "category": "decision",
+      "summary": "LESS files (71 total) and less-loader exist solely for Ant Design modifyVars theming — LESS is not a general-purpose styling choice in this project",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/less-antd-theme-only.md"
+    },
+    {
+      "slug": "license-apply-window-15d",
+      "category": "decision",
+      "summary": "Issued licenses must be applied within 15 days; expired licenses are immutable.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/license-apply-window-15d.md"
+    },
+    {
+      "slug": "live-chart-timestamp-normalization",
+      "category": "api",
+      "summary": "LIVE charts accept `normalizeTimestamp` + `normalizeIntervalMs` to align per-agent millisecond offsets into a single x-axis",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/api/live-chart-timestamp-normalization.md"
+    },
+    {
+      "slug": "live-mode-aggregation-exceptions",
+      "category": "arch",
+      "summary": "LIVE mode reads raw data by default, but equalizer / multi-resource / TopN charts still aggregate raw at query time",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/live-mode-aggregation-exceptions.md"
+    },
+    {
+      "slug": "llm-tool-calling-mxn-wire-format-problem",
+      "category": "arch",
+      "summary": "Open-source LLMs each encode tool calls in a different wire format (special tokens, XML, channel notation, JSON blocks), so M inference apps × N models = M×N parsers. Fix is declarative tool-call specs shipped with the model and consumed by both grammar engines and parsers.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/llm-tool-calling-mxn-wire-format-problem.md"
+    },
+    {
+      "slug": "lucida-framework-gate-annotations",
+      "category": "arch",
+      "summary": "Internal framework (lucida-framework-*) uses opt-in annotations (@EnabledMessage, @EnableDataExport, @EnableSchedule, @EnableCommand) on the Application class to gate auto-config; omitting one silently disables the feature.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/arch/lucida-framework-gate-annotations.md"
+    },
+    {
+      "slug": "measurement-batch-send-per-config",
+      "category": "decision",
+      "summary": "Send one bundled Kafka message per target per tick containing all metrics, instead of one message per (target, metric).",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/measurement-batch-send-per-config.md"
+    },
+    {
+      "slug": "mf-cross-remote-import-forbidden",
+      "category": "arch",
+      "summary": "In a Module Federation monorepo with per-remote webpack aliases, remotes must not import from sibling remotes directly — share code through `shared/` or through MF exposes.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/arch/mf-cross-remote-import-forbidden.md"
+    },
+    {
+      "slug": "mf-expose-requires-memoryrouter-wrapper",
+      "category": "arch",
+      "summary": "Components exposed via Module Federation that use react-router hooks must be wrapped in MemoryRouter at the expose boundary, not BrowserRouter and not a full-app router wrapper.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/arch/mf-expose-requires-memoryrouter-wrapper.md"
+    },
+    {
+      "slug": "mf-select-unstable-options-infinite-loop",
+      "category": "pitfall",
+      "summary": "Custom Select/Dropdown components that accept an `options` array and diff it by reference can infinite-loop when consumed across a Module Federation boundary; prefer pure HTML selects or stabilize the array.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/pitfall/mf-select-unstable-options-infinite-loop.md"
     },
     {
       "slug": "mongo-direct-connection-flag",
       "category": "pitfall",
       "summary": "MongoDB datasource connectionString requires directConnection=true in this deployment",
       "confidence": "medium",
-      "source_project": "lucida-builder-r3",
-      "path": "pitfall/mongo-direct-connection-flag",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/mongo-direct-connection-flag.md"
     },
     {
       "slug": "mongo-timeseries-forced-hint-kills-pushdown",
       "category": "pitfall",
-      "summary": "",
+      "summary": "\"Forcing `hint(indexName)` on a MongoDB time-series aggregation bypasses the optimizer's bucket-index rewrite — the plan scans every bucket with `control.min/max.timestamp = [MinKey, MaxKey]` instead of honoring the timestamp predicate.\"",
       "confidence": "high",
       "source_project": "",
-      "path": "pitfall/mongo-timeseries-forced-hint-kills-pushdown",
-      "linked_skills": []
+      "path": "knowledge/pitfall/mongo-timeseries-forced-hint-kills-pushdown.md"
     },
     {
       "slug": "mongo-timeseries-match-split-for-pushdown",
       "category": "pitfall",
-      "summary": "",
+      "summary": "\"On MongoDB time-series collections, combining timestamp range + metadata filters in a single `$match` disables bucket-level push-down — split into two sequential `$match` stages (timestamp first, metadata second) so the optimizer can synthesize `control.*.timestamp` bounds.\"",
       "confidence": "high",
       "source_project": "",
-      "path": "pitfall/mongo-timeseries-match-split-for-pushdown",
-      "linked_skills": []
+      "path": "knowledge/pitfall/mongo-timeseries-match-split-for-pushdown.md"
     },
     {
       "slug": "mongo-timeseries-view-pushdown-broken-8_2_3",
       "category": "pitfall",
-      "summary": "",
+      "summary": "\"On MongoDB 8.2.3, aggregations run against a view whose source is a time-series collection lose the timestamp bucket-index push-down — hot queries must target the base collection directly. Retest after server upgrades.\"",
       "confidence": "medium",
       "source_project": "",
-      "path": "pitfall/mongo-timeseries-view-pushdown-broken-8_2_3",
-      "linked_skills": []
+      "path": "knowledge/pitfall/mongo-timeseries-view-pushdown-broken-8_2_3.md"
+    },
+    {
+      "slug": "mongodb-aggregated-stats-as-views",
+      "category": "arch",
+      "summary": "Precomputed hour/day statistics exposed as MongoDB read-only views instead of physical collections to simplify reads and keep them consistent with source",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/arch/mongodb-aggregated-stats-as-views.md"
     },
     {
       "slug": "mongodb-changestream-resubscribe",
       "category": "pitfall",
-      "summary": "",
+      "summary": "MongoDB change streams do not self-heal after network hiccups or replica-set elections; must be explicitly stopped and restarted to resume receiving events",
       "confidence": "high",
       "source_project": "",
-      "path": "pitfall/mongodb-changestream-resubscribe",
-      "linked_skills": [
-        "mongodb-changestream-field-filter"
-      ]
+      "path": "knowledge/pitfall/mongodb-changestream-resubscribe.md"
     },
     {
       "slug": "mongodb-compound-index-on-views",
       "category": "pitfall",
-      "summary": "Spring Data @CompoundIndex annotations on a view-backed @Document are silently ignored — index the collection class",
+      "summary": "Spring Data @CompoundIndex annotations on a view-backed @Document class are silently ignored — the annotation must live on the collection-backed class or the collection stays unindexed.",
       "confidence": "high",
-      "source_project": "lucida-domain-apm",
-      "path": "pitfall/mongodb-compound-index-on-views",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/mongodb-compound-index-on-views.md"
     },
     {
       "slug": "mongodb-documentreference-lazy-removal",
       "category": "pitfall",
-      "summary": "",
+      "summary": "Spring Data MongoDB @DocumentReference (even with lazy=true) triggers N+1 queries on bulk reads; replace with explicit $lookup aggregation",
       "confidence": "high",
       "source_project": "",
-      "path": "pitfall/mongodb-documentreference-lazy-removal",
-      "linked_skills": []
+      "path": "knowledge/pitfall/mongodb-documentreference-lazy-removal.md"
+    },
+    {
+      "slug": "mongodb-exclude-system-databases",
+      "category": "domain",
+      "summary": "When enumerating tenant databases in a shared MongoDB cluster, filter out admin/config/local plus third-party DBs (yorkie-meta, migration) to avoid touching shared state",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/domain/mongodb-exclude-system-databases.md"
     },
     {
       "slug": "mongodb-field-name-underscore-to-dot",
@@ -4013,55 +3316,527 @@
       "summary": "|",
       "confidence": "medium",
       "source_project": "",
-      "path": "pitfall/mongodb-field-name-underscore-to-dot",
-      "linked_skills": []
+      "path": "knowledge/pitfall/mongodb-field-name-underscore-to-dot.md"
     },
     {
       "slug": "mongodb-single-node-directconnection",
       "category": "pitfall",
       "summary": "MongoDB clients must pass directConnection=true when connecting to a single-node replSet, otherwise they hang on primary discovery",
       "confidence": "high",
-      "source_project": "lucida-for-docker",
-      "path": "pitfall/mongodb-single-node-directconnection",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/mongodb-single-node-directconnection.md"
     },
     {
       "slug": "mongodb-string-id-field-type-mapping",
       "category": "pitfall",
       "summary": "Spring Data MongoDB coerces 24-char-hex @Id String values to ObjectId unless @Field(targetType = FieldType.STRING) is set",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/pitfall/mongodb-string-id-field-type-mapping.md"
+    },
+    {
+      "slug": "multi-domain-split-via-domain-mapping",
+      "category": "arch",
+      "summary": "Split multi-domain screens via a domain-mapping manifest — one OpenAPI file per owning domain",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/multi-domain-split-via-domain-mapping.md"
+    },
+    {
+      "slug": "multi-layer-css-architecture",
+      "category": "arch",
+      "summary": "Four-layer CSS architecture — SCSS (sirius design system), LESS (Ant Design vars), Tailwind v4 (AI Portal with scope isolation), plain CSS — each with distinct webpack rules and toolchains",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/multi-layer-css-architecture.md"
+    },
+    {
+      "slug": "multiprocess-architecture-via-ipc",
+      "category": "arch",
+      "summary": "Decompose a monolith into cooperating processes by defining interfaces in a neutral schema language (Cap'n Proto), then codegen client/server proxies that preserve the original C++ interface shape.",
       "confidence": "high",
-      "source_project": "lucida-domain-dpm",
-      "path": "pitfall/mongodb-string-id-field-type-mapping",
-      "linked_skills": []
+      "source_project": "bitcoin",
+      "path": "knowledge/arch/multiprocess-architecture-via-ipc.md"
+    },
+    {
+      "slug": "mysql-mariadb-performance-schema-detection",
+      "category": "domain",
+      "summary": "MySQL/MariaDB metric availability depends on per-instance Performance Schema state; detect at runtime, don't assume",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/domain/mysql-mariadb-performance-schema-detection.md"
+    },
+    {
+      "slug": "nfs-backed-volumes-for-docker-swarm",
+      "category": "arch",
+      "summary": "Cross-node Docker Swarm persistence via a single NFS share mounted at the same host path on every swarm node",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/arch/nfs-backed-volumes-for-docker-swarm.md"
+    },
+    {
+      "slug": "node-npm-pin-matches-jenkins",
+      "category": "decision",
+      "summary": "UI build is pinned to Node 24.6.0 + npm 11.5.1 to match the Jenkins build environment",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/node-npm-pin-matches-jenkins.md"
+    },
+    {
+      "slug": "oh-my-claudecode-ai-slop-cleaner",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"ai-slop-cleaner\\\" as: Clean AI-generated code slop with a regression-safe, deletion-first workflow and optional reviewer-only mode\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-ai-slop-cleaner.md"
+    },
+    {
+      "slug": "oh-my-claudecode-ask",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"ask\\\" as: Process-first advisor routing for Claude, Codex, or Gemini via `omc ask`, with artifact capture and no raw CLI assembly\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-ask.md"
+    },
+    {
+      "slug": "oh-my-claudecode-autopilot",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"autopilot\\\" as: Full autonomous execution from idea to working code\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-autopilot.md"
+    },
+    {
+      "slug": "oh-my-claudecode-cancel",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"cancel\\\" as: Cancel any active OMC mode (autopilot, ralph, ultrawork, ultraqa, swarm, ultrapilot, pipeline, team)\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-cancel.md"
+    },
+    {
+      "slug": "oh-my-claudecode-ccg",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"ccg\\\" as: Claude-Codex-Gemini tri-model orchestration via /ask codex + /ask gemini, then Claude synthesizes results\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-ccg.md"
+    },
+    {
+      "slug": "oh-my-claudecode-configure-notifications",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"configure-notifications\\\" as: Configure notification integrations (Telegram, Discord, Slack) via natural language\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-configure-notifications.md"
+    },
+    {
+      "slug": "oh-my-claudecode-debug",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"debug\\\" as: Diagnose the current OMC session or repo state using logs, traces, state, and focused reproduction\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-debug.md"
+    },
+    {
+      "slug": "oh-my-claudecode-deep-dive",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"deep-dive\\\" as: 2-stage pipeline: trace (causal investigation) -> deep-interview (requirements crystallization) with 3-point injection\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-deep-dive.md"
+    },
+    {
+      "slug": "oh-my-claudecode-deep-interview",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"deep-interview\\\" as: Socratic deep interview with mathematical ambiguity gating before autonomous execution\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-deep-interview.md"
+    },
+    {
+      "slug": "oh-my-claudecode-deepinit",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"deepinit\\\" as: Deep codebase initialization with hierarchical AGENTS.md documentation\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-deepinit.md"
+    },
+    {
+      "slug": "oh-my-claudecode-external-context",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"external-context\\\" as: Invoke parallel document-specialist agents for external web searches and documentation lookup\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-external-context.md"
+    },
+    {
+      "slug": "oh-my-claudecode-hud",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"hud\\\" as: Configure HUD display options (layout, presets, display elements)\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-hud.md"
+    },
+    {
+      "slug": "oh-my-claudecode-learner",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"learner\\\" as: Extract a learned skill from the current conversation\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-learner.md"
+    },
+    {
+      "slug": "oh-my-claudecode-mcp-setup",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"mcp-setup\\\" as: Configure popular MCP servers for enhanced agent capabilities\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-mcp-setup.md"
+    },
+    {
+      "slug": "oh-my-claudecode-omc-doctor",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"omc-doctor\\\" as: Diagnose and fix oh-my-claudecode installation issues\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-omc-doctor.md"
+    },
+    {
+      "slug": "oh-my-claudecode-omc-reference",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"omc-reference\\\" as: OMC agent catalog, available tools, team pipeline routing, commit protocol, and skills registry. Auto-loads when delegating to agents, using OMC tools, orchestrating teams, making commits, or invoking skills.\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-omc-reference.md"
+    },
+    {
+      "slug": "oh-my-claudecode-omc-setup",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"omc-setup\\\" as: Install or refresh oh-my-claudecode for plugin, npm, and local-dev setups from the canonical setup flow\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-omc-setup.md"
+    },
+    {
+      "slug": "oh-my-claudecode-omc-teams",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"omc-teams\\\" as: CLI-team runtime for claude, codex, or gemini workers in tmux panes when you need process-based parallel execution\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-omc-teams.md"
+    },
+    {
+      "slug": "oh-my-claudecode-plan",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"plan\\\" as: Strategic planning with optional interview workflow\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-plan.md"
+    },
+    {
+      "slug": "oh-my-claudecode-project-session-manager",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"project-session-manager\\\" as: Worktree-first dev environment manager for issues, PRs, and features with optional tmux sessions\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-project-session-manager.md"
+    },
+    {
+      "slug": "oh-my-claudecode-ralph",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"ralph\\\" as: Self-referential loop until task completion with configurable verification reviewer\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-ralph.md"
+    },
+    {
+      "slug": "oh-my-claudecode-ralplan",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"ralplan\\\" as: Consensus planning entrypoint that auto-gates vague ralph/autopilot/team requests before execution\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-ralplan.md"
+    },
+    {
+      "slug": "oh-my-claudecode-release",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"release\\\" as: Generic release assistant — analyzes repo release rules, caches them in .omc/RELEASE_RULE.md, then guides the release\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-release.md"
+    },
+    {
+      "slug": "oh-my-claudecode-remember",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"remember\\\" as: Review reusable project knowledge and decide what belongs in project memory, notepad, or durable docs\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-remember.md"
+    },
+    {
+      "slug": "oh-my-claudecode-sciomc",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"sciomc\\\" as: Orchestrate parallel scientist agents for comprehensive analysis with AUTO mode\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-sciomc.md"
+    },
+    {
+      "slug": "oh-my-claudecode-self-improve",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"self-improve\\\" as: Autonomous evolutionary code improvement engine with tournament selection\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-self-improve.md"
+    },
+    {
+      "slug": "oh-my-claudecode-setup",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"setup\\\" as: Use first for install/update routing — sends setup, doctor, or MCP requests to the correct OMC setup flow\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-setup.md"
+    },
+    {
+      "slug": "oh-my-claudecode-skill",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"skill\\\" as: Manage local skills - list, add, remove, search, edit, setup wizard\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-skill.md"
+    },
+    {
+      "slug": "oh-my-claudecode-skillify",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"skillify\\\" as: Turn a repeatable workflow from the current session into a reusable OMC skill draft\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-skillify.md"
+    },
+    {
+      "slug": "oh-my-claudecode-team",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"team\\\" as: N coordinated agents on shared task list using Claude Code native teams\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-team.md"
+    },
+    {
+      "slug": "oh-my-claudecode-trace",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"trace\\\" as: Evidence-driven tracing lane that orchestrates competing tracer hypotheses in Claude built-in team mode\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-trace.md"
+    },
+    {
+      "slug": "oh-my-claudecode-ultraqa",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"ultraqa\\\" as: QA cycling workflow - test, verify, fix, repeat until goal met\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-ultraqa.md"
+    },
+    {
+      "slug": "oh-my-claudecode-ultrawork",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"ultrawork\\\" as: Parallel execution engine for high-throughput task completion\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-ultrawork.md"
+    },
+    {
+      "slug": "oh-my-claudecode-verify",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"verify\\\" as: Verify that a change really works before you claim completion\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-verify.md"
+    },
+    {
+      "slug": "oh-my-claudecode-visual-verdict",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"visual-verdict\\\" as: Structured visual QA verdict for screenshot-to-reference comparisons\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-visual-verdict.md"
+    },
+    {
+      "slug": "oh-my-claudecode-wiki",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"wiki\\\" as: LLM Wiki — persistent markdown knowledge base that compounds across sessions (Karpathy model)\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-wiki.md"
+    },
+    {
+      "slug": "oh-my-claudecode-writer-memory",
+      "category": "arch",
+      "summary": "\"OMC implements \\\"writer-memory\\\" as: Agentic memory system for writers - track characters, relationships, scenes, and themes\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/oh-my-claudecode-writer-memory.md"
+    },
+    {
+      "slug": "one-default-template-per-type-rule",
+      "category": "domain",
+      "summary": "Exactly one default message template may exist per notification type; creating a second default is rejected, but editing the existing default is allowed",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/domain/one-default-template-per-type-rule.md"
+    },
+    {
+      "slug": "openapi-as-single-fe-be-contract",
+      "category": "arch",
+      "summary": "Use OpenAPI 3.0 as the only intermediate artifact between planning and codegen; both FE and BE generators consume the same file",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/arch/openapi-as-single-fe-be-contract.md"
+    },
+    {
+      "slug": "organization-soft-delete-grace-period",
+      "category": "decision",
+      "summary": "Organization deletion uses a 30-day grace period before permanent removal (DELETE_ORGANIZATION_INTERVAL_DAYS).",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/organization-soft-delete-grace-period.md"
     },
     {
       "slug": "oz-license-file-placement-flip-flop",
       "category": "pitfall",
-      "summary": "Vendor engines (OZ Report, Crystal, Jasper-Pro) often hard-code license file search paths - pin the path in the image and document it, or you will ship it broken repeatedly",
+      "summary": "Vendor engines (OZ Report, Crystal, Jasper-Pro) often hard-code license file search paths — pin the path in the image and document it, or you will ship it broken repeatedly",
       "confidence": "medium",
-      "source_project": "lucida-report",
-      "path": "pitfall/oz-license-file-placement-flip-flop",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/oz-license-file-placement-flip-flop.md"
     },
     {
       "slug": "page-map-returns-new-instance",
       "category": "pitfall",
-      "summary": "Spring Data Page is immutable — Page.map() returns a new instance; forgetting to reassign silently loses the mapping",
+      "summary": "Spring Data Page는 불변 — Page.map()은 새 인스턴스를 반환하므로 호출 결과를 반드시 재할당해야 한다",
       "confidence": "high",
-      "source_project": "lucida-domain-automation",
-      "path": "pitfall/page-map-returns-new-instance",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/page-map-returns-new-instance.md"
+    },
+    {
+      "slug": "period-interval-naming-convention",
+      "category": "domain",
+      "summary": "Period.Mode names encode both unit and multiplier (MIN_15, MONTH_2); monthly modes densify at 24h, not the unit itself",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/domain/period-interval-naming-convention.md"
+    },
+    {
+      "slug": "pims-write-requires-dryrun-confirm",
+      "category": "domain",
+      "summary": "\"PIMS 시간 기록/제출/일괄 갱신 등 모든 쓰기 API는 미리보기 → 사용자 확인 → 재시도 가능한 실행 플로우를 반드시 거친다. `--dry-run`은 API 쓰기 호출 자체가 금지.\"",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/domain/pims-write-requires-dryrun-confirm.md"
+    },
+    {
+      "slug": "planning-doc-in-issue-description",
+      "category": "decision",
+      "summary": "For AI pipelines that read planning docs from issue trackers, favor putting the full markdown in the issue description over wiki-link indirection",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/planning-doc-in-issue-description.md"
+    },
+    {
+      "slug": "plugin-architecture-runtime-vs-startup-loading",
+      "category": "arch",
+      "summary": "Scouter server loads hot-reloadable script plugins (.plug files) for alerts/filters and compiled JAR plugins for stateful data handlers (sinks, connection-pool-heavy integrations)",
+      "confidence": "medium",
+      "source_project": "scouter",
+      "path": "knowledge/arch/plugin-architecture-runtime-vs-startup-loading.md"
+    },
+    {
+      "slug": "plugin-repo-scope-generic-skills-only",
+      "category": "decision",
+      "summary": "\"nkia-skills 같은 공용 플러그인에는 범용 스킬만. 프로젝트 특화 스킬은 각 프로젝트의 `.claude/skills/`에 둔다.\"",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/plugin-repo-scope-generic-skills-only.md"
     },
     {
       "slug": "policy-edit-saveraw-loss",
       "category": "pitfall",
       "summary": "Editing a common collection policy can silently drop individual `saveRaw`/interval settings if not re-applied",
       "confidence": "high",
-      "source_project": "lucida-measurement",
-      "path": "pitfall/policy-edit-saveraw-loss",
-      "linked_skills": [
-        "non-metric-saveraw-null-rule"
-      ]
+      "source_project": "",
+      "path": "knowledge/pitfall/policy-edit-saveraw-loss.md"
+    },
+    {
+      "slug": "polymorphic-metadata-via-enum-switch",
+      "category": "arch",
+      "summary": "Store heterogeneous domain payloads under one field as raw Document, then deserialize with Gson chosen by an enum discriminator",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/arch/polymorphic-metadata-via-enum-switch.md"
+    },
+    {
+      "slug": "port-out-no-optional-raise-in-adapter",
+      "category": "arch",
+      "summary": "In hexagonal codegen, single-record lookups should raise a domain exception inside the Adapter rather than return `Optional<T>` from the Port-Out interface",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/port-out-no-optional-raise-in-adapter.md"
+    },
+    {
+      "slug": "postgres-version-rolling-support",
+      "category": "decision",
+      "summary": "Roll PostgreSQL major-version support forward incrementally (9.x → 18) rather than pinning one LTS",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/postgres-version-rolling-support.md"
+    },
+    {
+      "slug": "prefer-static-import-over-constant-inheritance",
+      "category": "decision",
+      "summary": "\"Access shared constants via `import static SomeConstants.*` instead of `extends SomeConstants` — inheritance for constants pollutes the single-inheritance slot, leaks protected visibility, and makes subclasses nonsensically \\\"is-a\\\" a constants bag.\"",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/prefer-static-import-over-constant-inheritance.md"
+    },
+    {
+      "slug": "published-vs-realtime-view-pages",
+      "category": "arch",
+      "summary": "PublishedViewPage renders a frozen deploy snapshot; RealTimeViewPage renders the live editable dashboard",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/arch/published-vs-realtime-view-pages.md"
+    },
+    {
+      "slug": "push-local-removed-use-doc-update",
+      "category": "decision",
+      "summary": "pushLocalChangesIntoRemote and its action-mapping helpers were removed; mutate Yorkie via doc.update directly",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/push-local-removed-use-doc-update.md"
+    },
+    {
+      "slug": "query-manager-version-conversion-fallback",
+      "category": "decision",
+      "summary": "Unknown target RDBMS versions fall back to a documented default bucket rather than erroring, keeping collection alive",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/query-manager-version-conversion-fallback.md"
+    },
+    {
+      "slug": "rcp-desktop-client-design-rationale-vs-saas-web",
+      "category": "decision",
+      "summary": "Scouter chose an Eclipse RCP desktop client over a browser UI to enable high-throughput binary streams, local caching, and real-time drill-down without HTTP/JSON overhead",
+      "confidence": "high",
+      "source_project": "scouter",
+      "path": "knowledge/decision/rcp-desktop-client-design-rationale-vs-saas-web.md"
+    },
+    {
+      "slug": "redis-change-counter-for-versioning-trigger",
+      "category": "arch",
+      "summary": "|",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/redis-change-counter-for-versioning-trigger.md"
     },
     {
       "slug": "refresh-token-do-not-regenerate",
@@ -4069,17 +3844,63 @@
       "summary": "A refresh call must issue a new ACCESS token only, never a new refresh token.",
       "confidence": "medium",
       "source_project": "",
-      "path": "pitfall/refresh-token-do-not-regenerate",
-      "linked_skills": []
+      "path": "knowledge/pitfall/refresh-token-do-not-regenerate.md"
+    },
+    {
+      "slug": "resource-mount-unmount-use-jar-defaults",
+      "category": "decision",
+      "summary": "Don't bind-mount i18n/exception/menu resource files into Spring Boot containers; let the jar ship its own defaults",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/resource-mount-unmount-use-jar-defaults.md"
+    },
+    {
+      "slug": "root-span-error-propagation",
+      "category": "domain",
+      "summary": "A trace's root-span isError flag must aggregate descendant span errors; otherwise scatter and list views disagree about which traces errored.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/domain/root-span-error-propagation.md"
+    },
+    {
+      "slug": "save-child-only-when-changed",
+      "category": "decision",
+      "summary": "When reconciling parent→child configurations, persistence is conditional on \"new\" or \"resourceName/tags changed\". Unconditional save caused unnecessary write load and spurious change events.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/save-child-only-when-changed.md"
+    },
+    {
+      "slug": "scatter-topic-1min-retention",
+      "category": "decision",
+      "summary": "Per-tenant scatter-plot/summary topics use 60s retention; metric-history topics use the cluster default. Class-of-data drives retention, not tenant.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/scatter-topic-1min-retention.md"
+    },
+    {
+      "slug": "scouter-three-tier-architecture",
+      "category": "arch",
+      "summary": "Scouter APM enforces strict agent → server → client separation, with an optional standalone HTTP webapp for horizontal scaling of query load",
+      "confidence": "high",
+      "source_project": "scouter",
+      "path": "knowledge/arch/scouter-three-tier-architecture.md"
     },
     {
       "slug": "serial-pipeline-failure-compounding",
       "category": "pitfall",
-      "summary": "",
+      "summary": "N-stage serial AI pipeline success = product of per-stage success rates; prefer developer-invoked skills at each boundary",
       "confidence": "high",
       "source_project": "",
-      "path": "pitfall/serial-pipeline-failure-compounding",
-      "linked_skills": []
+      "path": "knowledge/pitfall/serial-pipeline-failure-compounding.md"
+    },
+    {
+      "slug": "shallow-clone-mktemp-cleanup-pattern",
+      "category": "arch",
+      "summary": "\"publish/install/원격 목록 조회처럼 원격 git repo를 만질 때는 `mktemp -d → git clone --depth 1 → 작업 → rm -rf`. 작업 디렉토리를 오염시키지 않는다.\"",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/shallow-clone-mktemp-cleanup-pattern.md"
     },
     {
       "slug": "sibling-scoped-name-uniqueness",
@@ -4087,26 +3908,39 @@
       "summary": "A global unique index on group `name` was present and had to be dropped; uniqueness is correct only within the same parent.",
       "confidence": "high",
       "source_project": "",
-      "path": "pitfall/sibling-scoped-name-uniqueness",
-      "linked_skills": []
+      "path": "knowledge/pitfall/sibling-scoped-name-uniqueness.md"
     },
     {
       "slug": "simpledateformat-not-thread-safe",
       "category": "pitfall",
-      "summary": "SimpleDateFormat mutates Calendar state and corrupts under concurrency — use java.time.DateTimeFormatter",
+      "summary": "SimpleDateFormat은 스레드 안전하지 않아 공유 인스턴스 사용 시 포맷 깨짐/예외 발생 — java.time.DateTimeFormatter로 교체",
       "confidence": "high",
-      "source_project": "lucida-domain-automation",
-      "path": "pitfall/simpledateformat-not-thread-safe",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/simpledateformat-not-thread-safe.md"
+    },
+    {
+      "slug": "sirius-wraps-antd-design-system",
+      "category": "arch",
+      "summary": "Sirius design system wraps Ant Design components instead of replacing them — rationale, extension pattern, and upgrade implications",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/arch/sirius-wraps-antd-design-system.md"
+    },
+    {
+      "slug": "skill-registry-vs-skill-config-split",
+      "category": "decision",
+      "summary": "\"원격 저장소 정보는 `.claude/skill-registry.yaml`, 스킬별 런타임 옵션(출력 경로 등)은 `.claude/skill-config.yaml`. 파일 단위로 관심사 분리.\"",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/skill-registry-vs-skill-config-split.md"
     },
     {
       "slug": "skip-schedule-if-previous-running",
       "category": "pitfall",
-      "summary": "",
+      "summary": "When a periodic tick arrives and the previous execution for the same job is still running, skip the new tick — never queue it.",
       "confidence": "high",
       "source_project": "",
-      "path": "pitfall/skip-schedule-if-previous-running",
-      "linked_skills": []
+      "path": "knowledge/pitfall/skip-schedule-if-previous-running.md"
     },
     {
       "slug": "snmp-ifindex-not-stable",
@@ -4114,26 +3948,23 @@
       "summary": "SNMP `ifIndex` can change across device reboot/reconfig — never use it as a stable identifier",
       "confidence": "high",
       "source_project": "",
-      "path": "pitfall/snmp-ifindex-not-stable",
-      "linked_skills": []
+      "path": "knowledge/pitfall/snmp-ifindex-not-stable.md"
     },
     {
-      "slug": "build-gradle-secret-and-insecure-protocol",
+      "slug": "sonar-token-hardcoded-build-gradle",
       "category": "pitfall",
-      "summary": "",
+      "summary": "Hardcoded SonarQube login token in build.gradle plus `allowInsecureProtocol = true` on an internal Nexus are two common DevSecOps anti-patterns to fix together",
       "confidence": "high",
       "source_project": "",
-      "path": "pitfall/sonar-token-hardcoded-build-gradle",
-      "linked_skills": []
+      "path": "knowledge/pitfall/sonar-token-hardcoded-build-gradle.md"
     },
     {
       "slug": "span-hash-determinism",
       "category": "pitfall",
-      "summary": "Span-dedup hash must be stable; changing the hash definition yields duplicates during rollout and breaks historical joins",
+      "summary": "Span-dedup hash must be deterministic and stable; changing the hash definition produces duplicate rows during rollout and poisons historical joins.",
       "confidence": "medium",
-      "source_project": "lucida-domain-apm",
-      "path": "pitfall/span-hash-determinism",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/span-hash-determinism.md"
     },
     {
       "slug": "span-lifetime-safety-documentation",
@@ -4141,53 +3972,95 @@
       "summary": "std::span is a non-owning view — common C++20 hazards (dangling temporaries, vector realloc, implicit construction from rvalues) and the safe usage patterns that avoid UB.",
       "confidence": "medium",
       "source_project": "bitcoin",
-      "path": "pitfall/span-lifetime-safety-documentation",
-      "linked_skills": []
+      "path": "knowledge/pitfall/span-lifetime-safety-documentation.md"
     },
     {
       "slug": "spec-excluded-from-jest",
       "category": "pitfall",
       "summary": ".spec.ts files are excluded from the Jest runner in this project — only .test.ts is discovered",
       "confidence": "high",
-      "source_project": "lucida-builder-r3",
-      "path": "pitfall/spec-excluded-from-jest",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/spec-excluded-from-jest.md"
     },
     {
       "slug": "sql-hash-unsigned-integer",
       "category": "pitfall",
       "summary": "MySQL/MariaDB SQL digest hashes fit in an unsigned 32-bit range but arrive as signed Java int — negatives are legal and must not be dropped",
-      "confidence": "high",
-      "source_project": "lucida-domain-dpm",
-      "path": "pitfall/sql-hash-unsigned-integer",
-      "linked_skills": []
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/pitfall/sql-hash-unsigned-integer.md"
     },
     {
       "slug": "sql-text-null-check-session-history-consistency",
       "category": "pitfall",
       "summary": "Session history rows must omit sqlHash and queryTime when SQL text is missing, else they orphan in downstream joins",
-      "confidence": "high",
-      "source_project": "lucida-domain-dpm",
-      "path": "pitfall/sql-text-null-check-session-history-consistency",
-      "linked_skills": []
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/pitfall/sql-text-null-check-session-history-consistency.md"
     },
     {
       "slug": "sqlserver-sqltextinfo-index-constraint",
       "category": "pitfall",
       "summary": "Do not put a unique index on sqlHash for SQL Server text-info collection — duplicates are legitimate",
       "confidence": "medium",
-      "source_project": "lucida-domain-dpm",
-      "path": "pitfall/sqlserver-sqltextinfo-index-constraint",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/sqlserver-sqltextinfo-index-constraint.md"
     },
     {
       "slug": "static-value-injection-race-condition",
       "category": "pitfall",
-      "summary": "@Value on static fields causes init-order and visibility races — always inject into instance fields",
+      "summary": "static 필드에 @Value 주입은 setter 호출 타이밍과 멀티스레드 가시성으로 레이스 컨디션을 유발 — 인스턴스 필드로 직접 주입하라",
       "confidence": "high",
-      "source_project": "lucida-domain-automation",
-      "path": "pitfall/static-value-injection-race-condition",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/static-value-injection-race-condition.md"
+    },
+    {
+      "slug": "stomp-heartbeat-10s-bidirectional",
+      "category": "api",
+      "summary": "STOMP broker heartbeat set to 10s/10s (client↔server) is a reasonable default for detecting dead WebSocket sessions within ~20s",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/api/stomp-heartbeat-10s-bidirectional.md"
+    },
+    {
+      "slug": "stub-in-service-unblocks-fe-parallelism",
+      "category": "decision",
+      "summary": "Emit stub return values inside generated Service methods (tagged `// STUB:`) so FE can connect to a live BE without waiting on business logic",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/stub-in-service-unblocks-fe-parallelism.md"
+    },
+    {
+      "slug": "system-notification-shared-with-2fa-and-password-find",
+      "category": "decision",
+      "summary": "The `system_notification` config (SMTP/SMS credentials) is intentionally shared between 2FA and password-find flows rather than duplicated per flow",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/system-notification-shared-with-2fa-and-password-find.md"
+    },
+    {
+      "slug": "tabular-metric-excluded-from-list",
+      "category": "decision",
+      "summary": "TABULAR measurement type is intentionally excluded from searchable metric-definition list endpoints",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/tabular-metric-excluded-from-list.md"
+    },
+    {
+      "slug": "tag-values-separate-collection",
+      "category": "decision",
+      "summary": "TagValueInfo's `values` array was extracted from the parent tag document into a separate `tag_value_detail` collection to bound document size and index cost.",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/decision/tag-values-separate-collection.md"
+    },
+    {
+      "slug": "tailwind-mfa-css-isolation-pitfalls",
+      "category": "pitfall",
+      "summary": "CSS isolation failures when using Tailwind CSS in Module Federation — preflight leaks, portal scope loss, postcss-prefix-selector parse errors",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/pitfall/tailwind-mfa-css-isolation-pitfalls.md"
     },
     {
       "slug": "tenant-context-clear-after-completion",
@@ -4195,8 +4068,15 @@
       "summary": "Multi-tenant thread-locals must be cleared in a HandlerInterceptor `afterCompletion`, regardless of request outcome",
       "confidence": "high",
       "source_project": "",
-      "path": "pitfall/tenant-context-clear-after-completion",
-      "linked_skills": []
+      "path": "knowledge/pitfall/tenant-context-clear-after-completion.md"
+    },
+    {
+      "slug": "tenant-context-per-request-interceptor",
+      "category": "arch",
+      "summary": "Extract tenant id from JWT/header in preHandle, store in ThreadLocal, clear in afterCompletion to isolate multi-tenant data access",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/arch/tenant-context-per-request-interceptor.md"
     },
     {
       "slug": "tenant-flag-over-name-detection",
@@ -4204,26 +4084,39 @@
       "summary": "Identify special/system tenants by a boolean flag on the entity, never by matching on name.",
       "confidence": "medium",
       "source_project": "",
-      "path": "pitfall/tenant-flag-over-name-detection",
-      "linked_skills": []
+      "path": "knowledge/pitfall/tenant-flag-over-name-detection.md"
     },
     {
       "slug": "testcontainers-springboot-cache-conflict",
       "category": "pitfall",
-      "summary": "@Testcontainers clashes with @SpringBootTest context caching — use static start() + @DynamicPropertySource",
+      "summary": "@Testcontainers + @SpringBootTest 컨텍스트 캐싱 충돌 — @DynamicPropertySource + static start() 패턴으로 대체",
       "confidence": "high",
-      "source_project": "lucida-domain-automation",
-      "path": "pitfall/testcontainers-springboot-cache-conflict",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/testcontainers-springboot-cache-conflict.md"
     },
     {
       "slug": "time-unit-consistency-us-ms-ns",
       "category": "pitfall",
-      "summary": "Mixed time units (ns/μs/ms) across ingest, storage, filters, and UI are a recurring bug class — pick one canonical internal unit",
+      "summary": "Mixed time units (ns/μs/ms) across OTLP ingestion, storage, filters, and UI are a recurring high-severity bug class — pick one canonical internal unit and convert only at edges.",
       "confidence": "high",
-      "source_project": "lucida-domain-apm",
-      "path": "pitfall/time-unit-consistency-us-ms-ns",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/time-unit-consistency-us-ms-ns.md"
+    },
+    {
+      "slug": "timeselector-mode-interval-range-mapping",
+      "category": "api",
+      "summary": "Clients send a `mode` enum (RAW..YEAR); the server maps it to a (bin-interval, query-range) pair and picks the right pre-aggregated collection",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/api/timeselector-mode-interval-range-mapping.md"
+    },
+    {
+      "slug": "tomcat-request-timeout-1h-for-oz-report",
+      "category": "decision",
+      "summary": "Report-generation services should raise Tomcat connection/read timeout to ~1 hour because export of large OZ/Jasper reports is genuinely long-running",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/tomcat-request-timeout-1h-for-oz-report.md"
     },
     {
       "slug": "top-bottom-widest-collection-range",
@@ -4231,19 +4124,23 @@
       "summary": "For Top/Bottom selection queries, pick the collection whose bin granularity covers the widest range, not the finest-grained one",
       "confidence": "medium",
       "source_project": "",
-      "path": "pitfall/top-bottom-widest-collection-range",
-      "linked_skills": []
+      "path": "knowledge/pitfall/top-bottom-widest-collection-range.md"
     },
     {
       "slug": "topn-unwind-match-to-filter",
       "category": "pitfall",
       "summary": "TopN Mongo pipeline using `$unwind`+`$match` explodes documents; push predicate into `$filter` first",
       "confidence": "high",
-      "source_project": "lucida-measurement",
-      "path": "pitfall/topn-unwind-match-to-filter",
-      "linked_skills": [
-        "mongo-aggregation-filter-optimization"
-      ]
+      "source_project": "",
+      "path": "knowledge/pitfall/topn-unwind-match-to-filter.md"
+    },
+    {
+      "slug": "topresource-immediate-generation-invariant",
+      "category": "domain",
+      "summary": "In report immediate-generation, the topResource flag decides whether to query by resource-id (fast path) or the full conf-id set (slow path)",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/domain/topresource-immediate-generation-invariant.md"
     },
     {
       "slug": "trace-context-async-execution-propagation",
@@ -4251,44 +4148,119 @@
       "summary": "Thread-local trace context is lost across executor.submit / reactor.flatMap boundaries; scouter injects bytecode wrappers around async entry points to capture and restore it",
       "confidence": "medium",
       "source_project": "scouter",
-      "path": "pitfall/trace-context-async-execution-propagation",
-      "linked_skills": []
+      "path": "knowledge/pitfall/trace-context-async-execution-propagation.md"
     },
     {
       "slug": "traefik-2.11-requires-explicit-idletimeout",
       "category": "pitfall",
       "summary": "Traefik 2.11 silently drops idle backend connections without an explicit idleTimeout on the entrypoint/serversTransport",
       "confidence": "high",
-      "source_project": "lucida-for-docker",
-      "path": "pitfall/traefik-2.11-requires-explicit-idletimeout",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/traefik-2.11-requires-explicit-idletimeout.md"
+    },
+    {
+      "slug": "triple-styling-paradigm-coexistence",
+      "category": "decision",
+      "summary": "Why Tailwind CSS, SCSS modules, and styled-components coexist in the same codebase — migration path, isolation needs, and legacy constraints",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/triple-styling-paradigm-coexistence.md"
+    },
+    {
+      "slug": "typed-wikilinks-for-llm-knowledge-base",
+      "category": "decision",
+      "summary": "Flat `[[wikilinks]]` carry one bit of information. For an LLM-facing knowledge base, tag every link with a relationship type (supersedes, contradicts, causes, supports) so the graph is queryable rather than just traversable.",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/typed-wikilinks-for-llm-knowledge-base.md"
+    },
+    {
+      "slug": "udp-for-throughput-tcp-for-reliability",
+      "category": "decision",
+      "summary": "Scouter streams periodic metrics over UDP (lossy but cheap) and reserves TCP for config fetch, agent registration, and XLog profile uploads that demand delivery guarantees",
+      "confidence": "high",
+      "source_project": "scouter",
+      "path": "knowledge/decision/udp-for-throughput-tcp-for-reliability.md"
     },
     {
       "slug": "udp-receiver-needs-large-socket-buffer",
       "category": "pitfall",
       "summary": "UDP collectors behind Traefik/containers must raise SO_RCVBUF well above the 8KB default or drop packets under burst load",
       "confidence": "high",
-      "source_project": "lucida-for-docker",
-      "path": "pitfall/udp-receiver-needs-large-socket-buffer",
-      "linked_skills": []
+      "source_project": "",
+      "path": "knowledge/pitfall/udp-receiver-needs-large-socket-buffer.md"
     },
     {
       "slug": "unit-enum-silent-filter",
       "category": "pitfall",
-      "summary": "",
+      "summary": "When metric rows are filtered out because their `unit` is not defined in a Java enum, the symptom is \"items missing from the list UI\" — no error, no log — and the root cause is upstream data adding units faster than the enum is updated",
       "confidence": "high",
       "source_project": "",
-      "path": "pitfall/unit-enum-silent-filter",
-      "linked_skills": []
+      "path": "knowledge/pitfall/unit-enum-silent-filter.md"
     },
     {
       "slug": "user-sql-source-requires-select-only-and-readonly",
       "category": "pitfall",
-      "summary": "",
+      "summary": "\"When a feature lets end-users paste raw SQL for display, no single guard is enough — layer four defenses: SELECT-only keyword allow-list, token-aware destructive-keyword blocklist, JDBC `setReadOnly(true)`, and `setQueryTimeout` + `setMaxRows` caps.\"",
       "confidence": "medium",
       "source_project": "",
-      "path": "pitfall/user-sql-source-requires-select-only-and-readonly",
-      "linked_skills": []
+      "path": "knowledge/pitfall/user-sql-source-requires-select-only-and-readonly.md"
+    },
+    {
+      "slug": "variable-length-integer-encoding-for-metrics-bandwidth",
+      "category": "decision",
+      "summary": "Scouter's DataOutputX uses 3-byte (INT3) and 5-byte (LONG5) integer encodings to shrink UDP metric packs by 20-40% when most values fit within 24 / 40 bits",
+      "confidence": "medium",
+      "source_project": "scouter",
+      "path": "knowledge/decision/variable-length-integer-encoding-for-metrics-bandwidth.md"
+    },
+    {
+      "slug": "vllm-kv-cache-fp8-with-mtp",
+      "category": "decision",
+      "summary": "vLLM serving chose fp8_e4m3 KV cache + prefix caching + MTP speculative decoding for Qwen3.5 throughput",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/decision/vllm-kv-cache-fp8-with-mtp.md"
+    },
+    {
+      "slug": "wait-for-services-eureka-startup-init",
+      "category": "arch",
+      "summary": "Defer schema/index/data bootstrap until named services report ready in discovery, with bounded exponential backoff and leader election",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/arch/wait-for-services-eureka-startup-init.md"
+    },
+    {
+      "slug": "widget-high-prop-count-debt",
+      "category": "pitfall",
+      "summary": "Dashboard CardChart components accumulate 100+ props making them hard to maintain, version, and test — known tech debt with no current mitigation",
+      "confidence": "medium",
+      "source_project": "",
+      "path": "knowledge/pitfall/widget-high-prop-count-debt.md"
+    },
+    {
+      "slug": "widget-is-frozen-group-snapshot",
+      "category": "arch",
+      "summary": "Widgets are snapshots of a group at save time; later edits to the source group do not propagate",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/arch/widget-is-frozen-group-snapshot.md"
+    },
+    {
+      "slug": "xlog-extended-transaction-trace-with-compression",
+      "category": "api",
+      "summary": "XLog is scouter's per-request transaction trace format — hierarchical typed steps stored as compressed binary, indexed by end-time, with flat metadata for server-side filtering",
+      "confidence": "high",
+      "source_project": "scouter",
+      "path": "knowledge/api/xlog-extended-transaction-trace-with-compression.md"
+    },
+    {
+      "slug": "yorkie-team-server-split",
+      "category": "arch",
+      "summary": "Yorkie holds live canvas state; the team server holds metadata (projects, assets, datasources) — never mix",
+      "confidence": "high",
+      "source_project": "",
+      "path": "knowledge/arch/yorkie-team-server-split.md"
     }
   ]
 }

--- a/skills/workflow/swagger-ai-optimization/SKILL.md
+++ b/skills/workflow/swagger-ai-optimization/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: swagger-ai-optimization
 description: Spring Boot + springdoc 프로젝트의 Swagger/OpenAPI 스펙을 AI Agent용으로 최적화 (operationId, @Schema, @ApiResponse, x-filterable-fields 전수 적용)
+category: workflow
+version: 1.0.0
 triggers:
   - swagger ai 최적화
   - openapi ai optimization


### PR DESCRIPTION
## Summary

`/skills_cleanup --apply` 결과

### 수정 내용

- **CATEGORIES.md**: `design` 카테고리 추가 (8개 스킬 정상화)
- **swagger-ai-optimization**: 누락 필드 `category: workflow`, `version: 1.0.0` 추가
- **index.json**: 디스크 기준 전체 재생성 (232 skills, 232 knowledge)
  - 이름 변경 5건 반영 (avro-event-change-flags 등)
  - 신규 15건 추가 (design 8 + frontend 2 + 기타)

### 검증

- 중복: 없음
- 고아: 없음  
- 장기 미사용: 해당 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)