### PR TITLE
Cleanup: reindex 354 skills

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,1682 +1,4565 @@
 [
   {
+    "name": "actor-model-data-simulation",
+    "slug": "actor-model-data-simulation",
+    "category": "workflow",
+    "description": "Simulate actor system behavior using timer-driven state mutation with probabilistic failure injection and staged restart recovery.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "actor model data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/actor-model-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "actor-model-visualization-pattern",
+    "slug": "actor-model-visualization-pattern",
+    "category": "design",
+    "description": "Render actor systems using layered visual encoding — shape for identity, color for health state, animation for message activity, and spatial layout for hierarchy.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "actor model visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/actor-model-visualization-pattern",
+    "has_content": false
+  },
+  {
     "name": "adaptive-strategy-hot-swap",
+    "slug": "adaptive-strategy-hot-swap",
     "category": "arch",
     "description": "Periodically re-evaluate candidate strategies/policies against recent data, swap the active one only when a weighted composite score beats the incumbent by a hysteresis threshold — prevents flapping while staying adaptive.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/arch/adaptive-strategy-hot-swap/SKILL.md"
+    "path": "skills/arch/adaptive-strategy-hot-swap",
+    "has_content": true
   },
   {
     "name": "ag-grid-cell-renderer-pattern",
+    "slug": "ag-grid-cell-renderer-pattern",
     "category": "frontend",
     "description": "Structured AG-Grid custom cell renderer catalog with typed column definitions and category-based organization",
+    "tags": [],
+    "triggers": [
+      "ag-grid",
+      "cell renderer",
+      "grid column",
+      "custom renderer",
+      "grid cell"
+    ],
     "version": "1.0.0",
-    "path": "skills/frontend/ag-grid-cell-renderer-pattern/SKILL.md"
+    "path": "skills/frontend/ag-grid-cell-renderer-pattern",
+    "has_content": true
   },
   {
     "name": "ag-grid-custom-filter-system",
+    "slug": "ag-grid-custom-filter-system",
     "category": "design",
     "description": "ag-grid Enterprise wrapper with GridContext provider, custom filter components (Boolean, Number, DateRange, SelectMulti), and pagination state management",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/design/ag-grid-custom-filter-system/SKILL.md"
+    "path": "skills/design/ag-grid-custom-filter-system",
+    "has_content": false
   },
   {
     "name": "ai-call-with-mock-fallback",
+    "slug": "ai-call-with-mock-fallback",
     "category": "ai",
     "description": "Wrap unreliable LLM/AI calls with a deterministic mock fallback so the UI always receives a valid shape — annotate the response with a `mock: true` or `error:` field so the client can show a badge.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/ai/ai-call-with-mock-fallback/SKILL.md"
+    "path": "skills/ai/ai-call-with-mock-fallback",
+    "has_content": true
   },
   {
     "name": "ai-subagent-scope-narrowing",
+    "slug": "ai-subagent-scope-narrowing",
     "category": "ai",
     "description": "Orchestrator-first pattern for multi-agent AI coding — humans triage and curate context per task, subagents execute in isolated worktrees with narrowly-scoped briefs. Trades parallel throughput for reduced hallucination.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/ai/ai-subagent-scope-narrowing/SKILL.md"
+    "path": "skills/ai/ai-subagent-scope-narrowing",
+    "has_content": true
   },
   {
     "name": "antd-wrapper-component-pattern",
+    "slug": "antd-wrapper-component-pattern",
     "category": "design",
     "description": "Wrap Ant Design components with a custom design system layer (Sirius pattern) that extends props, enforces standards, and maintains upgrade compatibility",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/design/antd-wrapper-component-pattern/SKILL.md"
+    "path": "skills/design/antd-wrapper-component-pattern",
+    "has_content": false
+  },
+  {
+    "name": "api-versioning-data-simulation",
+    "slug": "api-versioning-data-simulation",
+    "category": "workflow",
+    "description": "Generate synthetic API version traffic, changelog events, and consumer migration progress for realistic demos",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "api versioning data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/api-versioning-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "api-versioning-visualization-pattern",
+    "slug": "api-versioning-visualization-pattern",
+    "category": "design",
+    "description": "Three-panel visual encoding for API version lifecycle — timeline, traffic flow, and deprecation health",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "api versioning visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/api-versioning-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "async-subagent-resume-on-missing-artifact",
+    "slug": "async-subagent-resume-on-missing-artifact",
     "category": "workflow",
     "description": "When an async subagent is reported \"completed\" but its final message hints at unfinished work (e.g., \"Now let me build…\"), verify the expected on-disk artifact before moving on; if missing, use SendMessage to the agent id to finalize rather than re-dispatching a fresh agent.",
+    "tags": [],
+    "triggers": [
+      "\"agent completed but artifact missing\"",
+      "\"subagent incomplete output\""
+    ],
     "version": "1.0.0",
-    "path": "skills/workflow/async-subagent-resume-on-missing-artifact/SKILL.md"
+    "path": "skills/workflow/async-subagent-resume-on-missing-artifact",
+    "has_content": false
   },
   {
     "name": "audit-change-data-capture-pattern",
+    "slug": "audit-change-data-capture-pattern",
     "category": "backend",
     "description": "Compute before/after diffs for audit logs by comparing two BSON/JSON documents field-by-field — always iterate the BEFORE doc and read from AFTER to avoid prev/after swap bugs",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/audit-change-data-capture-pattern/SKILL.md"
+    "path": "skills/backend/audit-change-data-capture-pattern",
+    "has_content": true
+  },
+  {
+    "name": "autoplan",
+    "slug": "autoplan",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/autoplan",
+    "has_content": false
   },
   {
     "name": "availability-ttl-punctuate-processor",
+    "slug": "availability-ttl-punctuate-processor",
     "category": "backend",
     "description": "Kafka Streams processor schedules a wall-clock `punctuate` for TTL eviction of the state store, and emits downstream only on value change. Wall-clock (not stream-time) so idle inputs still trigger cleanup.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/availability-ttl-punctuate-processor/SKILL.md"
+    "path": "skills/backend/availability-ttl-punctuate-processor",
+    "has_content": true
   },
   {
-    "name": "avro-event-change-flags",
+    "name": "avro-event-with-change-flags",
+    "slug": "avro-event-change-flags",
     "category": "backend",
     "description": "Design Kafka Avro event schemas that carry an actionType enum plus boolean \"changed\" flags per mutable section so consumers can branch cheaply without diffing payloads.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/avro-event-change-flags/SKILL.md"
+    "path": "skills/backend/avro-event-change-flags",
+    "has_content": true
   },
   {
     "name": "avro-gradle-kafka-schema-pipeline",
+    "slug": "avro-gradle-kafka-schema-pipeline",
     "category": "backend",
     "description": "Wire the davidmc24 Avro Gradle plugin so .avsc schemas generate Java sources consumed by Kafka producers/consumers with Confluent Schema Registry",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/avro-gradle-kafka-schema-pipeline/SKILL.md"
+    "path": "skills/backend/avro-gradle-kafka-schema-pipeline",
+    "has_content": true
   },
   {
     "name": "axios-refresh-queue-zustand",
+    "slug": "axios-refresh-queue-zustand",
     "category": "frontend",
     "description": "Axios response interceptor that intercepts 401, queues concurrent failed requests, refreshes the token once, and replays queued requests with the new token. Prevents thundering-herd refresh calls.",
+    "tags": [
+      "axios",
+      "jwt",
+      "refresh-token",
+      "interceptor",
+      "zustand",
+      "auth"
+    ],
+    "triggers": [
+      "axios 401 refresh",
+      "token refresh queue",
+      "isRefreshing flag",
+      "axios interceptor zustand",
+      "refresh thundering herd",
+      "retry original request"
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/frontend/axios-refresh-queue-zustand/SKILL.md"
+    "path": "skills/frontend/axios-refresh-queue-zustand",
+    "has_content": true
   },
   {
     "name": "axios-token-refresh-queue",
+    "slug": "axios-token-refresh-queue",
     "category": "backend",
     "description": "Axios interceptor with window-scoped request queue during JWT token refresh to prevent concurrent refresh races",
+    "tags": [],
+    "triggers": [
+      "token refresh",
+      "axios interceptor",
+      "jwt refresh",
+      "401 retry",
+      "authentication interceptor"
+    ],
     "version": "1.0.0",
-    "path": "skills/backend/axios-token-refresh-queue/SKILL.md"
+    "path": "skills/backend/axios-token-refresh-queue",
+    "has_content": true
+  },
+  {
+    "name": "backpressure-data-simulation",
+    "slug": "backpressure-data-simulation",
+    "category": "workflow",
+    "description": "Strategies for generating realistic backpressure scenarios with controllable producer/consumer imbalance, wave propagation, and load-shedding behavior.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "backpressure data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/backpressure-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "backpressure-visualization-pattern",
+    "slug": "backpressure-visualization-pattern",
+    "category": "design",
+    "description": "Reusable visual encoding patterns for rendering backpressure state across pipeline, wave, and dashboard views using Canvas and CSS.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "backpressure visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/backpressure-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "baseline-historical-comparison-threshold",
+    "slug": "baseline-historical-comparison-threshold",
     "category": "backend",
     "description": "Evaluate a current metric against a historical baseline (prev hour/day/week/month/year, with MIN/AVG/MAX aggregation) as a dynamic threshold; supports RATE or VALUE change modes and dampening.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/baseline-historical-comparison-threshold/SKILL.md"
+    "path": "skills/backend/baseline-historical-comparison-threshold",
+    "has_content": true
+  },
+  {
+    "name": "benchmark",
+    "slug": "benchmark",
+    "category": "testing",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/testing/benchmark",
+    "has_content": false
+  },
+  {
+    "name": "bff-pattern-data-simulation",
+    "slug": "bff-pattern-data-simulation",
+    "category": "workflow",
+    "description": "Stochastic latency simulation modeling per-service delays, BFF overhead, and sequential-vs-parallel aggregation to generate realistic request traces.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "bff pattern data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/bff-pattern-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "bff-pattern-visualization-pattern",
+    "slug": "bff-pattern-visualization-pattern",
+    "category": "design",
+    "description": "Three-tier canvas/SVG flow diagram showing client-to-BFF-to-microservice request routing with animated particle traces and glow-on-select feedback.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "bff pattern visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/bff-pattern-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "name": "blue-green-deploy-data-simulation",
+    "slug": "blue-green-deploy-data-simulation",
+    "category": "workflow",
+    "description": "Strategies for generating synthetic blue-green deployment events, traffic metrics, and state transitions for testing and demos.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "blue green deploy data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/blue-green-deploy-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "blue-green-deploy-visualization-pattern",
+    "slug": "blue-green-deploy-visualization-pattern",
+    "category": "design",
+    "description": "Reusable visual encoding patterns for rendering blue-green deployment state, traffic flow, and history on HTML5 Canvas and DOM.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "blue green deploy visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/blue-green-deploy-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "bootrun-jvmargs-jdwp-opens-java21",
+    "slug": "bootrun-jvmargs-jdwp-opens-java21",
     "category": "backend",
     "description": "Bake JDWP debug port and required --add-opens flags into Gradle bootRun so every dev gets the same Java 17/21-compatible local runtime",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/bootrun-jvmargs-jdwp-opens-java21/SKILL.md"
+    "path": "skills/backend/bootrun-jvmargs-jdwp-opens-java21",
+    "has_content": true
+  },
+  {
+    "name": "browse",
+    "slug": "browse",
+    "category": "testing",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.1.0",
+    "path": "skills/testing/browse",
+    "has_content": false
   },
   {
     "name": "bucket-parallel-java-annotation-dispatch",
+    "slug": "bucket-parallel-java-annotation-dispatch",
     "category": "workflow",
     "description": "For bulk Java annotation work (200+ @Operation methods across many controllers, or 500+ @Schema fields across many DTOs), dispatch N parallel executor subagents with disjoint file buckets. Leader runs a single compile at the end; agents never run gradle themselves.",
+    "tags": [],
+    "triggers": [
+      "\"bulk annotation\"",
+      "\"전수 적용\"",
+      "\"controller 전체 주석\"",
+      "\"DTO @Schema 전수\""
+    ],
     "version": "1.0.0",
-    "path": "skills/workflow/bucket-parallel-java-annotation-dispatch/SKILL.md"
+    "path": "skills/workflow/bucket-parallel-java-annotation-dispatch",
+    "has_content": false
   },
   {
     "name": "build-error-triage",
+    "slug": "build-error-triage",
     "category": "debug",
     "description": "Systematic triage workflow for build/compilation errors — classify by root cause (missing symbol, signature mismatch, instantiation failure), then isolate the first error before chasing cascades.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/debug/build-error-triage/SKILL.md"
+    "path": "skills/debug/build-error-triage",
+    "has_content": true
+  },
+  {
+    "name": "bulkhead-data-simulation",
+    "slug": "bulkhead-data-simulation",
+    "category": "workflow",
+    "description": "Tick-based probabilistic simulation patterns for modeling bulkhead breach flooding, thread pool request load, and partition stress testing.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "bulkhead data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/bulkhead-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "bulkhead-visualization-pattern",
+    "slug": "bulkhead-visualization-pattern",
+    "category": "design",
+    "description": "Reusable visual encoding patterns for rendering bulkhead compartmentalization, breach propagation, and structural integrity in canvas/SVG.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "bulkhead visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/bulkhead-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "byte-aware-sms-truncation-with-ellipsis",
+    "slug": "byte-aware-sms-truncation-with-ellipsis",
     "category": "backend",
     "description": "Truncate SMS message body to a byte budget (not char count) per charset, appending '...' without exceeding the budget",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/byte-aware-sms-truncation-with-ellipsis/SKILL.md"
+    "path": "skills/backend/byte-aware-sms-truncation-with-ellipsis",
+    "has_content": true
   },
   {
     "name": "cache-variance-ttl-jitter",
+    "slug": "cache-variance-ttl-jitter",
     "category": "backend",
     "description": "Add ±N% random jitter to cache TTLs so keys written together don't all expire in the same tick, avoiding synchronized recompute storms",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/cache-variance-ttl-jitter/SKILL.md"
+    "path": "skills/backend/cache-variance-ttl-jitter",
+    "has_content": true
   },
   {
     "name": "calendar-cron-vs-spring-cron-migration",
+    "slug": "calendar-cron-vs-spring-cron-migration",
     "category": "backend",
     "description": "Convert between Spring 6-field cron and Quartz/calendar 7-field cron without DST/leap-year regressions",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/calendar-cron-vs-spring-cron-migration/SKILL.md"
+    "path": "skills/backend/calendar-cron-vs-spring-cron-migration",
+    "has_content": true
+  },
+  {
+    "name": "canary",
+    "slug": "canary",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/canary",
+    "has_content": false
+  },
+  {
+    "name": "canary-release-data-simulation",
+    "slug": "canary-release-data-simulation",
+    "category": "workflow",
+    "description": "Tick-based probabilistic generators for canary traffic ratios, error injection, latency degradation, and phased auto-promotion.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "canary release data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/canary-release-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "canary-release-visualization-pattern",
+    "slug": "canary-release-visualization-pattern",
+    "category": "design",
+    "description": "Canvas particle traffic flow, SVG polyline metric charts, and vertical phase-dot timelines for canary deployment UIs.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "canary release visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/canary-release-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "name": "careful",
+    "slug": "careful",
+    "category": "security",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "0.1.0",
+    "path": "skills/security/careful",
+    "has_content": false
+  },
+  {
+    "name": "cdc-data-simulation",
+    "slug": "cdc-data-simulation",
+    "category": "workflow",
+    "description": "Synthetic CDC event generation patterns for realistic stream monitoring, table replay, and pipeline flow testing without a live database.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "cdc data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/cdc-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "cdc-visualization-pattern",
+    "slug": "cdc-visualization-pattern",
+    "category": "design",
+    "description": "Reusable visual encoding for Change Data Capture event streams across canvas, table-diff, and SVG pipeline views.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "cdc visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/cdc-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "challenge-response-auth-redis-ttl",
+    "slug": "challenge-response-auth-redis-ttl",
     "category": "backend",
     "description": "Replay-resistant two-step login — server issues a short-lived random challenge stored in Redis with TTL, client signs/hashes response, bounded attempts per key",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/challenge-response-auth-redis-ttl/SKILL.md"
+    "path": "skills/backend/challenge-response-auth-redis-ttl",
+    "has_content": true
+  },
+  {
+    "name": "chaos-engineering-data-simulation",
+    "slug": "chaos-engineering-data-simulation",
+    "category": "workflow",
+    "description": "Generate synthetic chaos experiment data including failure propagation, resilience scoring, and gameday event timelines for testing and demos.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "chaos engineering data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/chaos-engineering-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "chaos-engineering-visualization-pattern",
+    "slug": "chaos-engineering-visualization-pattern",
+    "category": "design",
+    "description": "Reusable visual encoding for chaos experiment state across service dependency graphs, resilience matrices, and operational dashboards.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "chaos engineering visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/chaos-engineering-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "character-sheet-multi-panel-consistency",
+    "slug": "character-sheet-multi-panel-consistency",
     "category": "ai",
     "description": "Keep a consistent character across multiple diffusion-model image generations by emitting a reusable \"character sheet\" description string from the LLM and prefixing it into every panel's image prompt.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/ai/character-sheet-multi-panel-consistency/SKILL.md"
+    "path": "skills/ai/character-sheet-multi-panel-consistency",
+    "has_content": true
+  },
+  {
+    "name": "checkpoint",
+    "slug": "checkpoint",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/checkpoint",
+    "has_content": false
   },
   {
     "name": "chunked-resource-id-batch-fetch",
+    "slug": "chunked-resource-id-batch-fetch",
     "category": "backend",
     "description": "Split large ID lists into ~1000-item chunks before querying DB or Elasticsearch to avoid bind-parameter limits (MSSQL 2100, Oracle 1000) and OOM on bulk responses",
+    "tags": [],
+    "triggers": [
+      "`WHERE id IN (?, ?, …)` with thousands of IDs",
+      "ES `terms` query near 65536-item ceiling",
+      "monitor/report accepts an unbounded target ID list"
+    ],
     "version": "1.0.0",
-    "path": "skills/backend/chunked-resource-id-batch-fetch/SKILL.md"
+    "path": "skills/backend/chunked-resource-id-batch-fetch",
+    "has_content": true
+  },
+  {
+    "name": "circuit-breaker-data-simulation",
+    "slug": "circuit-breaker-data-simulation",
+    "category": "workflow",
+    "description": "Tick-based probabilistic state machine for generating realistic circuit-breaker open/close/half-open transitions with configurable failure rates and cooldown jitter.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "circuit breaker data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/circuit-breaker-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "circuit-breaker-visualization-pattern",
+    "slug": "circuit-breaker-visualization-pattern",
+    "category": "design",
+    "description": "Three complementary visual metaphors for circuit-breaker state: ring gauge, flow diagram, and time-series timeline.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "circuit breaker visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/circuit-breaker-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "clang-tidy-integration-workflow",
+    "slug": "clang-tidy-integration-workflow",
     "category": "devops",
     "description": "Automated static analysis pipeline using clang-tidy with project-specific checks and suppression strategies for large multi-file C++ codebases.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/devops/clang-tidy-integration-workflow/SKILL.md"
+    "path": "skills/devops/clang-tidy-integration-workflow",
+    "has_content": false
   },
   {
     "name": "claude-cli-from-jvm-via-node-wrapper",
+    "slug": "claude-cli-from-jvm-via-node-wrapper",
     "category": "ai",
     "description": "Shell out to the `claude` CLI from a JVM / Spring Boot app by going through a tiny Node.js wrapper that supplies the required empty stdin — the CLI hangs when invoked with a directly-inherited TTY-less stdin from ProcessBuilder.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/ai/claude-cli-from-jvm-via-node-wrapper/SKILL.md"
+    "path": "skills/ai/claude-cli-from-jvm-via-node-wrapper",
+    "has_content": true
   },
   {
     "name": "claude-code-skill-scaffold",
+    "slug": "claude-code-skill-scaffold",
     "category": "devops",
     "description": "[Tooling] Claude Code 스킬 표준 구조(SKILL.md + prompts/ + scripts/ + references/)를 자동 생성하는 스캐폴딩.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/devops/claude-code-skill-scaffold/SKILL.md"
+    "path": "skills/devops/claude-code-skill-scaffold",
+    "has_content": false
   },
   {
     "name": "claude-plugin-catalog-publish",
+    "slug": "claude-plugin-catalog-publish",
     "category": "devops",
     "description": "[Tooling] 로컬 스킬을 원격 Git repo에 배포하고 AGENTS.md 카탈로그를 자동 갱신하는 publish 플로우.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/devops/claude-plugin-catalog-publish/SKILL.md"
+    "path": "skills/devops/claude-plugin-catalog-publish",
+    "has_content": false
+  },
+  {
+    "name": "codex",
+    "slug": "codex",
+    "category": "ai",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/ai/codex",
+    "has_content": false
   },
   {
     "name": "collection-routing-by-period",
+    "slug": "collection-routing-by-period",
     "category": "backend",
     "description": "Single resolver maps `(Period.Mode, from, to)` → time-series collection (raw view / 1-min / hour-with-monthly-suffix / day). Callers never hardcode collection names.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/collection-routing-by-period/SKILL.md"
+    "path": "skills/backend/collection-routing-by-period",
+    "has_content": true
+  },
+  {
+    "name": "command-query-data-simulation",
+    "slug": "command-query-data-simulation",
+    "category": "workflow",
+    "description": "Prefix-based verb classification and stochastic command/query/event generation for CQRS simulation loops.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "command query data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/command-query-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "command-query-visualization-pattern",
+    "slug": "command-query-visualization-pattern",
+    "category": "design",
+    "description": "Canvas-based dual-lane particle animation showing command (write) and query (read) paths through a CQRS topology.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "command query visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/command-query-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "compact-binary-wire-protocol-with-variable-length-encoding",
+    "slug": "compact-binary-wire-protocol-with-variable-length-encoding",
     "category": "backend",
     "description": "Define a custom binary wire format with variable-length integer encodings (e.g. 3-byte / 5-byte) to minimize UDP packet size for high-volume metric or telemetry streams",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/compact-binary-wire-protocol-with-variable-length-encoding/SKILL.md"
+    "path": "skills/backend/compact-binary-wire-protocol-with-variable-length-encoding",
+    "has_content": false
   },
   {
     "name": "concurrent-jdbc-pool-datasource-lifecycle",
+    "slug": "concurrent-jdbc-pool-datasource-lifecycle",
     "category": "backend",
     "description": "Manage a pool of short-lived JDBC targets for monitoring agents with dual maps (active vs all) and periodic revalidation",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/concurrent-jdbc-pool-datasource-lifecycle/SKILL.md"
+    "path": "skills/backend/concurrent-jdbc-pool-datasource-lifecycle",
+    "has_content": false
   },
   {
     "name": "conditional-feature-flag-rollout",
+    "slug": "conditional-feature-flag-rollout",
     "category": "backend",
     "description": "@ConditionalOnProperty로 구/신 구현을 공존시키고 런타임 속성 하나로 전환하는 점진적 롤아웃 패턴",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/conditional-feature-flag-rollout/SKILL.md"
+    "path": "skills/backend/conditional-feature-flag-rollout",
+    "has_content": true
+  },
+  {
+    "name": "connection-pool-data-simulation",
+    "slug": "connection-pool-data-simulation",
+    "category": "workflow",
+    "description": "Tick-based probabilistic simulation strategies for generating realistic connection-pool demand, state transitions, and lifecycle events.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "connection pool data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/connection-pool-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "connection-pool-visualization-pattern",
+    "slug": "connection-pool-visualization-pattern",
+    "category": "design",
+    "description": "Three complementary visual encodings for connection-pool state — time-series canvas chart, SVG bubble grid, and swimlane lifecycle cards.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "connection pool visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/connection-pool-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "name": "consistent-hashing-data-simulation",
+    "slug": "consistent-hashing-data-simulation",
+    "category": "workflow",
+    "description": "Parameterized simulation of key distribution across physical and virtual nodes with statistical balance metrics.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "consistent hashing data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/consistent-hashing-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "consistent-hashing-visualization-pattern",
+    "slug": "consistent-hashing-visualization-pattern",
+    "category": "design",
+    "description": "Canvas-based visual encoding for consistent hash rings with node-key assignment lines and per-node load counters.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "consistent hashing visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/consistent-hashing-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "name": "cso",
+    "slug": "cso",
+    "category": "security",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/security/cso",
+    "has_content": false
   },
   {
     "name": "custom-actuator-command-whitelist",
+    "slug": "custom-actuator-command-whitelist",
     "category": "backend",
     "description": "Expose safe remote OS command execution on a Spring Boot service via a custom Actuator endpoint, restricted by a command whitelist, an argument sanitizer, and an execution timeout.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/custom-actuator-command-whitelist/SKILL.md"
+    "path": "skills/backend/custom-actuator-command-whitelist",
+    "has_content": true
+  },
+  {
+    "name": "data-pipeline-data-simulation",
+    "slug": "data-pipeline-data-simulation",
+    "category": "workflow",
+    "description": "Strategies for generating synthetic pipeline telemetry — record flow, stage latencies, failure injection, and backpressure signals.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "data pipeline data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/data-pipeline-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "data-pipeline-visualization-pattern",
+    "slug": "data-pipeline-visualization-pattern",
+    "category": "design",
+    "description": "Reusable visual encoding patterns for rendering data pipeline stages, DAG topology, and record flow on Canvas/SVG.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "data pipeline visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/data-pipeline-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "name": "database-sharding-data-simulation",
+    "slug": "database-sharding-data-simulation",
+    "category": "workflow",
+    "description": "Stochastic data-generation strategies for simulating shard routing, load skew, hot-shard spikes, and latency degradation.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "database sharding data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/database-sharding-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "database-sharding-visualization-pattern",
+    "slug": "database-sharding-visualization-pattern",
+    "category": "design",
+    "description": "Canvas-based visual encoding patterns for shard topology, load distribution, and health monitoring in database-sharding UIs.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "database sharding visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/database-sharding-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "debug-lockorder-detection-system",
+    "slug": "debug-lockorder-detection-system",
     "category": "debug",
     "description": "Runtime lock-order deadlock detection via a DEBUG_LOCKORDER compile flag that tracks lock acquisition order and reports circular dependencies.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/debug/debug-lockorder-detection-system/SKILL.md"
+    "path": "skills/debug/debug-lockorder-detection-system",
+    "has_content": false
   },
   {
     "name": "definition-registry-helper-cache",
+    "slug": "definition-registry-helper-cache",
     "category": "arch",
     "description": "Static helper class with ConcurrentHashMap caches populated at startup by @PostConstruct providers, enabling zero-allocation hot-path lookups via static getters",
+    "tags": [],
+    "triggers": [
+      "static helper cache",
+      "ConcurrentHashMap static cache",
+      "PostConstruct populate static map",
+      "definition helper lookup",
+      "zero allocation hot path cache"
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/arch/definition-registry-helper-cache/SKILL.md"
+    "path": "skills/arch/definition-registry-helper-cache",
+    "has_content": false
   },
   {
     "name": "design-an-interface",
+    "slug": "design-an-interface",
     "category": "misc",
     "description": "Generate multiple radically different interface designs for a module using parallel sub-agents. Use when user wants to design an API, explore interface options, compare module shapes, or mentions \"design it twice\".",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/misc/design-an-interface/SKILL.md"
+    "path": "skills/misc/design-an-interface",
+    "has_content": false
+  },
+  {
+    "name": "design-consultation",
+    "slug": "design-consultation",
+    "category": "design",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/design/design-consultation",
+    "has_content": false
+  },
+  {
+    "name": "design-html",
+    "slug": "design-html",
+    "category": "design",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/design/design-html",
+    "has_content": false
+  },
+  {
+    "name": "design-review",
+    "slug": "design-review",
+    "category": "design",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/design/design-review",
+    "has_content": false
+  },
+  {
+    "name": "design-shotgun",
+    "slug": "design-shotgun",
+    "category": "design",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/design/design-shotgun",
+    "has_content": false
   },
   {
     "name": "deterministic-coverage-verification",
+    "slug": "deterministic-coverage-verification",
     "category": "testing",
     "description": "Run LLVM-instrumented tests multiple times and verify identical coverage reports — catches compiler/env non-determinism that can mask real bugs.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/testing/deterministic-coverage-verification/SKILL.md"
+    "path": "skills/testing/deterministic-coverage-verification",
+    "has_content": false
   },
   {
     "name": "dev-controller-tenant-wrapping-helper",
+    "slug": "dev-controller-tenant-wrapping-helper",
     "category": "backend",
     "description": "Dev/로컬 전용 컨트롤러의 테넌트+JWT 반복 래핑을 함수형 인터페이스 + 헬퍼 컴포넌트로 추출",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/dev-controller-tenant-wrapping-helper/SKILL.md"
+    "path": "skills/backend/dev-controller-tenant-wrapping-helper",
+    "has_content": true
+  },
+  {
+    "name": "devex-review",
+    "slug": "devex-review",
+    "category": "testing",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/testing/devex-review",
+    "has_content": false
   },
   {
     "name": "distributed-lock-mongodb",
+    "slug": "distributed-lock-mongodb",
     "category": "backend",
     "description": "MongoDB findAndModify-based distributed lock with TTL expiry, owner tagging, and retry loop for multi-instance Spring Boot services.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/distributed-lock-mongodb/SKILL.md"
+    "path": "skills/backend/distributed-lock-mongodb",
+    "has_content": true
+  },
+  {
+    "name": "distributed-tracing-data-simulation",
+    "slug": "distributed-tracing-data-simulation",
+    "category": "workflow",
+    "description": "Three strategies for generating synthetic distributed trace data — flat span lists, directed service graphs, and recursive span trees.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "distributed tracing data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/distributed-tracing-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "distributed-tracing-visualization-pattern",
+    "slug": "distributed-tracing-visualization-pattern",
+    "category": "design",
+    "description": "Three complementary visual encodings for rendering distributed traces — waterfall timeline, service topology graph, and span flame chart.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "distributed tracing visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/distributed-tracing-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "divide-by-zero-rate-guard",
+    "slug": "divide-by-zero-rate-guard",
     "category": "backend",
     "description": "Guard rate/percentage calculations against zero denominators to prevent NaN from poisoning downstream metrics and serialization.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/divide-by-zero-rate-guard/SKILL.md"
+    "path": "skills/backend/divide-by-zero-rate-guard",
+    "has_content": false
   },
   {
     "name": "dnd-kit-tab-reordering",
+    "slug": "dnd-kit-tab-reordering",
     "category": "design",
     "description": "Implement horizontal tab drag reordering using @dnd-kit/core + @dnd-kit/sortable with PointerSensor and CSS.Transform",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/design/dnd-kit-tab-reordering/SKILL.md"
+    "path": "skills/design/dnd-kit-tab-reordering",
+    "has_content": false
   },
   {
     "name": "docker-compose-service-inventory-files",
+    "slug": "docker-compose-service-inventory-files",
     "category": "devops",
     "description": "Manage large Docker Compose service fleets using flat inventory files with '#' as an EX (exclude) marker",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/devops/docker-compose-service-inventory-files/SKILL.md"
+    "path": "skills/devops/docker-compose-service-inventory-files",
+    "has_content": true
   },
   {
     "name": "docker-compose-v1-v2-auto-detect",
+    "slug": "docker-compose-v1-v2-auto-detect",
     "category": "devops",
     "description": "Shell helper that prefers `docker compose` (v2) over `docker-compose` (v1) with graceful fallback",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/devops/docker-compose-v1-v2-auto-detect/SKILL.md"
+    "path": "skills/devops/docker-compose-v1-v2-auto-detect",
+    "has_content": true
+  },
+  {
+    "name": "document-release",
+    "slug": "document-release",
+    "category": "docs",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/docs/document-release",
+    "has_content": false
   },
   {
     "name": "domain-category-endpoint-registry",
+    "slug": "domain-category-endpoint-registry",
     "category": "arch",
     "description": "Organize a large vendor-API client (100s of endpoints) under a three-level `{domain}/{category}/{Action}{Entity}` package convention with a shared base class and a single `initializeEndpoints()` registry — scalable, greppable, and uniformly logged.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/arch/domain-category-endpoint-registry/SKILL.md"
+    "path": "skills/arch/domain-category-endpoint-registry",
+    "has_content": true
+  },
+  {
+    "name": "domain-driven-data-simulation",
+    "slug": "domain-driven-data-simulation",
+    "category": "workflow",
+    "description": "Structured command-event-state triplets for simulating aggregate lifecycles and context relationships.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "domain driven data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/domain-driven-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "domain-driven-visualization-pattern",
+    "slug": "domain-driven-visualization-pattern",
+    "category": "design",
+    "description": "Canvas and card-based visual encodings for DDD strategic and tactical concepts with interactive exploration.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "domain driven visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/domain-driven-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "dotenv-multi-env-routing",
+    "slug": "dotenv-multi-env-routing",
     "category": "backend",
     "description": "Single ENV variable flips an entire stack (REST base URL, WebSocket base, per-operation transaction IDs) between production and sandbox tiers, loaded via dotenv with OS-env precedence.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/backend/dotenv-multi-env-routing/SKILL.md"
+    "path": "skills/backend/dotenv-multi-env-routing",
+    "has_content": true
   },
   {
     "name": "drawer-resizable-composition",
+    "slug": "drawer-resizable-composition",
     "category": "frontend",
     "description": "Drawer-as-primary-modal pattern with preset widths, resizable handles, and parent state composition for React apps",
+    "tags": [],
+    "triggers": [
+      "drawer",
+      "modal drawer",
+      "resizable drawer",
+      "side panel"
+    ],
     "version": "1.0.0",
-    "path": "skills/frontend/drawer-resizable-composition/SKILL.md"
+    "path": "skills/frontend/drawer-resizable-composition",
+    "has_content": true
   },
   {
     "name": "drawer-resizable-mouse-drag",
+    "slug": "drawer-resizable-mouse-drag",
     "category": "design",
     "description": "Make Ant Design Drawer resizable via mouse drag with styled-components handle, min/max width constraints, and transition suppression during drag",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/design/drawer-resizable-mouse-drag/SKILL.md"
+    "path": "skills/design/drawer-resizable-mouse-drag",
+    "has_content": false
   },
   {
     "name": "dry-run-confirm-retry-write-flow",
+    "slug": "dry-run-confirm-retry-write-flow",
     "category": "backend",
     "description": "[Backend] 트래커/외부 API 쓰기 작업에 적용하는 공통 플로우: 미리보기 → 사용자 확인 → 쓰기 → 재시도.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/dry-run-confirm-retry-write-flow/SKILL.md"
+    "path": "skills/backend/dry-run-confirm-retry-write-flow",
+    "has_content": false
   },
   {
     "name": "dual-jre-docker-oz-report",
+    "slug": "dual-jre-docker-oz-report",
     "category": "devops",
     "description": "Package a Java 21 Spring Boot app that bundles a legacy JRE 8 + sidecar Tomcat (OZ Report engine) in one Alpine container",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/devops/dual-jre-docker-oz-report/SKILL.md"
+    "path": "skills/devops/dual-jre-docker-oz-report",
+    "has_content": true
   },
   {
     "name": "dynamic-gridfs-template-multi-tenant",
+    "slug": "dynamic-gridfs-template-multi-tenant",
     "category": "backend",
     "description": "Resolve MongoDB GridFsTemplate per (tenant-db, bucket) pair with lazy caching, for storing large binary assets per tenant",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/dynamic-gridfs-template-multi-tenant/SKILL.md"
+    "path": "skills/backend/dynamic-gridfs-template-multi-tenant",
+    "has_content": true
   },
   {
     "name": "echarts-svg-worker-chart",
+    "slug": "echarts-svg-worker-chart",
     "category": "design",
     "description": "High-performance chart component using ECharts with custom SVG overlays (markLine/markArea/markPoint), worker thread data processing, and brush selection interaction",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/design/echarts-svg-worker-chart/SKILL.md"
+    "path": "skills/design/echarts-svg-worker-chart",
+    "has_content": false
   },
   {
     "name": "eclipse-rcp-rich-client-for-apm-ui",
+    "slug": "eclipse-rcp-rich-client-for-apm-ui",
     "category": "apm",
     "description": "Build a desktop-class APM / observability client on Eclipse RCP + ZEST/GEF for high-throughput real-time visualization that HTTP + JSON browsers struggle with",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/apm/eclipse-rcp-rich-client-for-apm-ui/SKILL.md"
+    "path": "skills/apm/eclipse-rcp-rich-client-for-apm-ui",
+    "has_content": false
   },
   {
     "name": "edit-article",
+    "slug": "edit-article",
     "category": "docs",
     "description": "Edit and improve articles by restructuring sections, improving clarity, and tightening prose. Use when user wants to edit, revise, or improve an article draft.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/docs/edit-article/SKILL.md"
+    "path": "skills/docs/edit-article",
+    "has_content": false
   },
   {
     "name": "elasticsearch-xpack-ssl-transport",
+    "slug": "elasticsearch-xpack-ssl-transport",
     "category": "backend",
     "description": "Gate `PreBuiltXPackTransportClient` vs `PreBuiltTransportClient` on auth flag (not SSL flag) and configure keystore/truststore as independent ES X-Pack settings",
+    "tags": [],
+    "triggers": [
+      "connect Java client to X-Pack-secured Elasticsearch cluster",
+      "production ES requires auth and optional transport TLS"
+    ],
     "version": "1.0.0",
-    "path": "skills/backend/elasticsearch-xpack-ssl-transport/SKILL.md"
+    "path": "skills/backend/elasticsearch-xpack-ssl-transport",
+    "has_content": true
   },
   {
     "name": "enable-async-tenant-aware",
+    "slug": "enable-async-tenant-aware",
     "category": "backend",
     "description": "Place @EnableAsync on a dedicated @Configuration that extends a tenant-aware AsyncConfigurer, so tenant/MDC context propagates across the executor boundary",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/enable-async-tenant-aware/SKILL.md"
+    "path": "skills/backend/enable-async-tenant-aware",
+    "has_content": true
   },
   {
     "name": "encrypted-pii-decrypt-before-send",
+    "slug": "encrypted-pii-decrypt-before-send",
     "category": "backend",
     "description": "Store user email/phone encrypted at rest; decrypt only inside the sender, never in cache/DTO/log boundaries",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/encrypted-pii-decrypt-before-send/SKILL.md"
+    "path": "skills/backend/encrypted-pii-decrypt-before-send",
+    "has_content": true
+  },
+  {
+    "name": "etl-data-simulation",
+    "slug": "etl-data-simulation",
+    "category": "workflow",
+    "description": "Generate realistic synthetic ETL pipeline data including job states, row volumes, null distributions, and time-series ingestion metrics for UI prototyping.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "etl data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/etl-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "etl-visualization-pattern",
+    "slug": "etl-visualization-pattern",
+    "category": "design",
+    "description": "Visual encoding patterns for representing ETL pipeline stages, data flow direction, and processing state transitions in dark-themed dashboards.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "etl visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/etl-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "eureka-service-discovery-wait-annotation",
+    "slug": "eureka-service-discovery-wait-annotation",
     "category": "backend",
     "description": "Declarative @WaitForServices annotation on @EventListener methods — blocks initialization until named Eureka services are healthy, with optional leader-only execution",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/eureka-service-discovery-wait-annotation/SKILL.md"
+    "path": "skills/backend/eureka-service-discovery-wait-annotation",
+    "has_content": true
   },
   {
     "name": "event-driven-kafka-scheduling",
+    "slug": "event-driven-kafka-scheduling",
     "category": "backend",
     "description": "Replace Spring @Scheduled with a Kafka-delivered JobExecuteNotice so a central scheduler service fans out tick events — with a skip-if-previous-still-running guard to prevent pile-up.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/event-driven-kafka-scheduling/SKILL.md"
+    "path": "skills/backend/event-driven-kafka-scheduling",
+    "has_content": true
+  },
+  {
+    "name": "event-sourcing-data-simulation",
+    "slug": "event-sourcing-data-simulation",
+    "category": "workflow",
+    "description": "Strategies for generating synthetic event streams with domain-typed events, versioned aggregates, and replay-capable stores for event-sourcing demos.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "event sourcing data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/event-sourcing-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "event-sourcing-visualization-pattern",
+    "slug": "event-sourcing-visualization-pattern",
+    "category": "design",
+    "description": "Reusable visual encoding patterns for rendering event streams, aggregate state, and CQRS data flow in browser-based event-sourcing UIs.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "event sourcing visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/event-sourcing-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "excel-download-null-date-range-handling",
+    "slug": "excel-download-null-date-range-handling",
     "category": "backend",
     "description": "Defensive pattern for grid/list excel-export endpoints — null-check every filter value and normalize field names before querying",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/excel-download-null-date-range-handling/SKILL.md"
+    "path": "skills/backend/excel-download-null-date-range-handling",
+    "has_content": true
   },
   {
     "name": "excel-export-enum-replacer",
+    "slug": "excel-export-enum-replacer",
     "category": "backend",
     "description": "Use DataToBeReplace.builder() to map enum/code values to display labels before passing content to ExcelExportManager.objectToExcelAndDownload()",
+    "tags": [],
+    "triggers": [
+      "excel export enum replace",
+      "DataToBeReplace",
+      "ExcelExportManager",
+      "objectToExcelAndDownload",
+      "excel download controller"
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/backend/excel-export-enum-replacer/SKILL.md"
+    "path": "skills/backend/excel-export-enum-replacer",
+    "has_content": false
   },
   {
     "name": "feed-envelope-frame",
+    "slug": "feed-envelope-frame",
     "category": "backend",
     "description": "Uniform WebSocket payload wrapper with Type (ACK/SNAPSHOT/DELTA/ERROR), PayloadKind, and correlation requestId, including null-safe factory methods",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/feed-envelope-frame/SKILL.md"
+    "path": "skills/backend/feed-envelope-frame",
+    "has_content": true
   },
   {
     "name": "figma-code-connect-react",
+    "slug": "figma-code-connect-react",
     "category": "frontend",
     "description": "Map Figma component variants to React props using @figma/code-connect with co-located *.figma.tsx files",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/frontend/figma-code-connect-react/SKILL.md"
+    "path": "skills/frontend/figma-code-connect-react",
+    "has_content": true
   },
   {
     "name": "figma-token-scss-style-dictionary-v3",
+    "slug": "figma-token-scss-style-dictionary-v3",
     "category": "frontend",
     "description": "Figma Tokens Studio JSON → split files → Style Dictionary v3 → SCSS variables, typography classes, and composition classes",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/frontend/figma-token-scss-style-dictionary-v3/SKILL.md"
+    "path": "skills/frontend/figma-token-scss-style-dictionary-v3",
+    "has_content": true
   },
   {
     "name": "figma-token-to-tailwind-theme",
+    "slug": "figma-token-to-tailwind-theme",
     "category": "design",
     "description": "Pipeline from Figma Token Studio JSON exports through Style Dictionary v5 to Tailwind v4 @theme CSS custom properties, with dark/light/contrast mode support and breaking change detection",
+    "tags": [],
+    "triggers": [],
     "version": "1.1.0",
-    "path": "skills/design/figma-token-to-tailwind-theme/SKILL.md"
+    "path": "skills/design/figma-token-to-tailwind-theme",
+    "has_content": true
+  },
+  {
+    "name": "finite-state-machine-data-simulation",
+    "slug": "finite-state-machine-data-simulation",
+    "category": "workflow",
+    "description": "Canonical FSM data models, transition lookup strategies, and step-through simulation loops for accept/reject testing.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "finite state machine data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/finite-state-machine-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "finite-state-machine-visualization-pattern",
+    "slug": "finite-state-machine-visualization-pattern",
+    "category": "design",
+    "description": "Circular-node state graph with directional arrows, active-state glow, and dark-theme FSM rendering on Canvas/SVG.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "finite state machine visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/finite-state-machine-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "folder-coloc-style-types",
+    "slug": "folder-coloc-style-types",
     "category": "frontend",
     "description": "Keep component, style, and types files at the same depth; never split into styles/ or types/ subfolders",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/frontend/folder-coloc-style-types/SKILL.md"
+    "path": "skills/frontend/folder-coloc-style-types",
+    "has_content": true
   },
   {
     "name": "font-cache-alpine-locale-docker",
+    "slug": "font-cache-alpine-locale-docker",
     "category": "devops",
     "description": "Make CJK/custom fonts usable inside an Alpine container by copying TTF/OTF and rebuilding the fontconfig cache",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/devops/font-cache-alpine-locale-docker/SKILL.md"
+    "path": "skills/devops/font-cache-alpine-locale-docker",
+    "has_content": true
   },
   {
     "name": "freemarker-two-phase-expression-subst",
+    "slug": "freemarker-two-phase-expression-subst",
     "category": "backend",
     "description": "Render templates by first replacing raw ${var} placeholders via string-replace, then running FreeMarker for expression-object binding, avoiding double-evaluation and escape conflicts",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/freemarker-two-phase-expression-subst/SKILL.md"
+    "path": "skills/backend/freemarker-two-phase-expression-subst",
+    "has_content": true
+  },
+  {
+    "name": "freeze",
+    "slug": "freeze",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "0.1.0",
+    "path": "skills/workflow/freeze",
+    "has_content": false
   },
   {
     "name": "frozen-detection-consecutive-count",
+    "slug": "frozen-detection-consecutive-count",
     "category": "backend",
     "description": "Detect a stuck/frozen metric (identical value for N consecutive samples) by CONSECUTIVE-dampening equality check; catches sensor/collector failures that threshold alarms miss.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/frozen-detection-consecutive-count/SKILL.md"
+    "path": "skills/backend/frozen-detection-consecutive-count",
+    "has_content": true
   },
   {
     "name": "fuzz-corpus-seed-management",
+    "slug": "fuzz-corpus-seed-management",
     "category": "testing",
     "description": "Structured libFuzzer workflow — seed corpora in a separate asset repo, determinism verification, and reproducible crash workflows.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/testing/fuzz-corpus-seed-management/SKILL.md"
+    "path": "skills/testing/fuzz-corpus-seed-management",
+    "has_content": false
   },
   {
     "name": "gacha-soft-hard-pity",
+    "slug": "gacha-soft-hard-pity",
     "category": "game-dev",
     "description": "Server-authoritative gacha with soft pity (rate ramp after N pulls), hard pity (guaranteed top rarity at M pulls), and 50/50 guarantee carryover. Split rate calculation from result resolution so probability is testable.",
+    "tags": [
+      "gacha",
+      "pity",
+      "probability",
+      "securerandom",
+      "loot",
+      "rng-fairness"
+    ],
+    "triggers": [
+      "gacha pity system",
+      "soft pity hard pity",
+      "50/50 pity",
+      "banner rate up",
+      "rate calculator"
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/game-dev/gacha-soft-hard-pity/SKILL.md"
+    "path": "skills/game-dev/gacha-soft-hard-pity",
+    "has_content": true
   },
   {
     "name": "git-guardrails-claude-code",
+    "slug": "git-guardrails-claude-code",
     "category": "cli",
     "description": "Set up Claude Code hooks to block dangerous git commands (push, reset --hard, clean, branch -D, etc.) before they execute. Use when user wants to prevent destructive git operations, add git safety hooks, or block git push/reset in Claude Code.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/cli/git-guardrails-claude-code/SKILL.md"
+    "path": "skills/cli/git-guardrails-claude-code",
+    "has_content": false
   },
   {
     "name": "git-tag-registry-versioning",
+    "slug": "git-tag-registry-versioning",
     "category": "arch",
     "description": "Add semver rollback and pinning to any git-backed asset registry (skills, prompts, commands, snippets) using namespaced annotated tags per item and per-release bundle.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/arch/git-tag-registry-versioning/SKILL.md"
+    "path": "skills/arch/git-tag-registry-versioning",
+    "has_content": true
   },
   {
     "name": "github-triage",
+    "slug": "github-triage",
     "category": "workflow",
     "description": "Triage GitHub issues through a label-based state machine with interactive grilling sessions. Use when user wants to triage issues, review incoming bugs or feature requests, prepare issues for an AFK agent, or manage issue workflow.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/workflow/github-triage/SKILL.md"
+    "path": "skills/workflow/github-triage",
+    "has_content": false
   },
   {
     "name": "gradle-bootjar-conditional-archive-bundle",
+    "slug": "gradle-bootjar-conditional-archive-bundle",
     "category": "arch",
     "description": "Gradle Spring Boot build that conditionally bundles the fat JAR plus externalized resources into a dated zip/tar for on-prem delivery, gated by a flag",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/arch/gradle-bootjar-conditional-archive-bundle/SKILL.md"
+    "path": "skills/arch/gradle-bootjar-conditional-archive-bundle",
+    "has_content": true
   },
   {
     "name": "gradle-bootrun-local-dev-env",
+    "slug": "gradle-bootrun-local-dev-env",
     "category": "devops",
     "description": "Gradle bootRun task recipe that wires local MongoDB/Kafka/Redis/MQTT/Eureka/Quartz via environment variables — no docker-compose needed",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/devops/gradle-bootrun-local-dev-env/SKILL.md"
+    "path": "skills/devops/gradle-bootrun-local-dev-env",
+    "has_content": true
   },
   {
     "name": "gradle-jacoco-exclusion-strategy",
+    "slug": "gradle-jacoco-exclusion-strategy",
     "category": "devops",
     "description": "Curated Jacoco/Sonar exclusion patterns for Spring Boot projects — skips config/DAO/entity/generated layers and Querydsl Q-classes",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/devops/gradle-jacoco-exclusion-strategy/SKILL.md"
+    "path": "skills/devops/gradle-jacoco-exclusion-strategy",
+    "has_content": true
   },
   {
     "name": "gradle-shared-exclusions-jacoco-sonar",
+    "slug": "gradle-shared-exclusions-jacoco-sonar",
     "category": "devops",
     "description": "Keep Jacoco report, Jacoco coverage verification, and SonarQube exclusions in sync by defining one `exclusionPatterns` list in Gradle ext",
+    "tags": [],
+    "triggers": [
+      "jacoco and sonarqube exclusion lists drift apart",
+      "adding a new package to coverage exclusions requires editing multiple blocks",
+      "querydsl Q-classes / generated code leaking into coverage reports"
+    ],
     "version": "1.0.0",
-    "path": "skills/devops/gradle-shared-exclusions-jacoco-sonar/SKILL.md"
+    "path": "skills/devops/gradle-shared-exclusions-jacoco-sonar",
+    "has_content": true
   },
   {
     "name": "grid-filter-to-criteria-converter",
+    "slug": "grid-filter-to-criteria-converter",
     "category": "backend",
     "description": "Convert a UI grid filter DTO (gridFilters + tagFilters + pageable) to MongoDB Criteria using CriteriaMakeHelper, supporting equals/contains/greaterThan/inRange operators",
+    "tags": [],
+    "triggers": [
+      "grid filter to criteria",
+      "FiltersPageableDto",
+      "CriteriaMakeHelper",
+      "mongodb dynamic filter",
+      "UI filter to query"
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/backend/grid-filter-to-criteria-converter/SKILL.md"
+    "path": "skills/backend/grid-filter-to-criteria-converter",
+    "has_content": false
   },
   {
     "name": "grill-me",
+    "slug": "grill-me",
     "category": "workflow",
     "description": "Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions \"grill me\".",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/workflow/grill-me/SKILL.md"
+    "path": "skills/workflow/grill-me",
+    "has_content": false
+  },
+  {
+    "name": "gstack",
+    "slug": "gstack",
+    "category": "cli",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.1.0",
+    "path": "skills/cli/gstack",
+    "has_content": false
+  },
+  {
+    "name": "gstack-qa",
+    "slug": "gstack-qa",
+    "category": "testing",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/testing/gstack-qa",
+    "has_content": false
+  },
+  {
+    "name": "gstack-qa-only",
+    "slug": "gstack-qa-only",
+    "category": "testing",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/testing/gstack-qa-only",
+    "has_content": false
+  },
+  {
+    "name": "gstack-upgrade",
+    "slug": "gstack-upgrade",
+    "category": "cli",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.1.0",
+    "path": "skills/cli/gstack-upgrade",
+    "has_content": false
+  },
+  {
+    "name": "guard",
+    "slug": "guard",
+    "category": "security",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "0.1.0",
+    "path": "skills/security/guard",
+    "has_content": false
+  },
+  {
+    "name": "health",
+    "slug": "health",
+    "category": "testing",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/testing/health",
+    "has_content": false
+  },
+  {
+    "name": "health-check-data-simulation",
+    "slug": "health-check-data-simulation",
+    "category": "workflow",
+    "description": "Stochastic tick-based simulation of service latency, resource utilization, and uptime status using biased random walks with threshold-triggered state transitions.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "health check data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/health-check-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "health-check-visualization-pattern",
+    "slug": "health-check-visualization-pattern",
+    "category": "design",
+    "description": "Three-tier visual encoding for service health — traffic-light palette, temporal pulse lines, and calendar heatmaps on a dark operations background.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "health check visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/health-check-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "name": "hexagonal-architecture-data-simulation",
+    "slug": "hexagonal-architecture-data-simulation",
+    "category": "workflow",
+    "description": "Structured node-edge-layer data model for simulating request flows, component placement, and dependency graphs in hexagonal architectures.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "hexagonal architecture data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/hexagonal-architecture-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "hexagonal-architecture-visualization-pattern",
+    "slug": "hexagonal-architecture-visualization-pattern",
+    "category": "design",
+    "description": "Three-ring concentric hexagon layout with layer-coded nodes, inward-flow edges, and polar positioning for domain/port/adapter components.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "hexagonal architecture visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/hexagonal-architecture-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "hibernate-multi-dialect-swap",
+    "slug": "hibernate-multi-dialect-swap",
     "category": "backend",
     "description": "Ship one WAR that connects to Oracle, PostgreSQL, MSSQL, Tibero, DB2, or MariaDB based on Spring profile — all JDBC drivers bundled, dialect and datasource resolved from externalized config",
+    "tags": [],
+    "triggers": [
+      "one deployable must support multiple RDBMS vendors without rebuild",
+      "hibernate dialect chosen at startup, not compile time",
+      "customer deployments dictate DB vendor"
+    ],
     "version": "1.0.0",
-    "path": "skills/backend/hibernate-multi-dialect-swap/SKILL.md"
+    "path": "skills/backend/hibernate-multi-dialect-swap",
+    "has_content": true
   },
   {
-    "name": "hierarchical-group-entity",
+    "name": "hierarchical-group-entity-mongo",
+    "slug": "hierarchical-group-entity",
     "category": "backend",
     "description": "Model a tree-structured group entity in MongoDB with parentId + path + pathIds + level, plus recursive child-path update on move and cycle detection.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/hierarchical-group-entity/SKILL.md"
+    "path": "skills/backend/hierarchical-group-entity",
+    "has_content": true
+  },
+  {
+    "name": "hub-make-parallel-build",
+    "slug": "hub-make-parallel-build",
+    "category": "workflow",
+    "description": "Build multiple zero-dep single-file HTML apps in parallel from installed skills/knowledge data, verify, and publish via PR branch",
+    "tags": [],
+    "triggers": [
+      "hub-make",
+      "build examples",
+      "parallel html build"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/hub-make-parallel-build",
+    "has_content": true
+  },
+  {
+    "name": "idempotency-data-simulation",
+    "slug": "idempotency-data-simulation",
+    "category": "workflow",
+    "description": "Synthetic data generation strategies for simulating idempotency key lookups, repeated function applications, and duplicate state-machine event dispatch.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "idempotency data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/idempotency-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "idempotency-visualization-pattern",
+    "slug": "idempotency-visualization-pattern",
+    "category": "design",
+    "description": "Visual encoding patterns for rendering idempotency key deduplication, function stability, and state machine no-ops in browser-based simulations.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "idempotency visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/idempotency-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "identifier-truncate-with-hash-suffix",
+    "slug": "identifier-truncate-with-hash-suffix",
     "category": "backend",
     "description": "Deterministically shrink any identifier to a length cap while preserving uniqueness by appending a short hash of the original.",
+    "tags": [],
+    "triggers": [
+      "\"name too long\"",
+      "\"identifier length limit\"",
+      "\"shorten tool name\"",
+      "\"truncate unique\""
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/backend/identifier-truncate-with-hash-suffix/SKILL.md"
+    "path": "skills/backend/identifier-truncate-with-hash-suffix",
+    "has_content": true
   },
   {
     "name": "immutable-action-event-log",
+    "slug": "immutable-action-event-log",
     "category": "arch",
     "description": "Model state transitions as `(state, action) → (newState, List<Event>)` where the event list is an append-only, serializable log. Enables deterministic replay, audit trails, cheat detection, and UI choreography without coupling engine to presentation.",
+    "tags": [
+      "event-sourcing",
+      "immutable-state",
+      "action-log",
+      "deterministic",
+      "replay",
+      "audit"
+    ],
+    "triggers": [
+      "action result log",
+      "state transition events",
+      "replay log",
+      "deterministic engine",
+      "audit trail events"
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/arch/immutable-action-event-log/SKILL.md"
+    "path": "skills/arch/immutable-action-event-log",
+    "has_content": true
   },
   {
     "name": "improve-codebase-architecture",
+    "slug": "improve-codebase-architecture",
     "category": "refactor",
     "description": "Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. Use when user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more AI-navigable.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/refactor/improve-codebase-architecture/SKILL.md"
+    "path": "skills/refactor/improve-codebase-architecture",
+    "has_content": false
   },
   {
     "name": "init-deadline-guard",
+    "slug": "init-deadline-guard",
     "category": "backend",
     "description": "Watchdog that force-exits a Spring Boot service if startup initialization (external discovery, topic creation, warmup) does not complete within a deadline",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/init-deadline-guard/SKILL.md"
+    "path": "skills/backend/init-deadline-guard",
+    "has_content": true
+  },
+  {
+    "name": "investigate",
+    "slug": "investigate",
+    "category": "debug",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/debug/investigate",
+    "has_content": false
   },
   {
     "name": "ip-allowlist-cidr-validator",
+    "slug": "ip-allowlist-cidr-validator",
     "category": "backend",
     "description": "Validate client IPs against user-supplied allow-lists accepting mixed notations — plain IPv4, CIDR, octet wildcards (192.168.*.*), and octet ranges (192.168.10-20.*)",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/ip-allowlist-cidr-validator/SKILL.md"
+    "path": "skills/backend/ip-allowlist-cidr-validator",
+    "has_content": true
   },
   {
     "name": "jacoco-exclude-boilerplate-layers",
+    "slug": "jacoco-exclude-boilerplate-layers",
     "category": "backend",
     "description": "Configure JaCoCo + SonarQube to exclude generated/boilerplate layers (avro, config, dto, entity, kafka, *Dev) from coverage so coverage % reflects business logic only",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/jacoco-exclude-boilerplate-layers/SKILL.md"
+    "path": "skills/backend/jacoco-exclude-boilerplate-layers",
+    "has_content": true
   },
   {
     "name": "jacoco-sonar-shared-exclusion-list",
+    "slug": "jacoco-sonar-shared-exclusion-list",
     "category": "backend",
     "description": "Define coverage/quality exclusions once in ext.exclusionPatterns and reuse across jacoco, sonar, and packaging tasks to prevent report drift",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/jacoco-sonar-shared-exclusion-list/SKILL.md"
+    "path": "skills/backend/jacoco-sonar-shared-exclusion-list",
+    "has_content": true
   },
   {
     "name": "java-agent-bytecode-instrumentation-with-asm",
+    "slug": "java-agent-bytecode-instrumentation-with-asm",
     "category": "backend",
     "description": "Build a JVM agent using ASM's ClassFileTransformer to inject profiling/monitoring hooks into application classes via pluggable visitor chains",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/java-agent-bytecode-instrumentation-with-asm/SKILL.md"
+    "path": "skills/backend/java-agent-bytecode-instrumentation-with-asm",
+    "has_content": false
   },
   {
     "name": "jdbc-configurable-sql-insert-sender",
+    "slug": "jdbc-configurable-sql-insert-sender",
     "category": "backend",
     "description": "Ship a notification/integration channel that writes to a user-configured external DB via user-supplied INSERT SQL with ${var} placeholders",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/jdbc-configurable-sql-insert-sender/SKILL.md"
+    "path": "skills/backend/jdbc-configurable-sql-insert-sender",
+    "has_content": true
   },
   {
     "name": "jenkins-dual-registry-docker-push",
+    "slug": "jenkins-dual-registry-docker-push",
     "category": "devops",
     "description": "Jenkins pipeline that builds one image and tags+pushes it to two registries (SaaS + on-prem) with both build-specific and rolling-latest tags",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/devops/jenkins-dual-registry-docker-push/SKILL.md"
+    "path": "skills/devops/jenkins-dual-registry-docker-push",
+    "has_content": true
   },
   {
     "name": "jest-test-file-naming-test-only",
+    "slug": "jest-test-file-naming-test-only",
     "category": "frontend",
     "description": "Use .test.ts naming (not .spec.ts) and explicitly import jest globals; .spec.ts is excluded from the runner",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/frontend/jest-test-file-naming-test-only/SKILL.md"
+    "path": "skills/frontend/jest-test-file-naming-test-only",
+    "has_content": true
   },
   {
     "name": "jj-jujutsu-day-one-workflow",
+    "slug": "jj-jujutsu-day-one-workflow",
     "category": "git",
     "description": "Minimum viable jj (Jujutsu) workflow for a git user — init on top of an existing git repo, the five commands that cover 95% of day-1 usage, and the mental-model shift from git's staging area.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/git/jj-jujutsu-day-one-workflow/SKILL.md"
+    "path": "skills/git/jj-jujutsu-day-one-workflow",
+    "has_content": true
   },
   {
     "name": "json-seeded-jpa-loader",
+    "slug": "json-seeded-jpa-loader",
     "category": "backend",
     "description": "Idempotent reference-data seeding for Spring Boot — Flyway owns DDL, CommandLineRunner reads `resources/data/*.json`, maps to JPA entities, and saves only if the table is empty. Keeps static content in editable JSON without bloating migrations.",
+    "tags": [
+      "spring-boot",
+      "jpa",
+      "seeding",
+      "flyway",
+      "commandlinerunner",
+      "jackson",
+      "reference-data"
+    ],
+    "triggers": [
+      "seed reference data spring",
+      "CommandLineRunner JSON",
+      "populate static content",
+      "data initializer spring",
+      "load catalog JSON"
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/backend/json-seeded-jpa-loader/SKILL.md"
+    "path": "skills/backend/json-seeded-jpa-loader",
+    "has_content": true
   },
   {
     "name": "jwt-extraction-via-base-controller",
+    "slug": "jwt-extraction-via-base-controller",
     "category": "backend",
     "description": "Consolidate repeated `JwtTokenService.getXxxFromBearerToken(headerAuthorization)` calls across Spring controllers by moving the service and helper methods onto a shared `BaseController`. Subclass controllers call `getOrganizationId(h)` / `getLoginId(h)` / `getRoleIds(h)` directly.",
+    "tags": [],
+    "triggers": [
+      "\"jwt extraction controller duplication\"",
+      "\"base controller jwt\"",
+      "\"getXxxFromBearerToken 중복 제거\""
+    ],
     "version": "1.0.0",
-    "path": "skills/backend/jwt-extraction-via-base-controller/SKILL.md"
+    "path": "skills/backend/jwt-extraction-via-base-controller",
+    "has_content": false
   },
   {
     "name": "jwt-refresh-rotation-spring",
+    "slug": "jwt-refresh-rotation-spring",
     "category": "security",
     "description": "Spring Boot 3 JWT with short-lived access token + long-lived refresh token, filter-chain integration, and stateless session config. Avoids common mistakes that silently break refresh flows.",
+    "tags": [
+      "jwt",
+      "spring-boot",
+      "auth",
+      "refresh-token",
+      "jjwt",
+      "security-filter"
+    ],
+    "triggers": [
+      "jwt spring boot",
+      "refresh token rotation",
+      "JwtAuthenticationFilter",
+      "jjwt 0.12",
+      "SessionCreationPolicy.STATELESS",
+      "access token refresh token"
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/security/jwt-refresh-rotation-spring/SKILL.md"
+    "path": "skills/security/jwt-refresh-rotation-spring",
+    "has_content": true
   },
   {
     "name": "k8s-health-via-getnodelist",
+    "slug": "k8s-health-via-getnodelist",
     "category": "backend",
     "description": "Use `listNode()` with readiness check for Kubernetes cluster health — `getVersion()` succeeds on degraded clusters that will fail real work",
+    "tags": [],
+    "triggers": [
+      "cluster liveness probe before running a collector pass",
+      "guard against API-server flaps"
+    ],
     "version": "1.0.0",
-    "path": "skills/backend/k8s-health-via-getnodelist/SKILL.md"
+    "path": "skills/backend/k8s-health-via-getnodelist",
+    "has_content": true
   },
   {
     "name": "kafka-avro-producer-gzip-30mb",
+    "slug": "kafka-avro-producer-gzip-30mb",
     "category": "backend",
     "description": "Spring Kafka producer config for Avro values with gzip compression and a raised 30MB max.request.size for schema-registry payloads",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/kafka-avro-producer-gzip-30mb/SKILL.md"
+    "path": "skills/backend/kafka-avro-producer-gzip-30mb",
+    "has_content": true
   },
   {
     "name": "kafka-avro-topic-auto-create-config",
+    "slug": "kafka-avro-topic-auto-create-config",
     "category": "arch",
     "description": "Spring Boot Kafka config bean that auto-creates topics on startup via ApplicationRunner, with Avro serde, manual-ack listener, and bounded concurrency",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/arch/kafka-avro-topic-auto-create-config/SKILL.md"
+    "path": "skills/arch/kafka-avro-topic-auto-create-config",
+    "has_content": true
   },
   {
     "name": "kafka-batch-consumer-partition-tuning",
+    "slug": "kafka-batch-consumer-partition-tuning",
     "category": "backend",
     "description": "Size Kafka partition count + max-poll-records per topic volume so heavy-processing batch consumers avoid max.poll.interval.ms breaches and maintain throughput via per-partition concurrency.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/kafka-batch-consumer-partition-tuning/SKILL.md"
+    "path": "skills/backend/kafka-batch-consumer-partition-tuning",
+    "has_content": true
   },
   {
     "name": "kafka-consumer-config-3-factories",
+    "slug": "kafka-consumer-config-3-factories",
     "category": "backend",
     "description": "Spring Kafka consumer setup with three ListenerContainerFactory variants (standard / batch / UUID-group) and autoStartup=false to allow topic bootstrap before listeners attach",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/kafka-consumer-config-3-factories/SKILL.md"
+    "path": "skills/backend/kafka-consumer-config-3-factories",
+    "has_content": true
   },
   {
     "name": "kafka-consumer-errorhandling-wrapper",
+    "slug": "kafka-consumer-errorhandling-wrapper",
     "category": "backend",
     "description": "Wrap key/value deserializers in Spring Kafka's ErrorHandlingDeserializer so a single poison record doesn't halt the consumer",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/kafka-consumer-errorhandling-wrapper/SKILL.md"
+    "path": "skills/backend/kafka-consumer-errorhandling-wrapper",
+    "has_content": true
   },
   {
     "name": "kafka-consumer-semaphore-chunking",
+    "slug": "kafka-consumer-semaphore-chunking",
     "category": "backend",
     "description": "Bound in-flight async work from a Kafka consumer with `Semaphore(poolSize + queueCapacity - 2)` plus fixed-size chunks; release in `whenComplete` on both success and failure.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/kafka-consumer-semaphore-chunking/SKILL.md"
+    "path": "skills/backend/kafka-consumer-semaphore-chunking",
+    "has_content": true
   },
   {
     "name": "kafka-consumer-tenant-fan-out",
+    "slug": "kafka-consumer-tenant-fan-out",
     "category": "backend",
     "description": "@KafkaListener pattern consuming a topicPattern across tenants, using a record header for tenant identity and routing to per-tenant downstream streams",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/kafka-consumer-tenant-fan-out/SKILL.md"
+    "path": "skills/backend/kafka-consumer-tenant-fan-out",
+    "has_content": true
   },
   {
     "name": "kafka-debounce-event-coalescing",
+    "slug": "kafka-debounce-event-coalescing",
     "category": "backend",
     "description": "Coalesce bursts of change events into one Kafka event per tenant per debounce window using Redis state (first/last change time + changed-tenant SET), with a MAX_WAIT fallback so a never-quiet stream still fires.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/kafka-debounce-event-coalescing/SKILL.md"
+    "path": "skills/backend/kafka-debounce-event-coalescing",
+    "has_content": true
   },
   {
     "name": "kafka-engine-distributed-job-framework",
+    "slug": "kafka-engine-distributed-job-framework",
     "category": "arch",
     "description": "Kafka 이벤트 기반 분산 작업 실행 프레임워크 스켈레톤 — Publisher→Topic→Consumer→Queue→Worker + Admission Control + Strategy SPI",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/arch/kafka-engine-distributed-job-framework/SKILL.md"
+    "path": "skills/arch/kafka-engine-distributed-job-framework",
+    "has_content": true
   },
   {
     "name": "kafka-message-header-metadata",
+    "slug": "kafka-message-header-metadata",
     "category": "backend",
     "description": "Attach org-id, user-id, and timestamp as RecordHeader[] on a ProducerRecord to enable multi-tenant event routing without polluting the Avro payload",
+    "tags": [],
+    "triggers": [
+      "kafka record headers",
+      "ProducerRecord headers",
+      "organization-id header kafka",
+      "multi-tenant kafka routing",
+      "RecordHeader metadata"
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/backend/kafka-message-header-metadata/SKILL.md"
+    "path": "skills/backend/kafka-message-header-metadata",
+    "has_content": false
   },
   {
     "name": "kafka-producer-async-callback",
+    "slug": "kafka-producer-async-callback",
     "category": "backend",
     "description": "Fire-and-log Kafka send pattern using CompletableFuture.whenComplete() for audit/event topics where the caller should not block",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/kafka-producer-async-callback/SKILL.md"
+    "path": "skills/backend/kafka-producer-async-callback",
+    "has_content": true
   },
   {
     "name": "kafka-producer-config-avro-schema-registry",
+    "slug": "kafka-producer-config-avro-schema-registry",
     "category": "backend",
     "description": "Kafka producer config template for Avro + Confluent Schema Registry with LZ4 compression, 30MB max request size, and acks=1",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/kafka-producer-config-avro-schema-registry/SKILL.md"
+    "path": "skills/backend/kafka-producer-config-avro-schema-registry",
+    "has_content": true
+  },
+  {
+    "name": "land-and-deploy",
+    "slug": "land-and-deploy",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/land-and-deploy",
+    "has_content": false
   },
   {
     "name": "layered-risk-gates",
+    "slug": "layered-risk-gates",
     "category": "arch",
     "description": "Three-layer safety pattern for autonomous action loops — pre-action admission gate, in-flight monitor (stop/target thresholds), and a consecutive-failure circuit breaker — so a single runaway loop can't clear out the account before a human sees it.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/arch/layered-risk-gates/SKILL.md"
+    "path": "skills/arch/layered-risk-gates",
+    "has_content": true
   },
   {
     "name": "lean-verified-code-threat-boundary",
+    "slug": "lean-verified-code-threat-boundary",
     "category": "security",
     "description": "When shipping formally-verified code (Lean 4, Coq, F*), explicitly map what is inside and outside the verification boundary — untrusted parsers, runtime, and TCB assumptions almost always harbor the real bugs.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/security/lean-verified-code-threat-boundary/SKILL.md"
+    "path": "skills/security/lean-verified-code-threat-boundary",
+    "has_content": true
+  },
+  {
+    "name": "learn",
+    "slug": "learn",
+    "category": "docs",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/docs/learn",
+    "has_content": false
   },
   {
     "name": "llm-integration-test-failure-diagnosis",
+    "slug": "llm-integration-test-failure-diagnosis",
     "category": "testing",
     "description": "Wire an LLM-based diagnosis step into your CI for integration-test failures — summarize noisy logs, identify probable root cause, post findings to the code-review/PR UI. Based on Google's Auto-Diagnose system (90%+ accuracy on 71-case study, adopted across 52k tests).",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/testing/llm-integration-test-failure-diagnosis/SKILL.md"
+    "path": "skills/testing/llm-integration-test-failure-diagnosis",
+    "has_content": true
   },
   {
     "name": "llm-json-extraction",
+    "slug": "llm-json-extraction",
     "category": "ai",
     "description": "Robustly extract a JSON object from free-form LLM text output — strip markdown fences, locate outermost braces, tolerate prelude/postlude prose.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/ai/llm-json-extraction/SKILL.md"
+    "path": "skills/ai/llm-json-extraction",
+    "has_content": true
+  },
+  {
+    "name": "load-balancer-data-simulation",
+    "slug": "load-balancer-data-simulation",
+    "category": "workflow",
+    "description": "Strategies for generating realistic synthetic load balancer traffic, server state fluctuations, and algorithm comparison data without real infrastructure.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "load balancer data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/load-balancer-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "load-balancer-visualization-pattern",
+    "slug": "load-balancer-visualization-pattern",
+    "category": "design",
+    "description": "Reusable visual encoding patterns for rendering load balancer topology, server health, and traffic distribution in canvas/DOM UIs.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "load balancer visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/load-balancer-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "name": "log-aggregation-data-simulation",
+    "slug": "log-aggregation-data-simulation",
+    "category": "workflow",
+    "description": "Strategies for generating realistic synthetic log streams, pattern distributions, and pipeline throughput metrics for development and demo environments.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "log aggregation data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/log-aggregation-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "log-aggregation-visualization-pattern",
+    "slug": "log-aggregation-visualization-pattern",
+    "category": "design",
+    "description": "Reusable visual encoding patterns for rendering log volume, severity distribution, and pipeline topology on a dark-themed ops dashboard.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "log aggregation visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/log-aggregation-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "name": "materialized-view-data-simulation",
+    "slug": "materialized-view-data-simulation",
+    "category": "workflow",
+    "description": "Generate realistic MV topology, freshness telemetry, and query-match scoring without a live database.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "materialized view data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/materialized-view-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "materialized-view-visualization-pattern",
+    "slug": "materialized-view-visualization-pattern",
+    "category": "design",
+    "description": "Render MV dependency graphs, freshness dashboards, and query plans using Canvas/SVG with staleness-aware color coding.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "materialized view visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/materialized-view-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "mcp-capability-negotiated-initialize",
+    "slug": "mcp-capability-negotiated-initialize",
     "category": "backend",
     "description": "In MCP `initialize`, advertise optional server capabilities (prompts, resources, sampling) only when the client declared matching support — avoids clients rejecting the handshake or spamming unsupported methods.",
+    "tags": [],
+    "triggers": [
+      "\"mcp initialize\"",
+      "\"capability negotiation\"",
+      "\"server capabilities\"",
+      "\"prompts/resources not showing\""
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/backend/mcp-capability-negotiated-initialize/SKILL.md"
+    "path": "skills/backend/mcp-capability-negotiated-initialize",
+    "has_content": true
   },
   {
     "name": "mcp-runtime-prompt-refresh",
+    "slug": "mcp-runtime-prompt-refresh",
     "category": "ai",
     "description": "Expose a built-in MCP tool that hot-swaps the server's prompt set at runtime, persists it to disk, and emits notifications/prompts/list_changed so clients pick it up without reconnecting.",
+    "tags": [],
+    "triggers": [
+      "\"refresh prompts\"",
+      "\"update mcp prompts at runtime\"",
+      "\"prompts list_changed\"",
+      "\"mcp hot reload\""
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/ai/mcp-runtime-prompt-refresh/SKILL.md"
+    "path": "skills/ai/mcp-runtime-prompt-refresh",
+    "has_content": true
   },
   {
     "name": "measurement-grouping-combiner",
+    "slug": "measurement-grouping-combiner",
     "category": "backend",
     "description": "Group rows by `(resourceId, metricId, bucketTs)` into `Map<K, List<T>>`, then a per-granularity pure `combine…ByKey` merges each list into one composite record. One combiner per granularity (raw/1m/5m/hour/day).",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/measurement-grouping-combiner/SKILL.md"
+    "path": "skills/backend/measurement-grouping-combiner",
+    "has_content": true
   },
   {
     "name": "menu-key-config-registry",
+    "slug": "menu-key-config-registry",
     "category": "frontend",
     "description": "Centralize sidebar/drawer menu keys as a union type + config object per domain, so menu rendering, drawer view switches, and default-expand state all reference the same source of truth. Eliminates string-key drift across the three places a menu key appears.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/frontend/menu-key-config-registry/SKILL.md"
+    "path": "skills/frontend/menu-key-config-registry",
+    "has_content": true
   },
   {
     "name": "mermaid-gitlab-mr-size-rules",
+    "slug": "mermaid-gitlab-mr-size-rules",
     "category": "workflow",
     "description": "Keep Mermaid diagrams in GitLab MRs readable — cap nodes, avoid nested subgraphs, quote IDs with special chars, connect all subgraphs",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/workflow/mermaid-gitlab-mr-size-rules/SKILL.md"
+    "path": "skills/workflow/mermaid-gitlab-mr-size-rules",
+    "has_content": true
   },
   {
     "name": "message-loader-gated-on-database-ready",
+    "slug": "message-loader-gated-on-database-ready",
     "category": "backend",
     "description": "Gate i18n/seed loading on database readiness + per-tenant distributed lock so the first instance wins initialization in a multi-replica rollout.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/message-loader-gated-on-database-ready/SKILL.md"
+    "path": "skills/backend/message-loader-gated-on-database-ready",
+    "has_content": true
   },
   {
     "name": "mfa-federated-component-loader",
+    "slug": "mfa-federated-component-loader",
     "category": "frontend",
     "description": "Three-layer dynamic component loading for Webpack 5 Module Federation with retry logic, script caching, and error boundaries",
+    "tags": [],
+    "triggers": [
+      "module federation",
+      "federated component",
+      "remote component loading",
+      "dynamic import remote",
+      "RemoteApp"
+    ],
     "version": "1.0.0",
-    "path": "skills/frontend/mfa-federated-component-loader/SKILL.md"
+    "path": "skills/frontend/mfa-federated-component-loader",
+    "has_content": true
   },
   {
     "name": "mfa-memoryrouter-isolation",
+    "slug": "mfa-memoryrouter-isolation",
     "category": "frontend",
     "description": "Wrap Module Federation-exposed React components in `MemoryRouter` so they own a private router context instead of inheriting the host's — avoids cross-origin router errors in dev and keeps the remote's routes from leaking into the host URL bar.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/frontend/mfa-memoryrouter-isolation/SKILL.md"
+    "path": "skills/frontend/mfa-memoryrouter-isolation",
+    "has_content": true
   },
   {
     "name": "mfa-plain-html-dropdown-escape-hatch",
+    "slug": "mfa-plain-html-dropdown-escape-hatch",
     "category": "frontend",
     "description": "When a library Dropdown component infinite-loops or cross-origin-fails inside a Module Federation remote, replace it with a plain HTML `<button>` + absolutely-positioned menu `<ul>`. Cheaper than debugging the library's portal/context assumptions.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/frontend/mfa-plain-html-dropdown-escape-hatch/SKILL.md"
+    "path": "skills/frontend/mfa-plain-html-dropdown-escape-hatch",
+    "has_content": true
   },
   {
     "name": "mfa-portal-css-isolation",
+    "slug": "mfa-portal-css-isolation",
     "category": "design",
     "description": "Isolate Tailwind CSS in Module Federation portals using lazyStyleTag injection, postcss-prefix-selector with :where() specificity control, scoped root elements, and Headless UI PortalGroup",
+    "tags": [],
+    "triggers": [],
     "version": "1.1.0",
-    "path": "skills/design/mfa-portal-css-isolation/SKILL.md"
+    "path": "skills/design/mfa-portal-css-isolation",
+    "has_content": true
   },
   {
     "name": "migrate-to-shoehorn",
+    "slug": "migrate-to-shoehorn",
     "category": "refactor",
     "description": "Migrate test files from `as` type assertions to @total-typescript/shoehorn. Use when user mentions shoehorn, wants to replace `as` in tests, or needs partial test data.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/refactor/migrate-to-shoehorn/SKILL.md"
+    "path": "skills/refactor/migrate-to-shoehorn",
+    "has_content": false
   },
   {
     "name": "migration-processor-pipeline",
+    "slug": "migration-processor-pipeline",
     "category": "backend",
     "description": "Abstract migration processor template — validate → load → transform → emit Kafka Avro event with org-id header → audit log, multi-tenant safe",
+    "tags": [],
+    "triggers": [
+      "migration processor",
+      "data migration pipeline",
+      "legacy data import",
+      "migration with kafka"
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/backend/migration-processor-pipeline/SKILL.md"
+    "path": "skills/backend/migration-processor-pipeline",
+    "has_content": false
   },
   {
     "name": "module-federation-expose-react-component",
+    "slug": "module-federation-expose-react-component",
     "category": "frontend",
     "description": "Expose a React component from one MF remote to be consumed by other remotes via a stable 6-step pipeline (implementation → expose wrapper → config → MF constant → RemoteApp wrapper → consumer import).",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/frontend/module-federation-expose-react-component/SKILL.md"
+    "path": "skills/frontend/module-federation-expose-react-component",
+    "has_content": true
   },
   {
     "name": "module-federation-expose-wrapper",
+    "slug": "module-federation-expose-wrapper",
     "category": "arch",
     "description": "Six-step pattern for exposing a component from one Module Federation remote and consuming it from another via a shared library — implementation → expose wrapper → MF config → MF name constant → RemoteApp wrapper in shared → consumer import. Prevents direct cross-remote imports and webpack alias collisions.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/arch/module-federation-expose-wrapper/SKILL.md"
+    "path": "skills/arch/module-federation-expose-wrapper",
+    "has_content": true
   },
   {
     "name": "mongo-aggregation-filter-optimization",
+    "slug": "mongo-aggregation-filter-optimization",
     "category": "backend",
     "description": "Replace `$unwind`+`$match` on array sub-documents with inline `$filter` so array elements are pruned before any downstream stage — avoids N× document explosion.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/mongo-aggregation-filter-optimization/SKILL.md"
+    "path": "skills/backend/mongo-aggregation-filter-optimization",
+    "has_content": true
   },
   {
     "name": "mongo-criteria-maker-elemmatch-and-or",
+    "slug": "mongo-criteria-maker-elemmatch-and-or",
     "category": "backend",
     "description": "Compose dynamic MongoDB Criteria with mixed AND/OR groups and elemMatch on tag-array fields using a stack-based builder",
+    "tags": [],
+    "triggers": [
+      "building MongoDB queries with user-defined AND/OR filter rows",
+      "matching key/value pairs inside an array field (tags, labels, attributes)",
+      "replacing string-concatenated Mongo queries with type-safe Criteria"
+    ],
     "version": "1.0.0",
-    "path": "skills/backend/mongo-criteria-maker-elemmatch-and-or/SKILL.md"
+    "path": "skills/backend/mongo-criteria-maker-elemmatch-and-or",
+    "has_content": true
   },
   {
-    "name": "mongo-repository-custom-impl-split",
+    "name": "spring-data-mongo-repository-custom-split",
+    "slug": "mongo-repository-custom-impl-split",
     "category": "backend",
     "description": "Standard 3-file split for MongoRepository — the base interface, a *Custom interface for handwritten queries, and a *Impl class that uses MongoTemplate — so complex queries live beside the CRUD without breaking derived-query inference.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/mongo-repository-custom-impl-split/SKILL.md"
+    "path": "skills/backend/mongo-repository-custom-impl-split",
+    "has_content": true
   },
   {
     "name": "mongo-timestamp-densification",
+    "slug": "mongo-timestamp-densification",
     "category": "backend",
     "description": "Fill sparse time-series gaps with `$dateTrunc` + `$densify` in Mongo, then a residual Java gap-fill loop for LIVE windows. Partition by series to keep multi-line charts aligned.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/mongo-timestamp-densification/SKILL.md"
+    "path": "skills/backend/mongo-timestamp-densification",
+    "has_content": true
   },
   {
     "name": "mongo-ttl-with-aggregation-delta",
+    "slug": "mongo-ttl-with-aggregation-delta",
     "category": "backend",
     "description": "Store short-lived counter snapshots in MongoDB with a TTL index for auto-expiry and compute delta-from-previous at read time via an aggregation $subtract pipeline.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/mongo-ttl-with-aggregation-delta/SKILL.md"
+    "path": "skills/backend/mongo-ttl-with-aggregation-delta",
+    "has_content": true
   },
   {
     "name": "mongodb-changestream-field-filter",
+    "slug": "mongodb-changestream-field-filter",
     "category": "backend",
     "description": "Filter MongoDB change stream UPDATE events by inspecting updateDescription.updatedFields so irrelevant mutations do not trigger downstream work; INSERT/DELETE fall through as always-relevant.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/mongodb-changestream-field-filter/SKILL.md"
+    "path": "skills/backend/mongodb-changestream-field-filter",
+    "has_content": true
   },
   {
     "name": "mongodb-compound-index-esr-rule",
+    "slug": "mongodb-compound-index-esr-rule",
     "category": "backend",
     "description": "Order MongoDB compound-index fields as Equality → Sort → Range so the query planner keeps a tight IXSCAN and avoids in-memory sorts.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/mongodb-compound-index-esr-rule/SKILL.md"
+    "path": "skills/backend/mongodb-compound-index-esr-rule",
+    "has_content": false
   },
   {
     "name": "mongodb-datetrunc-binsize-zero-guard",
+    "slug": "mongodb-datetrunc-binsize-zero-guard",
     "category": "backend",
     "description": "Guard MongoDB $dateTrunc binSize against 0 when your interval may be auto/unset; coerce to 1 to avoid runtime error",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/mongodb-datetrunc-binsize-zero-guard/SKILL.md"
+    "path": "skills/backend/mongodb-datetrunc-binsize-zero-guard",
+    "has_content": true
   },
   {
     "name": "mongodb-volume-copy-backup",
+    "slug": "mongodb-volume-copy-backup",
     "category": "devops",
     "description": "Back up and restore MongoDB Docker volumes via rsync volume-copy instead of mongodump/tar.gz",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/devops/mongodb-volume-copy-backup/SKILL.md"
+    "path": "skills/devops/mongodb-volume-copy-backup",
+    "has_content": true
   },
   {
     "name": "multi-dbms-resource-provider-pattern",
+    "slug": "multi-dbms-resource-provider-pattern",
     "category": "backend",
     "description": "Structure a polyglot RDBMS monitoring agent with one ResourceProvider + entity/dto/service per DBMS, sharing a common base",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/multi-dbms-resource-provider-pattern/SKILL.md"
+    "path": "skills/backend/multi-dbms-resource-provider-pattern",
+    "has_content": false
   },
   {
     "name": "multi-resource-or-batch-query",
+    "slug": "multi-resource-or-batch-query",
     "category": "backend",
     "description": "Collapse N per-resource Mongo queries into one pipeline using `Criteria.orOperator` (or `$in`) over resourceId, projecting a synthetic `key` field for service-side de-multiplexing. Chunk at ~200 for index-friendly `$or`.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/multi-resource-or-batch-query/SKILL.md"
+    "path": "skills/backend/multi-resource-or-batch-query",
+    "has_content": true
   },
   {
     "name": "multi-tenant-kafka-header-organization-context",
+    "slug": "multi-tenant-kafka-header-organization-context",
     "category": "backend",
     "description": "Propagate tenant/organization id from Kafka headers through async handler threads via a ThreadLocal context holder",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/multi-tenant-kafka-header-organization-context/SKILL.md"
+    "path": "skills/backend/multi-tenant-kafka-header-organization-context",
+    "has_content": false
   },
   {
     "name": "multi-tenant-scheduler-iteration",
+    "slug": "multi-tenant-scheduler-iteration",
     "category": "backend",
     "description": "|",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/backend/multi-tenant-scheduler-iteration/SKILL.md"
+    "path": "skills/backend/multi-tenant-scheduler-iteration",
+    "has_content": true
   },
   {
     "name": "nds-html-mockup-from-tokens",
+    "slug": "nds-html-mockup-from-tokens",
     "category": "design",
     "description": "lucida-ui 디자인 토큰을 추출하여 실제 제품과 동일한 스타일의 static HTML 목업 생성",
+    "tags": [],
+    "triggers": [
+      "\"HTML 목업\"",
+      "\"디자인 목업\"",
+      "\"NDS 스타일 HTML\"",
+      "\"lucida 디자인으로 HTML\"",
+      "\"화면 프로토타입\""
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/design/nds-html-mockup-from-tokens/SKILL.md"
+    "path": "skills/design/nds-html-mockup-from-tokens",
+    "has_content": false
   },
   {
     "name": "netty-tcp-reconnect-backoff",
+    "slug": "netty-tcp-reconnect-backoff",
     "category": "backend",
     "description": "On Netty `channelInactive`/EOF/read-timeout, reconnect with exponential backoff (100ms → 30s cap), reset on success, keep SO_KEEPALIVE + TCP_NODELAY",
+    "tags": [],
+    "triggers": [
+      "long-lived TCP client to a device or broker that drops silently",
+      "need to survive peer restarts without crashing the collector"
+    ],
     "version": "1.0.0",
-    "path": "skills/backend/netty-tcp-reconnect-backoff/SKILL.md"
+    "path": "skills/backend/netty-tcp-reconnect-backoff",
+    "has_content": true
   },
   {
     "name": "non-metric-saveraw-null-rule",
+    "slug": "non-metric-saveraw-null-rule",
     "category": "backend",
     "description": "Treat `saveRaw` as tri-state `Boolean` — `null` for non-METRIC types (Availability/Trait), `true`/`false` only for METRIC. Re-apply the rule on every policy mutation path.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/non-metric-saveraw-null-rule/SKILL.md"
+    "path": "skills/backend/non-metric-saveraw-null-rule",
+    "has_content": true
+  },
+  {
+    "name": "oauth-data-simulation",
+    "slug": "oauth-data-simulation",
+    "category": "workflow",
+    "description": "Client-side simulation strategies for generating realistic OAuth flow steps, JWT claims, and scope-permission matrices without any backend.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "oauth data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/oauth-data-simulation",
+    "has_content": false
   },
   {
     "name": "oauth-token-env-persistence",
+    "slug": "oauth-token-env-persistence",
     "category": "security",
     "description": "Persist OAuth access tokens to a sidecar env file (token + refresh + issue_time), refresh N minutes before expiry with a thread-safe guard, auto-inject into outgoing API calls — survives process restart without re-login.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/security/oauth-token-env-persistence/SKILL.md"
+    "path": "skills/security/oauth-token-env-persistence",
+    "has_content": true
+  },
+  {
+    "name": "oauth-visualization-pattern",
+    "slug": "oauth-visualization-pattern",
+    "category": "design",
+    "description": "Multi-panel SVG/CSS pattern for visualizing OAuth 2.0 flows, token structure, and scope-permission mappings in dark-themed educational UIs.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "oauth visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/oauth-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "name": "object-storage-data-simulation",
+    "slug": "object-storage-data-simulation",
+    "category": "workflow",
+    "description": "Strategies for generating realistic synthetic object-storage data — bucket populations, S3 API latency distributions, and tiered lifecycle transitions.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "object storage data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/object-storage-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "object-storage-visualization-pattern",
+    "slug": "object-storage-visualization-pattern",
+    "category": "design",
+    "description": "Reusable visual encoding patterns for rendering object-storage buckets, objects, and operations on a dark-themed canvas/SVG dashboard.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "object storage visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/object-storage-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "obsidian-vault",
+    "slug": "obsidian-vault",
     "category": "docs",
     "description": "Search, create, and manage notes in the Obsidian vault with wikilinks and index notes. Use when user wants to find, create, or organize notes in Obsidian.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/docs/obsidian-vault/SKILL.md"
+    "path": "skills/docs/obsidian-vault",
+    "has_content": false
+  },
+  {
+    "name": "office-hours",
+    "slug": "office-hours",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/workflow/office-hours",
+    "has_content": false
+  },
+  {
+    "name": "open-gstack-browser",
+    "slug": "open-gstack-browser",
+    "category": "cli",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "0.2.0",
+    "path": "skills/cli/open-gstack-browser",
+    "has_content": false
   },
   {
     "name": "openapi-to-mcp-tag-grouping",
+    "slug": "openapi-to-mcp-tag-grouping",
     "category": "ai",
     "description": "Convert OpenAPI specs into MCP tools by grouping operations under their OpenAPI tag, exposing one tool per tag with an operation selector and per-operation arguments.",
+    "tags": [],
+    "triggers": [
+      "\"openapi to mcp\"",
+      "\"swagger to mcp\"",
+      "\"generate mcp tools\"",
+      "\"tag based tool grouping\""
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/ai/openapi-to-mcp-tag-grouping/SKILL.md"
+    "path": "skills/ai/openapi-to-mcp-tag-grouping",
+    "has_content": true
   },
   {
     "name": "openssl-4-migration-checklist",
+    "slug": "openssl-4-migration-checklist",
     "category": "security",
     "description": "Step-by-step migration checklist for upgrading a C/C++ codebase from OpenSSL 3.x to 4.0.0 — const-qualified APIs, removed SSLv3 support, opaque ASN1_STRING, engine removal, cleanup semantics.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/security/openssl-4-migration-checklist/SKILL.md"
+    "path": "skills/security/openssl-4-migration-checklist",
+    "has_content": true
   },
   {
     "name": "opentelemetry-java-bootstrap",
+    "slug": "opentelemetry-java-bootstrap",
     "category": "apm",
     "description": "Minimal OpenTelemetry bootstrap for a Java service — OTLP exporter, resource attributes, auto-instrumentation agent, and graceful shutdown. Covers the common setup mistakes that cause spans to silently drop.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/apm/opentelemetry-java-bootstrap/SKILL.md"
+    "path": "skills/apm/opentelemetry-java-bootstrap",
+    "has_content": true
   },
   {
     "name": "optional-outbound-adapter-no-op-port",
+    "slug": "optional-outbound-adapter-no-op-port",
     "category": "arch",
     "description": "Register a No-Op implementation of an optional outbound port with @ConditionalOnMissingBean so services boot when the real adapter (Kafka audit, tracing, notifications) is absent.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/arch/optional-outbound-adapter-no-op-port/SKILL.md"
+    "path": "skills/arch/optional-outbound-adapter-no-op-port",
+    "has_content": false
   },
   {
     "name": "org-scoped-kafka-topic-bootstrap",
+    "slug": "org-scoped-kafka-topic-bootstrap",
     "category": "backend",
     "description": "On-startup and on-event creation of per-tenant Kafka topics, with retention overrides per topic class and a service-readiness gate",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/org-scoped-kafka-topic-bootstrap/SKILL.md"
+    "path": "skills/backend/org-scoped-kafka-topic-bootstrap",
+    "has_content": true
+  },
+  {
+    "name": "outbox-pattern-data-simulation",
+    "slug": "outbox-pattern-data-simulation",
+    "category": "workflow",
+    "description": "Tick-based and stream-based strategies for generating realistic outbox event flows with configurable failure rates, batch polling, and retry mechanics.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "outbox pattern data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/outbox-pattern-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "outbox-pattern-visualization-pattern",
+    "slug": "outbox-pattern-visualization-pattern",
+    "category": "design",
+    "description": "Three complementary visual encodings for outbox relay pipelines — lane flow, dashboard metrics, and SVG node graph with animated message lifecycle.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "outbox pattern visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/outbox-pattern-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "name": "pair-agent",
+    "slug": "pair-agent",
+    "category": "ai",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "0.1.0",
+    "path": "skills/ai/pair-agent",
+    "has_content": false
   },
   {
     "name": "paired-flag-multi-instance-registration",
+    "slug": "paired-flag-multi-instance-registration",
     "category": "cli",
     "description": "CLI pattern for registering N instances of a composite config (e.g. spec+baseUrl pairs) using repeated paired flags and a pending-state parser.",
+    "tags": [],
+    "triggers": [
+      "\"multiple config pairs\"",
+      "\"repeated flag\"",
+      "\"paired cli args\"",
+      "\"multi-spec cli\""
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/cli/paired-flag-multi-instance-registration/SKILL.md"
+    "path": "skills/cli/paired-flag-multi-instance-registration",
+    "has_content": true
   },
   {
     "name": "parallel-bulk-annotation",
+    "slug": "parallel-bulk-annotation",
     "category": "workflow",
     "description": "수십~수백 개 Java 파일에 어노테이션(@Schema, @Operation, @ApiResponse 등)을 대량 추가할 때 병렬 에이전트로 분산 실행하는 패턴",
+    "tags": [],
+    "triggers": [
+      "대량 어노테이션 추가",
+      "@Schema 전수 부여",
+      "operationId 전수 부여",
+      "200개 메서드 어노테이션",
+      "bulk annotation"
+    ],
     "version": "1.0.0",
-    "path": "skills/workflow/parallel-bulk-annotation/SKILL.md"
+    "path": "skills/workflow/parallel-bulk-annotation",
+    "has_content": false
   },
   {
     "name": "parallel-tasks-generic-extraction",
+    "slug": "parallel-tasks-generic-extraction",
     "category": "backend",
     "description": "invokeAll + Callable 반복 패턴을 제네릭 executeParallelTasks + TaskFactory로 추출",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/parallel-tasks-generic-extraction/SKILL.md"
+    "path": "skills/backend/parallel-tasks-generic-extraction",
+    "has_content": true
   },
   {
     "name": "period-mode-enum-config",
+    "slug": "period-mode-enum-config",
     "category": "backend",
     "description": "One enum `Mode` holds all (intervalMs, isFullData, dateFormat, retention, chartFormat) tuples for every time-series granularity — single source of truth across repository/service/chart layers.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/period-mode-enum-config/SKILL.md"
+    "path": "skills/backend/period-mode-enum-config",
+    "has_content": true
+  },
+  {
+    "name": "plan-ceo-review",
+    "slug": "plan-ceo-review",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/plan-ceo-review",
+    "has_content": false
+  },
+  {
+    "name": "plan-design-review",
+    "slug": "plan-design-review",
+    "category": "design",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/design/plan-design-review",
+    "has_content": false
+  },
+  {
+    "name": "plan-devex-review",
+    "slug": "plan-devex-review",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/workflow/plan-devex-review",
+    "has_content": false
+  },
+  {
+    "name": "plan-eng-review",
+    "slug": "plan-eng-review",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/plan-eng-review",
+    "has_content": false
   },
   {
     "name": "plan-to-screen-spec-conversion",
+    "slug": "plan-to-screen-spec-conversion",
     "category": "design",
     "description": "PLAN 작업지시서를 rules/fe/02-screen-spec-template.md 형식의 화면 스펙 문서로 변환",
+    "tags": [],
+    "triggers": [
+      "\"PLAN을 스펙으로\"",
+      "\"작업지시서를 화면 스펙으로\"",
+      "\"screen spec 변환\"",
+      "\"기획서를 스펙 템플릿으로\""
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/design/plan-to-screen-spec-conversion/SKILL.md"
+    "path": "skills/design/plan-to-screen-spec-conversion",
+    "has_content": false
   },
   {
     "name": "playwright-exception-advice",
+    "slug": "playwright-exception-advice",
     "category": "backend",
     "description": "Map PlaywrightException to a structured JSON error in Spring @ControllerAdvice, detecting common cases (cert errors, timeouts) and attaching actionable suggestions",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/backend/playwright-exception-advice/SKILL.md"
+    "path": "skills/backend/playwright-exception-advice",
+    "has_content": true
   },
   {
     "name": "playwright-inspector-codegen",
+    "slug": "playwright-inspector-codegen",
     "category": "debug",
     "description": "Enable Playwright Inspector / codegen from a running Java app by setting PWDEBUG env vars before Playwright.create() and exposing an mvn codegen invocation for the user",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/debug/playwright-inspector-codegen/SKILL.md"
+    "path": "skills/debug/playwright-inspector-codegen",
+    "has_content": true
   },
   {
     "name": "playwright-java-dockerfile",
+    "slug": "playwright-java-dockerfile",
     "category": "devops",
     "description": "Multi-stage Dockerfile that builds a Java/Maven app in a JDK image and runs it on the official Playwright Java runtime image, avoiding manual browser installation",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/devops/playwright-java-dockerfile/SKILL.md"
+    "path": "skills/devops/playwright-java-dockerfile",
+    "has_content": true
   },
   {
     "name": "playwright-java-spring-lifecycle",
+    "slug": "playwright-java-spring-lifecycle",
     "category": "backend",
     "description": "Share one Playwright+Browser instance across a Spring Boot app and create per-request BrowserContext/Page, cleaning up with try-with-resources and @PreDestroy",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/backend/playwright-java-spring-lifecycle/SKILL.md"
+    "path": "skills/backend/playwright-java-spring-lifecycle",
+    "has_content": true
   },
   {
     "name": "pluggable-sender-factory-pattern",
+    "slug": "pluggable-sender-factory-pattern",
     "category": "arch",
     "description": "Register multiple notification/transport backends (SMS, EMAIL, SMTP, JDBC, REST, SLACK, SOCKET) behind a single FactoryBean that dispatches by enum type",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/arch/pluggable-sender-factory-pattern/SKILL.md"
+    "path": "skills/arch/pluggable-sender-factory-pattern",
+    "has_content": true
   },
   {
     "name": "plugin-resource-provider-architecture",
+    "slug": "plugin-resource-provider-architecture",
     "category": "arch",
     "description": "Stable `ResourceProvider` SPI loaded via Spring component scan; each new device/resource type is a separate Gradle-module JAR packaged into the WAR — zero core edits",
+    "tags": [],
+    "triggers": [
+      "extensible monitoring/management platform",
+      "vendor support must be pluggable per deployment"
+    ],
     "version": "1.0.0",
-    "path": "skills/arch/plugin-resource-provider-architecture/SKILL.md"
+    "path": "skills/arch/plugin-resource-provider-architecture",
+    "has_content": true
   },
   {
     "name": "policy-target-evaluation-with-groups-tags",
+    "slug": "policy-target-evaluation-with-groups-tags",
     "category": "backend",
     "description": "Evaluate whether a resource matches a policy via direct IDs + static/dynamic groups + tag filters, with explicit exclusion rules that take precedence over includes.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/policy-target-evaluation-with-groups-tags/SKILL.md"
+    "path": "skills/backend/policy-target-evaluation-with-groups-tags",
+    "has_content": true
   },
   {
     "name": "polymorphic-command-entities",
+    "slug": "polymorphic-command-entities",
     "category": "backend",
     "description": "Expose a list of typed commands over JSON using Jackson @JsonTypeInfo + @JsonSubTypes so clients can submit executable scripts to a REST endpoint",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/backend/polymorphic-command-entities/SKILL.md"
+    "path": "skills/backend/polymorphic-command-entities",
+    "has_content": true
   },
   {
     "name": "prd-to-issues",
+    "slug": "prd-to-issues",
     "category": "workflow",
     "description": "Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. Use when user wants to convert a PRD to issues, create implementation tickets, or break down a PRD into work items.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/workflow/prd-to-issues/SKILL.md"
+    "path": "skills/workflow/prd-to-issues",
+    "has_content": false
   },
   {
     "name": "prd-to-plan",
+    "slug": "prd-to-plan",
     "category": "workflow",
     "description": "Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in ./plans/. Use when user wants to break down a PRD, create an implementation plan, plan phases from a PRD, or mentions \"tracer bullets\".",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/workflow/prd-to-plan/SKILL.md"
+    "path": "skills/workflow/prd-to-plan",
+    "has_content": false
+  },
+  {
+    "name": "pub-sub-data-simulation",
+    "slug": "pub-sub-data-simulation",
+    "category": "workflow",
+    "description": "Interval-driven mock message generation with domain-typed payloads, random topic selection, and bounded retention for pub-sub demos.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "pub sub data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/pub-sub-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "pub-sub-visualization-pattern",
+    "slug": "pub-sub-visualization-pattern",
+    "category": "design",
+    "description": "Reusable visual encoding for publisher-subscriber message flow using topic-colored particles, node graphs, and fan-out animation.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "pub sub visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/pub-sub-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "qa",
+    "slug": "qa",
     "category": "testing",
     "description": "Interactive QA session where user reports bugs or issues conversationally, and the agent files GitHub issues. Explores the codebase in the background for context and domain language. Use when user wants to report bugs, do QA, file issues conversationally, or mentions \"QA session\".",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/testing/qa/SKILL.md"
+    "path": "skills/testing/qa",
+    "has_content": false
   },
   {
     "name": "querydsl-q-class-exclusion-pattern",
+    "slug": "querydsl-q-class-exclusion-pattern",
     "category": "devops",
     "description": "One `exclusionPatterns` list drives Jacoco report + verification + Sonar exclusions; catches generated Querydsl Q-classes via `('A'..'Z').collect { \"**/**/Q${it}*\" }`.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/devops/querydsl-q-class-exclusion-pattern/SKILL.md"
+    "path": "skills/devops/querydsl-q-class-exclusion-pattern",
+    "has_content": true
+  },
+  {
+    "name": "rate-limiter-data-simulation",
+    "slug": "rate-limiter-data-simulation",
+    "category": "workflow",
+    "description": "Stochastic request generation with multi-speed tick separation and configurable traffic patterns for rate-limiter algorithm demos.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "rate limiter data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/rate-limiter-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "rate-limiter-visualization-pattern",
+    "slug": "rate-limiter-visualization-pattern",
+    "category": "design",
+    "description": "Canvas-based visual metaphor for rate-limiter algorithms with color-coded saturation, particle feedback, and real-time parameter controls.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "rate limiter visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/rate-limiter-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "react-native-android-emulator-localhost",
+    "slug": "react-native-android-emulator-localhost",
     "category": "mobile",
     "description": "Use Platform.select to pick the right loopback host when a React Native dev build talks to a backend on the host machine — Android emulator needs 10.0.2.2, iOS simulator uses localhost.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/mobile/react-native-android-emulator-localhost/SKILL.md"
+    "path": "skills/mobile/react-native-android-emulator-localhost",
+    "has_content": true
   },
   {
     "name": "reactive-webclient-ssl-jdk",
+    "slug": "reactive-webclient-ssl-jdk",
     "category": "backend",
     "description": "Force reactor-netty WebClient to SslProvider.JDK so SSL works in slim containers that lack netty-tcnative native libraries.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/reactive-webclient-ssl-jdk/SKILL.md"
+    "path": "skills/backend/reactive-webclient-ssl-jdk",
+    "has_content": false
   },
   {
     "name": "reactor-subscription-router-backpressure",
+    "slug": "reactor-subscription-router-backpressure",
     "category": "backend",
     "description": "Per-session, per-destination Reactor Flux router with bounded buffer + DROP_LATEST backpressure and automatic cleanup on session disconnect",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/reactor-subscription-router-backpressure/SKILL.md"
+    "path": "skills/backend/reactor-subscription-router-backpressure",
+    "has_content": true
   },
   {
     "name": "realtime-vs-polling-fallback",
+    "slug": "realtime-vs-polling-fallback",
     "category": "backend",
     "description": "Let each resource type declare `supportsRealtime`; scheduler runs push-mode at the realtime interval and falls back to a safe polling interval (e.g., 60s) otherwise",
+    "tags": [],
+    "triggers": [
+      "mixed collection pipeline (some resources push, some pull)",
+      "avoid hammering APIs that do not support realtime"
+    ],
     "version": "1.0.0",
-    "path": "skills/backend/realtime-vs-polling-fallback/SKILL.md"
+    "path": "skills/backend/realtime-vs-polling-fallback",
+    "has_content": true
   },
   {
     "name": "recoil-domain-atom-store",
+    "slug": "recoil-domain-atom-store",
     "category": "frontend",
     "description": "Domain-scoped Recoil atom organization with typed hook wrappers for large-scale React state management",
+    "tags": [],
+    "triggers": [
+      "recoil atom",
+      "state management",
+      "domain store",
+      "global state"
+    ],
     "version": "1.0.0",
-    "path": "skills/frontend/recoil-domain-atom-store/SKILL.md"
+    "path": "skills/frontend/recoil-domain-atom-store",
+    "has_content": true
   },
   {
     "name": "redis-lock-recheck-flag-pattern",
+    "slug": "redis-lock-recheck-flag-pattern",
     "category": "backend",
     "description": "Distributed Redis lock with a \"recheck\" flag so concurrent events arriving while the lock is held force the holder to run a second pass, instead of being silently dropped.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/redis-lock-recheck-flag-pattern/SKILL.md"
+    "path": "skills/backend/redis-lock-recheck-flag-pattern",
+    "has_content": true
   },
   {
     "name": "request-refactor-plan",
+    "slug": "request-refactor-plan",
     "category": "refactor",
     "description": "Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/refactor/request-refactor-plan/SKILL.md"
+    "path": "skills/refactor/request-refactor-plan",
+    "has_content": false
   },
   {
     "name": "resource-provider-registry",
+    "slug": "resource-provider-registry",
     "category": "arch",
     "description": "Spring DI plugin registry where @Component implementations of a typed interface are auto-discovered and looked up at runtime by a string type key",
+    "tags": [],
+    "triggers": [
+      "plugin registry",
+      "provider lookup by type",
+      "auto-discovered handlers",
+      "resource provider pattern"
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/arch/resource-provider-registry/SKILL.md"
+    "path": "skills/arch/resource-provider-registry",
+    "has_content": false
   },
   {
     "name": "resource-summary-resolve-override-template",
+    "slug": "resource-summary-resolve-override-template",
     "category": "arch",
     "description": "리소스 상세 화면의 \"요약\" 탭에서 `OVERRIDE → TEMPLATE → NONE` 순으로 대시보드를 결정하는 서버-클라이언트 패턴. 오버라이드 엔티티, resolve API, 상태별 UI 드롭다운 규칙까지 포함.",
+    "tags": [],
+    "triggers": [
+      "resource summary",
+      "리소스 요약",
+      "resolve override template",
+      "dashboard override",
+      "resourceSummary",
+      "composition override"
+    ],
     "version": "1.0.0",
-    "path": "skills/arch/resource-summary-resolve-override-template/SKILL.md"
+    "path": "skills/arch/resource-summary-resolve-override-template",
+    "has_content": false
+  },
+  {
+    "name": "retro",
+    "slug": "retro",
+    "category": "docs",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/docs/retro",
+    "has_content": false
+  },
+  {
+    "name": "retry-strategy-data-simulation",
+    "slug": "retry-strategy-data-simulation",
+    "category": "workflow",
+    "description": "Three simulation modes for retry data — real-time probabilistic, shared-sequence deterministic, and pure curve computation with jitter bands.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "retry strategy data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/retry-strategy-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "retry-strategy-visualization-pattern",
+    "slug": "retry-strategy-visualization-pattern",
+    "category": "design",
+    "description": "Three complementary visual encodings for retry delay curves, attempt timelines, and strategy comparison races.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "retry strategy visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/retry-strategy-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "name": "review",
+    "slug": "review",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/review",
+    "has_content": false
+  },
+  {
+    "name": "saga-pattern-data-simulation",
+    "slug": "saga-pattern-data-simulation",
+    "category": "workflow",
+    "description": "Generate synthetic saga execution traces with configurable failure injection, multi-service event sequences, and realistic compensation cascades.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "saga pattern data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/saga-pattern-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "saga-pattern-visualization-pattern",
+    "slug": "saga-pattern-visualization-pattern",
+    "category": "design",
+    "description": "Canvas and DOM rendering patterns for saga orchestration flows, compensation cascades, and multi-service event timelines.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "saga pattern visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/saga-pattern-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "scaffold-exercises",
+    "slug": "scaffold-exercises",
     "category": "misc",
     "description": "Create exercise directory structures with sections, problems, solutions, and explainers that pass linting. Use when user wants to scaffold exercises, create exercise stubs, or set up a new course section.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/misc/scaffold-exercises/SKILL.md"
+    "path": "skills/misc/scaffold-exercises",
+    "has_content": false
+  },
+  {
+    "name": "schema-registry-data-simulation",
+    "slug": "schema-registry-data-simulation",
+    "category": "workflow",
+    "description": "Generate realistic synthetic schema registry data covering multi-format subjects, version histories, and compatibility check results.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "schema registry data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/schema-registry-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "schema-registry-visualization-pattern",
+    "slug": "schema-registry-visualization-pattern",
+    "category": "design",
+    "description": "Three complementary visual encodings for schema registry data — explorer tree, version timeline, and compatibility heatmap.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "schema registry visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/schema-registry-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "second-aggregation-snapshot-merge",
+    "slug": "second-aggregation-snapshot-merge",
     "category": "backend",
     "description": "Per-second metric aggregation using in-memory counters + Flux.interval snapshot-and-reset + bounded parallel publish, to decouple request latency from downstream health.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/second-aggregation-snapshot-merge/SKILL.md"
+    "path": "skills/backend/second-aggregation-snapshot-merge",
+    "has_content": false
   },
   {
     "name": "server-plugin-scripting-and-builtin-extensibility",
+    "slug": "server-plugin-scripting-and-builtin-extensibility",
     "category": "backend",
     "description": "Dual plugin system for a monitoring server — hot-reload script plugins (alert rules, filters) plus compiled JAR plugins for stateful, performance-critical data handlers",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/server-plugin-scripting-and-builtin-extensibility/SKILL.md"
+    "path": "skills/backend/server-plugin-scripting-and-builtin-extensibility",
+    "has_content": false
   },
   {
     "name": "service-discovery-replica-leader-tracking",
+    "slug": "service-discovery-replica-leader-tracking",
     "category": "backend",
     "description": "Track Eureka replica UP/DOWN events and emit ServiceLeaderElected / ServiceReplicaAllDown Spring events for cluster-aware init",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/service-discovery-replica-leader-tracking/SKILL.md"
+    "path": "skills/backend/service-discovery-replica-leader-tracking",
+    "has_content": true
   },
   {
     "name": "service-readiness-event-listener-pattern",
+    "slug": "service-readiness-event-listener-pattern",
     "category": "backend",
     "description": "Two-phase startup where each instance initializes locally, but only the leader runs global one-time work (seed data, default report creation)",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/service-readiness-event-listener-pattern/SKILL.md"
+    "path": "skills/backend/service-readiness-event-listener-pattern",
+    "has_content": true
   },
   {
     "name": "service-status-provider-actuator",
+    "slug": "service-status-provider-actuator",
     "category": "backend",
     "description": "Spring Boot 3.5 ServiceStatusProvider that reports RUNNING vs READY based on MongoDB ping + Kafka listener container liveness",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/service-status-provider-actuator/SKILL.md"
+    "path": "skills/backend/service-status-provider-actuator",
+    "has_content": true
   },
   {
     "name": "servicejar-embeddable-library-task",
+    "slug": "servicejar-embeddable-library-task",
     "category": "backend",
     "description": "Gradle task that builds a library JAR alongside bootJar for embedding inside a host Spring Boot app — excludes Application class, web/OpenAPI configs, and bundled resources",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/servicejar-embeddable-library-task/SKILL.md"
+    "path": "skills/backend/servicejar-embeddable-library-task",
+    "has_content": true
   },
   {
     "name": "session-lock-tree-blocking-chain-modeling",
+    "slug": "session-lock-tree-blocking-chain-modeling",
     "category": "backend",
     "description": "Model RDBMS blocking sessions as a directed graph and persist the resolved lock tree alongside the session snapshot",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/session-lock-tree-blocking-chain-modeling/SKILL.md"
+    "path": "skills/backend/session-lock-tree-blocking-chain-modeling",
+    "has_content": false
+  },
+  {
+    "name": "setup-browser-cookies",
+    "slug": "setup-browser-cookies",
+    "category": "cli",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/setup-browser-cookies",
+    "has_content": false
+  },
+  {
+    "name": "setup-deploy",
+    "slug": "setup-deploy",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/setup-deploy",
+    "has_content": false
   },
   {
     "name": "setup-pre-commit",
+    "slug": "setup-pre-commit",
     "category": "cli",
     "description": "Set up Husky pre-commit hooks with lint-staged (Prettier), type checking, and tests in the current repo. Use when user wants to add pre-commit hooks, set up Husky, configure lint-staged, or add commit-time formatting/typechecking/testing.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/cli/setup-pre-commit/SKILL.md"
+    "path": "skills/cli/setup-pre-commit",
+    "has_content": false
   },
   {
     "name": "shared-apis-endpoint-service-pattern",
+    "slug": "shared-apis-endpoint-service-pattern",
     "category": "frontend",
     "description": "Module Federation 모노레포에서 REST 엔드포인트를 추가할 때 `endpoint 상수 → services 메서드 → commonApiService 호출` 3계층 레이어링으로 도메인 일관성을 유지하는 패턴.",
+    "tags": [],
+    "triggers": [
+      "엔드포인트 추가",
+      "widgetEndPoint",
+      "shared/apis",
+      "commonApiService",
+      "API 레이어 추가",
+      "endpoint constant"
+    ],
     "version": "1.0.0",
-    "path": "skills/frontend/shared-apis-endpoint-service-pattern/SKILL.md"
+    "path": "skills/frontend/shared-apis-endpoint-service-pattern",
+    "has_content": false
   },
   {
     "name": "shared-package-only-cross-module",
+    "slug": "shared-package-only-cross-module",
     "category": "arch",
     "description": "Enforce a one-way dependency graph in a multi-module repo — sibling modules may only import from a single `shared/` package, never from each other. Prevents webpack alias collisions, keeps module boundaries enforceable, and makes build/deploy units independent.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/arch/shared-package-only-cross-module/SKILL.md"
+    "path": "skills/arch/shared-package-only-cross-module",
+    "has_content": true
+  },
+  {
+    "name": "ship",
+    "slug": "ship",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/ship",
+    "has_content": false
+  },
+  {
+    "name": "sidecar-proxy-data-simulation",
+    "slug": "sidecar-proxy-data-simulation",
+    "category": "workflow",
+    "description": "Procedural generation of mesh topology, request-pipeline traffic, and time-series proxy metrics with multi-mode fault injection.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "sidecar proxy data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/sidecar-proxy-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "sidecar-proxy-visualization-pattern",
+    "slug": "sidecar-proxy-visualization-pattern",
+    "category": "design",
+    "description": "Three complementary canvas/DOM views — mesh topology, request pipeline, and ops dashboard — for sidecar-proxy architectures.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "sidecar proxy visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/sidecar-proxy-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "site-per-customer-override-modules",
+    "slug": "site-per-customer-override-modules",
     "category": "arch",
     "description": "One Gradle module per customer (`<product>-site-<customer>`) overrides core beans, auth, notification channels, and assets — keeps core customer-agnostic and scales to dozens of deployments",
+    "tags": [],
+    "triggers": [
+      "B2B product delivered to many customers with bespoke requirements",
+      "feature-flag soup is polluting core"
+    ],
     "version": "1.0.0",
-    "path": "skills/arch/site-per-customer-override-modules/SKILL.md"
+    "path": "skills/arch/site-per-customer-override-modules",
+    "has_content": true
   },
   {
     "name": "skill-md-validator",
+    "slug": "skill-md-validator",
     "category": "devops",
     "description": "[Tooling] SKILL.md frontmatter + 필수 섹션을 CRITICAL/WARNING 등급으로 검증하는 품질 게이트.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/devops/skill-md-validator/SKILL.md"
+    "path": "skills/devops/skill-md-validator",
+    "has_content": false
   },
   {
     "name": "skill-repo-bootstrap-architecture",
+    "slug": "skill-repo-bootstrap-architecture",
     "category": "workflow",
     "description": "Lay out a shared skill/knowledge git repo so it is simultaneously a catalog and a self-installer — separate bootstrap (commands + umbrella skill + installers) from skills (category/name/SKILL.md). Covers repo layout, safety gates, registry pinning, and skill deprecation lifecycle.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/workflow/skill-repo-bootstrap-architecture/SKILL.md"
+    "path": "skills/workflow/skill-repo-bootstrap-architecture",
+    "has_content": true
   },
   {
     "name": "slack-webhook-notify",
+    "slug": "slack-webhook-notify",
     "category": "devops",
     "description": "Slack Incoming Webhook으로 메시지를 전송한다. 빌드/테스트/배포 결과, 작업 완료 알림 등을 Slack 채널에 보낼 때 사용.",
+    "tags": [],
+    "triggers": [
+      "slack",
+      "슬랙",
+      "slack notify",
+      "webhook 알림",
+      "빌드 알림",
+      "작업 완료 알림"
+    ],
     "version": "1.0.0",
-    "path": "skills/devops/slack-webhook-notify/SKILL.md"
+    "path": "skills/devops/slack-webhook-notify",
+    "has_content": false
   },
   {
     "name": "slash-command-authoring",
+    "slug": "slash-command-authoring",
     "category": "workflow",
     "description": "Author Claude Code slash commands that read cleanly, include safety rules, and compose with OMC skills — frontmatter, argument-hint, step ordering, and dry-run patterns.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/workflow/slash-command-authoring/SKILL.md"
+    "path": "skills/workflow/slash-command-authoring",
+    "has_content": true
   },
   {
     "name": "spring-actuator-health-collector",
+    "slug": "spring-actuator-health-collector",
     "category": "backend",
     "description": "Poll remote Spring Boot services via Actuator (/health + /metrics/{name}) using OkHttp with per-target timeouts and a configurable metric whitelist, publishing results to a downstream bus.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/spring-actuator-health-collector/SKILL.md"
+    "path": "skills/backend/spring-actuator-health-collector",
+    "has_content": true
   },
   {
     "name": "spring-bootrun-local-dev-env-block",
+    "slug": "spring-bootrun-local-dev-env-block",
     "category": "devops",
     "description": "Gradle `bootRun` env block that wires local Redis/Mongo/Kafka/Eureka/MQTT for zero-config `./gradlew bootRun` developer experience",
+    "tags": [],
+    "triggers": [
+      "new engineer asks \"how do I run this locally?\"",
+      "application-local.yaml is gitignored and no-one knows the defaults",
+      "Spring Cloud service refuses to start locally because Eureka client is enabled"
+    ],
     "version": "1.0.0",
-    "path": "skills/devops/spring-bootrun-local-dev-env-block/SKILL.md"
+    "path": "skills/devops/spring-bootrun-local-dev-env-block",
+    "has_content": true
   },
   {
     "name": "spring-dual-profile-flyway",
+    "slug": "spring-dual-profile-flyway",
     "category": "backend",
     "description": "Spring Boot dual-profile setup — H2 file-mode for dev (zero install, console enabled), PostgreSQL for prod — with Flyway managing DDL and JPA set to validate-only. The profile split that keeps local dev fast without drifting from prod schema.",
+    "tags": [
+      "spring-boot",
+      "flyway",
+      "h2",
+      "postgresql",
+      "profiles",
+      "migrations",
+      "jpa"
+    ],
+    "triggers": [
+      "spring profiles dev prod",
+      "flyway migrations spring",
+      "h2 file mode dev",
+      "ddl-auto validate",
+      "postgresql production profile"
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/backend/spring-dual-profile-flyway/SKILL.md"
+    "path": "skills/backend/spring-dual-profile-flyway",
+    "has_content": true
   },
   {
     "name": "spring-mongo-lightweight-migration",
+    "slug": "spring-mongo-lightweight-migration",
     "category": "backend",
     "description": "Annotation-driven MongoDB migration runner for Spring Boot — `@MongoMigration` methods on `MigrationScript` beans execute in order at startup, with history in `{prefix}_migrations` collection. No Mongock dependency.",
+    "tags": [],
+    "triggers": [
+      "\"mongo migration spring boot\"",
+      "\"mongock 없이 마이그레이션\"",
+      "\"annotation-based mongo migration\""
+    ],
     "version": "1.0.0",
-    "path": "skills/backend/spring-mongo-lightweight-migration/SKILL.md"
+    "path": "skills/backend/spring-mongo-lightweight-migration",
+    "has_content": true
   },
   {
     "name": "spring-profile-datasource-activation",
+    "slug": "spring-profile-datasource-activation",
     "category": "backend",
     "description": "Select DB/Hibernate/logging config at JVM startup via `spring.profiles.active` so one build ships to dev, test, and prod without branching in code",
+    "tags": [],
+    "triggers": [
+      "same WAR goes to multiple environments",
+      "Spring profile chooses datasource and credentials"
+    ],
     "version": "1.0.0",
-    "path": "skills/backend/spring-profile-datasource-activation/SKILL.md"
+    "path": "skills/backend/spring-profile-datasource-activation",
+    "has_content": true
   },
   {
     "name": "spring-testcontainers-multitenant-base",
+    "slug": "spring-testcontainers-multitenant-base",
     "category": "testing",
     "description": "Base test class that boots Testcontainers (Mongo + Kafka), pre-sets tenant/auth context, and forces JVM halt in AfterAll to avoid leaked containers.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/testing/spring-testcontainers-multitenant-base/SKILL.md"
+    "path": "skills/testing/spring-testcontainers-multitenant-base",
+    "has_content": true
   },
   {
     "name": "spring-typed-config-properties",
+    "slug": "spring-typed-config-properties",
     "category": "backend",
     "description": "Type-safe, nested `@ConfigurationProperties` pattern for Spring Boot — centralizes tunable constants (rate limits, formula coefficients, balance numbers) in YAML with a single injected POJO tree. Beats scattered `@Value` strings.",
+    "tags": [
+      "spring-boot",
+      "configuration-properties",
+      "yaml",
+      "typed-config",
+      "constructor-binding"
+    ],
+    "triggers": [
+      "ConfigurationProperties nested",
+      "centralize tunable constants",
+      "spring typed config",
+      "balance config",
+      "constructor binding yaml"
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/backend/spring-typed-config-properties/SKILL.md"
+    "path": "skills/backend/spring-typed-config-properties",
+    "has_content": true
   },
   {
     "name": "springdoc-yaml-externalization",
+    "slug": "springdoc-yaml-externalization",
     "category": "backend",
     "description": "Move long `@Operation description` and `@RequestBody examples` text out of Spring controllers into per-controller YAML files under `resources/api-docs/`, injected at runtime via a single `OperationCustomizer` bean. Swagger UI output unchanged.",
+    "tags": [],
+    "triggers": [
+      "\"swagger externalize annotations\"",
+      "\"move swagger description to yaml\"",
+      "\"OperationCustomizer\""
+    ],
     "version": "1.0.0",
-    "path": "skills/backend/springdoc-yaml-externalization/SKILL.md"
+    "path": "skills/backend/springdoc-yaml-externalization",
+    "has_content": false
   },
   {
     "name": "sse-fetch-streaming",
+    "slug": "sse-fetch-streaming",
     "category": "frontend",
     "description": "Fetch-based Server-Sent Events streaming with pause/resume/close control for real-time chat and data feeds",
+    "tags": [],
+    "triggers": [
+      "sse",
+      "server-sent events",
+      "streaming",
+      "event stream",
+      "real-time chat"
+    ],
     "version": "1.0.0",
-    "path": "skills/frontend/sse-fetch-streaming/SKILL.md"
+    "path": "skills/frontend/sse-fetch-streaming",
+    "has_content": true
   },
   {
     "name": "stable-horde-async-poll",
+    "slug": "stable-horde-async-poll",
     "category": "ai",
     "description": "Submit-then-poll integration pattern for Stable Horde image generation — anonymous apikey, model fallback list, negative-prompt separator, bounded poll loop.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/ai/stable-horde-async-poll/SKILL.md"
+    "path": "skills/ai/stable-horde-async-poll",
+    "has_content": true
   },
   {
-    "name": "stack-tag-filter-to-mongo-criteria",
+    "name": "stack-parse-tag-filter-to-mongo-criteria",
+    "slug": "stack-tag-filter-to-mongo-criteria",
     "category": "backend",
     "description": "Parse a tokenized boolean filter expression (key=value, AND, OR, parens) into a MongoDB Criteria tree using a shunting-yard/stack algorithm, with elemMatch for array-of-tag subdocs.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/stack-tag-filter-to-mongo-criteria/SKILL.md"
+    "path": "skills/backend/stack-tag-filter-to-mongo-criteria",
+    "has_content": true
   },
   {
     "name": "stale-persistent-context-detection",
+    "slug": "stale-persistent-context-detection",
     "category": "workflow",
     "description": "Detect and remove stale error snapshots that LLM tools inject via persistent-context files (CLAUDE.md, AGENTS.md, system prompts, memory) before chasing a fix. If the current source already compiles, the injected error is a ghost from a previous session, not a real bug.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/workflow/stale-persistent-context-detection/SKILL.md"
+    "path": "skills/workflow/stale-persistent-context-detection",
+    "has_content": true
   },
   {
     "name": "stateless-turn-combat-engine",
+    "slug": "stateless-turn-combat-engine",
     "category": "game-dev",
     "description": "Turn-based combat as a pure function — `(state, action) → newState + events`. Speed-based turn order, deterministic damage, no hidden mutation. Makes combat unit-testable, replayable, and server-authoritative.",
+    "tags": [
+      "combat-engine",
+      "turn-based",
+      "rpg",
+      "pure-function",
+      "deterministic",
+      "server-authoritative"
+    ],
+    "triggers": [
+      "turn based combat",
+      "combat engine design",
+      "speed based turn order",
+      "server authoritative combat",
+      "stateless combat"
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/game-dev/stateless-turn-combat-engine/SKILL.md"
+    "path": "skills/game-dev/stateless-turn-combat-engine",
+    "has_content": true
   },
   {
     "name": "status-effect-enum-system",
+    "slug": "status-effect-enum-system",
     "category": "game-dev",
     "description": "Model status effects (burn, stun, buff, debuff) as enum-tagged records attached to units, with per-turn tick logic split between application, duration decay, and removal. Keeps damage-over-time and crowd control uniform and testable.",
+    "tags": [
+      "status-effect",
+      "buff-debuff",
+      "dot",
+      "cc",
+      "enum",
+      "turn-based"
+    ],
+    "triggers": [
+      "status effect system",
+      "buff debuff",
+      "damage over time",
+      "burn stun freeze",
+      "crowd control turn based"
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/game-dev/status-effect-enum-system/SKILL.md"
+    "path": "skills/game-dev/status-effect-enum-system",
+    "has_content": true
   },
   {
     "name": "stomp-cookie-auth-handshake",
+    "slug": "stomp-cookie-auth-handshake",
     "category": "backend",
     "description": "Authenticate STOMP WebSocket upgrade using an HttpOnly cookie extracted during the handshake, then bind identity to the STOMP session",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/stomp-cookie-auth-handshake/SKILL.md"
+    "path": "skills/backend/stomp-cookie-auth-handshake",
+    "has_content": true
   },
   {
     "name": "stomp-principal-jwt-channel",
+    "slug": "stomp-principal-jwt-channel",
     "category": "backend",
     "description": "STOMP ChannelInterceptor that validates a JWT on CONNECT and binds a multi-tenant Principal (orgId + userId + sessionId) for downstream routing",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/stomp-principal-jwt-channel/SKILL.md"
+    "path": "skills/backend/stomp-principal-jwt-channel",
+    "has_content": true
+  },
+  {
+    "name": "strangler-fig-data-simulation",
+    "slug": "strangler-fig-data-simulation",
+    "category": "workflow",
+    "description": "Incremental module-by-module migration simulation modeling the strangler fig pattern's facade-routing and legacy-decay lifecycle.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "strangler fig data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/strangler-fig-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "strangler-fig-visualization-pattern",
+    "slug": "strangler-fig-visualization-pattern",
+    "category": "design",
+    "description": "Canvas-based visual encoding of strangler fig lifecycle stages with host-tree decay and aerial root growth animation.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "strangler fig visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/strangler-fig-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "strategy-spi-list-to-map-autoinject",
+    "slug": "strategy-spi-list-to-map-autoinject",
     "category": "backend",
     "description": "Spring이 자동 주입하는 List<T>를 생성자에서 Map<Key,T>로 변환해 Strategy를 enum 키로 O(1) 디스패치하는 패턴",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/strategy-spi-list-to-map-autoinject/SKILL.md"
+    "path": "skills/backend/strategy-spi-list-to-map-autoinject",
+    "has_content": true
   },
   {
     "name": "swagger-ai-optimization",
+    "slug": "swagger-ai-optimization",
     "category": "workflow",
     "description": "Spring Boot + springdoc 프로젝트의 Swagger/OpenAPI 스펙을 AI Agent용으로 최적화 (operationId, @Schema, @ApiResponse, x-filterable-fields 전수 적용)",
+    "tags": [],
+    "triggers": [
+      "swagger ai 최적화",
+      "openapi ai optimization",
+      "MCP 연동 준비",
+      "swagger operationId 전수 부여",
+      "AI 이해도 테스트"
+    ],
     "version": "1.0.0",
-    "path": "skills/workflow/swagger-ai-optimization/SKILL.md"
+    "path": "skills/workflow/swagger-ai-optimization",
+    "has_content": false
   },
   {
     "name": "swagger-spec-baseline-from-git",
+    "slug": "swagger-spec-baseline-from-git",
     "category": "workflow",
     "description": "Re-run spec-based optimization workflow on a clean branch without running the Spring Boot app — restore prior baseline artifacts (swagger-before.json + scripts) via `git show <sha>:<path>` from the commit on another branch that already captured them.",
+    "tags": [],
+    "triggers": [
+      "\"swagger 전체 재실행\"",
+      "\"rerun swagger optimization\"",
+      "\"baseline 없이 시작\""
+    ],
     "version": "1.0.0",
-    "path": "skills/workflow/swagger-spec-baseline-from-git/SKILL.md"
+    "path": "skills/workflow/swagger-spec-baseline-from-git",
+    "has_content": false
   },
   {
-    "name": "system-data-initializer-runner",
+    "name": "spring-applicationrunner-system-seed",
+    "slug": "system-data-initializer-runner",
     "category": "backend",
     "description": "Use ApplicationRunner to seed required system/root records on startup, guarded by an exists-check and marked with a systemFlag so they can't be deleted or moved by users.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/system-data-initializer-runner/SKILL.md"
+    "path": "skills/backend/system-data-initializer-runner",
+    "has_content": true
   },
   {
     "name": "tdd",
+    "slug": "tdd",
     "category": "testing",
     "description": "Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions \"red-green-refactor\", wants integration tests, or asks for test-first development.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/testing/tdd/SKILL.md"
+    "path": "skills/testing/tdd",
+    "has_content": false
   },
   {
     "name": "tenant-context-holder-propagation",
+    "slug": "tenant-context-holder-propagation",
     "category": "arch",
     "description": "Set TenantContextHolder.INSTANCE.setTenantId(orgId) on the current thread so MongoDB tenant-isolated templates route queries correctly, always clearing in a finally block",
+    "tags": [],
+    "triggers": [
+      "TenantContextHolder",
+      "tenant context propagation",
+      "multi-tenant thread local",
+      "MONGODB_TEMPLATE_ISOLATION",
+      "tenant isolation mongodb"
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/arch/tenant-context-holder-propagation/SKILL.md"
+    "path": "skills/arch/tenant-context-holder-propagation",
+    "has_content": false
   },
   {
     "name": "tenant-context-try-finally-on-worker",
+    "slug": "tenant-context-try-finally-on-worker",
     "category": "backend",
     "description": "Kafka/Queue Worker에서 멀티테넌트 ThreadLocal 컨텍스트를 try-finally로 안전하게 세팅/정리하는 패턴",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/tenant-context-try-finally-on-worker/SKILL.md"
+    "path": "skills/backend/tenant-context-try-finally-on-worker",
+    "has_content": true
   },
   {
     "name": "tenant-db-initialization-on-startup",
+    "slug": "tenant-db-initialization-on-startup",
     "category": "backend",
     "description": "On leader startup, fetch tenant/org list from metadata service and provision per-tenant MongoDB databases — idempotent, leader-only",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/tenant-db-initialization-on-startup/SKILL.md"
+    "path": "skills/backend/tenant-db-initialization-on-startup",
+    "has_content": true
   },
   {
     "name": "tenant-isolated-mongo-collection",
+    "slug": "tenant-isolated-mongo-collection",
     "category": "backend",
     "description": "Route each tenant to its own MongoDB collection (or collection-name suffix) via a custom annotation resolved at repository/template layer, so application code stays tenant-agnostic.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/tenant-isolated-mongo-collection/SKILL.md"
+    "path": "skills/backend/tenant-isolated-mongo-collection",
+    "has_content": true
   },
   {
     "name": "tenant-per-database-mongo-routing",
+    "slug": "tenant-per-database-mongo-routing",
     "category": "backend",
     "description": "Route Spring Data Mongo operations to per-tenant databases via a ThreadLocal tenant holder and two MongoTemplate beans (isolated vs shared collections).",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/tenant-per-database-mongo-routing/SKILL.md"
+    "path": "skills/backend/tenant-per-database-mongo-routing",
+    "has_content": true
   },
   {
     "name": "testcontainers-mongo-kafka-abstract-base",
+    "slug": "testcontainers-mongo-kafka-abstract-base",
     "category": "backend",
     "description": "Abstract test base classes that spin up MongoDB + Kafka via Testcontainers with static start() and reuse=true, exposing mapped ports via System.setProperty",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/testcontainers-mongo-kafka-abstract-base/SKILL.md"
+    "path": "skills/backend/testcontainers-mongo-kafka-abstract-base",
+    "has_content": true
   },
   {
     "name": "testcontainers-reuse-disabled",
+    "slug": "testcontainers-reuse-disabled",
     "category": "backend",
     "description": "Set TESTCONTAINERS_REUSE_ENABLE=false on the Gradle test task so CI and shared dev machines never inherit stale container state across suites",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/testcontainers-reuse-disabled/SKILL.md"
+    "path": "skills/backend/testcontainers-reuse-disabled",
+    "has_content": true
   },
   {
     "name": "thread-pool-config-tenant-aware",
+    "slug": "thread-pool-config-tenant-aware",
     "category": "backend",
     "description": "Property-driven ThreadPoolTaskExecutor + Scheduler config that extends TenantAsyncConfigurerSupport so @Async tasks inherit tenant context",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/thread-pool-config-tenant-aware/SKILL.md"
+    "path": "skills/backend/thread-pool-config-tenant-aware",
+    "has_content": true
   },
   {
     "name": "thread-pool-queue-backpressure",
+    "slug": "thread-pool-queue-backpressure",
     "category": "backend",
     "description": "Bounded in-memory queue between Kafka consumer and async thread pool, with hysteretic pause/resume thresholds driving Spring Kafka container pause()/resume() so bursts do not OOM the JVM.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/thread-pool-queue-backpressure/SKILL.md"
+    "path": "skills/backend/thread-pool-queue-backpressure",
+    "has_content": true
   },
   {
     "name": "tiered-rebalance-schedule",
+    "slug": "tiered-rebalance-schedule",
     "category": "arch",
     "description": "Run three cadences against the same managed set — fast performance review, mid-frequency policy re-analysis, slow portfolio rebalance — each with its own trigger interval and mutation budget, so urgency scales with cost.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/arch/tiered-rebalance-schedule/SKILL.md"
+    "path": "skills/arch/tiered-rebalance-schedule",
+    "has_content": true
+  },
+  {
+    "name": "time-series-db-data-simulation",
+    "slug": "time-series-db-data-simulation",
+    "category": "workflow",
+    "description": "Generate realistic TSDB metric streams using sinusoidal base curves with random noise, configurable step intervals, and storage-cost estimation at 16 bytes per point.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "time series db data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/time-series-db-data-simulation",
+    "has_content": false
+  },
+  {
+    "name": "time-series-db-visualization-pattern",
+    "slug": "time-series-db-visualization-pattern",
+    "category": "design",
+    "description": "Render TSDB metrics as real-time area charts with gradient fills, stat cards, and DPR-aware canvas/SVG on a dark monitoring theme.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "time series db visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/time-series-db-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "transaction-trace-pack-serialization-with-step-hierarchy",
+    "slug": "transaction-trace-pack-serialization-with-step-hierarchy",
     "category": "apm",
     "description": "Encode per-request distributed traces as a hierarchical list of typed steps (method, DB, external call, error) in a compressed binary pack, indexed by request end-time",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/apm/transaction-trace-pack-serialization-with-step-hierarchy/SKILL.md"
+    "path": "skills/apm/transaction-trace-pack-serialization-with-step-hierarchy",
+    "has_content": false
   },
   {
     "name": "triage-issue",
+    "slug": "triage-issue",
     "category": "debug",
     "description": "Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. Use when user reports a bug, wants to file an issue, mentions \"triage\", or wants to investigate and plan a fix for a problem.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/debug/triage-issue/SKILL.md"
+    "path": "skills/debug/triage-issue",
+    "has_content": false
   },
   {
     "name": "triple-env-file-split-loader",
+    "slug": "triple-env-file-split-loader",
     "category": "devops",
     "description": "Split operator-facing env into three files (.env / .version / .memory) and load them in a fixed order",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/devops/triple-env-file-split-loader/SKILL.md"
+    "path": "skills/devops/triple-env-file-split-loader",
+    "has_content": true
   },
   {
     "name": "ts-type-prefix-convention",
+    "slug": "ts-type-prefix-convention",
     "category": "frontend",
     "description": "Prefix interfaces with I and type aliases with T; use type for unions/literals and interface for inheritable shapes",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/frontend/ts-type-prefix-convention/SKILL.md"
+    "path": "skills/frontend/ts-type-prefix-convention",
+    "has_content": true
   },
   {
     "name": "tsv-driven-permission-bootstrap",
+    "slug": "tsv-driven-permission-bootstrap",
     "category": "backend",
     "description": "Treat a version-controlled TSV file as source of truth for the Function/Permission/Menu catalog; the service reconciles the DB against it on startup",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/tsv-driven-permission-bootstrap/SKILL.md"
+    "path": "skills/backend/tsv-driven-permission-bootstrap",
+    "has_content": true
   },
   {
     "name": "ubiquitous-language",
+    "slug": "ubiquitous-language",
     "category": "docs",
     "description": "Extract a DDD-style ubiquitous language glossary from the current conversation, flagging ambiguities and proposing canonical terms. Saves to UBIQUITOUS_LANGUAGE.md. Use when user wants to define domain terms, build a glossary, harden terminology, create a ubiquitous language, or mentions \"domain model\" or \"DDD\".",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/docs/ubiquitous-language/SKILL.md"
+    "path": "skills/docs/ubiquitous-language",
+    "has_content": false
   },
   {
     "name": "udp-with-tcp-fallback-metrics-transport",
+    "slug": "udp-with-tcp-fallback-metrics-transport",
     "category": "backend",
     "description": "Transport telemetry via UDP for low-latency fire-and-forget streams, and fall back to TCP for critical request/response and bulk uploads that require delivery guarantees",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/udp-with-tcp-fallback-metrics-transport/SKILL.md"
+    "path": "skills/backend/udp-with-tcp-fallback-metrics-transport",
+    "has_content": false
+  },
+  {
+    "name": "unfreeze",
+    "slug": "unfreeze",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "0.1.0",
+    "path": "skills/workflow/unfreeze",
+    "has_content": false
   },
   {
     "name": "version-specific-sql-map-selection",
+    "slug": "version-specific-sql-map-selection",
     "category": "backend",
     "description": "Select MyBatis-style SQL maps at runtime by DBMS + version with graceful fallback to a default supported version",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/version-specific-sql-map-selection/SKILL.md"
+    "path": "skills/backend/version-specific-sql-map-selection",
+    "has_content": false
   },
   {
     "name": "vllm-nginx-tls-single-port-routing",
+    "slug": "vllm-nginx-tls-single-port-routing",
     "category": "ai",
     "description": "Serve multiple vLLM OpenAI-API backends behind one Nginx TLS proxy on 443 using path-based routing",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/ai/vllm-nginx-tls-single-port-routing/SKILL.md"
+    "path": "skills/ai/vllm-nginx-tls-single-port-routing",
+    "has_content": true
+  },
+  {
+    "name": "websocket-data-simulation",
+    "slug": "websocket-data-simulation",
+    "category": "workflow",
+    "description": "Generate realistic simulated WebSocket traffic (latency curves, typed frames, chat presence) without a live server using timer-driven random generators.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "websocket data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/websocket-data-simulation",
+    "has_content": false
   },
   {
     "name": "websocket-stomp-channel-pool-config",
+    "slug": "websocket-stomp-channel-pool-config",
     "category": "backend",
     "description": "Spring WebSocket STOMP config with separate inbound/outbound task executors and raised transport buffer limits, sized for burst notification fan-out to many role-filtered subscribers.",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/websocket-stomp-channel-pool-config/SKILL.md"
+    "path": "skills/backend/websocket-stomp-channel-pool-config",
+    "has_content": true
+  },
+  {
+    "name": "websocket-visualization-pattern",
+    "slug": "websocket-visualization-pattern",
+    "category": "design",
+    "description": "Render WebSocket traffic, latency, and connection state using three complementary visual encodings (canvas time-series, SVG frame flow, DOM chat stream).",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "websocket visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/websocket-visualization-pattern",
+    "has_content": false
   },
   {
     "name": "widget-card-composition",
+    "slug": "widget-card-composition",
     "category": "design",
     "description": "Dashboard widget composition pattern using a CardWidget chrome wrapper with domain-specific Card* content components, resize tracking, and popover menus",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/design/widget-card-composition/SKILL.md"
+    "path": "skills/design/widget-card-composition",
+    "has_content": false
   },
   {
     "name": "widget-confid-injection-sweep",
+    "slug": "widget-confid-injection-sweep",
     "category": "frontend",
     "description": "리소스 상세 대시보드에서 모든 위젯 데이터 요청에 `confId` 를 일관되게 주입하기 위한 위젯 fetch 지점 전수 스윕(sweep) 패턴 — 일부만 주입하면 같은 대시보드 안에서 위젯별 필터 동작이 갈라지는 버그를 방지한다.",
+    "tags": [],
+    "triggers": [
+      "confId 주입",
+      "selectCondition confId",
+      "위젯 필터링",
+      "widget scope injection",
+      "resource-scoped widget"
+    ],
     "version": "1.0.0",
-    "path": "skills/frontend/widget-confid-injection-sweep/SKILL.md"
+    "path": "skills/frontend/widget-confid-injection-sweep",
+    "has_content": false
   },
   {
     "name": "widget-grid-type-registration-checklist",
+    "slug": "widget-grid-type-registration-checklist",
     "category": "frontend",
     "description": "대시보드의 TableGrid/차트 위젯에 새로운 타입을 추가할 때 드리프트 없이 5곳(columns 매핑, fetch hook, 에디터 폼, detectType, 모델 DTO) 모두 반영하게 하는 체크리스트 스킬.",
+    "tags": [],
+    "triggers": [
+      "TableGridType",
+      "위젯 타입 추가",
+      "tableGridType",
+      "widget type registration",
+      "detectType",
+      "columns mapping"
+    ],
     "version": "1.0.0",
-    "path": "skills/frontend/widget-grid-type-registration-checklist/SKILL.md"
+    "path": "skills/frontend/widget-grid-type-registration-checklist",
+    "has_content": false
   },
   {
     "name": "write-a-prd",
+    "slug": "write-a-prd",
     "category": "workflow",
     "description": "Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. Use when user wants to write a PRD, create a product requirements document, or plan a new feature.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/workflow/write-a-prd/SKILL.md"
+    "path": "skills/workflow/write-a-prd",
+    "has_content": false
   },
   {
     "name": "write-a-skill",
+    "slug": "write-a-skill",
     "category": "misc",
     "description": "Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, or build a new skill.",
+    "tags": [],
+    "triggers": [],
     "version": "0.1.0-draft",
-    "path": "skills/misc/write-a-skill/SKILL.md"
+    "path": "skills/misc/write-a-skill",
+    "has_content": false
   },
   {
     "name": "x-filterable-fields-extraction",
+    "slug": "x-filterable-fields-extraction",
     "category": "workflow",
     "description": "OpenAPI 스펙에 x-filterable-fields 확장을 자동 생성하는 파이프라인. lucida-ui gridColumnDefs + lucida-meta i18n properties를 조합하여 필드명/한국어 title/operators를 추출",
+    "tags": [],
+    "triggers": [
+      "x-filterable-fields",
+      "필터 가능 필드 추출",
+      "gridFilters 메타데이터",
+      "tagFilters 메타데이터",
+      "리소스 키 추출",
+      "GridFilter 정확도 개선"
+    ],
     "version": "1.0.0",
-    "path": "skills/workflow/x-filterable-fields-extraction/SKILL.md"
+    "path": "skills/workflow/x-filterable-fields-extraction",
+    "has_content": false
   },
   {
     "name": "yorkie-crdt-sync-pattern",
+    "slug": "yorkie-crdt-sync-pattern",
     "category": "backend",
     "description": "Apply a single doc.update callback for local mutations and pullRemoteChangesIntoLocal(WithNodeIds) for remote→local sync in Yorkie-backed apps",
+    "tags": [],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/backend/yorkie-crdt-sync-pattern/SKILL.md"
+    "path": "skills/backend/yorkie-crdt-sync-pattern",
+    "has_content": true
   },
   {
     "name": "zustand-preset-manager",
+    "slug": "zustand-preset-manager",
     "category": "frontend",
     "description": "Zustand + persist middleware pattern for managing N named presets (team comps, saved filters, dashboard layouts) with active-selection, max-count guard, and auto-reselect on delete.",
+    "tags": [
+      "zustand",
+      "localstorage",
+      "preset",
+      "state-management",
+      "persist-middleware"
+    ],
+    "triggers": [
+      "zustand persist",
+      "saved presets",
+      "team presets",
+      "named configurations",
+      "localStorage preset",
+      "multi-preset selector"
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/frontend/zustand-preset-manager/SKILL.md"
+    "path": "skills/frontend/zustand-preset-manager",
+    "has_content": true
   }
 ]


### PR DESCRIPTION
## Summary
- Regenerated `index.json` from all 354 skill directories (was 240)
- Fixed CRLF-safe frontmatter parsing for YAML list-style tags/triggers
- 170 skills have content.md, 184 are stubs (SKILL.md only)

## Dry-run report
- Malformed SKILL.md: 0
- Category violations: 0
- Missing content.md: 168
- Ghost index entries: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)