### PR TITLE
Publish 1 skill + 4 knowledge entries (session 2026-04-16)

### DIFF
--- a/knowledge/decision/always-pr-branch-never-direct-push.md
+++ b/knowledge/decision/always-pr-branch-never-direct-push.md
@@ -1,0 +1,45 @@
+---
+name: always-pr-branch-never-direct-push
+description: "Always create a feature branch and PR for shared repos — never push directly to main, even for 'obvious' additions"
+type: knowledge
+category: decision
+source:
+  kind: session
+  ref: session-2026-04-16-hub-make-publish
+confidence: high
+tags: [git, pr, workflow, shared-repo, review]
+---
+
+## Fact
+
+When publishing hub-make examples, the first attempt pushed 2 commits directly to main. The user noticed no PR was created ("pr 이 안왔는데?"). Fix required: force-pushing main back to the pre-commit state, creating a feature branch from the commits, and then creating a proper PR.
+
+## Why
+
+Shared repos (like skills-hub) expect PR-based workflow for:
+- Code review before merge
+- CI checks on the branch
+- Notification to repo watchers
+- Ability to request changes before content lands in main
+- Audit trail of who approved what
+
+Direct pushes bypass all of these. The recovery (force-push main, create branch, re-push) is riskier than doing it right the first time.
+
+## How to apply
+
+```bash
+# ALWAYS this pattern for shared repos:
+git checkout -b feat/<descriptive-name>
+git add <files>
+git commit -m "<message>"
+git push -u origin feat/<descriptive-name>
+gh pr create --base main --head feat/<descriptive-name> --title "..." --body "..."
+```
+
+- Never `git push origin main` for content changes
+- If you accidentally push to main: `git checkout -b <branch> HEAD`, then `git checkout main && git reset --hard origin/main~N`, then `git push --force origin main` and `git push -u origin <branch>`
+- The `/hub-publish-example` skill should always use branches
+
+## Counter / Caveats
+
+For personal repos where you're the sole contributor, direct-to-main is fine. This rule is specifically for shared/team repos. Also, force-pushing main to recover is itself risky if others have pulled — do it quickly.

--- a/knowledge/pitfall/registry-json-dict-not-list.md
+++ b/knowledge/pitfall/registry-json-dict-not-list.md
@@ -1,0 +1,30 @@
+---
+name: registry-json-dict-not-list
+description: "skills-hub registry.json stores skills and knowledge as dicts keyed by name, not arrays — list.append() fails silently or throws"
+type: knowledge
+category: pitfall
+source:
+  kind: session
+  ref: session-2026-04-16-hub-install-all
+confidence: high
+tags: [registry, json, data-structure, skills-hub]
+---
+
+## Fact
+
+`~/.claude/skills-hub/registry.json` stores `skills` and `knowledge` as **dict objects keyed by entry name**, not as arrays. Code that calls `registry['skills'].append(...)` will throw `'dict' object has no attribute 'append'`.
+
+## Why
+
+The initial `/hub-install-all` implementation assumed the registry used arrays (like `index.json`). 23 out of 240 skill installs failed with `'dict' object has no attribute 'append'` before the bug was caught. The first 217 succeeded because they were skipped (already existed on disk) — the append was never reached.
+
+## How to apply
+
+- Always inspect the registry structure before writing: `type(registry.get('skills'))` → expect `dict`
+- Use dict assignment: `registry['skills'][name] = {...}` not `registry['skills'].append({...})`
+- Same applies to `registry['knowledge']`
+- When reading, iterate with `.items()` not enumerate
+
+## Counter / Caveats
+
+The registry format may change in future versions. Check the actual file before assuming either format. A defensive approach: detect the type and branch accordingly.

--- a/knowledge/pitfall/subagent-permission-denial-fallback.md
+++ b/knowledge/pitfall/subagent-permission-denial-fallback.md
@@ -1,0 +1,30 @@
+---
+name: subagent-permission-denial-fallback
+description: "Claude Code subagents (Agent tool) cannot obtain Write/Bash permissions independently — if user hasn't pre-granted them, all 3 agents fail and you must build directly"
+type: knowledge
+category: pitfall
+source:
+  kind: session
+  ref: session-2026-04-16-hub-make
+confidence: high
+tags: [claude-code, subagent, permissions, agent-tool, parallel]
+---
+
+## Fact
+
+When spawning background agents via the `Agent` tool with `run_in_background: true`, each agent independently requests tool permissions (Write, Bash, etc.). If the user's permission mode requires approval, the background agents cannot prompt the user — they simply fail with "permission denied" and return a message asking for permissions that will never be granted. All 3 parallel agents in this session failed identically.
+
+## Why
+
+The `/hub-make` workflow spawned 3 executor agents to build 3 HTML files in parallel. All 3 returned without writing anything because Write and Bash tools were denied. The total wasted time was ~5 minutes across all agents. The fix: build all 3 files directly in the main context using parallel Write tool calls (which CAN prompt the user).
+
+## How to apply
+
+- **Don't spawn subagents for file creation** unless you know permissions are pre-granted (e.g. `mode: "auto"` or `mode: "bypassPermissions"`)
+- For parallel file writes: use multiple `Write` tool calls in a single message — they run in parallel and can each prompt the user
+- For parallel reads/searches: subagents work fine since Read/Grep/Glob are typically allowed
+- If an agent fails with permission denial, don't retry — build directly in the main context
+
+## Counter / Caveats
+
+This only applies when the user hasn't pre-granted tool permissions. In `bypassPermissions` or `auto` mode, subagents work as expected. The issue is specific to interactive permission modes.

--- a/knowledge/pitfall/windows-python-utf8-explicit.md
+++ b/knowledge/pitfall/windows-python-utf8-explicit.md
@@ -1,0 +1,30 @@
+---
+name: windows-python-utf8-explicit
+description: "On Windows, Python defaults to cp949/cp1252 locale encoding — all file I/O on UTF-8 content (JSON with em-dashes, CJK text) must specify encoding='utf-8' explicitly"
+type: knowledge
+category: pitfall
+source:
+  kind: session
+  ref: session-2026-04-16-hub-install-all
+confidence: high
+tags: [windows, python, encoding, utf-8, cp949]
+---
+
+## Fact
+
+Python on Windows defaults to the system locale encoding (cp949 for Korean, cp1252 for Western). Reading a UTF-8 JSON file containing em-dashes (U+2014), CJK characters, or other non-ASCII without `encoding='utf-8'` raises `UnicodeDecodeError: 'cp949' codec can't decode byte 0xe2`. Similarly, `print()` to stdout fails with `UnicodeEncodeError` for the same characters.
+
+## Why
+
+The skills-hub `index.json` contains em-dashes in skill descriptions. A Python script reading it with `open(path)` (no encoding param) failed immediately on the first em-dash character. Fix required adding `encoding='utf-8'` to every `open()` call for both reads and writes, plus wrapping stdout for print statements.
+
+## How to apply
+
+- **Every** `open()` call on files that may contain non-ASCII: `open(path, encoding='utf-8')`
+- For stdout: `sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')` or redirect output to a file
+- For JSON: `json.dump(..., ensure_ascii=True)` sidesteps the issue by escaping non-ASCII, but loses readability
+- Use `datetime.now(timezone.utc)` not `datetime.utcnow()` (deprecated in Python 3.12+)
+
+## Counter / Caveats
+
+Setting `PYTHONUTF8=1` environment variable makes Python default to UTF-8 on Windows, but this is a global setting that may affect other scripts. The explicit `encoding=` parameter is safer per-call.

--- a/skills/workflow/hub-make-parallel-build/SKILL.md
+++ b/skills/workflow/hub-make-parallel-build/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: hub-make-parallel-build
+description: "Build multiple zero-dep single-file HTML apps in parallel from installed skills/knowledge data, verify, and publish via PR branch"
+category: workflow
+version: 1.0.0
+triggers:
+  - hub-make
+  - build examples
+  - parallel html build
+tags: [hub-make, parallel, html, zero-dep, examples, publish]
+---
+
+# Hub-Make Parallel Build
+
+## Purpose
+
+Efficient workflow for building multiple self-contained browser apps from skills-hub data in a single session. Each app embeds skill/knowledge data directly as JS constants — no server, no build step, no dependencies.
+
+## When to Activate
+
+- `/hub-make` with multiple candidates selected
+- User says "build all" or "전체" after candidate presentation
+- Batch creation of hub examples
+
+## Workflow
+
+### 1. Data Collection Phase
+Gather all source data upfront before building:
+- Read `index.json` for skill metadata (name, category, description)
+- Read knowledge `.md` files for content (pitfall, arch, decision categories)
+- Export to temp JSON if needed for embedding
+
+### 2. Parallel Build Phase
+- Create all project directories in one `mkdir -p` call
+- Write all HTML files in parallel `Write` tool calls (no dependencies between projects)
+- Each file is self-contained: HTML + CSS + JS in single file, data embedded as JS constants
+
+### 3. Verify Phase
+- Run `node -e` checks: confirm `</html>`, `</script>`, `</style>` tags present
+- Open all files in browser via `start ""` commands
+- Check file sizes are reasonable (10-25KB typical for data-rich single-file apps)
+
+### 4. Publish Phase — ALWAYS via PR branch
+```bash
+git checkout -b feat/<branch-name>
+# copy files + write manifest.json + README.md per example
+git add && git commit
+git push -u origin <branch>
+gh pr create --base main --head <branch>
+```
+**Never push directly to main.**
+
+## Key Patterns
+
+- **Data embedding**: `const SKILLS=[{n:"name",c:"cat",d:"desc"},...]` — compact but readable
+- **Zero-dep dark theme**: CSS custom properties + glassmorphism (`backdrop-filter:blur()`)
+- **Search**: TF-IDF in pure JS (~20 lines) with weighted fields
+- **Interactivity**: Vanilla JS event delegation, no framework overhead
+- **Responsive**: CSS Grid with `auto-fill, minmax()` for card layouts
+
+## Anti-patterns Discovered
+
+- Don't spawn subagents for file writes — they lack tool permissions. Build directly.
+- Don't use Python on Windows without `encoding='utf-8'` on every `open()` call.
+- Don't assume registry.json uses arrays — it uses dicts keyed by name.

--- a/skills/workflow/hub-make-parallel-build/content.md
+++ b/skills/workflow/hub-make-parallel-build/content.md
@@ -1,0 +1,86 @@
+# Implementation Reference
+
+## Manifest Template
+
+```json
+{
+  "slug": "<kebab-case-name>",
+  "title": "<Human Readable Title>",
+  "summary": "<One sentence describing what it does and why>",
+  "stack": ["html", "css", "js"],
+  "tags": ["<relevant>", "<tags>"],
+  "created_at": "<YYYY-MM-DD>",
+  "source_project": "hub-make",
+  "runtime": "browser",
+  "entrypoint": "index.html",
+  "author": "<email>"
+}
+```
+
+## README Template
+
+```markdown
+# <Title>
+
+> **Why.** <One paragraph explaining the gap this fills>
+
+## What it does
+<Bullet list of features>
+
+## Stack
+Single HTML file, zero external dependencies. Pure HTML + CSS + JS.
+
+## How to run
+Open `index.html` in any modern browser.
+```
+
+## PR Creation Pattern
+
+```bash
+# 1. Branch from main
+git checkout -b feat/hub-make-<N>-examples
+
+# 2. Copy artifacts
+cp project/index.html example/<slug>/index.html
+
+# 3. Add metadata
+# Write manifest.json + README.md
+
+# 4. Commit + push + PR
+git add example/<slug>/
+git commit -m "Add <N> new examples: <slugs>"
+git push -u origin feat/hub-make-<N>-examples
+gh pr create --base main --head feat/hub-make-<N>-examples \
+  --title "Add <N> new hub-make examples" \
+  --body "<summary + test plan>"
+```
+
+## TF-IDF Matching (Minimal Implementation)
+
+```javascript
+function tokenize(s) {
+  return s.toLowerCase().replace(/[^a-z0-9\-\s]/g, '')
+    .split(/[\s\-]+/).filter(t => t.length > 2);
+}
+
+function tfidf(query, corpus) {
+  const qt = tokenize(query);
+  if (!qt.length) return [];
+  const df = {};
+  corpus.forEach(s => {
+    const st = new Set(tokenize(s.name + ' ' + s.desc + ' ' + s.category));
+    st.forEach(t => { df[t] = (df[t] || 0) + 1 });
+  });
+  const N = corpus.length;
+  return corpus.map(s => {
+    const nt = tokenize(s.name), dt = tokenize(s.desc);
+    let score = 0;
+    qt.forEach(q => {
+      const idf = Math.log(N / (1 + (df[q] || 0)));
+      score += (nt.filter(t => t.includes(q)).length * 1.5
+              + dt.filter(t => t.includes(q)).length * 2) * idf;
+    });
+    return { ...s, score };
+  }).filter(s => s.score > 0).sort((a, b) => b.score - a.score);
+}
+```


### PR DESCRIPTION
## Skills

| Category | Name | Version |
|----------|------|---------|
| workflow | `hub-make-parallel-build` | v1.0.0 |

## Knowledge

| Category | Slug | Confidence |
|----------|------|------------|
| pitfall | `registry-json-dict-not-list` | high |
| pitfall | `windows-python-utf8-explicit` | high |
| pitfall | `subagent-permission-denial-fallback` | high |
| decision | `always-pr-branch-never-direct-push` | high |

## Source

Session 2026-04-16 — `/hub-install-all` + `/hub-make` (6 examples built, published via PR #97)

🤖 Generated with [Claude Code](https://claude.com/claude-code)