### PR TITLE
Add 6 new hub-make examples

### DIFF
--- a/example/adr-navigator/README.md
+++ b/example/adr-navigator/README.md
@@ -1,0 +1,21 @@
+# Architecture Decision Navigator
+
+> **Why.** `skills-explorer` is skill-centric — it shows patterns. This is knowledge-centric — it shows the *reasoning* behind patterns. Decision records and architecture knowledge explain why things are the way they are, which is what new team members and future maintainers actually need.
+
+## What it does
+
+- 16 entries: 6 decision records + 10 architecture knowledge entries
+- Filterable by category (decision / arch) and sortable (A-Z, confidence, category)
+- Fuzzy text search across titles, summaries, and body content
+- Click-to-expand detail view showing Fact, Why, How to Apply, Counter/Caveats
+- Confidence badges (high/medium/low) with colored indicators
+- Linked skill chips showing related installed skills
+- Stats ribbon with aggregate counts
+
+## Stack
+
+Single HTML file, zero external dependencies. Pure HTML + CSS + JS.
+
+## How to run
+
+Open `index.html` in any modern browser.

--- a/example/adr-navigator/index.html
+++ b/example/adr-navigator/index.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Architecture Decision Navigator</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#0d1117;--card:#161b22;--glass:rgba(255,255,255,0.04);--decision:#f0883e;--arch:#58a6ff;--high:#3fb950;--medium:#d29922;--low:#f85149;--text:#c9d1d9;--muted:#8b949e;--radius:12px;--border:rgba(255,255,255,0.08)}
+body{font-family:'Segoe UI',system-ui,sans-serif;background:var(--bg);color:var(--text);min-height:100vh}
+.header{padding:24px;text-align:center;border-bottom:1px solid var(--border)}
+h1{font-size:1.8rem;background:linear-gradient(135deg,var(--decision),var(--arch));-webkit-background-clip:text;-webkit-text-fill-color:transparent;margin-bottom:8px}
+.subtitle{color:var(--muted);font-size:.9rem}
+.stats-ribbon{display:flex;justify-content:center;gap:32px;padding:16px;background:var(--card);border-bottom:1px solid var(--border);flex-wrap:wrap}
+.ribbon-stat{text-align:center}.ribbon-val{font-size:1.3rem;font-weight:700}.ribbon-label{font-size:.7rem;color:var(--muted);text-transform:uppercase;letter-spacing:.5px}
+.controls{padding:16px 24px;display:flex;gap:12px;flex-wrap:wrap;align-items:center;border-bottom:1px solid var(--border);background:rgba(22,27,34,0.8);backdrop-filter:blur(8px);position:sticky;top:0;z-index:10}
+.search{flex:1;min-width:200px;padding:10px 14px;background:var(--glass);border:1px solid var(--border);border-radius:8px;color:var(--text);font-size:.9rem;outline:none}
+.search:focus{border-color:var(--arch)}
+.search::placeholder{color:var(--muted)}
+.filter-btn{padding:6px 14px;border-radius:20px;border:1px solid var(--border);background:transparent;color:var(--muted);cursor:pointer;font-size:.8rem;transition:all .2s}
+.filter-btn.active{color:#fff}
+.filter-btn.active[data-cat="decision"]{background:rgba(240,136,62,0.2);border-color:var(--decision);color:var(--decision)}
+.filter-btn.active[data-cat="arch"]{background:rgba(88,166,255,0.2);border-color:var(--arch);color:var(--arch)}
+.filter-btn.active[data-cat="all"]{background:rgba(255,255,255,0.1);border-color:rgba(255,255,255,0.3);color:var(--text)}
+select{padding:6px 10px;background:var(--card);border:1px solid var(--border);border-radius:8px;color:var(--text);font-size:.8rem;outline:none}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:16px;padding:24px}
+.adr-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);padding:20px;cursor:pointer;transition:all .25s;position:relative;overflow:hidden}
+.adr-card:hover{border-color:rgba(255,255,255,0.15);transform:translateY(-2px);box-shadow:0 4px 20px rgba(0,0,0,0.3)}
+.adr-card::before{content:'';position:absolute;top:0;left:0;width:3px;height:100%}
+.adr-card[data-cat="decision"]::before{background:var(--decision)}
+.adr-card[data-cat="arch"]::before{background:var(--arch)}
+.card-header{display:flex;align-items:center;gap:8px;margin-bottom:10px;flex-wrap:wrap}
+.cat-badge{padding:2px 8px;border-radius:12px;font-size:.65rem;font-weight:600;text-transform:uppercase;letter-spacing:.3px}
+.cat-badge.decision{background:rgba(240,136,62,0.15);color:var(--decision)}
+.cat-badge.arch{background:rgba(88,166,255,0.15);color:var(--arch)}
+.conf-dot{width:8px;height:8px;border-radius:50%;display:inline-block}
+.conf-dot.high{background:var(--high)}.conf-dot.medium{background:var(--medium)}.conf-dot.low{background:var(--low)}
+.conf-label{font-size:.7rem;color:var(--muted)}
+.card-title{font-size:.95rem;font-weight:600;margin-bottom:8px;line-height:1.4}
+.card-summary{font-size:.82rem;color:var(--muted);line-height:1.5;display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden}
+.card-detail{display:none;margin-top:16px;padding-top:16px;border-top:1px solid var(--border);animation:fadeIn .3s}
+.detail-section{margin-bottom:12px}.detail-section h4{font-size:.8rem;color:var(--arch);margin-bottom:4px;text-transform:uppercase;letter-spacing:.3px}
+.detail-section p{font-size:.85rem;line-height:1.6;color:var(--text)}
+.skill-chips{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
+.skill-chip{padding:2px 8px;background:rgba(88,166,255,0.1);border:1px solid rgba(88,166,255,0.2);border-radius:6px;font-size:.7rem;color:var(--arch)}
+.expanded .card-summary{display:block;-webkit-line-clamp:unset}
+.no-results{text-align:center;padding:60px;color:var(--muted)}
+@keyframes fadeIn{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:translateY(0)}}
+@media(max-width:600px){.grid{grid-template-columns:1fr;padding:12px}.controls{padding:12px}}
+</style>
+</head>
+<body>
+<div class="header">
+<h1>Architecture Decision Navigator</h1>
+<p class="subtitle">Browse architecture decisions and knowledge \u2014 the reasoning behind the patterns</p>
+</div>
+<div class="stats-ribbon" id="stats"></div>
+<div class="controls">
+<input type="text" class="search" id="search" placeholder="Search decisions and architecture knowledge...">
+<button class="filter-btn active" data-cat="all" onclick="setFilter('all',this)">All</button>
+<button class="filter-btn" data-cat="decision" onclick="setFilter('decision',this)">Decision</button>
+<button class="filter-btn" data-cat="arch" onclick="setFilter('arch',this)">Arch</button>
+<select id="sort" onchange="render()">
+<option value="alpha">A \u2192 Z</option>
+<option value="confidence">Confidence</option>
+<option value="category">Category</option>
+</select>
+</div>
+<div class="grid" id="grid"></div>
+
+<script>
+const ENTRIES=[
+{name:"actuator-endpoints-skip-auth-by-design",cat:"decision",confidence:"high",summary:"Monitoring collector stores auth config but intentionally does NOT apply it to /actuator/health calls. Auth reserved for non-actuator endpoints.",fact:"The HealthTarget.authConfig (BASIC/BEARER) is persisted but the HTTP client does not apply it to /actuator/health or /actuator/metrics/** calls.",why:"Actuator endpoints are expected to be publicly reachable from the monitoring plane; adding auth-per-target multiplies ops complexity for no security benefit inside the trusted network.",apply:"When you see stored credentials that 'look unused' in an Actuator collector, do NOT wire them into the call path. Apply auth only for non-actuator custom endpoints.",caveats:"Only holds when monitoring plane and targets share a trusted network. On multi-tenant SaaS over public internet, revisit.",skills:["spring-actuator-health-collector"]},
+{name:"admin-role-disabled-secretkey",cat:"decision",confidence:"medium",summary:"Default admins role ships disabled, shared SecretKey removed from config.properties. Closes 'default admin credential' vulnerability.",fact:"The built-in admins role ships disabled, and the shared SecretKey value was removed from config.properties.",why:"A shared key in a public config file meant every deployment trusted the same secret. Combined with an always-present admin role, it was an authorization-bypass.",apply:"Do not restore a default SecretKey to config.properties. If admin role needed, generate a per-install key out-of-band via environment.",caveats:"",skills:["challenge-response-auth-redis-ttl"]},
+{name:"alarm-raw-over-1min-aggregate",cat:"decision",confidence:"high",summary:"Alarm evaluation reads raw metrics, not 1-minute aggregates. Aggregation hid sub-minute spikes that should have paged.",fact:"Alarm evaluation was migrated off 1-minute aggregated metrics onto raw metrics.",why:"Aggregation at the minute boundary was hiding sub-minute spikes that should have paged, and delayed alarms by up to the aggregation lag.",apply:"Use raw metrics for alarm evaluation. Control throughput with semaphore + chunking backpressure plus a dedicated thread pool.",caveats:"Higher throughput cost on the alarm consumer path.",skills:["kafka-consumer-semaphore-chunking","baseline-historical-comparison-threshold"]},
+{name:"avro-private-fields-no-setters",cat:"decision",confidence:"high",summary:"Avro codegen configured with fieldVisibility=PRIVATE and createSetters=false to enforce immutability on event payloads.",fact:"Avro code generation uses private fields and no setters to enforce immutability.",why:"Event payloads should be immutable once created. Setters allow accidental mutation of in-flight events.",apply:"Configure avro { createSetters = false; fieldVisibility = 'PRIVATE' } in Gradle. Use Builder pattern for construction.",caveats:"Builders add verbosity. Some serialization frameworks expect setters.",skills:["avro-gradle-kafka-schema-pipeline","avro-event-with-change-flags"]},
+{name:"cache-even-when-enable-false",cat:"decision",confidence:"high",summary:"Notification configs with enable=false still loaded into cache. Toggling enable doesn't require cache reload.",fact:"The cache loader does NOT filter by enable. Both enabled and disabled records enter the cache. The enable flag is evaluated after cache lookup.",why:"Before the change, enabling a previously-disabled config required a manual cache reload. Including disabled records makes the cache authoritative.",apply:"Short-circuit on enable=false at the read site, not the cache load site. Toggling enable only needs flag flip + single evict.",caveats:"Slightly higher memory use for disabled configs in cache.",skills:["cache-variance-ttl-jitter"]},
+{name:"confid-only-query-over-resource-tuple",cat:"decision",confidence:"medium",summary:"Performance queries key off confId whenever available, falling back to (resourceType, resourceName) only when confId absent.",fact:"MeasurementMetricRepositoryImpl checks confIds first and routes through findConfInfoListWithConfIds.",why:"The tuple (resourceType, resourceName) is ambiguous in practice \u2014 some metrics exist without a resourceType value, and the tuple lookup misses them.",apply:"Prefer confId-based queries. Only fall back to resourceType + resourceName when confId is unavailable.",caveats:"Requires confId to be populated consistently across all metric sources.",skills:["measurement-grouping-combiner"]},
+{name:"additive-registry-schema-versioning",cat:"arch",confidence:"high",summary:"Plugin registry schema changes must be additive-only. Breaking changes require a new version namespace.",fact:"Schema evolution for plugin registries follows append-only semantics. New fields are added; old fields are never removed or renamed.",why:"Existing plugins depend on the current schema shape. Non-additive changes break them silently at runtime.",apply:"Add new fields alongside old ones. Deprecate but don't remove. Use version namespaces (v1/, v2/) for breaking changes.",caveats:"Schema bloat over time. Periodic major-version bumps needed to clean up.",skills:["plugin-resource-provider-architecture","resource-provider-registry"]},
+{name:"agent-memory-binding-vs-recall",cat:"arch",confidence:"high",summary:"Agent memory should bind at write-time (structured), not recall-time (free search). Structured binding enables deterministic retrieval.",fact:"Memory systems that tag at write-time with structured keys outperform free-text semantic search for recall reliability.",why:"Free-text search is probabilistic and degrades with corpus size. Structured keys enable deterministic, indexed lookups.",apply:"At write time, tag memories with structured keys (topic, entity, date, type). At read time, query by keys. Reserve semantic search for fallback only.",caveats:"Requires upfront schema design for memory keys. May miss cross-domain connections that semantic search would find.",skills:["ai-subagent-scope-narrowing"]},
+{name:"annotation-driven-authz-via-function-id",cat:"arch",confidence:"high",summary:"Authorization checks driven by function IDs on annotations, not URL patterns. URL patterns break on refactors.",fact:"Each API endpoint is annotated with a stable function ID. Authorization middleware checks the function ID, not the URL path.",why:"URL patterns are fragile \u2014 REST restructuring silently drops security checks. Function IDs are stable business identifiers.",apply:"Use @RequiresPermission('USER_MANAGE') instead of URL-matching rules. Wire authZ interceptor to read annotation metadata.",caveats:"Requires discipline to annotate every new endpoint. Missing annotation = open endpoint unless defaults are deny-all.",skills:["jwt-extraction-via-base-controller","jwt-refresh-rotation-spring"]},
+{name:"boilerplate-generated-business-logic-manual",cat:"arch",confidence:"high",summary:"Generated code handles only boilerplate (DTOs, mappers, CRUD). Business logic stays hand-written. Never generate business logic.",fact:"Code generation is strictly limited to structural/mechanical code. Business rules, validation, and workflow logic are always hand-authored.",why:"Business rules change independently of structural patterns. Regeneration overwrites hand-tuned logic. Debugging generated business code is harder than debugging boilerplate.",apply:"Draw a clear boundary: generate DTOs, mappers, repository interfaces, CRUD endpoints. Keep validation, pricing, workflow rules in hand-written code that generation never touches.",caveats:"The boundary can be hard to enforce when generators become more capable. Document the boundary explicitly.",skills:["migration-processor-pipeline"]},
+{name:"commons-logging-exclusion-strategy",cat:"arch",confidence:"high",summary:"Exclude commons-logging transitively and bridge to SLF4J. Multiple logging frameworks on classpath cause silent log loss.",fact:"All transitive commons-logging dependencies are excluded globally. jcl-over-slf4j bridges any remaining commons-logging calls to SLF4J.",why:"When both commons-logging and SLF4J are present, some classes bind to one, some to the other. Logs sent to the wrong framework vanish silently.",apply:"Add a global exclusion for commons-logging in your build tool. Add jcl-over-slf4j bridge. Verify with dependency tree after every new dependency addition.",caveats:"Some legacy libraries genuinely require commons-logging internals (not just the API). Test thoroughly after exclusion.",skills:["spring-typed-config-properties"]},
+{name:"dual-redis-lock-vs-access-control",cat:"arch",confidence:"high",summary:"Redis distributed locks are for coordination (only one runs), not access control (authorized to run). Don't conflate them.",fact:"Distributed locks provide mutual exclusion among cooperating processes. They do not provide authentication or authorization.",why:"Lock expiry means 'no one is coordinating', not 'anyone is authorized'. Conflating the two creates security holes when locks expire.",apply:"Use locks for mutual exclusion (one worker per job). Use a separate authZ layer (RBAC, JWT claims) for permission checks. Never derive permissions from lock state.",caveats:"In some systems, acquiring a lock IS the authorization mechanism by convention. Make this explicit if intentional.",skills:["distributed-lock-mongodb","redis-lock-recheck-flag-pattern"]},
+{name:"env-override-last-wins-chain",cat:"arch",confidence:"high",summary:"Environment variable override chains must follow last-wins semantics with documented precedence order.",fact:"Configuration resolution follows a strict precedence chain: defaults < config file < env var < CLI flag. Last source wins.",why:"Undocumented precedence leads to 'it works on my machine' debugging when env vars silently override config files or vice versa.",apply:"Document the precedence chain explicitly. In code, apply overrides in order so the last one wins. Log the effective config source at startup.",caveats:"Some frameworks have their own precedence rules (Spring Boot property sources). Align with the framework rather than fighting it.",skills:["dotenv-multi-env-routing","spring-profile-datasource-activation"]},
+{name:"data-patch-package-for-migrations",cat:"arch",confidence:"high",summary:"Use data-patch packages for database migrations rather than inline SQL in application code.",fact:"Database schema and data migrations are managed through dedicated migration packages, separate from application logic.",why:"Inline migration code in application startup couples deployment to migration success. Separate packages allow independent testing, rollback, and scheduling.",apply:"Create a dedicated migration module/package. Run migrations as a pre-deploy step, not at app startup. Include rollback scripts.",caveats:"Adds deployment complexity. Requires coordination between migration and application versions.",skills:["spring-mongo-lightweight-migration"]},
+{name:"domain-registry-plus-projects-yaml",cat:"arch",confidence:"medium",summary:"Central domain registry + projects.yaml for service discovery and ownership mapping.",fact:"A central YAML file maps services to domains, teams, and ownership metadata. Service discovery reads this registry.",why:"Without a central registry, service ownership becomes tribal knowledge. Incident response slows when no one knows who owns what.",apply:"Maintain a projects.yaml or service-catalog.yaml in a shared repo. Include: service name, owning team, domain, SLA tier, runbook link.",caveats:"YAML files drift from reality. Needs CI enforcement or automated sync from deployment manifests.",skills:["eureka-service-discovery-wait-annotation","service-discovery-replica-leader-tracking"]},
+{name:"interface-abstraction-for-modularity",cat:"arch",confidence:"high",summary:"Depend on interfaces, not implementations. Swap implementations via DI without changing consumers.",fact:"All cross-module dependencies go through interfaces. Implementations are registered in a DI container and resolved at runtime.",why:"Direct implementation dependencies create tight coupling. Interface boundaries enable testing, swapping, and parallel development.",apply:"Define interfaces in a shared/api module. Implementations live in their own modules. Wire via Spring @Component or explicit @Bean registration.",caveats:"Over-abstraction adds indirection cost. Apply at module boundaries, not within modules.",skills:["resource-provider-registry","plugin-resource-provider-architecture","optional-outbound-adapter-no-op-port"]}
+];
+
+let filter='all',expanded=null;
+const confOrder={high:0,medium:1,low:2};
+
+function getFiltered(){
+const q=document.getElementById('search').value.toLowerCase();
+const sort=document.getElementById('sort').value;
+let items=ENTRIES.filter(e=>{
+if(filter!=='all'&&e.cat!==filter)return false;
+if(q){const hay=(e.name+' '+e.summary+' '+e.fact+' '+e.why+' '+e.apply).toLowerCase();return hay.includes(q)}
+return true;
+});
+if(sort==='alpha')items.sort((a,b)=>a.name.localeCompare(b.name));
+else if(sort==='confidence')items.sort((a,b)=>(confOrder[a.confidence]||9)-(confOrder[b.confidence]||9));
+else if(sort==='category')items.sort((a,b)=>a.cat.localeCompare(b.cat)||a.name.localeCompare(b.name));
+return items;
+}
+
+function renderStats(){
+const dc=ENTRIES.filter(e=>e.cat==='decision').length;
+const ac=ENTRIES.filter(e=>e.cat==='arch').length;
+const hi=ENTRIES.filter(e=>e.confidence==='high').length;
+const md=ENTRIES.filter(e=>e.confidence==='medium').length;
+document.getElementById('stats').innerHTML=`
+<div class="ribbon-stat"><div class="ribbon-val">${ENTRIES.length}</div><div class="ribbon-label">Total</div></div>
+<div class="ribbon-stat"><div class="ribbon-val" style="color:var(--decision)">${dc}</div><div class="ribbon-label">Decisions</div></div>
+<div class="ribbon-stat"><div class="ribbon-val" style="color:var(--arch)">${ac}</div><div class="ribbon-label">Architecture</div></div>
+<div class="ribbon-stat"><div class="ribbon-val" style="color:var(--high)">${hi}</div><div class="ribbon-label">High Conf.</div></div>
+<div class="ribbon-stat"><div class="ribbon-val" style="color:var(--medium)">${md}</div><div class="ribbon-label">Medium Conf.</div></div>`;
+}
+
+function render(){
+const items=getFiltered();const grid=document.getElementById('grid');
+if(!items.length){grid.innerHTML='<div class="no-results">No entries match your search.</div>';return}
+grid.innerHTML=items.map(e=>`
+<div class="adr-card ${expanded===e.name?'expanded':''}" data-cat="${e.cat}" onclick="toggle('${e.name}')">
+<div class="card-header">
+<span class="cat-badge ${e.cat}">${e.cat}</span>
+<span class="conf-dot ${e.confidence}"></span>
+<span class="conf-label">${e.confidence}</span>
+</div>
+<div class="card-title">${e.name.replace(/-/g,' ')}</div>
+<div class="card-summary">${e.summary}</div>
+${expanded===e.name?`<div class="card-detail" style="display:block">
+<div class="detail-section"><h4>Fact</h4><p>${e.fact}</p></div>
+<div class="detail-section"><h4>Why</h4><p>${e.why}</p></div>
+<div class="detail-section"><h4>How to Apply</h4><p>${e.apply}</p></div>
+${e.caveats?`<div class="detail-section"><h4>Counter / Caveats</h4><p>${e.caveats}</p></div>`:''}
+${e.skills.length?`<div class="detail-section"><h4>Linked Skills</h4><div class="skill-chips">${e.skills.map(s=>`<span class="skill-chip">${s}</span>`).join('')}</div></div>`:''}
+</div>`:''}
+</div>`).join('');
+}
+
+function toggle(name){expanded=expanded===name?null:name;render()}
+function setFilter(cat,btn){filter=cat;document.querySelectorAll('.filter-btn').forEach(b=>b.classList.remove('active'));btn.classList.add('active');render()}
+
+let debounce;document.getElementById('search').addEventListener('input',()=>{clearTimeout(debounce);debounce=setTimeout(render,200)});
+renderStats();render();
+</script>
+</body>
+</html>

--- a/example/adr-navigator/manifest.json
+++ b/example/adr-navigator/manifest.json
@@ -1,0 +1,12 @@
+{
+  "slug": "adr-navigator",
+  "title": "Architecture Decision Navigator",
+  "summary": "Filterable card wall of architecture decisions and knowledge entries with search, sort, expand-to-detail, confidence badges, and linked skill chips.",
+  "stack": ["html", "css", "js"],
+  "tags": ["adr", "architecture", "decisions", "knowledge", "browser"],
+  "created_at": "2026-04-16",
+  "source_project": "hub-make",
+  "runtime": "browser",
+  "entrypoint": "index.html",
+  "author": "kjuhwa@nkia.co.kr"
+}

--- a/example/kafka-topology-designer/README.md
+++ b/example/kafka-topology-designer/README.md
@@ -1,0 +1,20 @@
+# Kafka Topology Designer
+
+> **Why.** The hub has 15+ Kafka skills but no visual surface for them. This canvas lets you sketch Kafka architectures with drag-and-drop components, see how they connect, and reference the relevant skills for each pattern.
+
+## What it does
+
+- Drag-and-drop: Producer, Topic, Consumer, Connector/Stream components
+- Connect mode: click two nodes to draw directed edges
+- Pre-built templates: Fan-out, Stream Pipeline, Multi-tenant
+- Right-click context menu: rename, duplicate, delete nodes
+- Export topology as SVG
+- Sidebar shows all 15 related Kafka skills from the hub
+
+## Stack
+
+Single HTML file, zero external dependencies. Pure HTML + CSS + JS + inline SVG.
+
+## How to run
+
+Open `index.html` in any modern browser.

--- a/example/kafka-topology-designer/index.html
+++ b/example/kafka-topology-designer/index.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Kafka Topology Designer</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#0a0e17;--panel:#111827;--border:rgba(255,255,255,0.08);--accent:#06b6d4;--producer:#22d3ee;--topic:#f59e0b;--consumer:#a78bfa;--connector:#34d399;--text:#e2e8f0;--muted:#64748b;--radius:10px}
+body{font-family:'Segoe UI',system-ui,sans-serif;background:var(--bg);color:var(--text);height:100vh;display:flex;overflow:hidden}
+.sidebar{width:260px;background:var(--panel);border-right:1px solid var(--border);display:flex;flex-direction:column;flex-shrink:0}
+.sidebar h1{font-size:1.1rem;padding:16px;border-bottom:1px solid var(--border);background:linear-gradient(135deg,var(--accent),#8b5cf6);-webkit-background-clip:text;-webkit-text-fill-color:transparent}
+.palette{padding:12px;flex:1;overflow-y:auto}
+.palette-section{margin-bottom:16px}
+.palette-section h3{font-size:.7rem;text-transform:uppercase;letter-spacing:1px;color:var(--muted);margin-bottom:8px}
+.palette-item{display:flex;align-items:center;gap:8px;padding:8px 10px;margin-bottom:4px;background:rgba(255,255,255,0.03);border:1px solid var(--border);border-radius:8px;cursor:grab;transition:background .15s;font-size:.82rem}
+.palette-item:hover{background:rgba(255,255,255,0.06)}
+.palette-item:active{cursor:grabbing}
+.dot{width:12px;height:12px;border-radius:3px;flex-shrink:0}
+.dot-producer{background:var(--producer)}.dot-topic{background:var(--topic)}.dot-consumer{background:var(--consumer)}.dot-connector{background:var(--connector)}
+.skills-panel{border-top:1px solid var(--border);padding:12px;max-height:200px;overflow-y:auto}
+.skills-panel h3{font-size:.7rem;text-transform:uppercase;letter-spacing:1px;color:var(--muted);margin-bottom:8px}
+.skill-tag{display:inline-block;padding:2px 7px;margin:2px;border-radius:4px;font-size:.65rem;background:rgba(6,182,212,0.1);border:1px solid rgba(6,182,212,0.2);color:var(--accent)}
+.canvas-wrap{flex:1;position:relative;overflow:hidden}
+.toolbar{position:absolute;top:12px;left:12px;display:flex;gap:6px;z-index:5}
+.tool-btn{padding:6px 12px;background:var(--panel);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:.75rem;cursor:pointer;transition:all .15s}
+.tool-btn:hover{background:rgba(255,255,255,0.05)}
+.tool-btn.active{border-color:var(--accent);color:var(--accent)}
+.info-bar{position:absolute;bottom:12px;left:12px;right:12px;display:flex;justify-content:space-between;font-size:.7rem;color:var(--muted);z-index:5}
+svg{width:100%;height:100%;cursor:crosshair}
+.node{cursor:move}
+.node rect,.node circle{stroke-width:2;transition:filter .15s}
+.node:hover rect,.node:hover circle{filter:brightness(1.3)}
+.node text{font-family:'Segoe UI',sans-serif;font-size:11px;fill:var(--text);pointer-events:none}
+.node .label{font-size:10px;fill:var(--muted)}
+.edge{stroke:rgba(255,255,255,0.2);stroke-width:1.5;fill:none;marker-end:url(#arrow)}
+.edge:hover{stroke:var(--accent);stroke-width:2}
+.grid-line{stroke:rgba(255,255,255,0.02);stroke-width:1}
+.selection-box{fill:rgba(6,182,212,0.1);stroke:var(--accent);stroke-width:1;stroke-dasharray:4}
+.context-menu{position:absolute;background:var(--panel);border:1px solid var(--border);border-radius:8px;padding:4px;z-index:20;min-width:140px;box-shadow:0 8px 24px rgba(0,0,0,0.4)}
+.ctx-item{padding:6px 12px;font-size:.8rem;cursor:pointer;border-radius:4px;transition:background .1s}
+.ctx-item:hover{background:rgba(255,255,255,0.06)}
+.ctx-item.danger{color:#ef4444}
+.hidden{display:none}
+@media(max-width:768px){.sidebar{width:200px}}
+</style>
+</head>
+<body>
+<div class="sidebar">
+<h1>Kafka Topology Designer</h1>
+<div class="palette">
+<div class="palette-section">
+<h3>Components</h3>
+<div class="palette-item" draggable="true" data-type="producer"><div class="dot dot-producer"></div>Producer</div>
+<div class="palette-item" draggable="true" data-type="topic"><div class="dot dot-topic"></div>Topic</div>
+<div class="palette-item" draggable="true" data-type="consumer"><div class="dot dot-consumer"></div>Consumer</div>
+<div class="palette-item" draggable="true" data-type="connector"><div class="dot dot-connector"></div>Connector / Stream</div>
+</div>
+<div class="palette-section">
+<h3>Templates</h3>
+<div class="palette-item" onclick="loadTemplate('fanout')"><div class="dot dot-topic"></div>Fan-out Pattern</div>
+<div class="palette-item" onclick="loadTemplate('pipeline')"><div class="dot dot-connector"></div>Stream Pipeline</div>
+<div class="palette-item" onclick="loadTemplate('multitenant')"><div class="dot dot-consumer"></div>Multi-tenant</div>
+</div>
+</div>
+<div class="skills-panel">
+<h3>Related Skills</h3>
+<span class="skill-tag">kafka-batch-consumer-partition-tuning</span>
+<span class="skill-tag">kafka-consumer-semaphore-chunking</span>
+<span class="skill-tag">kafka-debounce-event-coalescing</span>
+<span class="skill-tag">kafka-consumer-tenant-fan-out</span>
+<span class="skill-tag">kafka-message-header-metadata</span>
+<span class="skill-tag">kafka-producer-async-callback</span>
+<span class="skill-tag">kafka-avro-topic-auto-create-config</span>
+<span class="skill-tag">kafka-consumer-config-3-factories</span>
+<span class="skill-tag">kafka-consumer-errorhandling-wrapper</span>
+<span class="skill-tag">multi-tenant-kafka-header-organization-context</span>
+<span class="skill-tag">event-driven-kafka-scheduling</span>
+<span class="skill-tag">avro-gradle-kafka-schema-pipeline</span>
+<span class="skill-tag">kafka-engine-distributed-job-framework</span>
+<span class="skill-tag">thread-pool-queue-backpressure</span>
+<span class="skill-tag">availability-ttl-punctuate-processor</span>
+</div>
+</div>
+<div class="canvas-wrap" id="canvasWrap">
+<div class="toolbar">
+<button class="tool-btn active" data-tool="select" onclick="setTool('select')">Select</button>
+<button class="tool-btn" data-tool="connect" onclick="setTool('connect')">Connect</button>
+<button class="tool-btn" onclick="clearAll()">Clear</button>
+<button class="tool-btn" onclick="exportPNG()">Export PNG</button>
+</div>
+<div class="info-bar">
+<span id="nodeCount">Nodes: 0</span>
+<span id="edgeCount">Edges: 0</span>
+<span>Drag components from palette | Right-click to edit/delete</span>
+</div>
+<svg id="svg" xmlns="http://www.w3.org/2000/svg">
+<defs>
+<marker id="arrow" viewBox="0 0 10 6" refX="10" refY="3" markerWidth="8" markerHeight="6" orient="auto-start-reverse">
+<path d="M0,0 L10,3 L0,6 z" fill="rgba(255,255,255,0.3)"/>
+</marker>
+<pattern id="grid" width="20" height="20" patternUnits="userSpaceOnUse">
+<path d="M 20 0 L 0 0 0 20" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
+</pattern>
+</defs>
+<rect width="100%" height="100%" fill="url(#grid)"/>
+<g id="edgesGroup"></g>
+<g id="nodesGroup"></g>
+</svg>
+<div class="context-menu hidden" id="ctxMenu">
+<div class="ctx-item" onclick="renameNode()">Rename</div>
+<div class="ctx-item" onclick="duplicateNode()">Duplicate</div>
+<div class="ctx-item danger" onclick="deleteNode()">Delete</div>
+</div>
+</div>
+
+<script>
+const COLORS={producer:'#22d3ee',topic:'#f59e0b',consumer:'#a78bfa',connector:'#34d399'};
+const SHAPES={producer:'rect',topic:'hex',consumer:'rect',connector:'diamond'};
+let nodes=[],edges=[],nextId=1,tool='select',dragNode=null,dragOff={x:0,y:0},connectFrom=null,tempLine=null,ctxNode=null;
+
+function $(s){return document.querySelector(s)}
+function svgPt(e){const svg=$('#svg'),p=svg.createSVGPoint();p.x=e.clientX;p.y=e.clientY;return p.matrixTransform(svg.getScreenCTM().inverse())}
+
+function addNode(type,x,y,name){
+const id=nextId++;const n={id,type,x,y,name:name||(type.charAt(0).toUpperCase()+type.slice(1)+'-'+id)};
+nodes.push(n);renderNodes();updateCounts();return n;
+}
+
+function renderNodes(){
+const g=$('#nodesGroup');g.innerHTML='';
+nodes.forEach(n=>{
+const grp=document.createElementNS('http://www.w3.org/2000/svg','g');
+grp.classList.add('node');grp.dataset.id=n.id;grp.setAttribute('transform',`translate(${n.x},${n.y})`);
+const c=COLORS[n.type];
+if(n.type==='topic'){
+const hex=document.createElementNS('http://www.w3.org/2000/svg','polygon');
+hex.setAttribute('points','-50,-25 -35,-40 35,-40 50,-25 50,25 35,40 -35,40 -50,25');
+hex.setAttribute('fill',c+'15');hex.setAttribute('stroke',c);grp.appendChild(hex);
+}else if(n.type==='connector'){
+const d=document.createElementNS('http://www.w3.org/2000/svg','polygon');
+d.setAttribute('points','0,-30 50,0 0,30 -50,0');
+d.setAttribute('fill',c+'15');d.setAttribute('stroke',c);grp.appendChild(d);
+}else{
+const r=document.createElementNS('http://www.w3.org/2000/svg','rect');
+r.setAttribute('x',-50);r.setAttribute('y',-25);r.setAttribute('width',100);r.setAttribute('height',50);
+r.setAttribute('rx',8);r.setAttribute('fill',c+'15');r.setAttribute('stroke',c);grp.appendChild(r);
+}
+const t=document.createElementNS('http://www.w3.org/2000/svg','text');
+t.setAttribute('text-anchor','middle');t.setAttribute('dy','4');t.textContent=n.name.length>12?n.name.slice(0,11)+'..':n.name;grp.appendChild(t);
+const lb=document.createElementNS('http://www.w3.org/2000/svg','text');
+lb.classList.add('label');lb.setAttribute('text-anchor','middle');lb.setAttribute('dy','18');lb.textContent=n.type;grp.appendChild(lb);
+
+grp.addEventListener('mousedown',e=>{
+if(e.button===2){e.preventDefault();return}
+if(tool==='connect'){connectFrom=n;return}
+dragNode=n;const pt=svgPt(e);dragOff={x:pt.x-n.x,y:pt.y-n.y};
+});
+grp.addEventListener('contextmenu',e=>{e.preventDefault();showCtx(e,n)});
+g.appendChild(grp);
+});
+}
+
+function renderEdges(){
+const g=$('#edgesGroup');g.innerHTML='';
+edges.forEach(e=>{
+const from=nodes.find(n=>n.id===e.from),to=nodes.find(n=>n.id===e.to);
+if(!from||!to)return;
+const line=document.createElementNS('http://www.w3.org/2000/svg','line');
+line.classList.add('edge');line.setAttribute('x1',from.x);line.setAttribute('y1',from.y);
+line.setAttribute('x2',to.x);line.setAttribute('y2',to.y);
+line.addEventListener('contextmenu',ev=>{ev.preventDefault();if(confirm('Delete this connection?')){edges=edges.filter(x=>x!==e);renderEdges();updateCounts()}});
+g.appendChild(line);
+});
+}
+
+function updateCounts(){$('#nodeCount').textContent='Nodes: '+nodes.length;$('#edgeCount').textContent='Edges: '+edges.length}
+
+const svg=$('#svg');
+svg.addEventListener('mousemove',e=>{
+if(dragNode){const pt=svgPt(e);dragNode.x=pt.x-dragOff.x;dragNode.y=pt.y-dragOff.y;renderNodes();renderEdges()}
+if(connectFrom){
+if(!tempLine){tempLine=document.createElementNS('http://www.w3.org/2000/svg','line');tempLine.setAttribute('stroke','rgba(6,182,212,0.5)');tempLine.setAttribute('stroke-width','1.5');tempLine.setAttribute('stroke-dasharray','5');svg.appendChild(tempLine)}
+const pt=svgPt(e);tempLine.setAttribute('x1',connectFrom.x);tempLine.setAttribute('y1',connectFrom.y);tempLine.setAttribute('x2',pt.x);tempLine.setAttribute('y2',pt.y);
+}
+});
+
+svg.addEventListener('mouseup',e=>{
+if(connectFrom){
+const pt=svgPt(e);const target=nodes.find(n=>Math.abs(n.x-pt.x)<50&&Math.abs(n.y-pt.y)<40&&n.id!==connectFrom.id);
+if(target&&!edges.find(x=>x.from===connectFrom.id&&x.to===target.id)){edges.push({from:connectFrom.id,to:target.id});renderEdges();updateCounts()}
+connectFrom=null;if(tempLine){tempLine.remove();tempLine=null}
+}
+dragNode=null;
+});
+
+svg.addEventListener('contextmenu',e=>e.preventDefault());
+
+// Drop from palette
+document.querySelectorAll('.palette-item[draggable]').forEach(el=>{
+el.addEventListener('dragstart',e=>{e.dataTransfer.setData('type',el.dataset.type)});
+});
+$('#canvasWrap').addEventListener('dragover',e=>e.preventDefault());
+$('#canvasWrap').addEventListener('drop',e=>{
+e.preventDefault();const type=e.dataTransfer.getData('type');if(!type)return;
+const pt=svgPt(e);addNode(type,pt.x,pt.y);
+});
+
+function setTool(t){tool=t;document.querySelectorAll('.tool-btn[data-tool]').forEach(b=>b.classList.toggle('active',b.dataset.tool===t));svg.style.cursor=t==='connect'?'crosshair':'default'}
+function clearAll(){if(!confirm('Clear all?'))return;nodes=[];edges=[];nextId=1;renderNodes();renderEdges();updateCounts()}
+
+function showCtx(e,n){ctxNode=n;const m=$('#ctxMenu');m.classList.remove('hidden');m.style.left=e.clientX+'px';m.style.top=e.clientY+'px'}
+document.addEventListener('click',()=>{$('#ctxMenu').classList.add('hidden')});
+function renameNode(){if(!ctxNode)return;const name=prompt('Name:',ctxNode.name);if(name){ctxNode.name=name;renderNodes()}}
+function duplicateNode(){if(!ctxNode)return;addNode(ctxNode.type,ctxNode.x+60,ctxNode.y+40,ctxNode.name+'-copy')}
+function deleteNode(){if(!ctxNode)return;nodes=nodes.filter(n=>n.id!==ctxNode.id);edges=edges.filter(e=>e.from!==ctxNode.id&&e.to!==ctxNode.id);ctxNode=null;renderNodes();renderEdges();updateCounts()}
+
+function exportPNG(){
+const svgEl=$('#svg');const clone=svgEl.cloneNode(true);
+clone.setAttribute('xmlns','http://www.w3.org/2000/svg');
+const bg=clone.querySelector('rect');if(bg)bg.setAttribute('fill','#0a0e17');
+const data=new XMLSerializer().serializeToString(clone);
+const blob=new Blob([data],{type:'image/svg+xml'});
+const url=URL.createObjectURL(blob);const a=document.createElement('a');
+a.href=url;a.download='kafka-topology.svg';a.click();URL.revokeObjectURL(url);
+}
+
+function loadTemplate(name){
+clearAllSilent();
+if(name==='fanout'){
+addNode('producer',150,200,'OrderService');addNode('topic',350,200,'orders-topic');
+addNode('consumer',550,100,'EmailConsumer');addNode('consumer',550,200,'InventoryConsumer');addNode('consumer',550,300,'AnalyticsConsumer');
+edges.push({from:1,to:2},{from:2,to:3},{from:2,to:4},{from:2,to:5});
+}else if(name==='pipeline'){
+addNode('producer',100,200,'DataIngester');addNode('topic',280,200,'raw-events');
+addNode('connector',460,200,'StreamProcessor');addNode('topic',640,200,'enriched-events');addNode('consumer',820,200,'DashboardConsumer');
+edges.push({from:1,to:2},{from:2,to:3},{from:3,to:4},{from:4,to:5});
+}else if(name==='multitenant'){
+addNode('producer',150,200,'APIGateway');addNode('topic',350,200,'tenant-events');
+addNode('connector',550,200,'TenantRouter');addNode('consumer',750,100,'Tenant-A DB');addNode('consumer',750,200,'Tenant-B DB');addNode('consumer',750,300,'Tenant-C DB');
+edges.push({from:1,to:2},{from:2,to:3},{from:3,to:4},{from:3,to:5},{from:3,to:6});
+}
+renderNodes();renderEdges();updateCounts();
+}
+function clearAllSilent(){nodes=[];edges=[];nextId=1;renderNodes();renderEdges();updateCounts()}
+</script>
+</body>
+</html>

--- a/example/kafka-topology-designer/manifest.json
+++ b/example/kafka-topology-designer/manifest.json
@@ -1,0 +1,12 @@
+{
+  "slug": "kafka-topology-designer",
+  "title": "Kafka Topology Designer",
+  "summary": "Interactive SVG canvas for sketching Kafka architectures. Drag-and-drop producers, topics, consumers, connectors. Pre-built templates for fan-out, pipeline, and multi-tenant patterns.",
+  "stack": ["html", "css", "js", "svg"],
+  "tags": ["kafka", "topology", "diagram", "canvas", "interactive", "drag-and-drop"],
+  "created_at": "2026-04-16",
+  "source_project": "hub-make",
+  "runtime": "browser",
+  "entrypoint": "index.html",
+  "author": "kjuhwa@nkia.co.kr"
+}

--- a/example/knowledge-flashcards/README.md
+++ b/example/knowledge-flashcards/README.md
@@ -1,0 +1,21 @@
+# Knowledge Flashcards
+
+> **Why.** The Pitfall Quiz tests recognition (multiple choice). Flashcards build recall — you see the title and must remember the full explanation before flipping. SM-2 spaced repetition ensures you review cards just before you'd forget them.
+
+## What it does
+
+- 20 flashcards from pitfall, arch, decision knowledge entries
+- Click to flip: front shows title + summary, back reveals Fact, Why, How to Apply
+- Rate each card: Again, Hard, Good, Easy (SM-2 algorithm)
+- Progress tracked in localStorage across sessions
+- Filter by category (pitfall / arch / decision)
+- Progress bar: new / learning / mastered distribution
+- Reset button to start fresh
+
+## Stack
+
+Single HTML file, zero external dependencies. Pure HTML + CSS + JS.
+
+## How to run
+
+Open `index.html` in any modern browser.

--- a/example/knowledge-flashcards/index.html
+++ b/example/knowledge-flashcards/index.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Knowledge Flashcards</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#0c0a09;--card:#1c1917;--front:#292524;--back:#1a1612;--accent:#f97316;--accent2:#fb923c;--correct:#4ade80;--again:#ef4444;--hard:#fbbf24;--text:#e7e5e4;--muted:#a8a29e;--radius:16px;--border:rgba(255,255,255,0.08)}
+body{font-family:'Segoe UI',system-ui,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;flex-direction:column;align-items:center}
+.header{text-align:center;padding:24px 20px 16px;width:100%}
+h1{font-size:1.6rem;background:linear-gradient(135deg,var(--accent),var(--accent2));-webkit-background-clip:text;-webkit-text-fill-color:transparent}
+.sub{color:var(--muted);font-size:.82rem;margin-top:4px}
+.stats{display:flex;justify-content:center;gap:20px;padding:12px;flex-wrap:wrap}
+.stat{text-align:center}.stat b{font-size:1.2rem;display:block}.stat small{font-size:.7rem;color:var(--muted)}
+.stat b.new-c{color:var(--accent)}.stat b.learn-c{color:var(--hard)}.stat b.review-c{color:var(--correct)}.stat b.done-c{color:var(--muted)}
+.controls{display:flex;gap:8px;justify-content:center;margin-bottom:16px;flex-wrap:wrap}
+.ctrl-btn{padding:5px 12px;border-radius:8px;border:1px solid var(--border);background:transparent;color:var(--muted);font-size:.75rem;cursor:pointer;transition:all .15s}
+.ctrl-btn:hover{background:rgba(255,255,255,0.05)}
+.ctrl-btn.active{border-color:var(--accent);color:var(--accent)}
+.card-container{perspective:1000px;width:100%;max-width:600px;padding:0 20px;margin-bottom:20px}
+.flashcard{position:relative;width:100%;min-height:320px;transition:transform .5s;transform-style:preserve-3d;cursor:pointer}
+.flashcard.flipped{transform:rotateY(180deg)}
+.card-face{position:absolute;inset:0;backface-visibility:hidden;border-radius:var(--radius);padding:28px;display:flex;flex-direction:column;border:1px solid var(--border)}
+.card-front{background:var(--front)}
+.card-back{background:var(--back);transform:rotateY(180deg);overflow-y:auto;max-height:400px}
+.card-cat{display:inline-block;padding:3px 10px;border-radius:12px;font-size:.65rem;font-weight:600;text-transform:uppercase;margin-bottom:12px;width:fit-content}
+.cat-pitfall{background:rgba(249,115,22,0.15);color:var(--accent)}
+.cat-arch{background:rgba(96,165,250,0.15);color:#60a5fa}
+.cat-decision{background:rgba(167,139,250,0.15);color:#a78bfa}
+.cat-api{background:rgba(74,222,128,0.15);color:var(--correct)}
+.card-title{font-size:1.1rem;font-weight:700;margin-bottom:12px;line-height:1.4}
+.card-summary{font-size:.9rem;color:var(--muted);line-height:1.6;flex:1}
+.flip-hint{text-align:center;font-size:.75rem;color:var(--muted);margin-top:12px}
+.back-section{margin-bottom:12px}
+.back-section h4{font-size:.78rem;color:var(--accent);text-transform:uppercase;letter-spacing:.3px;margin-bottom:4px}
+.back-section p{font-size:.82rem;line-height:1.6}
+.rating-bar{display:flex;gap:10px;justify-content:center;max-width:600px;width:100%;padding:0 20px}
+.rate-btn{flex:1;padding:12px;border:none;border-radius:10px;font-size:.85rem;font-weight:600;cursor:pointer;transition:all .15s}
+.rate-btn:hover{transform:scale(1.03)}
+.rate-again{background:rgba(239,68,68,0.2);color:var(--again)}.rate-hard{background:rgba(251,191,36,0.2);color:var(--hard)}
+.rate-good{background:rgba(74,222,128,0.2);color:var(--correct)}.rate-easy{background:rgba(96,165,250,0.2);color:#60a5fa}
+.empty{text-align:center;padding:60px 20px;max-width:600px}
+.empty h2{margin-bottom:8px}.empty p{color:var(--muted);margin-bottom:20px}
+.reset-btn{padding:10px 28px;background:var(--accent);color:#111;border:none;border-radius:10px;font-weight:700;font-size:.95rem;cursor:pointer}
+.progress{width:100%;max-width:600px;height:4px;background:var(--border);border-radius:2px;margin-bottom:16px;overflow:hidden;padding:0 20px}
+.progress-inner{height:100%;display:flex}
+.prog-done{background:var(--correct)}.prog-learn{background:var(--hard)}.prog-new{background:var(--accent)}
+</style>
+</head>
+<body>
+<div class="header">
+<h1>Knowledge Flashcards</h1>
+<p class="sub">Spaced repetition from architecture, decision, pitfall, and API knowledge</p>
+</div>
+<div class="stats" id="stats"></div>
+<div class="controls" id="controls"></div>
+<div style="width:100%;max-width:640px;padding:0 20px"><div class="progress-inner" id="progress" style="display:flex;height:4px;background:var(--border);border-radius:2px;overflow:hidden;margin-bottom:16px"></div></div>
+<div class="card-container" id="cardContainer"></div>
+<div class="rating-bar hidden" id="ratingBar">
+<button class="rate-btn rate-again" onclick="rate(0)">Again</button>
+<button class="rate-btn rate-hard" onclick="rate(1)">Hard</button>
+<button class="rate-btn rate-good" onclick="rate(2)">Good</button>
+<button class="rate-btn rate-easy" onclick="rate(3)">Easy</button>
+</div>
+
+<script>
+const CARDS=[
+{id:1,cat:"pitfall",title:"Actuator Timeout Mixing",summary:"Use aggressive HTTP timeouts for /health, keep long timeouts for /heapdump",fact:"Health endpoints should answer in <50ms. Heapdump can take minutes.",why:"A single slow target stalled the collector thread pool, starving other targets. Ticks skipped, availability gapped.",apply:"Two HTTP client configs: fast-path (1s connect, 2s read) for health/metrics; slow-path (10s connect, 60s read) for heapdump/threaddump."},
+{id:2,cat:"pitfall",title:"Silent AI Guesses",summary:"When AI fills gaps, annotate guesses inline and emit a review checklist",fact:"Planning docs lack endpoint URLs, required fields, error codes. AI guesses these silently.",why:"Silent guesses became frozen wrong contracts, expensive to undo after code generation consumed them.",apply:"Tag every AI-inferred field with inline marker. Emit companion checklist. Structure prompt for guess + reason + confidence."},
+{id:3,cat:"pitfall",title:"Audit Before/After Swap",summary:"Diff logic iterated wrong doc, putting AFTER values into changedPrev",fact:"getChangedInfo() iterated the AFTER document and wrote AFTER values into changedPrev map.",why:"Parameters named baseDoc/targetDoc were ambiguous. No unit test asserted prev != after.",apply:"Name params beforeDoc/afterDoc. Write canonical test first: diff({x:1},{x:2}) => {prev:{x:1}, after:{x:2}}."},
+{id:4,cat:"pitfall",title:"Auto-lock Timestamp Pollution",summary:"Background lock jobs must not bump lastEditedTime on locked pages",fact:"Auto-lock shared the generic 'page updated' path which always bumped lastEditedTime.",why:"All N locked pages got identical timestamp, breaking 'recently edited' sort and the auto-lock job itself.",apply:"Automated state transitions write only their own columns. Use targeted query, not generic entity save path."},
+{id:5,cat:"pitfall",title:"binSize Zero Division",summary:"Guard MongoDB $dateTrunc/binSize against zero interval",fact:"$bucketAuto divides timestamps by binSize. Zero causes MongoDB evaluation error.",why:"Interval lands at 0 with unusual mode combinations or automated smoke runs.",apply:"Always guard: interval <= 0 ? 1 : interval. Centralize in resolveBinSize() helper."},
+{id:6,cat:"pitfall",title:"Lambda Instrumentation Gap",summary:"ASM-based JVM agents miss Java 8+ lambdas materialized at runtime",fact:"Lambdas compile to synthetic classes via LambdaMetafactory, bypassing naive ClassFileTransformer.",why:"Class names don't match registered patterns. Same for Spring CGLIB proxies.",apply:"Test against Spring Boot early. Expose hooks as individually-toggleable flags."},
+{id:7,cat:"pitfall",title:"Anonymize Skill Examples",summary:"SKILL.md examples must use anonymized dummy data, never real identifiers",fact:"Shared repos may be externally accessible. Real data triggers security audit flags.",why:"Security audit flagged real ticket numbers, names, and project names in examples.",apply:"Use dummy ticket #100001, names like Alice/Bob, neutral versions like v10.3.0."},
+{id:8,cat:"decision",title:"Actuator Skip Auth by Design",summary:"Monitoring collector stores auth but doesn't apply it to /actuator/health",fact:"HealthTarget.authConfig is persisted but NOT applied to health/metrics calls.",why:"Actuator endpoints are reachable from trusted monitoring plane. Network-level security, not per-request.",apply:"Don't wire stored credentials into actuator call path. Apply auth only for non-actuator custom endpoints."},
+{id:9,cat:"decision",title:"Alarm Raw Over Aggregate",summary:"Alarm evaluation reads raw metrics, not 1-minute aggregates",fact:"Aggregation at minute boundary was hiding sub-minute spikes that should have paged.",why:"1-min aggregation delayed alarms by aggregation lag and smoothed out real incidents.",apply:"Use raw metrics for alarm evaluation. Control throughput with semaphore + chunking."},
+{id:10,cat:"decision",title:"Avro Private No Setters",summary:"Avro codegen: fieldVisibility=PRIVATE, createSetters=false",fact:"Event payloads are immutable once created. Setters allow accidental mutation of in-flight events.",why:"Mutable events caused bugs where consumers modified shared payload objects.",apply:"Configure avro { createSetters=false; fieldVisibility='PRIVATE' }. Use Builder for construction."},
+{id:11,cat:"decision",title:"Cache Disabled Configs Too",summary:"Notification configs with enable=false still enter cache",fact:"Cache loader doesn't filter by enable flag. Both enabled and disabled records are cached.",why:"Before: enabling required manual cache reload. Now cache is always authoritative.",apply:"Short-circuit on enable=false at read site, not cache load site. Toggle = flag flip + single evict."},
+{id:12,cat:"decision",title:"confId Over Resource Tuple",summary:"Query by confId first, fall back to (resourceType, resourceName)",fact:"MeasurementMetricRepositoryImpl checks confIds first before falling back to tuple.",why:"Tuple (resourceType, resourceName) is ambiguous - some metrics lack resourceType.",apply:"Prefer confId-based queries. Fall back to tuple only when confId unavailable."},
+{id:13,cat:"arch",title:"Additive Schema Versioning",summary:"Plugin registry schema changes must be additive-only",fact:"New fields added alongside old ones. Never remove or rename existing fields.",why:"Existing plugins depend on current schema shape. Non-additive changes break them silently.",apply:"Deprecate but don't remove. Use version namespaces (v1/, v2/) for breaking changes."},
+{id:14,cat:"arch",title:"Agent Memory: Bind at Write",summary:"Structure memory at write-time, not recall-time",fact:"Write-time structured keys outperform free-text semantic search for recall reliability.",why:"Free-text search is probabilistic and degrades with corpus size.",apply:"Tag memories with structured keys (topic, entity, date). Query by keys. Semantic search = fallback only."},
+{id:15,cat:"arch",title:"Function ID Authorization",summary:"AuthZ by function ID annotations, not URL patterns",fact:"Each endpoint annotated with stable function ID. AuthZ checks the ID, not URL path.",why:"URL patterns are fragile - restructuring silently drops security checks.",apply:"Use @RequiresPermission('USER_MANAGE'). Wire authZ interceptor to read annotation metadata."},
+{id:16,cat:"arch",title:"Generated = Boilerplate Only",summary:"Never generate business logic. Only DTOs, mappers, CRUD.",fact:"Code generation is strictly limited to structural/mechanical code.",why:"Business rules change independently. Regeneration overwrites hand-tuned logic.",apply:"Draw clear boundary: generate DTOs, mappers, repos. Keep validation and workflow hand-written."},
+{id:17,cat:"arch",title:"Exclude commons-logging",summary:"Bridge to SLF4J to prevent silent log loss",fact:"All transitive commons-logging excluded globally. jcl-over-slf4j bridges remaining calls.",why:"Multiple logging frameworks: some classes bind to one, some to other. Wrong-framework logs vanish.",apply:"Global exclusion + jcl-over-slf4j bridge. Verify dependency tree after every new dependency."},
+{id:18,cat:"arch",title:"Redis Lock != Access Control",summary:"Distributed locks coordinate; they don't authorize",fact:"Locks provide mutual exclusion among cooperating processes. Not authentication or authorization.",why:"Lock expiry = 'no one coordinating', not 'anyone authorized'. Conflating creates security holes.",apply:"Locks for mutual exclusion. Separate authZ layer (RBAC, JWT) for permissions. Never derive permissions from lock state."},
+{id:19,cat:"arch",title:"Last-Wins Override Chain",summary:"Config precedence: defaults < file < env var < CLI flag",fact:"Strict precedence chain where last source wins.",why:"Undocumented precedence causes 'works on my machine' debugging.",apply:"Document the chain. Apply overrides in order. Log effective config source at startup."},
+{id:20,cat:"arch",title:"Interface Abstraction at Boundaries",summary:"Cross-module deps go through interfaces, not implementations",fact:"All cross-module dependencies resolved via DI container at runtime.",why:"Direct implementation deps create tight coupling. Interfaces enable testing and swapping.",apply:"Interfaces in shared/api module. Implementations in own modules. Wire via @Component or @Bean."}
+];
+
+const SM2_KEY='flashcard_sm2_v1';
+function loadSM2(){try{return JSON.parse(localStorage.getItem(SM2_KEY))||{}}catch(e){return{}}}
+function saveSM2(d){localStorage.setItem(SM2_KEY,JSON.stringify(d))}
+
+function getCardState(id){
+const d=loadSM2();
+return d[id]||{interval:0,repetition:0,easeFactor:2.5,nextReview:0,status:'new'};
+}
+
+function updateCard(id,quality){
+const d=loadSM2();const s=d[id]||{interval:0,repetition:0,easeFactor:2.5,nextReview:0,status:'new'};
+const now=Date.now();
+if(quality<2){s.repetition=0;s.interval=1;s.status='learning'}
+else{
+if(s.repetition===0)s.interval=1;
+else if(s.repetition===1)s.interval=3;
+else s.interval=Math.round(s.interval*s.easeFactor);
+s.repetition++;s.status='review';
+}
+s.easeFactor=Math.max(1.3,s.easeFactor+0.1-((3-quality)*(0.08+(3-quality)*0.02)));
+s.nextReview=now+s.interval*60000;
+if(quality>=2&&s.repetition>=3)s.status='mastered';
+d[id]=s;saveSM2(d);
+}
+
+let filter='all',currentCard=null,flipped=false;
+
+function getDueCards(){
+const now=Date.now();
+return CARDS.filter(c=>{
+const s=getCardState(c.id);
+if(filter!=='all'&&c.cat!==filter)return false;
+return s.status==='new'||s.nextReview<=now;
+}).sort((a,b)=>{
+const sa=getCardState(a.id),sb=getCardState(b.id);
+if(sa.status==='new'&&sb.status!=='new')return-1;
+if(sb.status==='new'&&sa.status!=='new')return 1;
+return(sa.nextReview||0)-(sb.nextReview||0);
+});
+}
+
+function renderStats(){
+const sm2=loadSM2();let nw=0,learn=0,review=0,mastered=0;
+CARDS.forEach(c=>{const s=sm2[c.id];if(!s||s.status==='new')nw++;else if(s.status==='learning')learn++;else if(s.status==='mastered')mastered++;else review++});
+document.getElementById('stats').innerHTML=`
+<div class="stat"><b class="new-c">${nw}</b><small>New</small></div>
+<div class="stat"><b class="learn-c">${learn}</b><small>Learning</small></div>
+<div class="stat"><b class="review-c">${review}</b><small>Review</small></div>
+<div class="stat"><b class="done-c">${mastered}</b><small>Mastered</small></div>`;
+const total=CARDS.length;
+document.getElementById('progress').innerHTML=`
+<div class="prog-done" style="width:${mastered/total*100}%"></div>
+<div class="prog-learn" style="width:${(learn+review)/total*100}%"></div>
+<div class="prog-new" style="width:${nw/total*100}%"></div>`;
+}
+
+function renderControls(){
+document.getElementById('controls').innerHTML=['all','pitfall','arch','decision','api'].map(c=>
+`<button class="ctrl-btn ${filter===c?'active':''}" onclick="setFilter('${c}')">${c}</button>`
+).join('')+`<button class="ctrl-btn" onclick="resetAll()">Reset</button>`;
+}
+
+function setFilter(f){filter=f;renderControls();showNext()}
+
+function showNext(){
+flipped=false;renderStats();
+const due=getDueCards();
+if(!due.length){
+document.getElementById('cardContainer').innerHTML=`<div class="empty"><h2>All caught up!</h2><p>No cards due for review. Come back later or reset progress.</p></div>`;
+document.getElementById('ratingBar').style.display='none';return;
+}
+currentCard=due[0];
+document.getElementById('cardContainer').innerHTML=`
+<div class="flashcard" id="flashcard" onclick="flipCard()">
+<div class="card-face card-front">
+<span class="card-cat cat-${currentCard.cat}">${currentCard.cat}</span>
+<div class="card-title">${currentCard.title}</div>
+<div class="card-summary">${currentCard.summary}</div>
+<div class="flip-hint">Click to reveal answer</div>
+</div>
+<div class="card-face card-back">
+<span class="card-cat cat-${currentCard.cat}">${currentCard.cat}</span>
+<div class="card-title">${currentCard.title}</div>
+<div class="back-section"><h4>Fact</h4><p>${currentCard.fact}</p></div>
+<div class="back-section"><h4>Why</h4><p>${currentCard.why}</p></div>
+<div class="back-section"><h4>How to Apply</h4><p>${currentCard.apply}</p></div>
+</div>
+</div>`;
+document.getElementById('ratingBar').style.display='none';
+}
+
+function flipCard(){
+if(flipped)return;flipped=true;
+document.getElementById('flashcard').classList.add('flipped');
+document.getElementById('ratingBar').style.display='flex';
+}
+
+function rate(quality){
+if(!currentCard)return;
+updateCard(currentCard.id,quality);
+showNext();
+}
+
+function resetAll(){
+if(!confirm('Reset all progress?'))return;
+localStorage.removeItem(SM2_KEY);showNext();
+}
+
+renderControls();showNext();
+</script>
+</body>
+</html>

--- a/example/knowledge-flashcards/manifest.json
+++ b/example/knowledge-flashcards/manifest.json
@@ -1,0 +1,12 @@
+{
+  "slug": "knowledge-flashcards",
+  "title": "Knowledge Flashcards",
+  "summary": "Spaced repetition flashcard system from architecture, decision, pitfall, and API knowledge entries. SM-2 algorithm tracks mastery per card across sessions via localStorage.",
+  "stack": ["html", "css", "js"],
+  "tags": ["flashcards", "spaced-repetition", "sm2", "learning", "knowledge"],
+  "created_at": "2026-04-16",
+  "source_project": "hub-make",
+  "runtime": "browser",
+  "entrypoint": "index.html",
+  "author": "kjuhwa@nkia.co.kr"
+}

--- a/example/pitfall-quiz-arena/README.md
+++ b/example/pitfall-quiz-arena/README.md
@@ -1,0 +1,20 @@
+# Pitfall Quiz Arena
+
+> **Why.** The pitfall and architecture knowledge entries are the most actionable content in the hub but have zero discoverability. Gamification makes them sticky — wrong answers reveal the full explanation, turning mistakes into learning moments.
+
+## What it does
+
+- 13 questions sourced from `pitfall/` and `arch/` knowledge entries
+- 15-second timer per question with visual countdown
+- 4 multiple-choice options per question
+- Wrong answer flips to reveal full explanation (Fact, Why, How to Apply)
+- Score tracking: base points + speed bonus + streak multiplier (up to 5x)
+- Final results screen with accuracy, timing stats, and per-question review
+
+## Stack
+
+Single HTML file, zero external dependencies. Pure HTML + CSS + JS.
+
+## How to run
+
+Open `index.html` in any modern browser.

--- a/example/pitfall-quiz-arena/index.html
+++ b/example/pitfall-quiz-arena/index.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Pitfall Quiz Arena</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#0f0f1a;--card:#1a1a2e;--glass:rgba(255,255,255,0.05);--accent:#ff6b6b;--accent2:#ffd93d;--correct:#4ecdc4;--text:#e0e0e0;--muted:#888;--radius:16px}
+body{font-family:'Segoe UI',system-ui,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;flex-direction:column;align-items:center}
+.container{max-width:800px;width:100%;padding:20px}
+h1{text-align:center;font-size:2rem;margin:20px 0;background:linear-gradient(135deg,var(--accent),var(--accent2));-webkit-background-clip:text;-webkit-text-fill-color:transparent}
+.stats-bar{display:flex;justify-content:center;gap:24px;margin-bottom:24px;flex-wrap:wrap}
+.stat{text-align:center}.stat-val{font-size:1.5rem;font-weight:700}.stat-label{font-size:.75rem;color:var(--muted)}
+.progress-wrap{width:100%;height:6px;background:var(--glass);border-radius:3px;margin-bottom:20px;overflow:hidden}
+.progress-fill{height:100%;background:linear-gradient(90deg,var(--accent),var(--accent2));transition:width .3s}
+.timer-bar{width:100%;height:4px;background:var(--glass);border-radius:2px;margin-bottom:20px;overflow:hidden}
+.timer-fill{height:100%;background:var(--accent);transition:width .1s linear}
+.card{background:var(--card);border:1px solid rgba(255,255,255,0.08);border-radius:var(--radius);padding:28px;margin-bottom:20px;backdrop-filter:blur(10px);position:relative;overflow:hidden}
+.card::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,var(--accent),var(--accent2))}
+.badge{display:inline-block;padding:3px 10px;border-radius:20px;font-size:.7rem;font-weight:600;text-transform:uppercase;margin-bottom:12px}
+.badge-pitfall{background:rgba(255,107,107,0.2);color:var(--accent)}
+.badge-arch{background:rgba(78,205,196,0.2);color:var(--correct)}
+.question-num{font-size:.8rem;color:var(--muted);margin-bottom:8px}
+.question-text{font-size:1.1rem;font-weight:600;line-height:1.5;margin-bottom:20px}
+.options{display:flex;flex-direction:column;gap:10px}
+.option{padding:14px 18px;background:var(--glass);border:1px solid rgba(255,255,255,0.1);border-radius:12px;cursor:pointer;transition:all .2s;font-size:.95rem;line-height:1.4}
+.option:hover{border-color:rgba(255,255,255,0.3);background:rgba(255,255,255,0.08)}
+.option.correct{border-color:var(--correct);background:rgba(78,205,196,0.15);color:var(--correct)}
+.option.wrong{border-color:var(--accent);background:rgba(255,107,107,0.15);color:var(--accent)}
+.option.disabled{pointer-events:none;opacity:.6}
+.explanation{margin-top:20px;padding:20px;background:rgba(255,107,107,0.05);border:1px solid rgba(255,107,107,0.2);border-radius:12px;display:none;animation:fadeIn .3s}
+.explanation h3{color:var(--accent2);margin-bottom:8px;font-size:.95rem}
+.explanation p{font-size:.85rem;line-height:1.6;color:var(--muted);margin-bottom:8px}
+.explanation p strong{color:var(--text)}
+.next-btn{display:none;margin-top:16px;padding:12px 32px;background:linear-gradient(135deg,var(--accent),#ee5a6f);color:#fff;border:none;border-radius:12px;font-size:1rem;font-weight:600;cursor:pointer;transition:transform .15s}
+.next-btn:hover{transform:scale(1.03)}
+.result-card{text-align:center}.result-card h2{font-size:1.8rem;margin-bottom:16px}
+.result-score{font-size:3rem;font-weight:800;background:linear-gradient(135deg,var(--accent),var(--accent2));-webkit-background-clip:text;-webkit-text-fill-color:transparent}
+.result-details{display:flex;justify-content:center;gap:32px;margin:24px 0;flex-wrap:wrap}
+.result-detail{text-align:center}.result-detail span{display:block;font-size:1.4rem;font-weight:700}.result-detail small{color:var(--muted)}
+.play-btn{padding:14px 40px;background:linear-gradient(135deg,var(--accent),var(--accent2));color:#111;border:none;border-radius:12px;font-size:1.1rem;font-weight:700;cursor:pointer;transition:transform .15s}
+.play-btn:hover{transform:scale(1.05)}
+.streak{position:fixed;top:20px;right:20px;background:var(--card);border:1px solid rgba(255,255,255,0.1);border-radius:12px;padding:8px 16px;font-size:.85rem;opacity:0;transition:opacity .3s}
+.streak.show{opacity:1}
+.streak-val{color:var(--accent2);font-weight:700}
+@keyframes fadeIn{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:translateY(0)}}
+@media(max-width:600px){.container{padding:12px}h1{font-size:1.4rem}.card{padding:18px}}
+.start-screen{text-align:center;padding:40px 20px}
+.start-screen p{color:var(--muted);margin:12px 0 28px;line-height:1.6}
+</style>
+</head>
+<body>
+<div class="container" id="app"></div>
+<div class="streak" id="streak">Streak: <span class="streak-val" id="streak-val">0</span></div>
+<script>
+const QUESTIONS=[
+{cat:"pitfall",title:"Actuator Timeout Trap",scenario:"Your monitoring collector polls /actuator/health AND /actuator/heapdump using the same HTTP client with a 500ms timeout. Suddenly, health checks start timing out and availability gaps appear in your dashboard.",question:"What's the pitfall?",options:["The health endpoint is returning too much data","Fast and slow actuator endpoints share the same timeout \u2014 a slow heapdump stalls the entire collector","The 500ms timeout is too aggressive for any endpoint","The collector should use async HTTP instead of sync"],correct:1,explanation:{fact:"Health/metric endpoints should answer in <50ms. Threaddump/heapdump can take seconds to minutes.",why:"A single slow target was stalling the collector thread pool and starving other targets. Symptom: ticks skipped, availability metrics gapped.",apply:"Keep TWO HTTP client configurations: fast-path (\u22641s connect, \u22642s read) for /health and /metrics; slow-path (5\u201310s connect, 60s+ read) for /threaddump and /heapdump."}},
+{cat:"pitfall",title:"Silent AI Guesses",scenario:"An LLM generates an OpenAPI spec from a planning document. The doc doesn't mention endpoint URLs, required fields, or error codes. The generated spec looks complete and passes validation.",question:"What goes wrong?",options:["The LLM will refuse to generate incomplete specs","Silent AI guesses become frozen wrong contracts that are expensive to undo","The OpenAPI validator catches all inferred fields","Planning docs always contain enough detail for API specs"],correct:1,explanation:{fact:"Screen-focused planning docs lack endpoint URLs, required-field markers, error codes, pagination, permissions. AI guesses these silently.",why:"In a prior POC, silent guesses became frozen contracts that were expensive to undo after code generation consumed them.",apply:"Annotate every AI-inferred field with an inline marker (e.g. '# \u26a0\ufe0f AI guess:') and emit a companion review checklist."}},
+{cat:"pitfall",title:"Skill Doc Data Leak",scenario:"A developer writes a SKILL.md example using real ticket numbers (#PROJ-4521), a colleague's name, and actual milestone versions from the internal project tracker.",question:"What's the pitfall?",options:["The ticket numbers won't resolve for external readers","Real data in shared repos triggers security audit flags \u2014 all examples must use anonymized dummies","SKILL.md files don't support ticket references","The milestone versions will become outdated"],correct:1,explanation:{fact:"Internal shared plugin repos may be externally accessible. All SKILL.md examples must be anonymized.",why:"Security audit flagged real ticket numbers, real names, and real project names in examples.",apply:"Use dummy data: ticket #100001, names like \ud64d\uae38\ub3d9/\uae40\ucca0\uc218, features \uae30\ub2a5A/\uae30\ub2a5B, neutral versions like v10.3.0."}},
+{cat:"pitfall",title:"Lambda Instrumentation Gap",scenario:"Your APM JVM agent instruments all Spring controller methods successfully. But async operations using CompletableFuture and reactive flatMap lambdas produce zero trace data.",question:"What's the pitfall?",options:["Lambdas don't support bytecode instrumentation at all","ASM-based agents miss Java 8+ lambda forms because they're synthesized at runtime by LambdaMetafactory","The reactive framework strips instrumentation headers","CompletableFuture is incompatible with APM tracing"],correct:1,explanation:{fact:"Java 8+ lambdas compile to synthetic classes materialized at runtime by LambdaMetafactory \u2014 these bypass naive ClassFileTransformer.",why:"Class names don't match patterns an agent would register. Similar issues with Spring CGLIB proxies ($$EnhancerBySpringCGLIB).",apply:"Test against a Spring Boot app early \u2014 it exercises CGLIB proxies, ByteBuddy classes, reactive lambdas. Expose hooks as individually-toggleable flags."}},
+{cat:"pitfall",title:"Audit Trail Inversion",scenario:"Your audit log shows that a user changed a config value from 'production' to 'staging'. But the actual change was from 'staging' to 'production'. Every UPDATE event has the before/after values swapped.",question:"What's the root cause?",options:["The audit log timestamp is wrong, showing events in reverse order","The diff logic iterates the AFTER document and writes AFTER values into the changedPrev map","The database returns documents in reverse chronological order","The UI component swaps the column headers"],correct:1,explanation:{fact:"An earlier getChangedInfo() iterated the AFTER document and wrote AFTER values into changedPrev. Change direction was inverted for every UPDATE.",why:"Parameters named baseDoc/targetDoc were ambiguous \u2014 no name told the reader which was 'before'. No unit test asserted prev != after.",apply:"Name parameters beforeDoc/afterDoc. Write the canonical test first: diff({x:1},{x:2}) => {prev:{x:1},after:{x:2}}. Assert BOTH sides."}},
+{cat:"pitfall",title:"Phantom Recent Edits",scenario:"Your auto-lock job processes 200 inactive pages nightly. Next morning, the 'Recently Edited' dashboard shows all 200 pages as 'just edited'. Users complain their actual recent work is buried.",question:"What's the pitfall?",options:["The auto-lock job runs too frequently","The locking code path updates lastEditedTime, making all locked pages appear freshly edited","The dashboard query doesn't filter by edit type","Users don't understand what 'recently edited' means"],correct:1,explanation:{fact:"When a scheduled job locks N pages, do NOT let the locking code path update lastEditedTime/modifiedAt.",why:"The auto-lock service shared the generic 'page updated' code path which always bumped lastEditedTime. All locked pages looked freshly edited.",apply:"Automated state transitions should write only state columns they own (locked, archived). Use their own targeted query, not the generic entity save path."}},
+{cat:"pitfall",title:"Zero Division Aggregation",scenario:"Your MongoDB time-series dashboard works fine for normal date ranges. But when a user picks a very small range with intervalMode=auto, the chart returns empty and the server logs show a MongoDB evaluation error.",question:"What causes this?",options:["MongoDB can't handle small date ranges","The computed binSize is 0, causing division by zero in $bucketAuto","The intervalMode=auto flag is not supported","Small ranges exceed the maximum number of buckets"],correct:1,explanation:{fact:"$bucketAuto divides timestamps by binSize. A zero binSize triggers a MongoDB evaluation error (division by zero).",why:"Interval can land at 0 when the caller passes unusual mode combinations or during automated smoke runs.",apply:"Any aggregation with a computed interval must guard: interval <= 0 ? 1 : interval. Centralize in a resolveBinSize() helper."}},
+{cat:"arch",title:"Schema Evolution Strategy",scenario:"Your plugin registry has 50 registered plugins. A new feature requires changing the registry schema. You plan to add a migration that renames a field and removes an obsolete one.",question:"What's the architectural concern?",options:["Migrations are unnecessary for plugin registries","Schema changes must be additive-only \u2014 renames and removals break existing plugins","You should version each plugin individually instead","Plugin registries shouldn't have schemas"],correct:1,explanation:{fact:"Plugin registry schema changes must be additive-only. Breaking changes require a new version namespace.",why:"Existing plugins depend on the current schema shape. Renames and removals break them silently at runtime.",apply:"Add new fields alongside old ones. Deprecate but don't remove. Use version namespaces for breaking changes."}},
+{cat:"arch",title:"Agent Memory Design",scenario:"Your AI agent stores conversation memories as free-text blobs. When recalling information, it searches memories using semantic similarity. Retrieval is unreliable \u2014 sometimes it finds the right memory, sometimes not.",question:"What's the better approach?",options:["Use a larger embedding model for better semantic search","Bind memory at write-time with structured keys, not at recall-time with free search","Store memories in a relational database instead of vector store","Limit the number of memories to reduce search space"],correct:1,explanation:{fact:"Agent memory should bind at write-time (structured), not recall-time (free search).",why:"Structured binding enables deterministic retrieval. Free-text search is probabilistic and degrades with corpus size.",apply:"At write time, tag memories with structured keys (topic, entity, date). At read time, query by keys for deterministic lookup."}},
+{cat:"arch",title:"URL-Based Authorization",scenario:"Your authorization system checks permissions based on URL patterns (/api/users/*, /api/admin/*). After a REST API refactoring that restructures URL paths, several endpoints lose their security checks.",question:"What's the architectural flaw?",options:["URL patterns are the standard way to handle authorization","Authorization should be driven by function IDs on annotations, not URL patterns","The refactoring should have updated all URL patterns first","A reverse proxy should handle authorization instead"],correct:1,explanation:{fact:"Authorization checks should be driven by function IDs on annotations, not URL patterns.",why:"URL patterns break on refactors. Function IDs are stable identifiers tied to business operations.",apply:"Annotate endpoints with @RequiresPermission('USER_MANAGE') instead of URL-matching rules. IDs survive URL restructuring."}},
+{cat:"arch",title:"Generated Code Boundary",scenario:"Your code generator produces both CRUD boilerplate AND business validation logic from a DSL. A business rule change requires modifying the DSL, regenerating, and hoping the new output is correct.",question:"What's the design mistake?",options:["Code generation is inherently unreliable","Generated code should handle only boilerplate; business logic must stay hand-written","The DSL should be more expressive to handle edge cases","Generated code should be manually edited after generation"],correct:1,explanation:{fact:"Generated code handles boilerplate; business logic stays hand-written. Never generate business logic.",why:"Business rules change independently of structural patterns. Regeneration overwrites hand-tuned logic.",apply:"Draw a clear boundary: generate DTOs, mappers, CRUD. Keep validation, pricing, workflow rules in hand-written code that generation never touches."}},
+{cat:"arch",title:"Logging Framework Clash",scenario:"After adding a new dependency, half your application's log statements silently disappear. No errors, no warnings \u2014 the logs just stop appearing in your configured appenders.",question:"What happened?",options:["The new dependency has a log level override","Multiple logging frameworks on classpath cause silent log loss \u2014 commons-logging wasn't excluded","The appender configuration has a package filter","Log rotation deleted the recent logs"],correct:1,explanation:{fact:"Exclude commons-logging transitively and bridge to SLF4J. Multiple logging frameworks cause silent log loss.",why:"When both commons-logging and SLF4J are present, some classes bind to one, some to the other. Logs sent to the wrong framework vanish.",apply:"Add a global exclusion for commons-logging in your build. Add jcl-over-slf4j bridge. Verify with dependency tree after every new dependency."}},
+{cat:"arch",title:"Redis Lock Misuse",scenario:"Your system uses Redis distributed locks to prevent unauthorized users from executing admin operations. An attacker discovers that expired locks grant access to anyone.",question:"What's the design flaw?",options:["Redis locks should have longer TTLs","Redis distributed locks are for coordination, not access control \u2014 don't conflate them","The lock implementation has a bug in TTL handling","Redis should be replaced with a proper mutex"],correct:1,explanation:{fact:"Redis distributed locks are for coordination ('only one runs'), not access control ('authorized to run').",why:"Lock expiry is a coordination mechanism. When a lock expires, it means 'no one is coordinating', not 'anyone is authorized'.",apply:"Use locks for mutual exclusion (only one worker processes a job). Use a separate authZ layer (RBAC, JWT claims) for permission checks. Never derive permissions from lock state."}}
+];
+
+let state={current:0,score:0,streak:0,maxStreak:0,correct:0,total:QUESTIONS.length,startTime:0,answers:[],timer:null,timeLeft:15,order:[]};
+
+function shuffle(a){for(let i=a.length-1;i>0;i--){const j=Math.floor(Math.random()*(i+1));[a[i],a[j]]=[a[j],a[i]]}return a}
+function init(){state={current:0,score:0,streak:0,maxStreak:0,correct:0,total:QUESTIONS.length,startTime:Date.now(),answers:[],timer:null,timeLeft:15,order:shuffle([...Array(QUESTIONS.length).keys()])};showStart()}
+
+function showStart(){
+document.getElementById('app').innerHTML=`
+<h1>Pitfall Quiz Arena</h1>
+<div class="card start-screen">
+<h2>Software Engineering Pitfalls</h2>
+<p>${QUESTIONS.length} questions from real-world pitfalls and architecture knowledge.<br>15 seconds per question. Speed bonus for fast answers. Streak multiplier for consecutive correct answers.</p>
+<button class="play-btn" onclick="startQuiz()">Start Quiz</button>
+</div>`;
+}
+
+function startQuiz(){state.startTime=Date.now();showQuestion()}
+
+function showQuestion(){
+clearInterval(state.timer);state.timeLeft=15;
+const idx=state.order[state.current];const q=QUESTIONS[idx];
+const pct=((state.current)/state.total*100).toFixed(0);
+document.getElementById('app').innerHTML=`
+<h1>Pitfall Quiz Arena</h1>
+<div class="stats-bar">
+<div class="stat"><div class="stat-val">${state.score}</div><div class="stat-label">Score</div></div>
+<div class="stat"><div class="stat-val">${state.correct}/${state.current}</div><div class="stat-label">Correct</div></div>
+<div class="stat"><div class="stat-val">${state.streak}</div><div class="stat-label">Streak</div></div>
+</div>
+<div class="progress-wrap"><div class="progress-fill" style="width:${pct}%"></div></div>
+<div class="timer-bar"><div class="timer-fill" id="timer-fill" style="width:100%"></div></div>
+<div class="card">
+<span class="badge ${q.cat==='pitfall'?'badge-pitfall':'badge-arch'}">${q.cat}</span>
+<div class="question-num">Question ${state.current+1} of ${state.total}</div>
+<div class="question-text">${q.title}</div>
+<p style="color:var(--muted);font-size:.9rem;line-height:1.5;margin-bottom:16px">${q.scenario}</p>
+<p style="font-weight:600;margin-bottom:12px">${q.question}</p>
+<div class="options" id="options">
+${q.options.map((o,i)=>`<div class="option" onclick="answer(${i})" data-idx="${i}">${o}</div>`).join('')}
+</div>
+<div class="explanation" id="explanation">
+<h3>${q.title} \u2014 Explanation</h3>
+<p><strong>Fact:</strong> ${q.explanation.fact}</p>
+<p><strong>Why:</strong> ${q.explanation.why}</p>
+<p><strong>How to apply:</strong> ${q.explanation.apply}</p>
+</div>
+<button class="next-btn" id="next-btn" onclick="nextQuestion()">Next Question \u2192</button>
+</div>`;
+state.timer=setInterval(()=>{state.timeLeft-=0.1;const pct=Math.max(0,(state.timeLeft/15)*100);document.getElementById('timer-fill').style.width=pct+'%';if(state.timeLeft<=0){clearInterval(state.timer);timeUp()}},100);
+}
+
+function timeUp(){
+const idx=state.order[state.current];const q=QUESTIONS[idx];
+document.querySelectorAll('.option').forEach((el,i)=>{el.classList.add('disabled');if(i===q.correct)el.classList.add('correct')});
+state.streak=0;updateStreak();
+document.getElementById('explanation').style.display='block';
+document.getElementById('next-btn').style.display='inline-block';
+state.answers.push({idx,correct:false,time:15});
+}
+
+function answer(i){
+clearInterval(state.timer);
+const idx=state.order[state.current];const q=QUESTIONS[idx];
+const timeTaken=15-state.timeLeft;
+const opts=document.querySelectorAll('.option');
+opts.forEach((el,j)=>{el.classList.add('disabled');if(j===q.correct)el.classList.add('correct');if(j===i&&j!==q.correct)el.classList.add('wrong')});
+
+if(i===q.correct){
+state.correct++;state.streak++;if(state.streak>state.maxStreak)state.maxStreak=state.streak;
+const speedBonus=Math.max(0,Math.round((state.timeLeft/15)*50));
+const streakMult=Math.min(state.streak,5);
+const pts=100*streakMult+speedBonus;
+state.score+=pts;
+state.answers.push({idx,correct:true,time:timeTaken});
+}else{
+state.streak=0;
+document.getElementById('explanation').style.display='block';
+state.answers.push({idx,correct:false,time:timeTaken});
+}
+updateStreak();
+document.getElementById('next-btn').style.display='inline-block';
+if(state.current===state.total-1)document.getElementById('next-btn').textContent='See Results \u2192';
+}
+
+function updateStreak(){
+const el=document.getElementById('streak');const val=document.getElementById('streak-val');
+val.textContent=state.streak;el.classList.toggle('show',state.streak>=2);
+}
+
+function nextQuestion(){
+state.current++;
+if(state.current>=state.total){showResults();return}
+showQuestion();
+}
+
+function showResults(){
+clearInterval(state.timer);
+const totalTime=((Date.now()-state.startTime)/1000).toFixed(1);
+const accuracy=state.total>0?Math.round((state.correct/state.total)*100):0;
+const avgTime=state.answers.length>0?(state.answers.reduce((a,b)=>a+b.time,0)/state.answers.length).toFixed(1):0;
+document.getElementById('streak').classList.remove('show');
+document.getElementById('app').innerHTML=`
+<h1>Pitfall Quiz Arena</h1>
+<div class="card result-card">
+<h2>Quiz Complete!</h2>
+<div class="result-score">${state.score}</div>
+<p style="color:var(--muted);margin-top:4px">points</p>
+<div class="result-details">
+<div class="result-detail"><span>${state.correct}/${state.total}</span><small>Correct</small></div>
+<div class="result-detail"><span>${accuracy}%</span><small>Accuracy</small></div>
+<div class="result-detail"><span>${avgTime}s</span><small>Avg Time</small></div>
+<div class="result-detail"><span>${state.maxStreak}</span><small>Best Streak</small></div>
+<div class="result-detail"><span>${totalTime}s</span><small>Total Time</small></div>
+</div>
+<div style="margin:20px 0;text-align:left">
+<h3 style="margin-bottom:12px;text-align:center;color:var(--accent2)">Review</h3>
+${state.answers.map((a,i)=>{const q=QUESTIONS[a.idx];return`<div style="display:flex;align-items:center;gap:8px;padding:6px 0;border-bottom:1px solid rgba(255,255,255,0.05)"><span style="color:${a.correct?'var(--correct)':'var(--accent)'};font-size:1.1rem">${a.correct?'\u2713':'\u2717'}</span><span style="flex:1;font-size:.85rem">${q.title}</span><span class="badge ${q.cat==='pitfall'?'badge-pitfall':'badge-arch'}" style="margin:0">${q.cat}</span><span style="font-size:.75rem;color:var(--muted)">${a.time.toFixed(1)}s</span></div>`}).join('')}
+</div>
+<button class="play-btn" onclick="init()">Play Again</button>
+</div>`;
+}
+
+init();
+</script>
+</body>
+</html>

--- a/example/pitfall-quiz-arena/manifest.json
+++ b/example/pitfall-quiz-arena/manifest.json
@@ -1,0 +1,12 @@
+{
+  "slug": "pitfall-quiz-arena",
+  "title": "Pitfall Quiz Arena",
+  "summary": "Timed multiple-choice quiz built from pitfall and architecture knowledge entries. Speed bonus, streak multiplier, full review with explanations.",
+  "stack": ["html", "css", "js"],
+  "tags": ["quiz", "gamification", "pitfall", "knowledge", "learning"],
+  "created_at": "2026-04-16",
+  "source_project": "hub-make",
+  "runtime": "browser",
+  "entrypoint": "index.html",
+  "author": "kjuhwa@nkia.co.kr"
+}

--- a/example/skill-cookbook/README.md
+++ b/example/skill-cookbook/README.md
@@ -1,0 +1,21 @@
+# Skill Cookbook
+
+> **Why.** `skill-tryout` tests routing of *one* skill at a time. Cookbook answers "which skills work *together*?" — the combinatorial view that was missing. Instead of browsing 240 skills individually, describe your problem and get a ready-made recipe.
+
+## What it does
+
+- Natural language search: "JWT token refresh without race conditions", "propagate tenant context through Kafka"
+- TF-IDF matching engine across 55 embedded skills (name 1.5x, description 2x, category 0.5x weighting)
+- Generates 2-3 recipe cards per query: primary solution, alternative approach, extended + safety
+- 6 pre-built popular recipes shown on empty state (Multi-tenant Kafka Pipeline, Secure JWT Flow, etc.)
+- Category-colored skill chips (backend/frontend/arch/ai/devops)
+- Relevance score bars per recipe
+- Search-as-you-type with debounce
+
+## Stack
+
+Single HTML file, zero external dependencies. Pure HTML + CSS + JS.
+
+## How to run
+
+Open `index.html` in any modern browser.

--- a/example/skill-cookbook/index.html
+++ b/example/skill-cookbook/index.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Skill Cookbook</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#1a1410;--card:#2a2218;--parchment:#3a3020;--accent:#e8a84c;--accent2:#c77b3f;--text:#e8dcc8;--muted:#9a8b72;--blue:#6ba3d6;--green:#7bc47f;--red:#d68a7b;--purple:#b088d4;--teal:#6bb8a8;--radius:12px;--border:rgba(232,168,76,0.15)}
+body{font-family:'Segoe UI',system-ui,sans-serif;background:var(--bg);color:var(--text);min-height:100vh}
+.header{padding:32px 24px 24px;text-align:center;border-bottom:1px solid var(--border)}
+h1{font-size:2rem;color:var(--accent);margin-bottom:6px}
+.subtitle{color:var(--muted);font-size:.9rem}
+.search-wrap{max-width:700px;margin:24px auto;padding:0 24px}
+.search{width:100%;padding:14px 20px;background:var(--card);border:2px solid var(--border);border-radius:var(--radius);color:var(--text);font-size:1rem;outline:none;transition:border-color .2s}
+.search:focus{border-color:var(--accent)}
+.search::placeholder{color:var(--muted)}
+.legend{display:flex;justify-content:center;gap:16px;padding:8px 24px 16px;flex-wrap:wrap}
+.legend-item{display:flex;align-items:center;gap:4px;font-size:.75rem;color:var(--muted)}
+.legend-dot{width:10px;height:10px;border-radius:3px}
+.content{max-width:900px;margin:0 auto;padding:0 24px 40px}
+.section-title{font-size:.85rem;text-transform:uppercase;letter-spacing:1px;color:var(--muted);margin:24px 0 12px;padding-bottom:6px;border-bottom:1px solid var(--border)}
+.recipe-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);padding:20px;margin-bottom:16px;position:relative;overflow:hidden;transition:transform .2s}
+.recipe-card:hover{transform:translateY(-1px)}
+.recipe-card::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,var(--accent),var(--accent2))}
+.recipe-name{font-size:1.1rem;font-weight:700;color:var(--accent);margin-bottom:8px}
+.recipe-desc{font-size:.85rem;color:var(--muted);line-height:1.5;margin-bottom:12px}
+.skill-chips{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:12px}
+.chip{padding:4px 10px;border-radius:8px;font-size:.75rem;font-weight:500;border:1px solid}
+.chip-backend{background:rgba(107,163,214,0.1);border-color:rgba(107,163,214,0.3);color:var(--blue)}
+.chip-frontend{background:rgba(123,196,127,0.1);border-color:rgba(123,196,127,0.3);color:var(--green)}
+.chip-arch{background:rgba(176,136,212,0.1);border-color:rgba(176,136,212,0.3);color:var(--purple)}
+.chip-ai{background:rgba(214,138,123,0.1);border-color:rgba(214,138,123,0.3);color:var(--red)}
+.chip-devops{background:rgba(107,184,168,0.1);border-color:rgba(107,184,168,0.3);color:var(--teal)}
+.chip-other{background:rgba(154,139,114,0.1);border-color:rgba(154,139,114,0.3);color:var(--muted)}
+.integration{padding:12px 16px;background:var(--parchment);border-radius:8px;font-size:.82rem;line-height:1.6;color:var(--text)}
+.integration strong{color:var(--accent)}
+.relevance{display:flex;align-items:center;gap:8px;margin-top:10px;font-size:.75rem;color:var(--muted)}
+.rel-bar{flex:1;max-width:120px;height:4px;background:rgba(232,168,76,0.1);border-radius:2px;overflow:hidden}
+.rel-fill{height:100%;background:var(--accent);border-radius:2px}
+.no-results{text-align:center;padding:60px;color:var(--muted);font-size:.95rem}
+.empty-hint{text-align:center;padding:12px;color:var(--muted);font-size:.8rem;font-style:italic}
+@media(max-width:600px){.content{padding:0 12px 24px}.search-wrap{padding:0 12px}}
+</style>
+</head>
+<body>
+<div class="header">
+<h1>Skill Cookbook</h1>
+<p class="subtitle">Describe your problem \u2014 get a recipe of skills that solve it together</p>
+</div>
+<div class="search-wrap">
+<input type="text" class="search" id="search" placeholder="e.g. 'JWT token refresh without race conditions' or 'propagate tenant context through Kafka'">
+</div>
+<div class="legend">
+<div class="legend-item"><div class="legend-dot" style="background:var(--blue)"></div>backend</div>
+<div class="legend-item"><div class="legend-dot" style="background:var(--green)"></div>frontend</div>
+<div class="legend-item"><div class="legend-dot" style="background:var(--purple)"></div>arch</div>
+<div class="legend-item"><div class="legend-dot" style="background:var(--red)"></div>ai</div>
+<div class="legend-item"><div class="legend-dot" style="background:var(--teal)"></div>devops</div>
+</div>
+<div class="content" id="content"></div>
+
+<script>
+const SKILLS=[
+{n:"audit-change-data-capture-pattern",c:"backend",d:"Compute before/after diffs for audit logs by comparing two BSON/JSON documents field-by-field"},
+{n:"availability-ttl-punctuate-processor",c:"backend",d:"Kafka Streams processor schedules wall-clock punctuate for TTL eviction of state store, emits downstream only on value change"},
+{n:"avro-gradle-kafka-schema-pipeline",c:"backend",d:"Wire davidmc24 Avro Gradle plugin so .avsc schemas generate Java sources consumed by Kafka producers/consumers with Schema Registry"},
+{n:"baseline-historical-comparison-threshold",c:"backend",d:"Evaluate current metric against historical baseline as dynamic threshold with rate or value change modes and dampening"},
+{n:"cache-variance-ttl-jitter",c:"backend",d:"Add random jitter to cache TTLs so entries don't expire simultaneously causing thundering herd"},
+{n:"challenge-response-auth-redis-ttl",c:"backend",d:"Replay-resistant two-step login with server-generated challenge stored in Redis with short TTL"},
+{n:"distributed-lock-mongodb",c:"backend",d:"MongoDB findAndModify-based distributed lock for coordination across multiple service instances"},
+{n:"event-driven-kafka-scheduling",c:"backend",d:"Replace Spring @Scheduled with Kafka event-driven triggers for distributed job execution"},
+{n:"jwt-refresh-rotation-spring",c:"backend",d:"Spring Boot 3 JWT with short-lived access tokens and rotating refresh tokens"},
+{n:"kafka-batch-consumer-partition-tuning",c:"backend",d:"Size Kafka partition count and max-poll-records for optimal batch consumer throughput"},
+{n:"kafka-consumer-semaphore-chunking",c:"backend",d:"Bound in-flight async work from a Kafka consumer using semaphore and chunked processing"},
+{n:"kafka-debounce-event-coalescing",c:"backend",d:"Coalesce bursts of change events into single processing units using time-windowed deduplication"},
+{n:"kafka-consumer-tenant-fan-out",c:"backend",d:"Fan out Kafka messages to tenant-specific processors based on message headers"},
+{n:"kafka-message-header-metadata",c:"backend",d:"Attach org-id, user-id, and timestamp metadata to Kafka message headers for cross-service context propagation"},
+{n:"kafka-producer-async-callback",c:"backend",d:"Fire-and-log Kafka send pattern using async callbacks for non-blocking production"},
+{n:"mongo-aggregation-filter-optimization",c:"backend",d:"Replace unwind+match on array subfields with $filter for better MongoDB aggregation performance"},
+{n:"mongo-criteria-maker-elemmatch-and-or",c:"backend",d:"Compose dynamic MongoDB Criteria with elemMatch and boolean OR/AND logic"},
+{n:"multi-tenant-kafka-header-organization-context",c:"backend",d:"Propagate tenant/organization id from HTTP request through Kafka headers to downstream consumers"},
+{n:"multi-tenant-scheduler-iteration",c:"backend",d:"Pattern for scheduled jobs that must iterate over all tenants and process each independently"},
+{n:"netty-tcp-reconnect-backoff",c:"backend",d:"Netty channelInactive/EOF/read-timeout reconnection with exponential backoff"},
+{n:"redis-lock-recheck-flag-pattern",c:"backend",d:"Distributed Redis lock with recheck flag to handle lock-release race conditions"},
+{n:"spring-typed-config-properties",c:"backend",d:"Type-safe nested ConfigurationProperties with validation for Spring Boot applications"},
+{n:"tenant-per-database-mongo-routing",c:"backend",d:"Route Spring Data Mongo operations to tenant-specific databases dynamically"},
+{n:"thread-pool-queue-backpressure",c:"backend",d:"Bounded in-memory queue between Kafka consumer and worker threads with backpressure signaling"},
+{n:"spring-mongo-lightweight-migration",c:"backend",d:"Annotation-driven MongoDB migration runner for schema evolution without heavy frameworks"},
+{n:"tenant-context-holder-propagation",c:"backend",d:"Set TenantContextHolder in request interceptor and propagate to async threads"},
+{n:"stomp-cookie-auth-handshake",c:"backend",d:"Authenticate STOMP WebSocket upgrade using session cookie validation at handshake"},
+{n:"spring-actuator-health-collector",c:"backend",d:"Poll remote Spring Boot services via Actuator health endpoints for centralized monitoring"},
+{n:"pluggable-sender-factory-pattern",c:"backend",d:"Register multiple notification transport senders via factory pattern for extensible delivery"},
+{n:"encrypted-pii-decrypt-before-send",c:"backend",d:"Store user email/phone encrypted at rest, decrypt only at send-time for notification delivery"},
+{n:"axios-refresh-queue-zustand",c:"frontend",d:"Axios response interceptor that queues concurrent failed 401 requests, refreshes token once, replays all"},
+{n:"folder-coloc-style-types",c:"frontend",d:"Keep component, style, and types files colocated in the same folder for maintainability"},
+{n:"module-federation-expose-react-component",c:"frontend",d:"Expose a React component from one Module Federation remote for consumption by host apps"},
+{n:"mfa-memoryrouter-isolation",c:"frontend",d:"Wrap Module Federation-exposed React components in MemoryRouter to prevent routing conflicts"},
+{n:"mfa-plain-html-dropdown-escape-hatch",c:"frontend",d:"When library Dropdown components cause infinite loops in MF, use plain HTML select as escape hatch"},
+{n:"adaptive-strategy-hot-swap",c:"arch",d:"Periodically re-evaluate candidate strategies against recent data, swap active one when weighted score beats incumbent by hysteresis threshold"},
+{n:"layered-risk-gates",c:"arch",d:"Three-layer safety pattern for autonomous AI agents: input validation, action review, output verification"},
+{n:"plugin-resource-provider-architecture",c:"arch",d:"Stable ResourceProvider SPI loaded via ServiceLoader or Spring DI for extensible plugin systems"},
+{n:"resource-provider-registry",c:"arch",d:"Spring DI plugin registry where Component-annotated providers auto-register by resource type"},
+{n:"ai-call-with-mock-fallback",c:"ai",d:"Wrap unreliable LLM/AI calls with deterministic mock fallback so UI always receives valid shape"},
+{n:"ai-subagent-scope-narrowing",c:"ai",d:"Orchestrator-first pattern for multi-agent AI coding - humans curate context per task, subagents execute in isolated worktrees"},
+{n:"docker-compose-v1-v2-auto-detect",c:"devops",d:"Shell helper that prefers docker compose v2 command, falls back to docker-compose v1"},
+{n:"gradle-bootrun-local-dev-env",c:"devops",d:"Gradle bootRun task recipe that wires local dev environment variables and profiles"},
+{n:"jenkins-dual-registry-docker-push",c:"devops",d:"Jenkins pipeline that builds one Docker image and pushes to two container registries"},
+{n:"spring-profile-datasource-activation",c:"backend",d:"Select DB/Hibernate/logging config at startup based on Spring active profile"},
+{n:"spring-dual-profile-flyway",c:"backend",d:"Spring Boot dual-profile setup with H2 for dev and production DB with Flyway migrations"},
+{n:"testcontainers-mongo-kafka-abstract-base",c:"backend",d:"Abstract test base classes that spin up MongoDB and Kafka via Testcontainers for integration testing"},
+{n:"opentelemetry-java-bootstrap",c:"backend",d:"Minimal OpenTelemetry bootstrap for a Spring Boot application with trace context propagation"},
+{n:"kafka-avro-topic-auto-create-config",c:"backend",d:"Spring Boot Kafka config bean that auto-creates topics with Avro schema registration on startup"},
+{n:"kafka-consumer-config-3-factories",c:"backend",d:"Spring Kafka consumer setup with three listener container factories for different deserialization needs"},
+{n:"immutable-action-event-log",c:"arch",d:"Model state transitions as (state, action) pairs in an append-only event log for auditability"},
+{n:"policy-target-evaluation-with-groups-tags",c:"backend",d:"Evaluate whether a resource matches a policy target using group membership and tag intersection"},
+{n:"polymorphic-command-entities",c:"backend",d:"Expose a list of typed commands over JPA with discriminator-based polymorphic entity hierarchy"},
+{n:"identifier-truncate-with-hash-suffix",c:"backend",d:"Deterministically shrink any identifier to a max length by truncating and appending a hash suffix"},
+{n:"byte-aware-sms-truncation-with-ellipsis",c:"backend",d:"Truncate SMS message body to a byte budget while preserving character boundaries and adding ellipsis"},
+{n:"divide-by-zero-rate-guard",c:"backend",d:"Guard rate/percentage calculations against division by zero with explicit fallback value"}
+];
+
+const PREBUILT=[
+{name:"Multi-tenant Kafka Pipeline",skills:["kafka-consumer-tenant-fan-out","multi-tenant-kafka-header-organization-context","tenant-per-database-mongo-routing"],desc:"Propagate tenant context from HTTP requests through Kafka message headers, fan out to tenant-specific consumers, and route each to its own MongoDB database. End-to-end tenant isolation without shared-nothing infrastructure.",score:95},
+{name:"Secure JWT Flow",skills:["jwt-refresh-rotation-spring","axios-refresh-queue-zustand","challenge-response-auth-redis-ttl"],desc:"Short-lived access tokens with rotating refresh tokens on the backend. Axios interceptor queues concurrent 401s and replays after a single refresh. Redis-backed challenge-response prevents replay attacks at login.",score:92},
+{name:"Event-Driven Monitoring",skills:["event-driven-kafka-scheduling","baseline-historical-comparison-threshold","availability-ttl-punctuate-processor"],desc:"Replace cron-based scheduled checks with Kafka event triggers. Compare current metrics against historical baselines for dynamic alerting. TTL-based state eviction ensures stale availability data auto-expires.",score:88},
+{name:"Plugin Architecture",skills:["plugin-resource-provider-architecture","resource-provider-registry","adaptive-strategy-hot-swap"],desc:"Define a stable SPI for resource providers. Auto-register implementations via Spring DI. Periodically evaluate which strategy/plugin performs best and hot-swap the active one with hysteresis to prevent flapping.",score:85},
+{name:"Kafka Backpressure Pipeline",skills:["kafka-consumer-semaphore-chunking","thread-pool-queue-backpressure","kafka-batch-consumer-partition-tuning"],desc:"Bound concurrent async processing with semaphores, add a bounded queue between consumer and workers, and tune partition count + poll records for optimal throughput without overwhelming downstream systems.",score:87},
+{name:"AI Agent Safety",skills:["layered-risk-gates","ai-call-with-mock-fallback","ai-subagent-scope-narrowing"],desc:"Three-layer safety gates for autonomous agents. Mock fallbacks ensure UI stability when LLM calls fail. Narrow subagent scope to minimize hallucination blast radius in multi-agent systems.",score:83}
+];
+
+function tokenize(s){return s.toLowerCase().replace(/[^a-z0-9\-\s]/g,'').split(/[\s\-]+/).filter(t=>t.length>2)}
+function tfidf(query){
+const qt=tokenize(query);if(!qt.length)return[];
+const df={};SKILLS.forEach(s=>{const st=new Set(tokenize(s.n+' '+s.d+' '+s.c));st.forEach(t=>{df[t]=(df[t]||0)+1})});
+const N=SKILLS.length;
+return SKILLS.map(s=>{
+const nt=tokenize(s.n),dt=tokenize(s.d),ct=tokenize(s.c);
+let score=0;
+qt.forEach(q=>{
+const idf=Math.log(N/(1+(df[q]||0)));
+const nMatch=nt.filter(t=>t.includes(q)||q.includes(t)).length;
+const dMatch=dt.filter(t=>t.includes(q)||q.includes(t)).length;
+const cMatch=ct.filter(t=>t.includes(q)||q.includes(t)).length;
+score+=(nMatch*1.5+dMatch*2+cMatch*0.5)*idf;
+});
+return{...s,score};
+}).filter(s=>s.score>0).sort((a,b)=>b.score-a.score);
+}
+
+function chipClass(c){
+const m={backend:'chip-backend',frontend:'chip-frontend',arch:'chip-arch',ai:'chip-ai',devops:'chip-devops'};
+return m[c]||'chip-other';
+}
+
+function makeRecipes(ranked){
+if(ranked.length<2)return ranked.length?[{name:ranked[0].n.replace(/-/g,' '),skills:[ranked[0]],desc:ranked[0].d,score:ranked[0].score}]:[];
+const recipes=[];
+const used=new Set();
+// Recipe 1: top 3
+const r1=ranked.slice(0,3);
+const cats1=[...new Set(r1.map(s=>s.c))];
+recipes.push({name:cats1.map(c=>c.charAt(0).toUpperCase()+c.slice(1)).join(' + ')+' Solution',skills:r1,desc:`Primary recipe combining the highest-relevance skills: ${r1.map(s=>s.n.replace(/-/g,' ')).join(', ')}.`,score:Math.round(r1.reduce((a,b)=>a+b.score,0)/r1.length*10)});
+r1.forEach(s=>used.add(s.n));
+
+// Recipe 2: alternative category mix
+const alt=ranked.filter(s=>!used.has(s.n)).slice(0,3);
+if(alt.length>=2){
+const cats2=[...new Set(alt.map(s=>s.c))];
+recipes.push({name:'Alternative: '+cats2.map(c=>c.charAt(0).toUpperCase()+c.slice(1)).join(' + '),skills:alt,desc:`Different angle: ${alt.map(s=>s.n.replace(/-/g,' ')).join(', ')}.`,score:Math.round(alt.reduce((a,b)=>a+b.score,0)/alt.length*10)});
+alt.forEach(s=>used.add(s.n));
+}
+
+// Recipe 3: extended with monitoring/safety
+const ext=ranked.filter(s=>!used.has(s.n)&&(s.c==='arch'||s.d.includes('monitor')||s.d.includes('safe')||s.d.includes('test'))).slice(0,2);
+const core=ranked.filter(s=>!used.has(s.n)).slice(0,1);
+const r3=[...core,...ext].slice(0,3);
+if(r3.length>=2){
+recipes.push({name:'Extended + Safety',skills:r3,desc:`Extended solution with monitoring and safety: ${r3.map(s=>s.n.replace(/-/g,' ')).join(', ')}.`,score:Math.round(r3.reduce((a,b)=>a+b.score,0)/r3.length*10)});
+}
+return recipes;
+}
+
+function renderCard(r,maxScore){
+const pct=maxScore>0?Math.min(100,Math.round(r.score/maxScore*100)):50;
+const skills=r.skills||[];
+return`<div class="recipe-card">
+<div class="recipe-name">${r.name}</div>
+<div class="skill-chips">${(skills.length?skills:[]).map(s=>{const sk=typeof s==='string'?SKILLS.find(x=>x.n===s)||{n:s,c:'backend'}:s;return`<span class="chip ${chipClass(sk.c)}">${sk.n}</span>`}).join('')}</div>
+<div class="integration">${r.desc}</div>
+<div class="relevance"><span>Relevance</span><div class="rel-bar"><div class="rel-fill" style="width:${pct}%"></div></div><span>${pct}%</span></div>
+</div>`;
+}
+
+function render(){
+const q=document.getElementById('search').value.trim();
+const el=document.getElementById('content');
+if(!q){
+el.innerHTML=`<div class="section-title">Popular Recipes</div>${PREBUILT.map(r=>renderCard({...r,skills:r.skills.map(sn=>SKILLS.find(s=>s.n===sn)||{n:sn,c:'backend'})},95)).join('')}<div class="empty-hint">Type a problem description above to get personalized skill recipes</div>`;
+return;
+}
+const ranked=tfidf(q);
+if(!ranked.length){el.innerHTML='<div class="no-results">No matching skills found. Try different keywords.</div>';return}
+const recipes=makeRecipes(ranked);
+const maxScore=recipes.length?Math.max(...recipes.map(r=>r.score)):1;
+el.innerHTML=`<div class="section-title">Recipes for: "${q}"</div>${recipes.map(r=>renderCard(r,maxScore)).join('')}<div class="section-title">All Matching Skills (${ranked.length})</div>${ranked.slice(0,10).map(s=>`<div style="display:flex;align-items:center;gap:8px;padding:8px 0;border-bottom:1px solid var(--border)"><span class="chip ${chipClass(s.c)}">${s.c}</span><span style="flex:1;font-size:.85rem">${s.n.replace(/-/g,' ')}</span><span style="font-size:.75rem;color:var(--muted)">${s.score.toFixed(1)}</span></div>`).join('')}`;
+}
+
+let debounce;document.getElementById('search').addEventListener('input',()=>{clearTimeout(debounce);debounce=setTimeout(render,250)});
+render();
+</script>
+</body>
+</html>

--- a/example/skill-cookbook/manifest.json
+++ b/example/skill-cookbook/manifest.json
@@ -1,0 +1,12 @@
+{
+  "slug": "skill-cookbook",
+  "title": "Skill Cookbook",
+  "summary": "Describe a problem, get a recipe of 2-3 skills that solve it together. TF-IDF matching with pre-built popular recipes and category-colored chips.",
+  "stack": ["html", "css", "js"],
+  "tags": ["cookbook", "recipe", "search", "tfidf", "skills-hub", "combination"],
+  "created_at": "2026-04-16",
+  "source_project": "hub-make",
+  "runtime": "browser",
+  "entrypoint": "index.html",
+  "author": "kjuhwa@nkia.co.kr"
+}

--- a/example/spring-starter-wizard/README.md
+++ b/example/spring-starter-wizard/README.md
@@ -1,0 +1,19 @@
+# Spring Boot Starter Wizard
+
+> **Why.** 115 backend skills are overwhelming. This wizard is the "what do I need?" entry point — pick your requirements from 6 categories and get a curated, ordered skill recipe with implementation dependencies resolved.
+
+## What it does
+
+- 6-step wizard: Data Layer, Messaging, Auth & Security, Multi-tenancy, Observability, Infrastructure
+- Multiple selections per step, skip what you don't need
+- Auto-resolves dependencies (e.g. Kafka-Avro requires Kafka, MFA requires JWT)
+- Results page: ordered skill list with descriptions + dependency graph
+- Copy recipe as text for sharing
+
+## Stack
+
+Single HTML file, zero external dependencies. Pure HTML + CSS + JS.
+
+## How to run
+
+Open `index.html` in any modern browser.

--- a/example/spring-starter-wizard/index.html
+++ b/example/spring-starter-wizard/index.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Spring Boot Starter Wizard</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#0f172a;--card:#1e293b;--border:rgba(255,255,255,0.08);--accent:#6366f1;--accent2:#818cf8;--green:#4ade80;--amber:#fbbf24;--text:#e2e8f0;--muted:#94a3b8;--radius:12px}
+body{font-family:'Segoe UI',system-ui,sans-serif;background:var(--bg);color:var(--text);min-height:100vh}
+.header{text-align:center;padding:32px 20px 24px;border-bottom:1px solid var(--border)}
+h1{font-size:1.8rem;background:linear-gradient(135deg,var(--accent),var(--green));-webkit-background-clip:text;-webkit-text-fill-color:transparent}
+.sub{color:var(--muted);font-size:.85rem;margin-top:6px}
+.container{max-width:1000px;margin:0 auto;padding:24px}
+.step-indicator{display:flex;justify-content:center;gap:8px;margin-bottom:28px}
+.step-dot{width:10px;height:10px;border-radius:50%;background:var(--border);transition:all .3s}
+.step-dot.active{background:var(--accent);transform:scale(1.3)}
+.step-dot.done{background:var(--green)}
+.card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);padding:24px;margin-bottom:20px}
+.card h2{font-size:1.2rem;margin-bottom:4px}.card p{color:var(--muted);font-size:.85rem;margin-bottom:16px}
+.options-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:10px}
+.opt{padding:14px;background:rgba(255,255,255,0.02);border:2px solid var(--border);border-radius:10px;cursor:pointer;transition:all .2s;text-align:center}
+.opt:hover{border-color:rgba(255,255,255,0.15)}
+.opt.selected{border-color:var(--accent);background:rgba(99,102,241,0.1)}
+.opt-icon{font-size:1.5rem;margin-bottom:6px}
+.opt-name{font-weight:600;font-size:.9rem}.opt-desc{font-size:.72rem;color:var(--muted);margin-top:4px}
+.nav{display:flex;justify-content:space-between;margin-top:20px}
+.btn{padding:10px 28px;border:none;border-radius:8px;font-size:.9rem;font-weight:600;cursor:pointer;transition:all .15s}
+.btn-primary{background:var(--accent);color:#fff}.btn-primary:hover{background:var(--accent2)}
+.btn-outline{background:transparent;border:1px solid var(--border);color:var(--text)}.btn-outline:hover{background:rgba(255,255,255,0.05)}
+.result-section{margin-bottom:24px}
+.result-section h3{font-size:1rem;margin-bottom:12px;color:var(--accent2)}
+.skill-card{display:flex;align-items:start;gap:12px;padding:12px;background:rgba(255,255,255,0.02);border:1px solid var(--border);border-radius:8px;margin-bottom:8px}
+.skill-order{width:28px;height:28px;border-radius:50%;background:var(--accent);color:#fff;display:flex;align-items:center;justify-content:center;font-size:.8rem;font-weight:700;flex-shrink:0}
+.skill-info{flex:1}.skill-name{font-weight:600;font-size:.85rem}.skill-desc{font-size:.75rem;color:var(--muted);margin-top:2px}
+.dep-graph{padding:16px;background:rgba(0,0,0,0.2);border-radius:8px;overflow-x:auto}
+.dep-row{display:flex;align-items:center;gap:8px;margin-bottom:6px;font-size:.8rem}
+.dep-box{padding:4px 10px;border-radius:6px;font-size:.75rem;white-space:nowrap}
+.dep-arrow{color:var(--muted)}
+.tag{display:inline-block;padding:2px 8px;border-radius:4px;font-size:.65rem;margin:1px}
+.tag-backend{background:rgba(99,102,241,0.15);color:var(--accent2)}
+.tag-infra{background:rgba(74,222,128,0.15);color:var(--green)}
+.tag-security{background:rgba(251,191,36,0.15);color:var(--amber)}
+</style>
+</head>
+<body>
+<div class="header">
+<h1>Spring Boot Starter Wizard</h1>
+<p class="sub">Pick your requirements. Get an ordered skill recipe with implementation dependencies.</p>
+</div>
+<div class="container">
+<div class="step-indicator" id="steps"></div>
+<div id="content"></div>
+</div>
+
+<script>
+const CATEGORIES=[
+{id:'data',name:'Data Layer',icon:'\ud83d\uddc4\ufe0f',options:[
+{id:'mongo',name:'MongoDB',desc:'Document store with Spring Data Mongo'},
+{id:'jpa',name:'JPA / SQL',desc:'Relational DB with Hibernate'},
+{id:'redis',name:'Redis',desc:'Cache and distributed locks'},
+{id:'multi-db',name:'Multi-Database',desc:'Polyglot persistence'}
+]},
+{id:'messaging',name:'Messaging',icon:'\ud83d\udce8',options:[
+{id:'kafka',name:'Kafka',desc:'Event streaming platform'},
+{id:'kafka-avro',name:'Kafka + Avro',desc:'Schema Registry with Avro codegen'},
+{id:'websocket',name:'WebSocket / STOMP',desc:'Real-time bidirectional communication'},
+{id:'sse',name:'SSE',desc:'Server-Sent Events streaming'}
+]},
+{id:'auth',name:'Auth & Security',icon:'\ud83d\udd12',options:[
+{id:'jwt',name:'JWT Auth',desc:'Access + refresh token rotation'},
+{id:'rbac',name:'RBAC',desc:'Role-based access control'},
+{id:'mfa',name:'MFA',desc:'Multi-factor authentication'},
+{id:'encryption',name:'PII Encryption',desc:'Encrypt sensitive data at rest'}
+]},
+{id:'multi-tenant',name:'Multi-tenancy',icon:'\ud83c\udfe2',options:[
+{id:'tenant-db',name:'DB per Tenant',desc:'Tenant-isolated databases'},
+{id:'tenant-header',name:'Header Propagation',desc:'Tenant context via HTTP/Kafka headers'},
+{id:'tenant-scheduler',name:'Tenant-aware Jobs',desc:'Scheduled tasks iterate all tenants'}
+]},
+{id:'observability',name:'Observability',icon:'\ud83d\udcca',options:[
+{id:'actuator',name:'Actuator Health',desc:'Health endpoint monitoring'},
+{id:'otel',name:'OpenTelemetry',desc:'Distributed tracing'},
+{id:'metrics',name:'Metrics Pipeline',desc:'Collect, aggregate, alert on metrics'},
+{id:'audit',name:'Audit Logging',desc:'Before/after change tracking'}
+]},
+{id:'infra',name:'Infrastructure',icon:'\u2699\ufe0f',options:[
+{id:'docker',name:'Docker',desc:'Containerized deployment'},
+{id:'testcontainers',name:'Testcontainers',desc:'Integration tests with real services'},
+{id:'ci-jenkins',name:'Jenkins CI',desc:'Build and deploy pipelines'},
+{id:'config',name:'Typed Config',desc:'Type-safe configuration properties'}
+]}
+];
+
+const SKILL_MAP={
+'mongo':['spring-data-mongo-repository-custom-split','spring-mongo-lightweight-migration','mongo-aggregation-filter-optimization'],
+'jpa':['json-seeded-jpa-loader','hibernate-multi-dialect-swap','spring-dual-profile-flyway'],
+'redis':['redis-lock-recheck-flag-pattern','distributed-lock-mongodb','cache-variance-ttl-jitter'],
+'multi-db':['multi-dbms-resource-provider-pattern','spring-profile-datasource-activation','concurrent-jdbc-pool-datasource-lifecycle'],
+'kafka':['kafka-batch-consumer-partition-tuning','kafka-consumer-semaphore-chunking','kafka-producer-async-callback','kafka-consumer-config-3-factories'],
+'kafka-avro':['avro-gradle-kafka-schema-pipeline','kafka-avro-topic-auto-create-config','kafka-producer-config-avro-schema-registry','avro-event-with-change-flags'],
+'websocket':['stomp-cookie-auth-handshake','stomp-principal-jwt-channel','websocket-stomp-channel-pool-config'],
+'sse':['feed-envelope-frame','reactor-subscription-router-backpressure'],
+'jwt':['jwt-refresh-rotation-spring','jwt-extraction-via-base-controller','challenge-response-auth-redis-ttl'],
+'rbac':['annotation-driven-authz-via-function-id','tsv-driven-permission-bootstrap','policy-target-evaluation-with-groups-tags'],
+'mfa':['challenge-response-auth-redis-ttl','encrypted-pii-decrypt-before-send'],
+'encryption':['encrypted-pii-decrypt-before-send'],
+'tenant-db':['tenant-per-database-mongo-routing','tenant-isolated-mongo-collection','dynamic-gridfs-template-multi-tenant'],
+'tenant-header':['multi-tenant-kafka-header-organization-context','tenant-context-holder-propagation','kafka-consumer-tenant-fan-out'],
+'tenant-scheduler':['multi-tenant-scheduler-iteration','thread-pool-config-tenant-aware','event-driven-kafka-scheduling'],
+'actuator':['spring-actuator-health-collector','service-readiness-event-listener-pattern','k8s-health-via-getnodelist'],
+'otel':['opentelemetry-java-bootstrap','transaction-trace-pack-serialization-with-step-hierarchy'],
+'metrics':['baseline-historical-comparison-threshold','measurement-grouping-combiner','second-aggregation-snapshot-merge','availability-ttl-punctuate-processor'],
+'audit':['audit-change-data-capture-pattern','immutable-action-event-log'],
+'docker':['docker-compose-v1-v2-auto-detect','docker-compose-service-inventory-files','dual-jre-docker-oz-report','font-cache-alpine-locale-docker'],
+'testcontainers':['testcontainers-mongo-kafka-abstract-base','spring-testcontainers-multitenant-base','testcontainers-reuse-disabled'],
+'ci-jenkins':['jenkins-dual-registry-docker-push','gradle-bootjar-conditional-archive-bundle','gradle-bootrun-local-dev-env'],
+'config':['spring-typed-config-properties','dotenv-multi-env-routing','spring-profile-datasource-activation']
+};
+
+const SKILL_DESCS={
+'spring-data-mongo-repository-custom-split':'Standard 3-file split for MongoRepository with custom query methods',
+'spring-mongo-lightweight-migration':'Annotation-driven MongoDB migration runner for schema evolution',
+'mongo-aggregation-filter-optimization':'Replace $unwind+$match with $filter for better performance',
+'kafka-batch-consumer-partition-tuning':'Size partition count + max-poll-records for throughput',
+'kafka-consumer-semaphore-chunking':'Bound in-flight async work with semaphore + chunks',
+'kafka-producer-async-callback':'Fire-and-log send pattern using async callbacks',
+'kafka-consumer-config-3-factories':'Three listener container factories for different deserialization',
+'avro-gradle-kafka-schema-pipeline':'Avro Gradle plugin wiring for Schema Registry',
+'kafka-avro-topic-auto-create-config':'Auto-create topics with Avro schema on startup',
+'jwt-refresh-rotation-spring':'Short-lived access + rotating refresh tokens',
+'jwt-extraction-via-base-controller':'Consolidate JWT extraction in base controller',
+'challenge-response-auth-redis-ttl':'Replay-resistant two-step login with Redis TTL',
+'tenant-per-database-mongo-routing':'Route Mongo operations to tenant-specific databases',
+'multi-tenant-kafka-header-organization-context':'Propagate tenant ID through Kafka headers',
+'tenant-context-holder-propagation':'Set tenant context in request interceptor',
+'kafka-consumer-tenant-fan-out':'Fan out messages to tenant-specific processors',
+'spring-actuator-health-collector':'Poll remote services via Actuator health endpoints',
+'opentelemetry-java-bootstrap':'Minimal OpenTelemetry bootstrap for Spring Boot',
+'audit-change-data-capture-pattern':'Before/after diffs for audit logs',
+'spring-typed-config-properties':'Type-safe nested @ConfigurationProperties',
+'redis-lock-recheck-flag-pattern':'Redis lock with recheck flag for race conditions',
+'cache-variance-ttl-jitter':'Random jitter on cache TTLs to prevent thundering herd',
+'testcontainers-mongo-kafka-abstract-base':'Abstract test base with MongoDB + Kafka via Testcontainers',
+'docker-compose-v1-v2-auto-detect':'Shell helper preferring docker compose v2',
+'jenkins-dual-registry-docker-push':'Build once, push to two container registries',
+'baseline-historical-comparison-threshold':'Dynamic threshold from historical metric baseline',
+'annotation-driven-authz-via-function-id':'AuthZ by function ID annotations, not URL patterns',
+'multi-tenant-scheduler-iteration':'Scheduled jobs iterating over all tenants',
+'encrypted-pii-decrypt-before-send':'Decrypt PII only at notification send-time'
+};
+
+const DEPS={'kafka-avro':['kafka'],'tenant-header':['kafka'],'tenant-scheduler':['tenant-header'],'tenant-db':['mongo'],'mfa':['jwt'],'rbac':['jwt'],'metrics':['actuator'],'testcontainers':['docker']};
+
+let step=0,selections={};
+
+function renderSteps(){
+$('#steps').innerHTML=CATEGORIES.map((_,i)=>`<div class="step-dot ${i<step?'done':i===step?'active':''}"></div>`).join('')+'<div class="step-dot '+(step>=CATEGORIES.length?'active':'')+'"></div>';
+}
+
+function render(){
+renderSteps();
+if(step<CATEGORIES.length){
+const cat=CATEGORIES[step];const sel=selections[cat.id]||[];
+$('#content').innerHTML=`
+<div class="card">
+<h2>${cat.icon} ${cat.name}</h2>
+<p>Select what you need (multiple allowed). Skip if not needed.</p>
+<div class="options-grid">
+${cat.options.map(o=>`<div class="opt ${sel.includes(o.id)?'selected':''}" onclick="toggleOpt('${cat.id}','${o.id}',this)">
+<div class="opt-name">${o.name}</div>
+<div class="opt-desc">${o.desc}</div>
+</div>`).join('')}
+</div>
+</div>
+<div class="nav">
+<button class="btn btn-outline" onclick="prev()" ${step===0?'disabled':''}>Back</button>
+<div>
+<button class="btn btn-outline" onclick="skip()" style="margin-right:8px">Skip</button>
+<button class="btn btn-primary" onclick="next()">Next</button>
+</div>
+</div>`;
+}else showResults();
+}
+
+function toggleOpt(catId,optId,el){
+if(!selections[catId])selections[catId]=[];
+const idx=selections[catId].indexOf(optId);
+if(idx>=0)selections[catId].splice(idx,1);else selections[catId].push(optId);
+el.classList.toggle('selected');
+}
+
+function next(){step++;render()}
+function prev(){step=Math.max(0,step-1);render()}
+function skip(){step++;render()}
+function $(s){return document.querySelector(s)}
+
+function showResults(){
+const allSelected=[];
+Object.values(selections).forEach(arr=>arr.forEach(id=>allSelected.push(id)));
+if(!allSelected.length){$('#content').innerHTML='<div class="card"><h2>No selections made</h2><p>Go back and pick some requirements.</p><div class="nav"><button class="btn btn-outline" onclick="step=0;render()">Start Over</button></div></div>';return}
+
+// Resolve dependencies
+const resolved=new Set(allSelected);
+allSelected.forEach(id=>{if(DEPS[id])DEPS[id].forEach(d=>{if(!resolved.has(d))resolved.add(d)})});
+
+// Collect skills in order
+const skillOrder=[];const seen=new Set();
+[...resolved].forEach(optId=>{
+const skills=SKILL_MAP[optId]||[];
+skills.forEach(s=>{if(!seen.has(s)){seen.add(s);skillOrder.push({skill:s,from:optId})}});
+});
+
+// Build dependency graph
+const depPairs=[];
+[...resolved].forEach(id=>{if(DEPS[id])DEPS[id].forEach(d=>depPairs.push({from:d,to:id}))});
+
+$('#content').innerHTML=`
+<div class="card">
+<h2>Your Skill Recipe</h2>
+<p>${skillOrder.length} skills across ${resolved.size} requirements</p>
+</div>
+<div class="result-section">
+<h3>Implementation Order</h3>
+${skillOrder.map((s,i)=>`<div class="skill-card">
+<div class="skill-order">${i+1}</div>
+<div class="skill-info">
+<div class="skill-name">${s.skill}</div>
+<div class="skill-desc">${SKILL_DESCS[s.skill]||'Skill pattern from hub'}</div>
+<span class="tag tag-backend">${s.from}</span>
+</div>
+</div>`).join('')}
+</div>
+${depPairs.length?`<div class="result-section">
+<h3>Dependency Graph</h3>
+<div class="dep-graph">
+${depPairs.map(d=>`<div class="dep-row">
+<span class="dep-box" style="background:rgba(99,102,241,0.15);color:var(--accent2)">${d.from}</span>
+<span class="dep-arrow">\u2192 required by \u2192</span>
+<span class="dep-box" style="background:rgba(74,222,128,0.15);color:var(--green)">${d.to}</span>
+</div>`).join('')}
+</div>
+</div>`:''}
+<div class="nav">
+<button class="btn btn-outline" onclick="step=0;selections={};render()">Start Over</button>
+<button class="btn btn-primary" onclick="copyRecipe()">Copy as Text</button>
+</div>`;
+}
+
+function copyRecipe(){
+const allSelected=[];Object.values(selections).forEach(arr=>arr.forEach(id=>allSelected.push(id)));
+const resolved=new Set(allSelected);allSelected.forEach(id=>{if(DEPS[id])DEPS[id].forEach(d=>resolved.add(d))});
+const skills=[];const seen=new Set();
+[...resolved].forEach(optId=>{(SKILL_MAP[optId]||[]).forEach(s=>{if(!seen.has(s)){seen.add(s);skills.push(s)}})});
+const text='Spring Boot Starter Recipe\n'+skills.map((s,i)=>`${i+1}. ${s}`).join('\n');
+navigator.clipboard.writeText(text).then(()=>alert('Copied!'));
+}
+
+render();
+</script>
+</body>
+</html>

--- a/example/spring-starter-wizard/manifest.json
+++ b/example/spring-starter-wizard/manifest.json
@@ -1,0 +1,12 @@
+{
+  "slug": "spring-starter-wizard",
+  "title": "Spring Boot Starter Wizard",
+  "summary": "Step-by-step wizard: pick data layer, messaging, auth, multi-tenancy, observability, and infra needs. Get an ordered skill recipe with dependency graph.",
+  "stack": ["html", "css", "js"],
+  "tags": ["spring-boot", "wizard", "starter", "recipe", "backend", "planning"],
+  "created_at": "2026-04-16",
+  "source_project": "hub-make",
+  "runtime": "browser",
+  "entrypoint": "index.html",
+  "author": "kjuhwa@nkia.co.kr"
+}


### PR DESCRIPTION
## Summary

- **pitfall-quiz-arena** — Timed multiple-choice quiz from pitfall/arch knowledge entries (13 questions, streak scoring, full explanations)
- **adr-navigator** — Filterable ADR card wall with search, sort, expand-to-detail, confidence badges, linked skill chips (16 entries)
- **skill-cookbook** — Problem-to-recipe TF-IDF matcher generating 2-3 skill combination recipes (55 skills, 6 pre-built combos)
- **kafka-topology-designer** — Interactive SVG canvas for Kafka architectures with drag-and-drop, connect mode, and 3 pre-built templates
- **spring-starter-wizard** — 6-step requirement wizard (data/messaging/auth/multi-tenant/observability/infra) outputting ordered skill recipes with dependency graph
- **knowledge-flashcards** — SM-2 spaced repetition system from 20 knowledge entries with localStorage persistence and category filters

All are zero-dependency single-file HTML apps, built via `/hub-make`.

## Test plan

- [ ] Open each `index.html` in a browser and verify rendering
- [ ] pitfall-quiz-arena: complete a full quiz run, verify score and review screen
- [ ] adr-navigator: test search, category filter, sort, card expand/collapse
- [ ] skill-cookbook: search "kafka tenant" and "jwt refresh", verify recipe generation
- [ ] kafka-topology-designer: drag components, connect nodes, load templates, export SVG
- [ ] spring-starter-wizard: complete wizard with selections, verify dependency resolution
- [ ] knowledge-flashcards: flip cards, rate them, verify SM-2 persistence after page reload
- [ ] Verify manifest.json and README.md present for each example

🤖 Generated with [Claude Code](https://claude.com/claude-code)