### PR TITLE
Bootstrap v2.1.0: add /hub-install-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ bootstrap/
     hub-list-skills.md
     hub-list-knowledge.md
     hub-list-examples.md
+    hub-install-example.md
     hub-show.md
     hub-status.md
     hub-sync.md
@@ -124,6 +125,7 @@ Should report "no skills installed yet" plus the empty registry — proves the h
 | `/hub-list-skills` | Show installed skills with source, version, pin state | no |
 | `/hub-list-knowledge [--category/--tag/--linked-to/--orphans]` | List locally installed knowledge entries | no |
 | `/hub-list-examples [--refresh/--verbose]` | List projects published under `example/` in the remote | no |
+| `/hub-install-example [keyword] [--list/--stack=/--open]` | Browse and install example projects from `example/` into cwd | local copy |
 | `/hub-show <name>` | Display the full content of an installed skill or knowledge entry | no |
 | `/hub-status` | Show a compact summary of the skills hub (counts, staleness, health) | no |
 | `/hub-sync [--skill=.. --version=..]` | Refresh cache; bulk update, targeted rollback, or `--unpin` | local |
@@ -174,6 +176,10 @@ Should report "no skills installed yet" plus the empty registry — proves the h
 /hub-install backend         → grab useful backend patterns
 
 # During work — nothing needed, installed skills auto-activate via triggers
+
+# Browse & install example projects
+/hub-install-example dashboard → search + install matching examples
+/hub-install-example --list    → browse all available examples
 
 # Extract what you learned
 /hub-extract-session          → drafts from just this session

--- a/bootstrap/commands/hub-install-example.md
+++ b/bootstrap/commands/hub-install-example.md
@@ -1,0 +1,75 @@
+---
+description: Browse and install examples from kjuhwa/skills.git into the current project directory
+argument-hint: [keyword] [--list] [--stack=<name>] [--open]
+---
+
+# /hub-install-example $ARGUMENTS
+
+Install example projects from the central repository into the current working directory.
+
+## Steps
+
+1. **Ensure remote cache exists**
+   - Path: `~/.claude/skills-hub/remote/`
+   - If missing: `git clone https://github.com/kjuhwa/skills.git ~/.claude/skills-hub/remote` (full clone).
+   - If present and older than 1h: `git -C ~/.claude/skills-hub/remote fetch --tags --prune origin && git -C ~/.claude/skills-hub/remote reset --hard origin/main`.
+
+2. **Scan available examples**
+   - Read all `example/*/manifest.json` files from the remote cache.
+   - Build a list: `slug`, `title`, `stack[]`, `created_at`.
+   - If no `manifest.json` exists for an example dir, infer slug from directory name and mark stack as `unknown`.
+
+3. **Filter**
+   - If `$ARGUMENTS` contains `--list` (no keyword): show all examples as a numbered table and stop.
+   - If keyword provided: match against `slug`, `title`, and `stack[]` (case-insensitive, substring match).
+   - If `--stack=<name>` flag present: also filter by stack array containing that value.
+
+4. **Present matches**
+   - Show a numbered list:
+     ```
+      #  Slug                          Stack                Created
+      1  circuit-breaker-dashboard     html, css, vanilla-js  2026-04-16
+      2  backpressure-pipeline         html, css, vanilla-js  2026-04-16
+     ```
+   - If zero matches: list all available slugs and stop.
+   - If exactly 1 match: auto-select it, show details and confirm.
+
+5. **Ask user** which to install (accept number, slug name, `all`, or `cancel`).
+
+6. **Install selected example(s)**
+   - Destination: `./<slug>/` in the current working directory.
+   - If destination already exists: warn and ask overwrite / skip / rename.
+   - Copy the entire `example/<slug>/` directory from the remote cache to the destination.
+   - Preserve directory structure (some examples have subdirectories like `browser/`).
+
+7. **Post-install**
+   - Show the installed file list.
+   - If `--open` flag present AND `index.html` exists in the installed example: open it in the default browser (`start` on Windows, `open` on macOS, `xdg-open` on Linux).
+   - Print: `Installed <slug> → ./<slug>/`
+
+## Examples
+
+```bash
+# List all available examples
+/hub-install-example --list
+
+# Search by keyword
+/hub-install-example dashboard
+
+# Filter by stack
+/hub-install-example --stack=react
+
+# Install and open in browser
+/hub-install-example circuit-breaker-dashboard --open
+
+# Install multiple
+/hub-install-example pipeline
+```
+
+## Rules
+
+- **Read-only on remote cache.** Copy files out; never modify the cache.
+- Never install without explicit user confirmation unless only 1 exact-slug match.
+- If the example contains a `package.json`, remind the user to run `npm install` after installation.
+- Do NOT modify any installed files — deliver them exactly as they exist in the remote.
+- If `$ARGUMENTS` is empty, behave as `--list`.


### PR DESCRIPTION
## Summary
- New `/hub-install-example` command: browse and install example projects from `example/` into cwd
- Supports keyword search, `--stack=` filtering, `--list` browsing, and `--open` to launch in browser
- Updated README.md: layout section, command reference table, and typical workflow

## Files changed
- `bootstrap/commands/hub-install-example.md` (new)
- `README.md` (3 additions)

## Tag
`bootstrap/v2.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)