### PR TITLE
Publish 2 skills + 1 knowledge: NDS design mockup workflow

### DIFF
--- a/knowledge/arch/lucida-ui-design-token-reference.md
+++ b/knowledge/arch/lucida-ui-design-token-reference.md
@@ -1,0 +1,149 @@
+---
+name: lucida-ui-design-token-reference
+type: knowledge
+category: arch
+tags: [lucida-ui, nds, design-token, sirius, scss, figma]
+summary: "lucida-ui 프로젝트의 실제 디자인 토큰 값 참조표 — 팔레트, 시맨틱, 사이즈, 타이포, 컴포넌트 스타일"
+source:
+  kind: session
+  ref: session-2026-04-16
+  repo: D:/21_LUCIDA/lucida-ui
+confidence: high
+linked_skills:
+  - nds-html-mockup-from-tokens
+  - plan-to-screen-spec-conversion
+supersedes: null
+extracted_at: 2026-04-16
+extracted_by: skills_extract_knowledge v1
+---
+
+## Fact
+lucida-ui의 디자인 시스템은 Figma Token Studio → Style Dictionary → SCSS 파이프라인으로 생성된다.
+Primary 브랜드 색상은 `#004cff` (blue 계열)이며, `--indigo-6`(#3a55b1)과는 다르다.
+
+## Context / Why
+- Figma NDS 디자인 시스템과 코드 사이의 토큰 매핑을 정확히 알아야 목업/코드 생성 시 실제 제품과 동일한 룩앤필 재현 가능
+- SCSS 변수($)와 CSS 변수(--)가 혼재: 팔레트는 CSS 변수, 시맨틱 토큰은 SCSS 변수로 정의
+
+## Evidence
+- `packages/sirius/src/styles/base/_palette.scss` — CSS 변수 팔레트
+- `packages/sirius/src/styles/tokens/themes/_demo_light-mode.scss` — 시맨틱 토큰 (SCSS)
+- `packages/sirius/src/styles/tokens/base/_demo_size.scss` — spacing, border-radius
+- `packages/sirius/src/styles/tokens/base/_demo_font.scss` — typography
+- `packages/sirius/src/styles/base/fonts/_font.scss` — @font-face
+- `packages/sirius/src/styles/components/antd/*.scss` — 컴포넌트 오버라이드
+
+## Applies when
+- lucida-ui 기반 화면 개발 또는 HTML 목업 생성
+- NDS 컴포넌트 스타일 참조가 필요할 때
+- 디자인 토큰을 코드에 매핑할 때
+
+## Token Reference
+
+### 팔레트 (CSS 변수, _palette.scss)
+```
+--white: #ffffff / --black: #000000
+--indigo: #0a2042(10) ~ #f1f3f9(1), 기본 #3a55b1(6)
+--gray:   #1a1a1a(10) ~ #f7f8f8(1)
+--blue:   #0f2a6b(10) ~ #e8f2ff(1), 기본 #437aff(6)
+--green:  #002b1f(10) ~ #edfff9(1), 기본 #1ac484(6)
+--red:    #5c0011(10) ~ #fff1f0(1), 기본 #f5222d(6)
+--orange: #612500(10) ~ #fff7e6(1), 기본 #fa8c16(6)
+--yellow: #614700(10) ~ #feffe6(1), 기본 #ffdc25(6)
+```
+
+### 시맨틱 토큰 (SCSS, _demo_light-mode.scss)
+```
+Fill:
+  fill-standard-default: #fff
+  fill-standard-hover: #f4f5f5
+  fill-secondary-default: hsl(180 4.76% 98.8%)
+  fill-tertiary-default: hsl(180 4.76% 97.1%)
+  fill-primary-default: #004cff       ← PRIMARY 브랜드
+  fill-primary-hover: #0042db
+  fill-primary-active: #0036b3
+
+Line/Border:
+  line-primary-default: #004cff
+  line-standard-default: hsl(192 6.49% 92.5%)
+  line-secondary-default: #d6dadb
+  border-secondary: 1px solid #d6dadb
+
+Text:
+  text-standard-default: #1d1f20
+  text-secondary-default: #5c6061
+  text-tertiary-default: #797f81
+  text-inverse-default: #fff
+  text-placeholder-default: #c1c6c8
+  text-primary-default: #004cff
+
+State:
+  state-error-default: #ed121d / opacity: #fde7e8
+  state-success-default: #25bb4d / opacity: #e8f8ec
+  state-caution-default: #f56a00
+  state-warning-default: #f5b800
+  state-info-default: #004cff / opacity: #e5edff
+
+Alarm:
+  alarm-normal: default #25bb4d / text #156a2c / bg #cdefd6
+  alarm-critical: default #ed121d / text #850a10
+  alarm-major: default #f56a00 / text #ad4b00
+  alarm-info: default #004cff / bg #c2d4ff
+
+Misc:
+  sider-background: #000614
+  column-bg-hover: hsl(222 100% 96.4%)
+  modal-shadow-default: 2px 4px 8px 2px hsl(195 3.13% 25.1%/0.4), ...
+```
+
+### 테마 변수 (_lightTheme.scss)
+```
+--background: var(--white)
+--contents-background: var(--gray-1)    (#f7f8f8)
+--background-menu: #161f30
+--background-menu-active: #152268
+--text-primary: var(--black)
+--border: rgba(0, 0, 0, 0.15)
+```
+
+### 사이즈 (_demo_size.scss)
+```
+border-radius: none=0 / xs=0.2rem / sm=0.4rem / md=0.8rem / lg=1.2rem
+spacing: 0=0.2rem / 1=0.4rem / 2=0.8rem / 3=1.2rem / 4=1.6rem / 5=2rem / 6=2.4rem / 7=2.8rem / 8=3.2rem
+```
+
+### 타이포그래피 (실제 font shorthand)
+```
+font-family: 'Spoqa Han Sans Neo', 'Roboto mono', '맑은고딕', sans-serif
+letter-spacing: 0.3px
+
+xs-normal:  400 1rem/1.6rem     sm-normal:  400 1.2rem/2rem
+sm-strong:  500 1.2rem/2rem     sm-extra:   700 1.2rem/2rem
+md-normal:  400 1.4rem/2.2rem   md-strong:  500 1.4rem/2.2rem   md-extra: 700 1.4rem/2.2rem
+lg-normal:  400 1.6rem/2.4rem   lg-extra:   700 1.6rem/2.4rem
+xl-extra:   700 2rem/2.8rem
+heading-4:  700 2rem/2.8rem     heading-3:  700 2.4rem/3.2rem
+```
+
+### 컴포넌트 치수
+```
+Button:  height 2.8rem, padding 3px 12px, icon-only 2.8rem, sm 2.4rem, lg 4rem
+Select:  height 2.8rem, line-height 2.8rem
+Tab:     nav padding 0 2rem, tab padding 0.8rem
+Modal:   min-width 32rem, content padding 1.6rem 2.4rem
+Form:    label font sm-strong, control min-height 3rem
+Sider:   menu item height 3.6rem, sub item height 3.4rem, padding 0 1.6rem
+```
+
+### 차트 legend 색상
+```
+level-1: #007bf5   level-2: #007b7e   level-3: #618dec   level-4: #96eb54
+level-5: #0088c4   level-6: #437dad   level-7: #ff4e96   level-8: #198fe4
+level-9: #f57fe9   level-10: #ff6c2c  level-11: #ffc42c  level-12: #a57ff5
+```
+
+## Counter / Caveats
+- 토큰은 Figma 동기화 시 변경될 수 있음 (파일 헤더에 "Generated on Mon, 04 Aug 2025" 명시)
+- `_demo_*` prefix 파일은 임시 Figma 토큰이며 최종 확정 전 변경 가능성 있음
+- 다크 테마 토큰은 `_darkTheme.scss`에 일부만 정의 (완전하지 않음)
+- SCSS 변수($)는 빌드 타임에 해소되어 런타임 CSS 변수(--)와 직접 대응하지 않는 경우 있음

--- a/registry.json
+++ b/registry.json
@@ -3620,6 +3620,27 @@
       "linked_skills": [
         "recoil-domain-atom-store"
       ]
+    },
+    "lucida-ui-design-token-reference": {
+      "category": "arch",
+      "scope": "project",
+      "path": "knowledge/arch/lucida-ui-design-token-reference.md",
+      "source": {
+        "kind": "session",
+        "ref": "session-2026-04-16"
+      },
+      "confidence": "high",
+      "linked_skills": [
+        "nds-html-mockup-from-tokens",
+        "plan-to-screen-spec-conversion"
+      ],
+      "tags": [
+        "lucida-ui",
+        "nds",
+        "design-token",
+        "sirius"
+      ],
+      "extracted_at": "2026-04-16"
     }
   }
 }

--- a/skills/design/nds-html-mockup-from-tokens/SKILL.md
+++ b/skills/design/nds-html-mockup-from-tokens/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: nds-html-mockup-from-tokens
+description: lucida-ui 디자인 토큰을 추출하여 실제 제품과 동일한 스타일의 static HTML 목업 생성
+version: 0.1.0-draft
+category: design
+triggers:
+  - "HTML 목업"
+  - "디자인 목업"
+  - "NDS 스타일 HTML"
+  - "lucida 디자인으로 HTML"
+  - "화면 프로토타입"
+source_project: polestar10-auto-pipeline
+linked_knowledge:
+  - lucida-ui-design-token-reference
+---
+
+# NDS 디자인 토큰 기반 HTML 목업 생성
+
+## Purpose
+lucida-ui 프로젝트의 실제 SCSS 디자인 토큰을 추출하여, 제품과 동일한 룩앤필의 static HTML 프로토타입을 만든다.
+개발 전 디자인 검증 및 이해관계자 리뷰에 사용한다.
+
+## When to Activate
+- 사용자가 화면 디자인 목업, HTML 프로토타입 요청
+- "디자인을 HTML로 볼 수 있게 해줘", "NDS 스타일로 목업 만들어줘"
+
+## Prerequisites
+- lucida-ui 프로젝트 접근 가능 (`D:/21_LUCIDA/lucida-ui/`)
+- 또는 linked knowledge `lucida-ui-design-token-reference` 참조
+
+## Steps
+
+### 1. 토큰 소스 파일 읽기
+lucida-ui에서 다음 파일들을 읽어 실제 값 확보:
+```
+packages/sirius/src/styles/
+├── base/_palette.scss               → CSS 변수 팔레트 (--indigo-6 등)
+├── tokens/base/_demo_size.scss       → spacing, border-radius
+├── tokens/base/_demo_font.scss       → font-family, size, weight, line-height
+├── tokens/themes/_demo_light-mode.scss → 시맨틱 토큰 (fill, line, text, state, alarm 등)
+├── themes/_lightTheme.scss           → 테마 변수 (--background, --border 등)
+├── themes/_darkTheme.scss            → 다크 테마 오버라이드
+├── base/fonts/_font.scss             → @font-face, $siri-font
+└── components/antd/                  → 컴포넌트별 오버라이드 (_button, _modal, _tab 등)
+```
+
+### 2. HTML 기본 구조
+```html
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap" rel="stylesheet">
+  <style>
+    html { font-size: 10px; }  /* rem 기준 */
+    body { font: 400 1.4rem/2.2rem 'Spoqa Han Sans Neo','Noto Sans KR','맑은고딕',sans-serif; }
+  </style>
+</head>
+<body data-theme="sirius-theme">
+```
+
+### 3. CSS 변수 선언 규칙
+- `:root`에 팔레트 + 시맨틱 토큰 모두 CSS 변수로 선언
+- **하드코딩 색상 절대 금지** — 모든 곳에서 `var(--토큰명)` 사용
+- 사이즈는 rem 단위 (`0.4rem` = 4px, `0.8rem` = 8px 등)
+
+### 4. 컴포넌트별 스타일 (실제 antd 오버라이드 반영)
+
+| 컴포넌트 | 핵심 스타일 |
+|---------|-----------|
+| Button default | height: 2.8rem, bg fill-standard-default, border 1px solid #d6dadb, border-radius-sm(0.4rem) |
+| Button primary | bg fill-primary-default(#004cff), color text-inverse-default(#fff) |
+| Select | height: 2.8rem, border-radius-sm |
+| Input | border line-secondary-default, border-radius-sm |
+| Tab | nav padding 0 2rem, tab padding 0.8rem, ink-bar fill-primary-default, active text-primary-default |
+| Modal | bg fill-secondary-default, border-radius-sm, shadow modal-shadow-default, padding 1.6rem 2.4rem |
+| Form label | font typography-sm-strong, color text-standard-default |
+| Sider | bg #000614, menu color rgba(255,255,255,0.6), item height 3.6rem |
+| Grid header | bg fill-tertiary-default, border line-standard-default |
+| Summary Card | bg fill-standard-default, border line-standard-default, border-radius-sm |
+| Tag | border-radius 999rem (pill) |
+
+### 5. NDS 레이아웃 규칙
+- **Title → 콘텐츠**: gap spacing-4 (1.6rem)
+- **Subtitle → 콘텐츠**: gap spacing-2 (0.8rem)
+- **블록 → 블록**: gap spacing-6 (2.4rem)
+- **Summary Card 간**: gap spacing-2 (0.8rem), flex-wrap
+- **일반 Card 간**: gap spacing-4 (1.6rem)
+- **차트**: 2열 grid, gap spacing-4
+
+### 6. Grid(테이블) 정렬 규칙
+- 텍스트: left
+- 숫자/퍼센트: right
+- 아이콘/상태: center
+
+### 7. 탭 네비게이션 JS
+각 화면을 탭으로 분리, JavaScript로 전환 구현.
+
+## Output
+- `design-{기능명}.html` — 단일 HTML 파일 (CSS/JS 포함, 외부 의존성 없음)
+
+## Rules
+- html font-size: 10px 기반 rem 단위
+- 모든 색상 CSS 변수 사용
+- data-theme="sirius-theme" 스코핑
+- 차트 색상: chart-data-legend-level-1~15 사용
+- letter-spacing: 0.3px 전역
+- 1200px (120rem) 고정폭 권장

--- a/skills/design/plan-to-screen-spec-conversion/SKILL.md
+++ b/skills/design/plan-to-screen-spec-conversion/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: plan-to-screen-spec-conversion
+description: PLAN 작업지시서를 rules/fe/02-screen-spec-template.md 형식의 화면 스펙 문서로 변환
+version: 0.1.0-draft
+category: workflow
+triggers:
+  - "PLAN을 스펙으로"
+  - "작업지시서를 화면 스펙으로"
+  - "screen spec 변환"
+  - "기획서를 스펙 템플릿으로"
+source_project: polestar10-auto-pipeline
+linked_knowledge:
+  - lucida-ui-design-token-reference
+---
+
+# PLAN → 화면 스펙 변환
+
+## Purpose
+PLAN 작업지시서(자유 형식 기획서)를 `rules/fe/02-screen-spec-template.md` 표준 화면 스펙 형식으로 변환한다.
+변환된 스펙은 `/generate-screen` 스킬의 입력으로 사용할 수 있다.
+
+## When to Activate
+- 사용자가 PLAN 또는 기획서를 화면 스펙으로 변환 요청
+- "기획서 기반으로 스펙 만들어줘", "PLAN을 스펙으로 변환해줘"
+
+## Input
+- PLAN 작업지시서 파일 경로 (예: `examples/custom-table/PLAN_CUSTOM_TABLE_WIDGET.md`)
+
+## Steps
+
+### 1. PLAN 읽기 및 분석
+- PLAN 파일을 읽고 핵심 구조를 파악:
+  - 화면 목적, 데이터 구조, 엔티티, API, UI 흐름
+
+### 2. 템플릿 참조
+- `rules/fe/02-screen-spec-template.md`를 읽어 필수 섹션 구조 확인
+
+### 3. 섹션별 매핑
+
+| PLAN 섹션 | 스펙 섹션 |
+|-----------|----------|
+| 개요/목적 | 📋 기본 정보 + 🎯 화면 목적 |
+| 엔티티/필드 정의 | 📊 데이터 구조 (필드/타입/설명/필수 테이블) |
+| 프론트엔드 UI 구성 | 🎨 UI 요구사항 (레이아웃 ASCII + Sirius 컴포넌트 매핑) |
+| API 엔드포인트 | 🔌 API 명세 (모두 POST 규칙 적용) |
+| 보안 고려사항 | 🔒 권한 및 예외 처리 |
+| 구현 순서 | 📝 추가 고려사항 |
+
+### 4. Sirius 컴포넌트 매핑
+PLAN의 UI 요소를 NDS/Sirius 컴포넌트로 매핑:
+- 테이블 → `GridScroll` (AG Grid 기반)
+- 폼 → `FormItem` (Vertical 기본)
+- 팝업/다이얼로그 → `Modal` / `Confirm`
+- 드롭다운 → `Select` / `Dropdown`
+- 토글 → `Switch`
+- 상태표시 → `Tag`
+- 빈 상태 → `Empty`
+
+### 5. i18n 키 생성
+- 네임스페이스: `{모듈}.{기능}` (예: `widget.customTable`)
+- 공통 키 사용: `cmm.search`, `cmm.reset`, `cmm.create` 등
+- 화면 고유 키 목록 작성
+
+### 6. 스펙 파일 생성
+- 동일 디렉토리에 `SPEC_{기능명}.md` 파일 생성
+- 체크리스트 섹션 포함
+
+## Output
+- `SPEC_{기능명}.md` — 화면 스펙 템플릿 형식 문서
+
+## Rules
+- API는 모두 POST (`05-api-guide.md` 규칙)
+- Ant Design 직접 참조 금지 → Sirius 컴포넌트만
+- 모든 UI 텍스트 → `tt()` 함수 (i18n)
+- Grid → `GridScroll` (AG Grid), `Table` 사용 금지
+- Form → `FormItem`, `Form.Item` 사용 금지


### PR DESCRIPTION
## Skills

| Slug | Category | Version | Description |
|------|----------|---------|-------------|
| `plan-to-screen-spec-conversion` | design | v0.1.0-draft | PLAN 작업지시서 → 화면 스펙 템플릿 변환 워크플로우 |
| `nds-html-mockup-from-tokens` | design | v0.1.0-draft | lucida-ui 디자인 토큰 기반 HTML 프로토타입 생성 |

## Knowledge

| Slug | Category | Confidence | Description |
|------|----------|------------|-------------|
| `lucida-ui-design-token-reference` | arch | high | lucida-ui 실제 디자인 토큰 참조표 (팔레트, 시맨틱, 사이즈, 타이포, 컴포넌트) |

## Cross-links

- `lucida-ui-design-token-reference` ↔ `nds-html-mockup-from-tokens`
- `lucida-ui-design-token-reference` ↔ `plan-to-screen-spec-conversion`

## Source

- Project: `polestar10-auto-pipeline`
- Session: 2026-04-16
- External: `D:/21_LUCIDA/lucida-ui/packages/sirius/src/styles/`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)