### PR TITLE
Publish 6 skills + 6 knowledge from lucida-ui FE extraction

### DIFF
--- a/knowledge/api/endpoint-service-dual-pattern.md
+++ b/knowledge/api/endpoint-service-dual-pattern.md
@@ -1,0 +1,85 @@
+---
+name: endpoint-service-dual-pattern
+description: Two coexisting API service patterns — factory functions (apmServices) and direct functional exports (alarmService) — with centralized endpoint constants
+category: api
+source:
+  kind: project
+  ref: lucida-ui@4b922a9043
+---
+
+# Endpoint + Service Dual Pattern
+
+## Fact
+
+The API layer has two coexisting service patterns, both consuming centralized endpoint constants from `shared/apis/endpoint/`. Neither pattern is deprecated — new services use either based on developer preference.
+
+## Pattern A: Factory Service (Older, Larger Domains)
+
+```typescript
+// shared/apis/nkia/apm/apmServices.ts (620+ lines, 100+ methods)
+export default (axiosInstance: AxiosInstance) => ({
+  getServiceLists(payload: ServiceListParams) {
+    return response(axiosInstance.post(APM_EP.SERVICE_LIST, payload))
+  },
+  getServiceDetail(payload: GetServiceListInput) {
+    return response(axiosInstance.get(APM_EP.SERVICE_DETAIL(payload.serviceId)))
+  },
+})
+```
+
+- Returns object with methods, injected with axios instance
+- Instantiated once in `apiAxiosInstance.ts`: `apmService: apmServices(axiosPublic)`
+- 15+ domain services aggregated into single `IApi` interface
+
+## Pattern B: Functional Export (Newer, Smaller Domains)
+
+```typescript
+// shared/apis/nkia/alarm/alarmService.ts (596 lines)
+export const postAlarmDefinition = (params: IdvAlarmDefinition) =>
+  requestPostNew<number, null>(ALARM_EP.ALARM_DEFINITION, params)
+
+export const postAlarmSeverityModify = (params: FormData) => {
+  const header = { 'Content-Type': 'multipart/form-data' }
+  return requestPostNew<AlarmSeveritySetting[]>(
+    ALARM_EP.ALARM_SEVERITY_MODIFY, params, undefined, undefined, header
+  )
+}
+```
+
+- Individual exports, no factory
+- Uses `requestPostNew<T>` directly (not `response()` wrapper)
+- Tree-shakeable — unused functions can be eliminated
+
+## Endpoint Constants
+
+```typescript
+// shared/apis/endpoint/accountEndPoint.ts
+import { BASE_URL } from '@lucida-ui/shared/apis/constants/url'
+
+// Static endpoints
+export const AUTH_LOGIN = `${BASE_URL}/api/account/login`
+
+// Parameterized endpoints
+export const SERVICE_DETAIL = (serviceId: string) =>
+  `${BASE_URL}/services/${serviceId}`
+
+// Barrel export
+// shared/apis/endpoint/index.ts
+export * as ACCOUNT_EP from './accountEndPoint'
+export * as ALARM_EP from './alarmEndPoint'
+export * as APM_EP from './apmEndPoint'
+// ... 30+ domains
+```
+
+## Evidence
+
+- Factory pattern: `apmServices.ts` (620 lines), `dpmServices.ts`, `performanceServices.ts`
+- Functional pattern: `alarmService.ts` (596 lines), `account/user.ts`, `account/role.ts`
+- Both use typed responses: `IApiResult<T>` with `{ data, status, message, success, errorCode }`
+- 40+ endpoint files in `shared/apis/endpoint/`
+
+## Why Two Patterns Coexist
+
+1. **Organic evolution** — factory pattern came first (DI-friendly); functional exports adopted later for simplicity
+2. **No migration mandate** — both work; refactoring 620-line service files carries risk with low reward
+3. **Different ergonomics** — factory groups related methods; functional enables tree-shaking

--- a/knowledge/arch/mf-shared-singleton-config.md
+++ b/knowledge/arch/mf-shared-singleton-config.md
@@ -1,0 +1,33 @@
+---
+name: mf-shared-singleton-config
+description: 227 shared dependencies configured as Webpack Module Federation singletons with strict versioning; react-router-dom intentionally excluded
+category: arch
+source:
+  kind: project
+  ref: lucida-ui@4b922a9043
+---
+
+# Module Federation Shared Singleton Configuration
+
+## Fact
+
+`mf-shared.config.js` configures 227 npm packages as Module Federation shared singletons with `strictVersion: true`. This ensures all 25 remotes + 1 host load exactly one copy of each library. Notably, `react-router-dom` is **not** shared — each remote manages its own router context.
+
+## Evidence
+
+- `mf-shared.config.js`: 227 entries, all with `singleton: true`
+- Critical singletons: `react@18.3.1`, `react-dom@18.3.1`, `recoil@0.7.7`, `antd@5.28.0`, `echarts@5.4.0`, `ag-grid-react@33.2.1`
+- `react-router-dom` absent from shared config
+- `withRouterWrapper` HOC exists specifically because router context is per-remote
+
+## Why react-router-dom Is Excluded
+
+1. **Router isolation** — each remote needs its own `BrowserRouter` or `MemoryRouter` to avoid route collisions
+2. **MFA expose pattern** — `withRouterWrapper` detects if a router context exists and wraps only when needed
+3. **Independent navigation** — remotes can define their own route trees without conflicting with the host
+
+## Why Strict Versioning
+
+- **Runtime crashes** — version mismatches in React (e.g., two React instances) cause hooks to break silently
+- **Bundle size** — without singleton, each remote bundles its own copy of antd (1MB+), echarts, etc.
+- **State sharing** — Recoil atoms only work if all remotes share the exact same Recoil instance

--- a/knowledge/arch/scss-css-variable-theme-system.md
+++ b/knowledge/arch/scss-css-variable-theme-system.md
@@ -1,0 +1,48 @@
+---
+name: scss-css-variable-theme-system
+description: Architecture decision — SCSS + CSS custom properties + data-theme attribute for dark/light theming in a large React monorepo
+category: arch
+source:
+  kind: project
+  ref: lucida-ui@4b922a9043
+---
+
+# SCSS + CSS Variable Theme System
+
+## Fact
+
+The project uses SCSS as the primary styling approach with 100+ CSS custom properties for theming. Theme switching is implemented via a `data-theme` attribute on `<html>` toggled by a React Context + localStorage, not via CSS-in-JS runtime theming.
+
+## Architecture
+
+```
+packages/sirius/src/styles/
+├── base/_palette.scss          # 100+ CSS variables (--blue-1..10, --gray-1..10, etc.)
+├── themes/
+│   ├── _lightTheme.scss        # :root { --background: var(--white); ... }
+│   └── _darkTheme.scss         # [data-theme="dark"] { --background: var(--gray-10); ... }
+├── tokens/
+│   ├── base/                   # Base design tokens
+│   ├── themes/                 # Theme-specific tokens
+│   └── semantic/               # Semantic tokens (--text-primary, --border, etc.)
+└── components/                 # Component-specific SCSS
+
+shared/contexts/theme/ThemeProvider.tsx
+  └── React Context + localStorage('lucida-fe-theme')
+  └── Sets document.documentElement.dataset.theme = 'dark' | 'light'
+```
+
+## Evidence
+
+- `_palette.scss`: 100+ color variables defined on `:root`
+- `_darkTheme.scss`: overrides via `[data-theme="dark"]` selector
+- `ThemeProvider.tsx`: persists theme choice to `localStorage`, applies via `dataset.theme`
+- `styled-components` used in <5 files (e.g., `DashboardOverall.tsx`) — minimal CSS-in-JS
+- No Tailwind CSS (despite `@tailwindcss/postcss` in dependencies — only used for AI portal storybook)
+
+## Why This Matters
+
+1. **Zero runtime cost** — CSS variables resolve at browser level, no JS re-renders on theme change
+2. **MFA-compatible** — all micro-frontends share the same CSS variables via the host's `<html>` attribute
+3. **SCSS mixins reusable** — `@mixin ellipsis($line)`, `@mixin flex-row($gap)` etc. provide utility without runtime overhead
+4. **Ant Design integration** — Ant's CSS overrides live alongside SCSS in sirius package

--- a/knowledge/arch/sirius-component-taxonomy.md
+++ b/knowledge/arch/sirius-component-taxonomy.md
@@ -1,0 +1,45 @@
+---
+name: sirius-component-taxonomy
+description: Sirius design system (@nkia/sirius) organizes 200+ components into 5 categories — data-display, data-entry, feedback, layout, navigation
+category: arch
+source:
+  kind: project
+  ref: lucida-ui@4b922a9043
+---
+
+# Sirius Design System Component Taxonomy
+
+## Fact
+
+The `@nkia/sirius` package (v0.2.21) provides 200+ React components organized into 5 categories following Ant Design's categorization model. Components are consumed via direct source imports, not compiled packages.
+
+## Categories
+
+### data-display/ (visualization & read-only)
+AlarmCard, Avatar, Badge, Card, CardSummary, Chart, ChartLegendGrid, EqualizerChart, HexagonChart, Collapse, CollapsePanel, Descriptions, DescriptionsForm, Grid, GridPercentBar, Popover, PopConfirm, Progress, Slider, Segmented, Tabs, Tag, TagFilterList, Tooltip, Tour, Tree
+
+### data-entry/ (forms & input)
+AutoComplete, Button, CascadingSelect, CheckboxGroup, CheckboxMulti, CheckboxSingle, CodeEditor, ColorPicker, DatePicker, Dropdown, DropdownButton, DropdownSearch, FileUpload, Form, FormItem, FormTable, Input, InputNumber, JsonViewer, Radio, RangePicker, Select, Switch, TextArea, TimePicker, Toggle, Upload
+
+### feedback/ (user notifications)
+Confirm, Drawer (basic, preset, resizable), Empty, InfoBox, LoadingDot, Message, Modal, Spin
+
+### layout/ (structure & spacing)
+Col, Row, Divider, Space, FormTitleTemplate, GridTitleTemplate, Layout variants (Layout_h2, Layout_h3, Layout_v2–v10), Titlebar
+
+### navigation/ (routing & wayfinding)
+Anchor, Breadcrumb, Menu, Pagination, TextLink, Wizard
+
+## Import Pattern
+
+```typescript
+// Direct source import (not compiled)
+import { Button, Tabs, Icon } from '@nkia/sirius/src/components'
+```
+
+## Evidence
+
+- `packages/sirius/src/components/index.ts`: barrel export of all 200+ components
+- `packages/sirius/src/styles/components/`: matching SCSS per component category
+- `packages/sirius/src/components/hoc/`: HOCs (withAccess, withCellEditorValueChange)
+- Used by all 25 remotes + host via workspace dependency

--- a/knowledge/decision/drawer-over-modal.md
+++ b/knowledge/decision/drawer-over-modal.md
@@ -1,0 +1,29 @@
+---
+name: drawer-over-modal
+description: Decision to use side drawers (463 files) instead of centered modals (10 usages) as the primary overlay pattern
+category: decision
+source:
+  kind: project
+  ref: lucida-ui@4b922a9043
+---
+
+# Drawer Over Modal
+
+## Fact
+
+Drawers are the dominant overlay pattern with 463 drawer-related files vs ~10 direct `Modal.warn`/`Modal.confirm` usages. The base `Drawer` component provides preset width tiers (`1dp`–`7dp`), resizable handles, and standardized footer actions.
+
+## Evidence
+
+- `shared/components/commons/drawer/Drawer.tsx`: base component with `TypeDrawerWidth` presets
+- `shared/components/commons/drawer/DrawerActions.tsx`: standardized footer (Save/Close)
+- 463 files matching `*Drawer*` or `*drawer*` across shared/ and remotes/
+- Direct `Modal.warn()` only in `PrivateRoute.tsx` (session expiry) and a few confirmation dialogs
+- Every domain (alarm, apm, dpm, widget, config) uses drawer for detail views
+
+## Why This Choice
+
+1. **Context preservation** — drawer slides in from the side, keeping the parent list/grid visible for reference
+2. **Data density** — monitoring UIs show dense grids; drawers provide detail without losing the overview
+3. **Consistent UX** — preset widths (`1dp`=24rem to `7dp`=full) give designers a vocabulary
+4. **Nested drawers** — drawers can stack (e.g., list → detail drawer → sub-detail drawer) more naturally than nested modals

--- a/knowledge/decision/recoil-over-redux.md
+++ b/knowledge/decision/recoil-over-redux.md
@@ -1,0 +1,35 @@
+---
+name: recoil-over-redux
+description: Decision to use Recoil atoms (2697 usages, 53 store files) as sole state management instead of Redux in a 25-remote MFA monorepo
+category: decision
+source:
+  kind: project
+  ref: lucida-ui@4b922a9043
+---
+
+# Recoil Over Redux
+
+## Fact
+
+The project uses Recoil as its sole global state management library — 2,697 Recoil hook usages across 53 store files. No Redux, Zustand, or Jotai present. Context API is used only for cross-cutting concerns (theme, language, loading, grid config) — not for domain state.
+
+## Evidence
+
+- `shared/store/atom/global/`: 18 global atoms (user, date, filter, grid, modal, menu, etc.)
+- `shared/store/atom/remote/`: 15+ domain-scoped atom modules (apm, dpm, alarm, widget, etc.)
+- `shared/store/hook/`: typed hook wrappers (useTimeSelector, useDashboardFilter)
+- `mf-shared.config.js`: Recoil shared as singleton (`requiredVersion: '0.7.7'`)
+- No `redux`, `@reduxjs/toolkit`, `zustand`, or `jotai` in dependencies
+
+## Why This Choice
+
+1. **Atom granularity** — each piece of state is independently subscribable; avoids monolithic store
+2. **MFA singleton sharing** — Recoil shared via Module Federation singleton means all remotes share the same atom instances
+3. **No boilerplate** — no actions/reducers/slices; atoms + selectors + hooks only
+4. **Selector composition** — derived state via selectors (e.g., `alarmCollapsedSelector` returns function for parameterized lookup)
+
+## Trade-offs
+
+- **No DevTools** — Recoil lacks mature DevTools compared to Redux DevTools
+- **React 18+ deprecation risk** — Recoil's maintenance has slowed; future migration to Jotai may be needed
+- **No middleware** — side effects handled in hooks, not in a middleware layer

--- a/registry.json
+++ b/registry.json
@@ -1899,6 +1899,62 @@
       "source_commit": "f11166f9f5f8a11e668346fe1c1e37270868b2ba",
       "pinned": false,
       "linked_knowledge": []
+    },
+    "mfa-federated-component-loader": {
+      "category": "frontend",
+      "version": "1.0.0",
+      "scope": "global",
+      "installed_at": "2026-04-16",
+      "source_commit": "4b922a9043",
+      "pinned": false,
+      "linked_knowledge": []
+    },
+    "ag-grid-cell-renderer-pattern": {
+      "category": "frontend",
+      "version": "1.0.0",
+      "scope": "global",
+      "installed_at": "2026-04-16",
+      "source_commit": "4b922a9043",
+      "pinned": false,
+      "linked_knowledge": []
+    },
+    "recoil-domain-atom-store": {
+      "category": "frontend",
+      "version": "1.0.0",
+      "scope": "global",
+      "installed_at": "2026-04-16",
+      "source_commit": "4b922a9043",
+      "pinned": false,
+      "linked_knowledge": []
+    },
+    "drawer-resizable-composition": {
+      "category": "frontend",
+      "version": "1.0.0",
+      "scope": "global",
+      "installed_at": "2026-04-16",
+      "source_commit": "4b922a9043",
+      "pinned": false,
+      "linked_knowledge": [
+        "drawer-over-modal"
+      ]
+    },
+    "axios-token-refresh-queue": {
+      "category": "backend",
+      "version": "1.0.0",
+      "scope": "global",
+      "installed_at": "2026-04-16",
+      "source_commit": "4b922a9043",
+      "pinned": false,
+      "linked_knowledge": []
+    },
+    "sse-fetch-streaming": {
+      "category": "frontend",
+      "version": "1.0.0",
+      "scope": "global",
+      "installed_at": "2026-04-16",
+      "source_commit": "4b922a9043",
+      "pinned": false,
+      "linked_knowledge": []
     }
   },
   "knowledge": {
@@ -3521,6 +3577,48 @@
       "added_at": "2026-04-16",
       "linked_skills": [
         "mfa-portal-css-isolation"
+      ]
+    },
+    "endpoint-service-dual-pattern": {
+      "category": "api",
+      "source_project": "lucida-ui",
+      "added_at": "2026-04-16",
+      "linked_skills": []
+    },
+    "mf-shared-singleton-config": {
+      "category": "arch",
+      "source_project": "lucida-ui",
+      "added_at": "2026-04-16",
+      "linked_skills": [
+        "mfa-federated-component-loader"
+      ]
+    },
+    "scss-css-variable-theme-system": {
+      "category": "arch",
+      "source_project": "lucida-ui",
+      "added_at": "2026-04-16",
+      "linked_skills": []
+    },
+    "sirius-component-taxonomy": {
+      "category": "arch",
+      "source_project": "lucida-ui",
+      "added_at": "2026-04-16",
+      "linked_skills": []
+    },
+    "drawer-over-modal": {
+      "category": "decision",
+      "source_project": "lucida-ui",
+      "added_at": "2026-04-16",
+      "linked_skills": [
+        "drawer-resizable-composition"
+      ]
+    },
+    "recoil-over-redux": {
+      "category": "decision",
+      "source_project": "lucida-ui",
+      "added_at": "2026-04-16",
+      "linked_skills": [
+        "recoil-domain-atom-store"
       ]
     }
   }

--- a/skills/backend/axios-token-refresh-queue/SKILL.md
+++ b/skills/backend/axios-token-refresh-queue/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: axios-token-refresh-queue
+description: Axios interceptor with window-scoped request queue during JWT token refresh to prevent concurrent refresh races
+triggers:
+  - token refresh
+  - axios interceptor
+  - jwt refresh
+  - 401 retry
+  - authentication interceptor
+category: backend
+version: 1.0.0
+source_project: lucida-ui
+---
+
+# Axios Token Refresh Queue
+
+## Purpose
+
+Prevent concurrent token refresh races in SPA applications. When a 401/token-expired response arrives, queue all subsequent failed requests and replay them after a single token refresh completes.
+
+## When to Use
+
+- SPA with JWT access + refresh token flow
+- Multiple concurrent API calls that may all receive 401 simultaneously
+- Need to avoid N parallel refresh token requests
+
+## Pattern
+
+See `content.md` for full implementation.

--- a/skills/backend/axios-token-refresh-queue/content.md
+++ b/skills/backend/axios-token-refresh-queue/content.md
@@ -1,0 +1,129 @@
+## Implementation
+
+```typescript
+// shared/apis/request.ts
+
+// Window-scoped state to coordinate refresh across micro-frontends
+declare global {
+  interface Window {
+    __isTokenRefreshing: boolean
+    __refreshSubscribers: ((token: string) => void)[]
+  }
+}
+
+window.__isTokenRefreshing = false
+window.__refreshSubscribers = []
+
+const subscribeTokenRefresh = (callback: (token: string) => void) => {
+  window.__refreshSubscribers.push(callback)
+}
+
+const onTokenRefreshed = (newToken: string) => {
+  window.__refreshSubscribers.forEach((callback) => callback(newToken))
+  window.__refreshSubscribers = []
+}
+
+// --- Axios Response Interceptor ---
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config
+    const errorCode = error.response?.data?.errorCode
+
+    // Session terminated errors — no retry, force logout
+    const SESSION_ERRORS = ['POLESTAR_00110', 'POLESTAR_00112']
+    if (SESSION_ERRORS.includes(errorCode)) {
+      Modal.warn({ content: getSessionErrorMessage(errorCode) })
+      redirectToLogin()
+      return Promise.reject(error)
+    }
+
+    // Token expired — refresh and retry
+    const TOKEN_ERRORS = ['AUTHENTICATION', 'POLESTAR_00102']
+    if (TOKEN_ERRORS.includes(errorCode) && !originalRequest._retry) {
+      originalRequest._retry = true
+
+      if (window.__isTokenRefreshing) {
+        // Queue this request — it will be replayed after refresh
+        return new Promise((resolve) => {
+          subscribeTokenRefresh((newToken: string) => {
+            originalRequest.headers.Authorization = `Bearer ${newToken}`
+            resolve(axiosInstance(originalRequest))
+          })
+        })
+      }
+
+      // First 401 — initiate refresh
+      window.__isTokenRefreshing = true
+
+      try {
+        const { data } = await axiosPublic.post('/api/account/refresh', {
+          refreshToken: getRefreshToken(),
+        })
+
+        setAccessToken(data.accessToken)
+        setRefreshToken(data.refreshToken)
+
+        // Replay all queued requests with new token
+        onTokenRefreshed(data.accessToken)
+
+        // Retry the original request
+        originalRequest.headers.Authorization = `Bearer ${data.accessToken}`
+        return axiosInstance(originalRequest)
+      } catch (refreshError) {
+        // Refresh failed — clear queue and redirect to login
+        window.__refreshSubscribers = []
+        redirectToLogin()
+        return Promise.reject(refreshError)
+      } finally {
+        window.__isTokenRefreshing = false
+      }
+    }
+
+    return Promise.reject(error)
+  }
+)
+```
+
+## Dual Axios Instance Setup
+
+```typescript
+// Authenticated instance (with refresh interceptor)
+const axiosInstance = axios.create({
+  timeout: 60000,
+  headers: { 'Content-Type': 'application/json' },
+  withCredentials: true,
+})
+
+// Public instance (login/refresh — no interceptor)
+const axiosPublic = axios.create({
+  timeout: 60000,
+  headers: { 'Content-Type': 'application/json' },
+  withCredentials: true,
+})
+```
+
+## Request Interceptor (Header Enhancement)
+
+```typescript
+axiosInstance.interceptors.request.use((config) => {
+  // Inject locale for server-side i18n
+  config.headers['Accept-Language'] = getCurrentLocale()
+
+  // Inject auth token
+  const token = getAccessToken()
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`
+  }
+
+  return config
+})
+```
+
+## Key Design Decisions
+
+1. **Window-scoped state** — `window.__isTokenRefreshing` works across Module Federation remotes sharing the same window
+2. **Subscriber pattern** — queued requests resolve via callback when refresh completes
+3. **`_retry` flag** — prevents infinite retry loops on permanent auth failures
+4. **Session vs Token errors** — session termination (concurrent login, inactivity) forces logout immediately; token expiry triggers refresh
+5. **Dual instances** — public instance for login/refresh avoids circular interceptor calls

--- a/skills/frontend/ag-grid-cell-renderer-pattern/SKILL.md
+++ b/skills/frontend/ag-grid-cell-renderer-pattern/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: ag-grid-cell-renderer-pattern
+description: Structured AG-Grid custom cell renderer catalog with typed column definitions and category-based organization
+triggers:
+  - ag-grid
+  - cell renderer
+  - grid column
+  - custom renderer
+  - grid cell
+category: frontend
+version: 1.0.0
+source_project: lucida-ui
+---
+
+# AG-Grid Cell Renderer Pattern
+
+## Purpose
+
+Organize custom AG-Grid cell renderers into a typed, category-based catalog. Provides a `CommonColumnDefs` base interface and standard renderer patterns for buttons, data display, form editors, and charts.
+
+## When to Use
+
+- Project uses AG-Grid with 10+ custom cell renderers
+- Need consistent column definition typing across grids
+- Want reusable renderer components (buttons, dropdowns, charts, etc.)
+
+## Pattern
+
+See `content.md` for full implementation.

--- a/skills/frontend/ag-grid-cell-renderer-pattern/content.md
+++ b/skills/frontend/ag-grid-cell-renderer-pattern/content.md
@@ -1,0 +1,136 @@
+## Column Definition Base Interface
+
+```typescript
+// shared/models/common/common.ts
+interface CommonColumnDefs {
+  checkboxSelection?: boolean | ((value: CellRendererParams) => boolean)
+  headerCheckboxSelection?: boolean
+  autoHeight?: boolean
+  displayName?: string
+  aliasField?: string
+  cellRenderer?: string | React.ComponentType
+  cellRendererParams?: (params: any) => any
+  filter?: GridFilter.Text | GridFilter.Number | GridFilter.Date
+  sortable?: boolean
+  flex?: number
+  minWidth?: number
+  width?: number
+  hide?: boolean
+  pinned?: 'left' | 'right'
+}
+```
+
+## Renderer Catalog Organization
+
+```
+shared/components/commons/grid/cell-renderer/
+├── button/
+│   ├── ActionButtonsRenderer.tsx      # Multi-action buttons
+│   ├── ApprovalButtonsRenderer.tsx    # Approve/reject flows
+│   ├── MultiButtonsRenderer.tsx       # Configurable button array
+│   ├── SearchButton.tsx
+│   ├── TextButtonRenderer.tsx
+│   └── DeleteButton.tsx
+├── data-display/
+│   ├── AvailabilityCellRenderer.tsx   # Status indicators
+│   ├── TickIcon.tsx                    # Boolean checkmark
+│   ├── EllipsisCellRenderer.tsx       # Text overflow + tooltip
+│   ├── CountNumberRenderer.tsx
+│   └── DatePickerCellRenderer.tsx
+├── form-editor/
+│   ├── DropdownCellRenderer.tsx       # Inline select
+│   ├── GroupTreeSelectRenderer.tsx     # Hierarchical select
+│   └── TextDropdownCellRenderer.tsx
+├── chart/
+│   ├── GridChart.tsx                  # Inline sparklines
+│   ├── GridChartDetail.tsx
+│   └── MaxUtilizationChart.tsx
+└── specialized/
+    ├── ColorThemeRenderer.tsx
+    ├── BookmarkRenderer.tsx
+    └── AlarmSeverityDivRenderer.tsx
+```
+
+## Renderer Implementation Pattern
+
+### Button Renderer
+
+```tsx
+interface MultiButtonsPropsData {
+  label: string
+  type: TypeButtonVariant
+  onClick: () => void
+  disabled?: boolean
+  icon?: React.ReactNode
+}
+
+interface MultiButtonsRendererProps {
+  value: MultiButtonsPropsData[]
+}
+
+const MultiButtonsRenderer: React.FC<MultiButtonsRendererProps> = ({ value }) => {
+  return (
+    <div className="cell-buttons">
+      {value.map((btn, idx) => (
+        <Button key={idx} type={btn.type} onClick={btn.onClick} disabled={btn.disabled}>
+          {btn.icon}{btn.label}
+        </Button>
+      ))}
+    </div>
+  )
+}
+```
+
+### Data Display Renderer
+
+```tsx
+const EllipsisCellRenderer: React.FC<ICellRendererParams> = ({ value, colDef }) => {
+  return (
+    <Tooltip title={value}>
+      <span className="ellipsis-cell">{value}</span>
+    </Tooltip>
+  )
+}
+```
+
+## Column Definition Usage
+
+```tsx
+const columnDefs: CommonColumnDefs[] = useMemo(() => [
+  {
+    field: 'name',
+    displayName: tt('cmm.name'),
+    cellRenderer: EllipsisCellRenderer,
+    flex: 2,
+    sortable: true,
+    filter: GridFilter.Text,
+  },
+  {
+    field: 'status',
+    displayName: tt('cmm.status'),
+    cellRenderer: AvailabilityCellRenderer,
+    width: 100,
+  },
+  {
+    field: 'actions',
+    displayName: '',
+    cellRenderer: MultiButtonsRenderer,
+    cellRendererParams: (params) => ({
+      value: [
+        { label: tt('cmm.edit'), type: 'link', onClick: () => handleEdit(params.data) },
+        { label: tt('cmm.delete'), type: 'link', onClick: () => handleDelete(params.data) },
+      ],
+    }),
+    pinned: 'right',
+    width: 150,
+  },
+], [])
+```
+
+## Key Design Decisions
+
+1. **Category-based organization** — renderers grouped by function (button, display, editor, chart) for discoverability
+2. **CommonColumnDefs base** — typed column definitions shared across all grids, extended per domain
+3. **`cellRendererParams` as function** — enables dynamic prop injection from row data
+4. **`displayName` + `tt()`** — all column headers go through i18n translation
+5. **92 renderers at scale** — this catalog approach keeps renderers reusable rather than inline

--- a/skills/frontend/drawer-resizable-composition/SKILL.md
+++ b/skills/frontend/drawer-resizable-composition/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: drawer-resizable-composition
+description: Drawer-as-primary-modal pattern with preset widths, resizable handles, and parent state composition for React apps
+triggers:
+  - drawer
+  - modal drawer
+  - resizable drawer
+  - side panel
+category: frontend
+version: 1.0.0
+source_project: lucida-ui
+---
+
+# Drawer Resizable Composition
+
+## Purpose
+
+Use drawers instead of modals as the primary overlay pattern. Provides preset width tiers, resizable handles, and a consistent parent-child state composition pattern for opening/closing.
+
+## When to Use
+
+- Building data-heavy UIs where modals feel cramped
+- Need resizable detail panels alongside list views
+- Want consistent open/close state management across 100+ drawer usages
+
+## Pattern
+
+See `content.md` for full implementation.

--- a/skills/frontend/drawer-resizable-composition/content.md
+++ b/skills/frontend/drawer-resizable-composition/content.md
@@ -1,0 +1,123 @@
+## Drawer Base Component
+
+```tsx
+type TypeDrawerWidth = 'default' | '1dp' | '2dp' | '3dp' | '4dp' | '5dp' | '6dp' | '7dp' | 'option'
+
+interface TypeDrawerProps {
+  width?: TypeDrawerWidth
+  open: boolean
+  onClose: () => void
+  children: React.ReactNode
+  presetBtn?: boolean
+  minWidth?: string
+  maxWidth?: string
+  headerRightContent?: React.ReactNode
+  resizable?: boolean
+  footerConfirmText?: string    // default: 'Save'
+  footerCancelText?: string     // default: 'Close'
+  onConfirm?: () => void
+}
+
+const Drawer: React.FC<TypeDrawerProps> = ({
+  width = 'default',
+  open,
+  onClose,
+  children,
+  resizable = false,
+  ...rest
+}) => {
+  const widthValue = resolveWidth(width) // maps '1dp'→'24rem', '7dp'→'100%'
+
+  return (
+    <div className={`drawer ${open ? 'open' : ''}`} style={{ width: widthValue }}>
+      {resizable && <ResizeHandle />}
+      <DrawerHeader rightContent={rest.headerRightContent} onClose={onClose} />
+      <DrawerBody>{children}</DrawerBody>
+      <DrawerActions
+        confirmText={rest.footerConfirmText}
+        cancelText={rest.footerCancelText}
+        onConfirm={rest.onConfirm}
+        onCancel={onClose}
+      />
+    </div>
+  )
+}
+```
+
+## Parent-Child State Composition
+
+Standard pattern for every drawer usage (463+ instances):
+
+```tsx
+// Parent component (list/page)
+const ParentPage: React.FC = () => {
+  const [openDrawer, setOpenDrawer] = useState(false)
+  const [selectedItem, setSelectedItem] = useState<Item | null>(null)
+
+  const handleOpenDrawer = (item: Item) => {
+    setSelectedItem(item)
+    setOpenDrawer(true)
+  }
+
+  const handleCloseDrawer = () => {
+    setOpenDrawer(false)
+    setSelectedItem(null)
+  }
+
+  return (
+    <>
+      <DataGrid onRowClick={handleOpenDrawer} />
+      {openDrawer && (
+        <ItemDetailDrawer
+          openDrawer={openDrawer}
+          handleCloseDrawer={handleCloseDrawer}
+          item={selectedItem}
+        />
+      )}
+    </>
+  )
+}
+```
+
+```tsx
+// Child drawer component
+interface ItemDetailDrawerProps {
+  openDrawer: boolean
+  handleCloseDrawer: () => void
+  item: Item | null
+}
+
+const ItemDetailDrawer: React.FC<ItemDetailDrawerProps> = ({
+  openDrawer,
+  handleCloseDrawer,
+  item,
+}) => {
+  return (
+    <Drawer open={openDrawer} onClose={handleCloseDrawer} width="4dp" resizable>
+      <ItemDetailContent item={item} />
+    </Drawer>
+  )
+}
+```
+
+## Width Presets
+
+| Preset | Width | Use Case |
+|--------|-------|----------|
+| `default` | `24rem` | Simple forms, small detail |
+| `1dp` | `24rem` | Narrow panels |
+| `2dp` | `36rem` | Standard forms |
+| `3dp` | `48rem` | Detail views |
+| `4dp` | `60rem` | Complex forms with grids |
+| `5dp` | `72rem` | Dashboard-like detail |
+| `6dp` | `84rem` | Wide content |
+| `7dp` | `100%` | Full-screen overlay |
+| `option` | `auto` | Content-driven width |
+
+## Key Design Decisions
+
+1. **Drawer > Modal** — drawers keep parent context visible; better for data-heavy UIs
+2. **Conditional rendering** — `{openDrawer && <Drawer />}` unmounts on close, clearing state
+3. **Preset widths** — `1dp`–`7dp` scale provides consistent sizing vocabulary
+4. **Resizable option** — drag handle for user-adjustable width on complex views
+5. **Footer actions** — standardized Save/Close buttons via `DrawerActions` component

--- a/skills/frontend/mfa-federated-component-loader/SKILL.md
+++ b/skills/frontend/mfa-federated-component-loader/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: mfa-federated-component-loader
+description: Three-layer dynamic component loading for Webpack 5 Module Federation with retry logic, script caching, and error boundaries
+triggers:
+  - module federation
+  - federated component
+  - remote component loading
+  - dynamic import remote
+  - RemoteApp
+category: frontend
+version: 1.0.0
+source_project: lucida-ui
+---
+
+# MFA Federated Component Loader
+
+## Purpose
+
+Implement a robust three-layer dynamic component loading system for Webpack 5 Module Federation. Handles script loading failures gracefully with retry logic, prevents duplicate script injection, and provides type-safe remote consumption.
+
+## When to Use
+
+- Building a micro-frontend architecture with Webpack 5 Module Federation
+- Need resilient remote component loading with retry and caching
+- Want type-safe consumption of dynamically loaded remote components
+- Need to handle network failures when loading remote entries
+
+## Pattern
+
+See `content.md` for full implementation.

--- a/skills/frontend/mfa-federated-component-loader/content.md
+++ b/skills/frontend/mfa-federated-component-loader/content.md
@@ -1,0 +1,178 @@
+## Architecture
+
+Three-layer loading stack:
+
+```
+RemoteApp (consumption layer)
+  └─ FederatedComponent (loading UI layer)
+       └─ useFederatedComponent (script loading + caching hook)
+```
+
+## Layer 1: useFederatedComponent Hook
+
+Core hook that handles dynamic script loading with retry and caching.
+
+```typescript
+// shared/hooks/useFederatedComponent.tsx
+const componentCache = new Map<string, { Component: React.LazyExoticComponent<any> }>()
+const urlCache = new Set<string>()
+
+const loadComponent = (scope: string, module: string, remoteUrl: string) => {
+  return async () => {
+    await __webpack_init_sharing__('default')
+    const MAX_RETRIES = 5
+    let retries = 0
+
+    const loadRemoteScript = async () => {
+      return new Promise<void>((resolve, reject) => {
+        // Skip if script already loaded
+        if (urlCache.has(remoteUrl)) {
+          resolve()
+          return
+        }
+        const script = document.createElement('script')
+        script.src = remoteUrl
+        script.async = true
+        script.onload = () => {
+          urlCache.add(remoteUrl)
+          resolve()
+        }
+        script.onerror = () => {
+          // Clean up stale scope on failure
+          if (window[scope] != null) delete window[scope]
+          reject(new Error(`Failed to load remote module at ${remoteUrl}`))
+        }
+        document.head.appendChild(script)
+      })
+    }
+
+    while (!window[scope] && retries < MAX_RETRIES) {
+      try {
+        await loadRemoteScript()
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+      } catch (e) {
+        retries++
+      }
+    }
+
+    if (!window[scope]) {
+      throw new Error(`Remote scope ${scope} not available after ${MAX_RETRIES} retries`)
+    }
+
+    const container = window[scope]
+    await container.init(__webpack_share_scopes__.default)
+    const factory = await container.get(module)
+    return factory()
+  }
+}
+
+export function useFederatedComponent(remoteUrl: string, scope: string, module: string) {
+  const cacheKey = `${remoteUrl}-${scope}-${module}`
+
+  const [Component, setComponent] = useState<React.LazyExoticComponent<any> | null>(null)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    if (componentCache.has(cacheKey)) {
+      setComponent(componentCache.get(cacheKey)!.Component)
+      return
+    }
+
+    try {
+      const LazyComponent = React.lazy(loadComponent(scope, module, remoteUrl))
+      componentCache.set(cacheKey, { Component: LazyComponent })
+      setComponent(LazyComponent)
+    } catch (e) {
+      setError(e as Error)
+    }
+  }, [cacheKey])
+
+  return { Component, error }
+}
+```
+
+## Layer 2: FederatedComponent
+
+Loading UI wrapper with Suspense and error fallback.
+
+```tsx
+// shared/components/remote/FederatedComponent.tsx
+interface FederatedComponentProps {
+  url: string
+  scope: string
+  module: string
+  [key: string]: any
+}
+
+const FederatedComponent: React.FC<FederatedComponentProps> = ({
+  url, scope, module, ...rest
+}) => {
+  const { Component, error } = useFederatedComponent(url, scope, module)
+
+  if (error) return <ErrorFallback error={error} />
+  if (!Component) return <ModuleLoader />
+
+  return (
+    <Suspense fallback={<ModuleLoader />}>
+      <Component {...rest} />
+    </Suspense>
+  )
+}
+```
+
+## Layer 3: RemoteApp
+
+Consumption layer that resolves remote URLs from config.
+
+```tsx
+// shared/components/remote/RemoteApp.tsx
+interface RemoteAppProps {
+  appInfo: [string, string]  // [remoteName, componentName]
+  [key: string]: any
+}
+
+const RemoteApp: React.FC<RemoteAppProps> = ({ appInfo, ...rest }) => {
+  const [remoteName, componentName] = appInfo
+
+  let baseUrl = RemoteAppInfoUtil.readUrl(remoteName)
+
+  if (process.env.NODE_ENV === 'development') {
+    const remoteEntryUrl = nfEnv.env.remoteEntryUrl[remoteName]
+    if (remoteEntryUrl === '') {
+      const port = nfEnv.env.remotePort[remoteName]
+      baseUrl = `${window.location.protocol}//${window.location.hostname}:${port}`
+    }
+  }
+
+  const remoteEntryPoint = `${baseUrl}/${remoteName}RemoteEntry.js`
+
+  return (
+    <FederatedComponent
+      module={`./${componentName}`}
+      scope={remoteName}
+      url={remoteEntryPoint}
+      {...rest}
+    />
+  )
+}
+```
+
+## Consumption Example
+
+```tsx
+// host/src/remote-components/apm/ApmHome.tsx
+import RemoteApp from '@shared/components/remote/RemoteApp'
+import { MF_NAME_APM, MF_APM_HOME } from '@shared/types/remoteAppProps'
+
+export default () => (
+  <RemoteApp appInfo={[MF_NAME_APM, MF_APM_HOME]} />
+)
+```
+
+## Key Design Decisions
+
+1. **Component caching via Map** — prevents re-instantiation of lazy components on re-render
+2. **URL deduplication via Set** — avoids injecting duplicate `<script>` tags
+3. **5-retry with 1s delay** — handles transient network failures without infinite loops
+4. **Scope cleanup on failure** — `delete window[scope]` prevents stale partial loads
+5. **Config-driven URLs** — remote URLs from JSON config enable multi-environment support (dev ports, prod URLs)

--- a/skills/frontend/recoil-domain-atom-store/SKILL.md
+++ b/skills/frontend/recoil-domain-atom-store/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: recoil-domain-atom-store
+description: Domain-scoped Recoil atom organization with typed hook wrappers for large-scale React state management
+triggers:
+  - recoil atom
+  - state management
+  - domain store
+  - global state
+category: frontend
+version: 1.0.0
+source_project: lucida-ui
+---
+
+# Recoil Domain Atom Store
+
+## Purpose
+
+Organize Recoil atoms into domain-scoped modules with typed hook wrappers. Scales to 2000+ usages across a monorepo by separating atoms (global vs remote-domain), selectors, and consumer hooks.
+
+## When to Use
+
+- React project using Recoil with 20+ atoms
+- Multi-module/micro-frontend architecture needing shared state
+- Want clean separation between global and domain-specific state
+
+## Pattern
+
+See `content.md` for full implementation.

--- a/skills/frontend/recoil-domain-atom-store/content.md
+++ b/skills/frontend/recoil-domain-atom-store/content.md
@@ -1,0 +1,122 @@
+## Directory Structure
+
+```
+shared/store/
+├── atom/
+│   ├── global/                    # App-wide state
+│   │   ├── userAtom.ts            # Login user & profile
+│   │   ├── dateAtom.ts            # Global timestamp
+│   │   ├── filterAtom.ts          # Search filter state
+│   │   ├── gridAtom.ts            # Grid configuration
+│   │   ├── modalAtom.ts           # Modal open/close
+│   │   ├── menuAtom.ts            # Menu selection
+│   │   ├── breadcrumbAtom.ts      # Navigation breadcrumbs
+│   │   ├── localeMessageAtom.ts   # i18n messages
+│   │   ├── actionDispatchAtom.ts  # Refresh triggers (counter-based)
+│   │   ├── screenSizeAtom.ts      # Responsive breakpoints
+│   │   └── refreshAtom.ts         # Generic refresh triggers
+│   ├── app/
+│   │   └── layoutAtom.ts          # Layout metadata + menu collapse
+│   └── remote/                    # Domain-scoped state
+│       ├── apm/detail.ts, summary.ts
+│       ├── dpm/main.ts, timeRange.ts
+│       ├── alarm/main.ts
+│       ├── kcm/main.ts
+│       ├── widget/main.ts
+│       └── [domain]/main.ts
+└── hook/                          # Typed consumer hooks
+    ├── useTimeSelector.ts
+    ├── useDashboardFilter.ts
+    └── filterHook.ts
+```
+
+## Pattern 1: Global Atom
+
+```typescript
+// shared/store/atom/global/actionDispatchAtom.ts
+import { atom } from 'recoil'
+
+export const actionDispatchAtom = atom<number>({
+  key: 'actionDispatchAtom',
+  default: 0,
+})
+```
+
+## Pattern 2: Domain Atom with Persistence
+
+```typescript
+// shared/store/atom/app/layoutAtom.ts
+import { atom, selector } from 'recoil'
+
+export const menuCollapsedAtom = atom<boolean>({
+  key: 'menuCollapsedAtom',
+  default: sessionStorage.getItem('menuCollapsed') === 'true',
+})
+
+export const alarmCollapsedAtom = atom<Record<string, boolean>>({
+  key: 'alarmCollapsedAtom',
+  default: {},
+})
+
+// Derived state via selector
+export const alarmCollapsedSelector = selector({
+  key: 'alarmCollapsedSelector',
+  get: ({ get }) => {
+    const collapsed = get(alarmCollapsedAtom)
+    return (domain: string) => collapsed[domain] ?? false
+  },
+})
+```
+
+## Pattern 3: Hook Wrapper
+
+```typescript
+// shared/store/hook/useTimeSelector.ts
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil'
+import { timeRangeAtom, showTimeSelectorAtom } from '../atom/remote/dpm/timeRange'
+
+const useTimeSelector = () => {
+  const modeTime = useRecoilValue(timeRangeAtom)
+  const setModeTime = useSetRecoilState(timeRangeAtom)
+  const resetModeTime = () => setModeTime(defaultTimeRange)
+  const isShowTimeSelector = useRecoilValue(showTimeSelectorAtom)
+  const setIsShowTimeSelector = useSetRecoilState(showTimeSelectorAtom)
+
+  return {
+    modeTime,
+    setModeTime,
+    resetModeTime,
+    isShowTimeSelector,
+    setIsShowTimeSelector,
+  }
+}
+
+export default useTimeSelector
+```
+
+## Pattern 4: Counter-Based Refresh Trigger
+
+```typescript
+// Usage: increment atom to trigger dependent useEffect
+const useActionDispatch = () => {
+  const setDispatch = useSetRecoilState(actionDispatchAtom)
+  const reload = () => setDispatch((prev) => prev + 1)
+  return { reload }
+}
+
+// Consumer
+const Component = () => {
+  const refreshState = useRecoilValue(actionDispatchAtom)
+  useEffect(() => {
+    fetchData()
+  }, [refreshState])
+}
+```
+
+## Key Design Decisions
+
+1. **Global vs Remote separation** — global atoms for cross-cutting concerns, remote atoms scoped to feature domains
+2. **Hook wrappers** — typed hooks hide atom internals, expose clean API
+3. **Counter-based refresh** — simple `atom<number>` with increment for triggering re-fetches without event buses
+4. **SessionStorage backing** — UI layout state persisted across page refreshes via sessionStorage defaults
+5. **Selector for derived state** — function-returning selectors for parameterized lookups (e.g., `(domain) => boolean`)

--- a/skills/frontend/sse-fetch-streaming/SKILL.md
+++ b/skills/frontend/sse-fetch-streaming/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: sse-fetch-streaming
+description: Fetch-based Server-Sent Events streaming with pause/resume/close control for real-time chat and data feeds
+triggers:
+  - sse
+  - server-sent events
+  - streaming
+  - event stream
+  - real-time chat
+category: frontend
+version: 1.0.0
+source_project: lucida-ui
+---
+
+# SSE Fetch Streaming
+
+## Purpose
+
+Implement Server-Sent Events using the Fetch API (not EventSource) for POST-capable streaming with pause/resume/close control. Suitable for AI chat responses, real-time data feeds, and progressive loading.
+
+## When to Use
+
+- Need SSE with POST requests (EventSource only supports GET)
+- Want pause/resume control over the stream
+- Building AI chat UIs with streaming responses
+- Need custom header injection (auth tokens, locale)
+
+## Pattern
+
+See `content.md` for full implementation.

--- a/skills/frontend/sse-fetch-streaming/content.md
+++ b/skills/frontend/sse-fetch-streaming/content.md
@@ -1,0 +1,157 @@
+## Implementation
+
+```typescript
+// shared/apis/requestSSE.ts
+
+interface SSEStream {
+  onmessage: (event: { event: string; data: any }) => void
+  oncomplete: () => void
+  onerror: (error: any) => void
+  pause: () => void
+  resume: () => void
+  close: () => void
+}
+
+export const requestSSE = (
+  url: string,
+  params?: Record<string, any>,
+  formData?: FormData
+): SSEStream => {
+  let paused = false
+  let isClosed = false
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null
+
+  const stream: SSEStream = {
+    onmessage: () => {},
+    oncomplete: () => {},
+    onerror: () => {},
+    pause() { paused = true },
+    resume() { paused = false; read() },
+    close() { isClosed = true; reader?.cancel() },
+  }
+
+  const body = formData || (params ? JSON.stringify(params) : undefined)
+  const headers: Record<string, string> = {
+    'Accept-Language': getCurrentLocale(),
+  }
+  if (!formData) {
+    headers['Content-Type'] = 'application/json'
+  }
+
+  const token = getAccessToken()
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`
+  }
+
+  fetch(url, {
+    method: 'POST',
+    headers,
+    body,
+    credentials: 'include',
+  })
+    .then((response) => {
+      if (!response.ok) throw new Error(`SSE failed: ${response.status}`)
+      reader = response.body!.getReader()
+      read()
+    })
+    .catch((error) => stream.onerror(error))
+
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  function read() {
+    if (isClosed || paused || !reader) return
+
+    reader.read().then(({ done, value }) => {
+      if (done) {
+        stream.oncomplete()
+        return
+      }
+
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split('\n')
+      buffer = lines.pop() || '' // Keep incomplete line in buffer
+
+      for (const line of lines) {
+        if (!line.startsWith('data:')) continue
+        const jsonStr = line.slice(5).trim()
+        if (!jsonStr || jsonStr === '[DONE]') continue
+
+        try {
+          const data = JSON.parse(jsonStr)
+          const event = data.event || (data.answer ? 'message' : 'unknown')
+          stream.onmessage({ event, data })
+        } catch {
+          // Non-JSON data line, skip
+        }
+      }
+
+      read() // Continue reading
+    }).catch((error) => {
+      if (!isClosed) stream.onerror(error)
+    })
+  }
+
+  return stream
+}
+```
+
+## Usage: Chat Hook
+
+```typescript
+// shared/hooks/useChatBot.tsx
+const useChatBot = () => {
+  const [messages, setMessages] = useState<Message[]>([])
+  const [isStreaming, setIsStreaming] = useState(false)
+  const streamRef = useRef<SSEStream | null>(null)
+
+  const sendMessage = (text: string) => {
+    setIsStreaming(true)
+    const stream = requestSSE('/api/ai/chat', { message: text })
+
+    stream.onmessage = ({ event, data }) => {
+      if (event === 'message') {
+        setMessages((prev) => {
+          const last = prev[prev.length - 1]
+          if (last?.role === 'assistant' && last.streaming) {
+            return [
+              ...prev.slice(0, -1),
+              { ...last, content: last.content + data.answer },
+            ]
+          }
+          return [...prev, { role: 'assistant', content: data.answer, streaming: true }]
+        })
+      }
+    }
+
+    stream.oncomplete = () => {
+      setIsStreaming(false)
+      setMessages((prev) => prev.map((m) => ({ ...m, streaming: false })))
+    }
+
+    stream.onerror = (error) => {
+      setIsStreaming(false)
+      console.error('SSE error:', error)
+    }
+
+    streamRef.current = stream
+  }
+
+  const stopStreaming = () => streamRef.current?.close()
+
+  useEffect(() => {
+    return () => streamRef.current?.close()
+  }, [])
+
+  return { messages, isStreaming, sendMessage, stopStreaming }
+}
+```
+
+## Key Design Decisions
+
+1. **Fetch over EventSource** — EventSource only supports GET; Fetch enables POST with JSON body
+2. **Pause/resume** — boolean flag stops `read()` loop without cancelling the stream
+3. **Line buffering** — incomplete lines kept in buffer across chunks for correct SSE parsing
+4. **`[DONE]` sentinel** — standard SSE completion signal (compatible with OpenAI-style APIs)
+5. **Locale + auth headers** — injected automatically, unlike EventSource which has no header support
+6. **Ref-based cleanup** — stream closed on component unmount via useEffect cleanup


### PR DESCRIPTION
## Summary

Frontend pattern extraction from lucida-ui monorepo (MFA, React, AG-Grid, Recoil, Axios).

## Skills (6)

| Slug | Category | Version | Description |
|------|----------|---------|-------------|
| `mfa-federated-component-loader` | frontend | v1.0.0 | 3-layer RemoteApp→FederatedComponent→hook with retry/caching |
| `ag-grid-cell-renderer-pattern` | frontend | v1.0.0 | 92-renderer catalog with CommonColumnDefs typing |
| `recoil-domain-atom-store` | frontend | v1.0.0 | Domain-scoped atoms with hook wrappers |
| `drawer-resizable-composition` | frontend | v1.0.0 | Drawer-as-modal with preset widths (1dp-7dp) |
| `axios-token-refresh-queue` | backend | v1.0.0 | Window-scoped subscriber queue for token refresh |
| `sse-fetch-streaming` | frontend | v1.0.0 | Fetch-based SSE with pause/resume for AI chat |

## Knowledge (6)

| Slug | Category | Description |
|------|----------|-------------|
| `endpoint-service-dual-pattern` | api | Factory vs functional API service coexistence |
| `mf-shared-singleton-config` | arch | 227 MF shared singletons, react-router-dom excluded |
| `scss-css-variable-theme-system` | arch | SCSS + CSS vars + data-theme for MFA theming |
| `sirius-component-taxonomy` | arch | 200+ components in 5 categories |
| `drawer-over-modal` | decision | Drawers (463 files) over modals as primary overlay |
| `recoil-over-redux` | decision | Recoil atoms (2697 usages) as sole state management |

## Cross-links

- `drawer-resizable-composition` ↔ `drawer-over-modal`
- `recoil-domain-atom-store` ↔ `recoil-over-redux`
- `mfa-federated-component-loader` ↔ `mf-shared-singleton-config`

## Source

Project: `lucida-ui@4b922a9043` (release-10.2.4_2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)