### PR TITLE
docs: regenerate example catalog (542 examples)

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -6,427 +6,560 @@ End-to-end, runnable **example projects** built from (and demonstrating) skills 
 
 - Browse the catalog below, pick one, `git clone` or copy its folder.
 - Each folder has a self-contained `README.md` with runnable instructions.
-- Regenerate this catalog by running `/example_list --refresh` (it re-walks each subfolder's manifest).
+- Total: **542 examples**
 
 ## Catalog
 
 | slug | title | stack | created |
 |---|---|---|---|
-| [skills-explorer](skills-explorer/) | Skills Explorer — offline search dashboard for a local skills-hub checkout | node, html, js | 2026-04-16 |
-| [skill-doctor](skill-doctor/)       | Skill Doctor — zero-dep linter for SKILL.md and knowledge/*.md, CI-ready exit codes | node, cli | 2026-04-16 |
-| [skill-graph](skill-graph/)         | Skill Graph — browser-based force-directed graph of skills ↔ knowledge relationships | node, html, svg, js | 2026-04-16 |
-| [skill-stats](skill-stats/)         | Skill Stats — aggregate KPIs, category donut, ranked tag/project bars | node, html, svg, js | 2026-04-16 |
-| [skill-timeline](skill-timeline/)   | Skill Timeline — git-history commit heatmap + top-churned slugs for a hub working copy | node, html, svg, js | 2026-04-16 |
-| [skill-tryout](skill-tryout/)       | Skill Tryout — offline TF-IDF trigger matcher REPL for debugging skill discoverability | node, html, js | 2026-04-16 |
-| [skill-diff](skill-diff/)           | Skill Diff — per-slug added/modified/removed viewer with description/tag/trigger deltas between two hub refs | node, html, js | 2026-04-16 |
-| [json-diff-tree](json-diff-tree/)   | JSON Diff Tree — structural JSON diff with collapsible tree, ignore-filter, and RFC 6902 JSON Patch export | html, js, css | 2026-04-16 |
-| [cron-explainer](cron-explainer/)   | Cron Explainer — parse 5/6/7-field cron to English, next 10 firings, 1-year firing-density heatmap | html, js, css | 2026-04-16 |
-| [tiny-regex-lab](tiny-regex-lab/)   | Tiny Regex Lab — offline regex playground with per-group highlighting, preset library, and share-link | html, js, css | 2026-04-16 |
-| [skill-multiplier](skill-multiplier/) | Skill Multiplier — self-running generational loop that breeds skills × knowledge into new children that themselves become parents, infinite propagation | node, html, js, css | 2026-04-16 |
-| [skill-breeder](skill-breeder/) | Skill Breeder — manual breeding station with autocomplete parent pickers, preview, accept/discard, and parent-chain lineage viewer | node, html, js, css | 2026-04-16 |
-| [skill-reactor](skill-reactor/) | Skill Reactor — rule-based reaction engine over the hub pool (`category=X + tag=Y → new skill`), cooldowns, per-rule stats, localStorage-persisted rules | node, html, js, css | 2026-04-16 |
-| [agent-orchestration-dashboard](agent-orchestration-dashboard/) | AI Agent Orchestration Dashboard — D3.js force graph visualizing multi-agent workflows with particle animations, live stats, 3 cycling scenarios | html, js, css, d3 | 2026-04-16 |
-| [mcp-protocol-playground](mcp-protocol-playground/) | MCP Protocol Playground — VS Code-inspired IDE for designing, validating, and simulating MCP tool schemas with 10 templates | html, js, css | 2026-04-16 |
-| [vibe-coding-canvas](vibe-coding-canvas/) | Vibe Coding Canvas — natural language to UI component generator, Korean/English input, live preview with generated HTML/CSS | html, js, css | 2026-04-16 |
-| [apm-dashboard](apm-dashboard/) | APM Suite Dashboard — trace waterfall, metrics dashboard (4 golden signals), service topology map with 7+ monitoring skills | html, css, vanilla-js | 2026-04-16 |
-| [binary-protocol-inspector](binary-protocol-inspector/) | Binary Protocol Inspector — hex editor, schema designer, VarInt visualizer, decode/encode with field highlighting | html, css, vanilla-js | 2026-04-16 |
-| [distributed-lock-visualizer](distributed-lock-visualizer/) | Distributed Lock Visualizer — MongoDB/Redis lock simulation with deadlock, thundering herd, split brain scenarios | html, css, vanilla-js, canvas | 2026-04-16 |
-| [gacha-simulator](gacha-simulator/) | Gacha Simulator Arena — pull system with soft/hard pity, character collection, turn-based combat, status effects | html, css, vanilla-js | 2026-04-16 |
-
-| [object-storage-galaxy](object-storage-galaxy/) | Object Storage Galaxy — auto-generated object-storage tool | html, css, vanilla-js | 2026-04-16 |
-
-| [auto-hub-loop](auto-hub-loop/) | Hub Auto-Loop Dashboard — automated pipeline with web dashboard for generating, publishing, and learning | node, html, css, vanilla-js | 2026-04-16 |
-| [dlq-flow-visualizer](dlq-flow-visualizer/) | Dlq Flow Visualizer — auto-generated dead-letter-queue tool | html, css, vanilla-js | 2026-04-16 |
-
-| [actor-lifecycle-sim](actor-lifecycle-sim/) | Actor Lifecycle Sim — auto-generated actor-model tool | html, css, vanilla-js | 2026-04-16 |
-
-| [mv-dependency-graph](mv-dependency-graph/) | Mv Dependency Graph — auto-generated materialized-view tool | html, css, vanilla-js | 2026-04-16 |
-
-| [tsdb-live-dashboard](tsdb-live-dashboard/) | Tsdb Live Dashboard — auto-generated time-series-db tool | html, css, vanilla-js | 2026-04-16 |
-
-| [ws-packet-visualizer](ws-packet-visualizer/) | Ws Packet Visualizer — auto-generated websocket tool | html, css, vanilla-js | 2026-04-16 |
-
-| [token-bucket-visualizer](token-bucket-visualizer/) | Token Bucket Visualizer — auto-generated rate-limiter tool | html, css, vanilla-js | 2026-04-16 |
-
-| [shard-flow-visualizer](shard-flow-visualizer/) | Shard Flow Visualizer — auto-generated database-sharding tool | html, css, vanilla-js | 2026-04-16 |
-
-| [circuit-breaker-dashboard](circuit-breaker-dashboard/) | Circuit Breaker Dashboard — auto-generated circuit-breaker tool | html, css, vanilla-js | 2026-04-16 |
-
-| [cdc-stream-monitor](cdc-stream-monitor/) | Cdc Stream Monitor — auto-generated cdc tool | html, css, vanilla-js | 2026-04-16 |
-
-| [consistent-hashing-ring](consistent-hashing-ring/) | Consistent Hashing Ring — auto-generated consistent-hashing tool | html, css, vanilla-js | 2026-04-16 |
-
-| [strangler-fig-growth](strangler-fig-growth/) | Strangler Fig Growth — auto-generated strangler-fig tool | html, css, vanilla-js | 2026-04-16 |
-
-| [chaos-blast-radius](chaos-blast-radius/) | Chaos Blast Radius — auto-generated chaos-engineering tool | html, css, vanilla-js | 2026-04-16 |
-
-| [etl-pipeline-viz](etl-pipeline-viz/) | Etl Pipeline Viz — auto-generated etl tool | html, css, vanilla-js | 2026-04-16 |
-
-| [bulkhead-simulator](bulkhead-simulator/) | Bulkhead Simulator — auto-generated bulkhead tool | html, css, vanilla-js | 2026-04-16 |
-
-| [event-sourcing-timeline](event-sourcing-timeline/) | Event Sourcing Timeline — auto-generated event-sourcing tool | html, css, vanilla-js | 2026-04-16 |
-
-| [log-stream-monitor](log-stream-monitor/) | Log Stream Monitor — auto-generated log-aggregation tool | html, css, vanilla-js | 2026-04-16 |
-
-| [backpressure-pipeline](backpressure-pipeline/) | Backpressure Pipeline — auto-generated backpressure tool | html, css, vanilla-js | 2026-04-16 |
-
-| [domain-driven-bounded-context-map](domain-driven-bounded-context-map/) | Domain Driven Bounded Context Map — auto-generated domain-driven tool | html, css, vanilla-js | 2026-04-16 |
-
-| [saga-orchestrator-sim](saga-orchestrator-sim/) | Saga Orchestrator Sim — auto-generated saga-pattern tool | html, css, vanilla-js | 2026-04-16 |
-
-| [retry-strategy-visualizer](retry-strategy-visualizer/) | Retry Strategy Visualizer — auto-generated retry-strategy tool | html, css, vanilla-js | 2026-04-16 |
-
-| [schema-registry-explorer](schema-registry-explorer/) | Schema Registry Explorer — auto-generated schema-registry tool | html, css, vanilla-js | 2026-04-16 |
-
-| [blue-green-deploy-simulator](blue-green-deploy-simulator/) | Blue Green Deploy Simulator — auto-generated blue-green-deploy tool | html, css, vanilla-js | 2026-04-16 |
-
-| [idempotency-key-vault](idempotency-key-vault/) | Idempotency Key Vault — auto-generated idempotency tool | html, css, vanilla-js | 2026-04-16 |
-
-| [pipeline-flow-monitor](pipeline-flow-monitor/) | Pipeline Flow Monitor — auto-generated data-pipeline tool | html, css, vanilla-js | 2026-04-16 |
-
-| [load-balancer-simulator](load-balancer-simulator/) | Load Balancer Simulator — auto-generated load-balancer tool | html, css, vanilla-js | 2026-04-16 |
-
-| [connection-pool-monitor](connection-pool-monitor/) | Connection Pool Monitor — auto-generated connection-pool tool | html, css, vanilla-js | 2026-04-16 |
-
-| [canary-release-traffic-shifter](canary-release-traffic-shifter/) | Canary Release Traffic Shifter — auto-generated canary-release tool | html, css, vanilla-js | 2026-04-16 |
-
-| [hex-arch-flow-simulator](hex-arch-flow-simulator/) | Hex Arch Flow Simulator — auto-generated hexagonal-architecture tool | html, css, vanilla-js | 2026-04-16 |
-
-| [api-version-timeline](api-version-timeline/) | Api Version Timeline — auto-generated api-versioning tool | html, css, vanilla-js | 2026-04-16 |
-
-| [trace-waterfall](trace-waterfall/) | Trace Waterfall — auto-generated distributed-tracing tool | html, css, vanilla-js | 2026-04-16 |
-
-| [bff-pattern-flow](bff-pattern-flow/) | Bff Pattern Flow — auto-generated bff-pattern tool | html, css, vanilla-js | 2026-04-16 |
-
-| [fsm-visual-simulator](fsm-visual-simulator/) | Fsm Visual Simulator — auto-generated finite-state-machine tool | html, css, vanilla-js | 2026-04-16 |
-
-| [outbox-flow-simulator](outbox-flow-simulator/) | Outbox Flow Simulator — auto-generated outbox-pattern tool | html, css, vanilla-js | 2026-04-16 |
-
-| [command-query-pipeline](command-query-pipeline/) | Command Query Pipeline — auto-generated command-query tool | html, css, vanilla-js | 2026-04-16 |
-
-| [pub-sub-flow-canvas](pub-sub-flow-canvas/) | Pub Sub Flow Canvas — auto-generated pub-sub tool | html, css, vanilla-js | 2026-04-16 |
-
-| [sidecar-proxy-topology](sidecar-proxy-topology/) | Sidecar Proxy Topology — auto-generated sidecar-proxy tool | html, css, vanilla-js | 2026-04-16 |
-
-| [heartbeat-monitor](heartbeat-monitor/) | Heartbeat Monitor — auto-generated health-check tool | html, css, vanilla-js | 2026-04-16 |
-
-| [oauth-flow-visualizer](oauth-flow-visualizer/) | Oauth Flow Visualizer — auto-generated oauth tool | html, css, vanilla-js | 2026-04-16 |
-
-| [oauth-token-inspector](oauth-token-inspector/) | Oauth Token Inspector — auto-generated oauth tool | html, css, vanilla-js | 2026-04-16 |
-
-| [shard-ring-router](shard-ring-router/) | Shard Ring Router — auto-generated database-sharding tool | html, css, vanilla-js | 2026-04-16 |
-
-| [retry-strategy-simulator](retry-strategy-simulator/) | Retry Strategy Simulator — auto-generated retry-strategy tool | html, css, vanilla-js | 2026-04-16 |
-
-| [etl-pipeline-flow](etl-pipeline-flow/) | Etl Pipeline Flow — auto-generated etl tool | html, css, vanilla-js | 2026-04-16 |
-
-| [object-storage-bucket-viz](object-storage-bucket-viz/) | Object Storage Bucket Viz — auto-generated object-storage tool | html, css, vanilla-js | 2026-04-16 |
-
-| [websocket-pulse](websocket-pulse/) | Websocket Pulse — auto-generated websocket tool | html, css, vanilla-js | 2026-04-16 |
-
-| [strangler-fig-simulator](strangler-fig-simulator/) | Strangler Fig Simulator — auto-generated strangler-fig tool | html, css, vanilla-js | 2026-04-16 |
-
-| [chaos-monkey-dashboard](chaos-monkey-dashboard/) | Chaos Monkey Dashboard — auto-generated chaos-engineering tool | html, css, vanilla-js | 2026-04-16 |
-
-| [materialized-view-dag](materialized-view-dag/) | Materialized View Dag — auto-generated materialized-view tool | html, css, vanilla-js | 2026-04-16 |
-
-| [blue-green-traffic-flow](blue-green-traffic-flow/) | Blue Green Traffic Flow — auto-generated blue-green-deploy tool | html, css, vanilla-js | 2026-04-16 |
-
-| [actor-message-flow](actor-message-flow/) | Actor Message Flow — auto-generated actor-model tool | html, css, vanilla-js | 2026-04-16 |
-
-| [saga-pattern-orchestrator](saga-pattern-orchestrator/) | Saga Pattern Orchestrator — auto-generated saga-pattern tool | html, css, vanilla-js | 2026-04-16 |
-
-| [outbox-pattern-flow](outbox-pattern-flow/) | Outbox Pattern Flow — auto-generated outbox-pattern tool | html, css, vanilla-js | 2026-04-16 |
-
-| [raft-election-arena](raft-election-arena/) | Raft Election Arena — auto-generated raft-consensus tool | html, css, vanilla-js | 2026-04-16 |
-
-| [domain-driven-context-map](domain-driven-context-map/) | Domain Driven Context Map — auto-generated domain-driven tool | html, css, vanilla-js | 2026-04-16 |
-
-| [bloom-filter-visualizer](bloom-filter-visualizer/) | Bloom Filter Visualizer — auto-generated bloom-filter tool | html, css, vanilla-js | 2026-04-16 |
-
-| [raft-leader-election](raft-leader-election/) | Raft Leader Election — auto-generated raft-consensus tool | html, css, vanilla-js | 2026-04-16 |
-
-| [circuit-breaker-simulator](circuit-breaker-simulator/) | Circuit Breaker Simulator — auto-generated circuit-breaker tool | html, css, vanilla-js | 2026-04-16 |
-
-| [service-topology](service-topology/) | Service Topology — auto-generated distributed-tracing tool | html, css, vanilla-js | 2026-04-16 |
-
-| [idempotency-proof-canvas](idempotency-proof-canvas/) | Idempotency Proof Canvas — auto-generated idempotency tool | html, css, vanilla-js | 2026-04-16 |
-
-| [fsm-regex-tester](fsm-regex-tester/) | Fsm Regex Tester — auto-generated finite-state-machine tool | html, css, vanilla-js | 2026-04-16 |
-
-| [strangler-fig-ecosystem](strangler-fig-ecosystem/) | Strangler Fig Ecosystem — auto-generated strangler-fig tool | html, css, vanilla-js | 2026-04-16 |
-
-| [service-mesh-topology](service-mesh-topology/) | Service Mesh Topology — auto-generated service-mesh tool | html, css, vanilla-js | 2026-04-16 |
-
-| [canary-release-timeline](canary-release-timeline/) | Canary Release Timeline — auto-generated canary-release tool | html, css, vanilla-js | 2026-04-16 |
-
-| [cdc-table-diff](cdc-table-diff/) | Cdc Table Diff — auto-generated cdc tool | html, css, vanilla-js | 2026-04-16 |
-
-| [tsdb-query-playground](tsdb-query-playground/) | Tsdb Query Playground — auto-generated time-series-db tool | html, css, vanilla-js | 2026-04-16 |
-
-| [pipeline-dag-builder](pipeline-dag-builder/) | Pipeline Dag Builder — auto-generated data-pipeline tool | html, css, vanilla-js | 2026-04-16 |
-
-| [event-sourcing-bank](event-sourcing-bank/) | Event Sourcing Bank — auto-generated event-sourcing tool | html, css, vanilla-js | 2026-04-16 |
-
-| [api-versioning-timeline](api-versioning-timeline/) | Api Versioning Timeline — auto-generated api-versioning tool | html, css, vanilla-js | 2026-04-16 |
-
-| [chaos-fault-injector](chaos-fault-injector/) | Chaos Fault Injector — auto-generated chaos-engineering tool | html, css, vanilla-js | 2026-04-16 |
-
-| [rate-limiter-playground](rate-limiter-playground/) | Rate Limiter Playground — auto-generated rate-limiter tool | html, css, vanilla-js | 2026-04-16 |
-
-| [websocket-frames](websocket-frames/) | Websocket Frames — auto-generated websocket tool | html, css, vanilla-js | 2026-04-16 |
-
-| [circuit-breaker-flow](circuit-breaker-flow/) | Circuit Breaker Flow — auto-generated circuit-breaker tool | html, css, vanilla-js | 2026-04-16 |
-
-| [saga-pattern-timeline](saga-pattern-timeline/) | Saga Pattern Timeline — auto-generated saga-pattern tool | html, css, vanilla-js | 2026-04-16 |
-
-| [dlq-autopsy-table](dlq-autopsy-table/) | Dlq Autopsy Table — auto-generated dead-letter-queue tool | html, css, vanilla-js | 2026-04-16 |
-
-| [message-queue-flow](message-queue-flow/) | Message Queue Flow — auto-generated message-queue tool | html, css, vanilla-js | 2026-04-16 |
-
-| [tsdb-live-monitor](tsdb-live-monitor/) | Tsdb Live Monitor — auto-generated time-series-db tool | html, css, vanilla-js | 2026-04-16 |
-
-| [connection-pool-bubbles](connection-pool-bubbles/) | Connection Pool Bubbles — auto-generated connection-pool tool | html, css, vanilla-js | 2026-04-16 |
-
-| [event-sourcing-ledger](event-sourcing-ledger/) | Event Sourcing Ledger — auto-generated event-sourcing tool | html, css, vanilla-js | 2026-04-16 |
-
-| [canary-release-dashboard](canary-release-dashboard/) | Canary Release Dashboard — auto-generated canary-release tool | html, css, vanilla-js | 2026-04-16 |
-
-| [schema-version-timeline](schema-version-timeline/) | Schema Version Timeline — auto-generated schema-registry tool | html, css, vanilla-js | 2026-04-16 |
-
-| [idempotency-sandbox](idempotency-sandbox/) | Idempotency Sandbox — auto-generated idempotency tool | html, css, vanilla-js | 2026-04-16 |
-
-| [bulkhead-ship](bulkhead-ship/) | Bulkhead Ship — auto-generated bulkhead tool | html, css, vanilla-js | 2026-04-16 |
-
-| [circuit-breaker-visualizer](circuit-breaker-visualizer/) | Circuit Breaker Visualizer — auto-generated circuit-breaker tool | html, css, vanilla-js | 2026-04-16 |
-
-| [sidecar-proxy-traffic-flow](sidecar-proxy-traffic-flow/) | Sidecar Proxy Traffic Flow — auto-generated sidecar-proxy tool | html, css, vanilla-js | 2026-04-16 |
-
-| [cqrs-event-flow](cqrs-event-flow/) | Cqrs Event Flow — auto-generated cqrs tool | html, css, vanilla-js | 2026-04-16 |
-
-| [event-sourcing-stream](event-sourcing-stream/) | Event Sourcing Stream — auto-generated event-sourcing tool | html, css, vanilla-js | 2026-04-16 |
-
-| [retry-strategy-timeline](retry-strategy-timeline/) | Retry Strategy Timeline — auto-generated retry-strategy tool | html, css, vanilla-js | 2026-04-16 |
-
-| [command-query-separator](command-query-separator/) | Command Query Separator — auto-generated command-query tool | html, css, vanilla-js | 2026-04-16 |
-
-| [object-storage-treemap](object-storage-treemap/) | Object Storage Treemap — auto-generated object-storage tool | html, css, vanilla-js | 2026-04-16 |
-
-| [pub-sub-galaxy](pub-sub-galaxy/) | Pub Sub Galaxy — auto-generated pub-sub tool | html, css, vanilla-js | 2026-04-16 |
-
-| [graphql-schema-galaxy](graphql-schema-galaxy/) | Graphql Schema Galaxy — auto-generated graphql tool | html, css, vanilla-js | 2026-04-16 |
-
-| [lb-traffic-flow](lb-traffic-flow/) | Lb Traffic Flow — auto-generated load-balancer tool | html, css, vanilla-js | 2026-04-16 |
-
-| [queue-monitor-dashboard](queue-monitor-dashboard/) | Queue Monitor Dashboard — auto-generated message-queue tool | html, css, vanilla-js | 2026-04-16 |
-
-| [chaos-monkey-simulator](chaos-monkey-simulator/) | Chaos Monkey Simulator — auto-generated chaos-engineering tool | html, css, vanilla-js | 2026-04-16 |
-
-| [tsdb-retention-planner](tsdb-retention-planner/) | Tsdb Retention Planner — auto-generated time-series-db tool | html, css, vanilla-js | 2026-04-16 |
-
-| [cdc-stream-visualizer](cdc-stream-visualizer/) | Cdc Stream Visualizer — auto-generated cdc tool | html, css, vanilla-js | 2026-04-16 |
-
-| [health-check-pulse](health-check-pulse/) | Health Check Pulse — auto-generated health-check tool | html, css, vanilla-js | 2026-04-16 |
-
-| [idempotency-replay-lab](idempotency-replay-lab/) | Idempotency Replay Lab — auto-generated idempotency tool | html, css, vanilla-js | 2026-04-16 |
-
-| [api-versioning-drift-monitor](api-versioning-drift-monitor/) | Api Versioning Drift Monitor — auto-generated api-versioning tool | html, css, vanilla-js | 2026-04-16 |
-
-| [bloom-filter-false-positive](bloom-filter-false-positive/) | Bloom Filter False Positive — auto-generated bloom-filter tool | html, css, vanilla-js | 2026-04-16 |
-
-| [consistent-hashing-load](consistent-hashing-load/) | Consistent Hashing Load — auto-generated consistent-hashing tool | html, css, vanilla-js | 2026-04-16 |
-
-| [pipeline-throughput-dashboard](pipeline-throughput-dashboard/) | Pipeline Throughput Dashboard — auto-generated data-pipeline tool | html, css, vanilla-js | 2026-04-16 |
-
-| [connection-pool-tuner](connection-pool-tuner/) | Connection Pool Tuner — auto-generated connection-pool tool | html, css, vanilla-js | 2026-04-16 |
-
-| [bff-pattern-dashboard](bff-pattern-dashboard/) | Bff Pattern Dashboard — auto-generated bff-pattern tool | html, css, vanilla-js | 2026-04-16 |
-
-| [fsm-traffic-controller](fsm-traffic-controller/) | Fsm Traffic Controller — auto-generated finite-state-machine tool | html, css, vanilla-js | 2026-04-16 |
-
-| [domain-driven-aggregate-builder](domain-driven-aggregate-builder/) | Domain Driven Aggregate Builder — auto-generated domain-driven tool | html, css, vanilla-js | 2026-04-16 |
-
-| [log-stream-waterfall](log-stream-waterfall/) | Log Stream Waterfall — auto-generated log-aggregation tool | html, css, vanilla-js | 2026-04-16 |
-
-| [schema-compatibility-checker](schema-compatibility-checker/) | Schema Compatibility Checker — auto-generated schema-registry tool | html, css, vanilla-js | 2026-04-16 |
-
-| [hex-arch-port-adapter-sim](hex-arch-port-adapter-sim/) | Hex Arch Port Adapter Sim — auto-generated hexagonal-architecture tool | html, css, vanilla-js | 2026-04-16 |
-
-| [trace-waterfall-viewer](trace-waterfall-viewer/) | Trace Waterfall Viewer — auto-generated distributed-tracing tool | html, css, vanilla-js | 2026-04-16 |
-
-| [bff-pattern-builder](bff-pattern-builder/) | Bff Pattern Builder — auto-generated bff-pattern tool | html, css, vanilla-js | 2026-04-16 |
-
-| [object-storage-flow](object-storage-flow/) | Object Storage Flow — auto-generated object-storage tool | html, css, vanilla-js | 2026-04-16 |
-
-| [dlq-pulse-monitor](dlq-pulse-monitor/) | Dlq Pulse Monitor — auto-generated dead-letter-queue tool | html, css, vanilla-js | 2026-04-16 |
-
-| [canary-release-simulator](canary-release-simulator/) | Canary Release Simulator — auto-generated canary-release tool | html, css, vanilla-js | 2026-04-16 |
-
-| [log-heatmap-grid](log-heatmap-grid/) | Log Heatmap Grid — auto-generated log-aggregation tool | html, css, vanilla-js | 2026-04-16 |
-
-| [oauth-scope-playground](oauth-scope-playground/) | Oauth Scope Playground — auto-generated oauth tool | html, css, vanilla-js | 2026-04-16 |
-
-| [read-replica-topology](read-replica-topology/) | Read Replica Topology — auto-generated read-replica tool | html, css, vanilla-js | 2026-04-16 |
-
-| [fsm-playground](fsm-playground/) | Fsm Playground — auto-generated finite-state-machine tool | html, css, vanilla-js | 2026-04-16 |
-
-| [hex-arch-visualizer](hex-arch-visualizer/) | Hex Arch Visualizer — auto-generated hexagonal-architecture tool | html, css, vanilla-js | 2026-04-16 |
-
-| [command-query-timeline](command-query-timeline/) | Command Query Timeline — auto-generated command-query tool | html, css, vanilla-js | 2026-04-16 |
-
-| [rate-limiter-bucket](rate-limiter-bucket/) | Rate Limiter Bucket — auto-generated rate-limiter tool | html, css, vanilla-js | 2026-04-16 |
-
-| [schema-evolution-timeline](schema-evolution-timeline/) | Schema Evolution Timeline — auto-generated schema-registry tool | html, css, vanilla-js | 2026-04-16 |
-
-| [etl-pipeline-visualizer](etl-pipeline-visualizer/) | Etl Pipeline Visualizer — auto-generated etl tool | html, css, vanilla-js | 2026-04-16 |
-
-| [load-balancer-arena](load-balancer-arena/) | Load Balancer Arena — auto-generated load-balancer tool | html, css, vanilla-js | 2026-04-16 |
-
-| [backpressure-river](backpressure-river/) | Backpressure River — auto-generated backpressure tool | html, css, vanilla-js | 2026-04-16 |
-
-| [actor-mailbox-simulator](actor-mailbox-simulator/) | Actor Mailbox Simulator — auto-generated actor-model tool | html, css, vanilla-js | 2026-04-16 |
-
-| [shard-router-visualizer](shard-router-visualizer/) | Shard Router Visualizer — auto-generated database-sharding tool | html, css, vanilla-js | 2026-04-16 |
-
-| [service-mesh-traffic-visualizer](service-mesh-traffic-visualizer/) | Service Mesh Traffic Visualizer — auto-generated service-mesh tool | html, css, vanilla-js | 2026-04-16 |
-
-| [sidecar-proxy-flow](sidecar-proxy-flow/) | Sidecar Proxy Flow — auto-generated sidecar-proxy tool | html, css, vanilla-js | 2026-04-16 |
-
-| [raft-consensus-quiz](raft-consensus-quiz/) | Raft Consensus Quiz — auto-generated raft-consensus tool | html, css, vanilla-js | 2026-04-16 |
-
-| [bloom-filter-explorer](bloom-filter-explorer/) | Bloom Filter Explorer — auto-generated bloom-filter tool | html, css, vanilla-js | 2026-04-16 |
-
-| [message-queue-conveyor](message-queue-conveyor/) | Message Queue Conveyor — auto-generated message-queue tool | html, css, vanilla-js | 2026-04-16 |
-
-| [blue-green-traffic-shifter](blue-green-traffic-shifter/) | Blue Green Traffic Shifter — auto-generated blue-green-deploy tool | html, css, vanilla-js | 2026-04-16 |
-
-| [circuit-breaker-puzzle](circuit-breaker-puzzle/) | Circuit Breaker Puzzle — auto-generated circuit-breaker tool | html, css, vanilla-js | 2026-04-16 |
-
-| [cqrs-flow-visualizer](cqrs-flow-visualizer/) | Cqrs Flow Visualizer — auto-generated cqrs tool | html, css, vanilla-js | 2026-04-16 |
-
-| [materialized-view-builder](materialized-view-builder/) | Materialized View Builder — auto-generated materialized-view tool | html, css, vanilla-js | 2026-04-16 |
-
-| [chaos-blast-radius-simulator](chaos-blast-radius-simulator/) | Chaos Blast Radius Simulator — auto-generated chaos-engineering tool | html, css, vanilla-js | 2026-04-16 |
-
-| [topic-river](topic-river/) | Topic River — auto-generated pub-sub tool | html, css, vanilla-js | 2026-04-16 |
-
-| [cdc-replay-timeline](cdc-replay-timeline/) | Cdc Replay Timeline — auto-generated cdc tool | html, css, vanilla-js | 2026-04-16 |
-
-| [idempotent-function-playground](idempotent-function-playground/) | Idempotent Function Playground — auto-generated idempotency tool | html, css, vanilla-js | 2026-04-16 |
-
-| [websocket-pulse-monitor](websocket-pulse-monitor/) | Websocket Pulse Monitor — auto-generated websocket tool | html, css, vanilla-js | 2026-04-16 |
-
-| [retry-strategy-explorer](retry-strategy-explorer/) | Retry Strategy Explorer — auto-generated retry-strategy tool | html, css, vanilla-js | 2026-04-16 |
-
-| [feature-flags-rollout-simulator](feature-flags-rollout-simulator/) | Feature Flags Rollout Simulator — auto-generated feature-flags tool | html, css, vanilla-js | 2026-04-16 |
-
-| [api-gateway-traffic-router](api-gateway-traffic-router/) | Api Gateway Traffic Router — auto-generated api-gateway-pattern tool | html, css, vanilla-js | 2026-04-16 |
-
-| [event-replay-timeline](event-replay-timeline/) | Event Replay Timeline — auto-generated event-sourcing tool | html, css, vanilla-js | 2026-04-16 |
-
-| [bulkhead-pool-simulator](bulkhead-pool-simulator/) | Bulkhead Pool Simulator — auto-generated bulkhead tool | html, css, vanilla-js | 2026-04-16 |
-
-| [saga-orchestrator-flow](saga-orchestrator-flow/) | Saga Orchestrator Flow — auto-generated saga-pattern tool | html, css, vanilla-js | 2026-04-16 |
-
-| [api-versioning-diff-simulator](api-versioning-diff-simulator/) | Api Versioning Diff Simulator — auto-generated api-versioning tool | html, css, vanilla-js | 2026-04-16 |
-
-| [domain-driven-explorer](domain-driven-explorer/) | Domain Driven Explorer — auto-generated domain-driven tool | html, css, vanilla-js | 2026-04-16 |
-
-| [data-pipeline-flow](data-pipeline-flow/) | Data Pipeline Flow — auto-generated data-pipeline tool | html, css, vanilla-js | 2026-04-16 |
-
-| [graphql-query-playground](graphql-query-playground/) | Graphql Query Playground — auto-generated graphql tool | html, css, vanilla-js | 2026-04-16 |
-
-| [health-check-radar](health-check-radar/) | Health Check Radar — auto-generated health-check tool | html, css, vanilla-js | 2026-04-16 |
-
-| [connection-pool-visualizer](connection-pool-visualizer/) | Connection Pool Visualizer — auto-generated connection-pool tool | html, css, vanilla-js | 2026-04-16 |
-
-| [outbox-pattern-simulator](outbox-pattern-simulator/) | Outbox Pattern Simulator — auto-generated outbox-pattern tool | html, css, vanilla-js | 2026-04-16 |
-
-| [crdt-counter-cluster](crdt-counter-cluster/) | Crdt Counter Cluster — auto-generated crdt tool | html, css, vanilla-js | 2026-04-16 |
-
-| [hash-ring-visualizer](hash-ring-visualizer/) | Hash Ring Visualizer — auto-generated consistent-hashing tool | html, css, vanilla-js | 2026-04-16 |
-
-| [time-series-db-explorer](time-series-db-explorer/) | Time Series Db Explorer — auto-generated time-series-db tool | html, css, vanilla-js | 2026-04-16 |
-
-| [strangler-fig-migrator](strangler-fig-migrator/) | Strangler Fig Migrator — auto-generated strangler-fig tool | html, css, vanilla-js | 2026-04-16 |
-
-| [event-ledger-replay](event-ledger-replay/) | Event Ledger Replay — auto-generated event-sourcing tool | html, css, vanilla-js | 2026-04-16 |
-
-| [jwt-token-inspector](jwt-token-inspector/) | Jwt Token Inspector — auto-generated oauth tool | html, css, vanilla-js | 2026-04-16 |
-
-| [api-gateway-policy-lab](api-gateway-policy-lab/) | Api Gateway Policy Lab — auto-generated api-gateway-pattern tool | html, css, vanilla-js | 2026-04-16 |
-
-| [pipeline-flow-visualizer](pipeline-flow-visualizer/) | Pipeline Flow Visualizer — auto-generated data-pipeline tool | html, css, vanilla-js | 2026-04-16 |
-
-| [bulkhead-ship-damage](bulkhead-ship-damage/) | Bulkhead Ship Damage — auto-generated bulkhead tool | html, css, vanilla-js | 2026-04-16 |
-
-| [saga-choreography-swarm](saga-choreography-swarm/) | Saga Choreography Swarm — auto-generated saga-pattern tool | html, css, vanilla-js | 2026-04-16 |
-
-| [traffic-light-fsm](traffic-light-fsm/) | Traffic Light Fsm — auto-generated finite-state-machine tool | html, css, vanilla-js | 2026-04-16 |
-
-| [object-storage-explorer](object-storage-explorer/) | Object Storage Explorer — auto-generated object-storage tool | html, css, vanilla-js | 2026-04-16 |
-
-| [pub-sub-newsroom](pub-sub-newsroom/) | Pub Sub Newsroom — auto-generated pub-sub tool | html, css, vanilla-js | 2026-04-16 |
-
-| [feature-flag-rollout-simulator](feature-flag-rollout-simulator/) | Feature Flag Rollout Simulator — auto-generated feature-flags tool | html, css, vanilla-js | 2026-04-16 |
-
-| [event-sourced-counter](event-sourced-counter/) | Event Sourced Counter — auto-generated cqrs tool | html, css, vanilla-js | 2026-04-16 |
-
-| [rebalance-simulator](rebalance-simulator/) | Rebalance Simulator — auto-generated consistent-hashing tool | html, css, vanilla-js | 2026-04-16 |
-
-| [log-stream-river](log-stream-river/) | Log Stream River — auto-generated log-aggregation tool | html, css, vanilla-js | 2026-04-16 |
-
-| [websocket-handshake-visualizer](websocket-handshake-visualizer/) | Websocket Handshake Visualizer — auto-generated websocket tool | html, css, vanilla-js | 2026-04-16 |
-
-| [crdt-orset-graph](crdt-orset-graph/) | Crdt Orset Graph — auto-generated crdt tool | html, css, vanilla-js | 2026-04-16 |
-
-| [materialized-view-graph](materialized-view-graph/) | Materialized View Graph — auto-generated materialized-view tool | html, css, vanilla-js | 2026-04-16 |
-
-| [materialized-view-query-race](materialized-view-query-race/) | Materialized View Query Race — auto-generated materialized-view tool | html, css, vanilla-js | 2026-04-16 |
-
-| [outbox-pattern-timeline](outbox-pattern-timeline/) | Outbox Pattern Timeline — auto-generated outbox-pattern tool | html, css, vanilla-js | 2026-04-16 |
-
-| [outbox-pattern-lab](outbox-pattern-lab/) | Outbox Pattern Lab — auto-generated outbox-pattern tool | html, css, vanilla-js | 2026-04-16 |
-
-| [strangler-fig-timeline](strangler-fig-timeline/) | Strangler Fig Timeline — auto-generated strangler-fig tool | html, css, vanilla-js | 2026-04-16 |
-
-| [priority-queue-puzzle](priority-queue-puzzle/) | Priority Queue Puzzle — auto-generated message-queue tool | html, css, vanilla-js | 2026-04-16 |
-
-| [topic-pubsub-monitor](topic-pubsub-monitor/) | Topic Pubsub Monitor — auto-generated message-queue tool | html, css, vanilla-js | 2026-04-16 |
-
-| [connection-pool-config-lab](connection-pool-config-lab/) | Connection Pool Config Lab — auto-generated connection-pool tool | html, css, vanilla-js | 2026-04-16 |
-
-| [aggregate-event-stream](aggregate-event-stream/) | Aggregate Event Stream — auto-generated domain-driven tool | html, css, vanilla-js | 2026-04-16 |
-
-| [ubiquitous-language-glossary](ubiquitous-language-glossary/) | Ubiquitous Language Glossary — auto-generated domain-driven tool | html, css, vanilla-js | 2026-04-16 |
-
-| [reactive-stream-window](reactive-stream-window/) | Reactive Stream Window — auto-generated backpressure tool | html, css, vanilla-js | 2026-04-16 |
-
-| [conveyor-belt-jam](conveyor-belt-jam/) | Conveyor Belt Jam — auto-generated backpressure tool | html, css, vanilla-js | 2026-04-16 |
-
-| [health-check-dashboard](health-check-dashboard/) | Health Check Dashboard — auto-generated load-balancer tool | html, css, vanilla-js | 2026-04-16 |
-
-| [etl-data-quality-radar](etl-data-quality-radar/) | Etl Data Quality Radar — auto-generated etl tool | html, css, vanilla-js | 2026-04-16 |
-
-| [blue-green-deploy-timeline](blue-green-deploy-timeline/) | Blue Green Deploy Timeline — auto-generated blue-green-deploy tool | html, css, vanilla-js | 2026-04-16 |
-
-| [query-playground](query-playground/) | Query Playground — auto-generated command-query tool | html, css, vanilla-js | 2026-04-16 |
-
-| [separation-visualizer](separation-visualizer/) | Separation Visualizer — auto-generated command-query tool | html, css, vanilla-js | 2026-04-16 |
-
-| [hexagonal-dependency-inverter](hexagonal-dependency-inverter/) | Hexagonal Dependency Inverter — auto-generated hexagonal-architecture tool | html, css, vanilla-js | 2026-04-16 |
-
-| [hexagonal-request-tracer](hexagonal-request-tracer/) | Hexagonal Request Tracer — auto-generated hexagonal-architecture tool | html, css, vanilla-js | 2026-04-16 |
-
-| [sidecar-proxy-playground](sidecar-proxy-playground/) | Sidecar Proxy Playground — auto-generated service-mesh tool | html, css, vanilla-js | 2026-04-16 |
+| [actor-chat-repl](actor-chat-repl/) | Actor Chat Repl — Auto-generated actor-model visualization tool from hub-auto-loop cycle 300. | html, css, vanilla-js | 2026-04-16 |
+| [actor-hierarchy-tree](actor-hierarchy-tree/) | Actor Hierarchy Tree — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [actor-lifecycle-sim](actor-lifecycle-sim/) | Actor Lifecycle Sim — Auto-generated actor-model visualization tool from hub-auto-loop cycle 3. | html, css, vanilla-js | 2026-04-16 |
+| [actor-mailbox-sim](actor-mailbox-sim/) | Actor Mailbox Sim — Auto-generated actor-model visualization tool from hub-auto-loop cycle 300. | html, css, vanilla-js | 2026-04-16 |
+| [actor-mailbox-simulator](actor-mailbox-simulator/) | Actor Mailbox Simulator — Auto-generated actor-model visualization tool from hub-auto-loop cycle 213. | html, css, vanilla-js | 2026-04-16 |
+| [actor-mailbox-theater](actor-mailbox-theater/) | Actor Mailbox Theater — Auto-generated actor-model visualization tool from hub-auto-loop cycle 279. | html, css, vanilla-js | 2026-04-16 |
+| [actor-message-flow](actor-message-flow/) | Actor Message Flow — Auto-generated actor-model visualization tool from hub-auto-loop cycle 60. | html, css, vanilla-js | 2026-04-16 |
+| [actor-ping-pong-arena](actor-ping-pong-arena/) | Actor Ping Pong Arena — Auto-generated actor-model visualization tool from hub-auto-loop cycle 279. | html, css, vanilla-js | 2026-04-16 |
+| [actor-supervision-tree](actor-supervision-tree/) | Actor Supervision Tree — Auto-generated actor-model visualization tool from hub-auto-loop cycle 279. | html, css, vanilla-js | 2026-04-16 |
+| [adr-navigator](adr-navigator/) | Architecture Decision Navigator — `skills-explorer` is skill-centric — it shows patterns. This is knowledge-centric — it shows the *reasoning* behind patterns. Decision records and architecture knowledge explain why things are the way they are, which is what new team members and future maintainers actually need. | html, css, js | 2026-04-16 |
+| [agent-dashboard](agent-dashboard/) | Agent Dashboard — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [agent-orchestration-dashboard](agent-orchestration-dashboard/) | AI Agent Orchestration Dashboard — Multi-agent AI systems are the defining trend of 2025-2026, but understanding how agents communicate, delegate, and collaborate is hard without visualization. This dashboard renders agent orchestration flows as an interactive force-directed graph with real-time particle animations, message logs, and aggregate stats. | html, js, css, d3 | 2026-04-16 |
+| [aggregate-event-stream](aggregate-event-stream/) | Aggregate Event Stream — Auto-generated domain-driven visualization tool from hub-auto-loop cycle 266. | html, css, vanilla-js | 2026-04-16 |
+| [aggregate-invariant-simulator](aggregate-invariant-simulator/) | Aggregate Invariant Simulator — Auto-generated domain-driven visualization tool from hub-auto-loop cycle 296. | html, css, vanilla-js | 2026-04-16 |
+| [ai-timeline](ai-timeline/) | Ai Timeline — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [ai-timeline-chronicle](ai-timeline-chronicle/) | AI Timeline Chronicle — 2023-2026 AI/Tech 마일스톤 57개를 수평 타임라인으로 시각화 — LLM, Agents, Open Source, Regulation, Hardware 5개 레인에서 흐름을 한눈에 파악 | html, css, js | 2026-04-16 |
+| [algorithm-race-lab](algorithm-race-lab/) | Algorithm Race Lab — Auto-generated load-balancer visualization tool from hub-auto-loop cycle 270. | html, css, vanilla-js | 2026-04-16 |
+| [algorithm-showdown](algorithm-showdown/) | Algorithm Showdown — Auto-generated load-balancer visualization tool from hub-auto-loop cycle 303. | html, css, vanilla-js | 2026-04-16 |
+| [anomaly-alert-playground](anomaly-alert-playground/) | Anomaly Alert Playground — Auto-generated time-series-db visualization tool from hub-auto-loop cycle 244. | html, css, vanilla-js | 2026-04-16 |
+| [api-deprecation-dashboard](api-deprecation-dashboard/) | Api Deprecation Dashboard — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [api-diff-viewer](api-diff-viewer/) | Api Diff Viewer — Auto-generated api-versioning visualization tool from hub-auto-loop cycle 293. | html, css, vanilla-js | 2026-04-16 |
+| [api-gateway-filter-chain-simulator](api-gateway-filter-chain-simulator/) | Api Gateway Filter Chain Simulator — Auto-generated api-gateway-pattern visualization tool from hub-auto-loop cycle 231. | html, css, vanilla-js | 2026-04-16 |
+| [api-gateway-latency-dashboard](api-gateway-latency-dashboard/) | Api Gateway Latency Dashboard — Auto-generated api-gateway-pattern visualization tool from hub-auto-loop cycle 248. | html, css, vanilla-js | 2026-04-16 |
+| [api-gateway-pattern-config-builder](api-gateway-pattern-config-builder/) | Api Gateway Pattern Config Builder — Auto-generated api-gateway-pattern visualization tool from hub-auto-loop cycle 231. | html, css, vanilla-js | 2026-04-16 |
+| [api-gateway-policy-lab](api-gateway-policy-lab/) | Api Gateway Policy Lab — Auto-generated api-gateway-pattern visualization tool from hub-auto-loop cycle 248. | html, css, vanilla-js | 2026-04-16 |
+| [api-gateway-rate-limiter](api-gateway-rate-limiter/) | Api Gateway Rate Limiter — Auto-generated api-gateway-pattern visualization tool from hub-auto-loop cycle 295. | html, css, vanilla-js | 2026-04-16 |
+| [api-gateway-request-inspector](api-gateway-request-inspector/) | Api Gateway Request Inspector — Auto-generated api-gateway-pattern visualization tool from hub-auto-loop cycle 295. | html, css, vanilla-js | 2026-04-16 |
+| [api-gateway-traffic-router](api-gateway-traffic-router/) | Api Gateway Traffic Router — Auto-generated api-gateway-pattern visualization tool from hub-auto-loop cycle 231. | html, css, vanilla-js | 2026-04-16 |
+| [api-quota-dashboard](api-quota-dashboard/) | Api Quota Dashboard — Auto-generated rate-limiter visualization tool from hub-auto-loop cycle 291. | html, css, vanilla-js | 2026-04-16 |
+| [api-traffic-router](api-traffic-router/) | Api Traffic Router — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [api-version-timeline](api-version-timeline/) | Api Version Timeline — Auto-generated api-versioning visualization tool from hub-auto-loop cycle 40. | html, css, vanilla-js | 2026-04-16 |
+| [api-version-traffic](api-version-traffic/) | Api Version Traffic — Auto-generated api-versioning visualization tool from hub-auto-loop cycle 293. | html, css, vanilla-js | 2026-04-16 |
+| [api-versioning-compatibility-matrix](api-versioning-compatibility-matrix/) | Api Versioning Compatibility Matrix — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [api-versioning-diff-simulator](api-versioning-diff-simulator/) | Api Versioning Diff Simulator — Auto-generated api-versioning visualization tool from hub-auto-loop cycle 235. | html, css, vanilla-js | 2026-04-16 |
+| [api-versioning-drift-monitor](api-versioning-drift-monitor/) | Api Versioning Drift Monitor — Auto-generated api-versioning visualization tool from hub-auto-loop cycle 186. | html, css, vanilla-js | 2026-04-16 |
+| [api-versioning-negotiator](api-versioning-negotiator/) | Api Versioning Negotiator — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [api-versioning-timeline](api-versioning-timeline/) | Api Versioning Timeline — Auto-generated api-versioning visualization tool from hub-auto-loop cycle 71. | html, css, vanilla-js | 2026-04-16 |
+| [api-versioning-traffic-monitor](api-versioning-traffic-monitor/) | Api Versioning Traffic Monitor — Auto-generated api-versioning visualization tool from hub-auto-loop cycle 235. | html, css, vanilla-js | 2026-04-16 |
+| [apm-dashboard](apm-dashboard/) | APM Suite Dashboard — Interactive APM tool with trace waterfall, metrics dashboard, and service topology map — showcases 7+ monitoring skills in a single zero-dependency app. | html, css, vanilla-js | 2026-04-16 |
+| [auto-hub-loop](auto-hub-loop/) | Hub Auto-Loop Dashboard — Fully automated pipeline that generates apps, publishes to skills-hub, extracts skills/knowledge, and loops — with a real-time web dashboard for monitoring. | node, html, css, vanilla-js | 2026-04-16 |
+| [backpressure-dashboard](backpressure-dashboard/) | Backpressure Dashboard — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [backpressure-pipeline](backpressure-pipeline/) | Backpressure Pipeline — Auto-generated backpressure visualization tool from hub-auto-loop cycle 28. | html, css, vanilla-js | 2026-04-16 |
+| [backpressure-river](backpressure-river/) | Backpressure River — Auto-generated backpressure visualization tool from hub-auto-loop cycle 212. | html, css, vanilla-js | 2026-04-16 |
+| [backpressure-waves](backpressure-waves/) | Backpressure Waves — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [bff-pattern-builder](bff-pattern-builder/) | Bff Pattern Builder — Auto-generated bff-pattern visualization tool from hub-auto-loop cycle 198. | html, css, vanilla-js | 2026-04-16 |
+| [bff-pattern-comparator](bff-pattern-comparator/) | Bff Pattern Comparator — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [bff-pattern-dashboard](bff-pattern-dashboard/) | Bff Pattern Dashboard — Auto-generated bff-pattern visualization tool from hub-auto-loop cycle 191. | html, css, vanilla-js | 2026-04-16 |
+| [bff-pattern-flow](bff-pattern-flow/) | Bff Pattern Flow — Auto-generated bff-pattern visualization tool from hub-auto-loop cycle 42. | html, css, vanilla-js | 2026-04-16 |
+| [bff-pattern-latency](bff-pattern-latency/) | Bff Pattern Latency — Auto-generated bff-pattern visualization tool from hub-auto-loop cycle 284. | html, css, vanilla-js | 2026-04-16 |
+| [bff-pattern-payload](bff-pattern-payload/) | Bff Pattern Payload — Auto-generated bff-pattern visualization tool from hub-auto-loop cycle 284. | html, css, vanilla-js | 2026-04-16 |
+| [bff-pattern-router](bff-pattern-router/) | Bff Pattern Router — Auto-generated bff-pattern visualization tool from hub-auto-loop cycle 284. | html, css, vanilla-js | 2026-04-16 |
+| [bff-pattern-simulator](bff-pattern-simulator/) | Bff Pattern Simulator — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [binary-protocol](binary-protocol/) | Binary Protocol — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [binary-protocol-inspector](binary-protocol-inspector/) | Binary Protocol Inspector — Hex editor + binary protocol decoder with custom schema designer, VarInt visualizer, and field-to-byte highlighting — showcases wire protocol and frame envelope skills. | html, css, vanilla-js | 2026-04-16 |
+| [blast-radius-explorer](blast-radius-explorer/) | Blast Radius Explorer — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [bloom-filter-benchmark](bloom-filter-benchmark/) | Bloom Filter Benchmark — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [bloom-filter-collision-race](bloom-filter-collision-race/) | Bloom Filter Collision Race — Auto-generated bloom-filter visualization tool from hub-auto-loop cycle 287. | html, css, vanilla-js | 2026-04-16 |
+| [bloom-filter-comparison](bloom-filter-comparison/) | Bloom Filter Comparison | html, css, vanilla-js | 2026-04-16 |
+| [bloom-filter-explorer](bloom-filter-explorer/) | Bloom Filter Explorer — Auto-generated bloom-filter visualization tool from hub-auto-loop cycle 218. | html, css, vanilla-js | 2026-04-16 |
+| [bloom-filter-false-positive](bloom-filter-false-positive/) | Bloom Filter False Positive — Auto-generated bloom-filter visualization tool from hub-auto-loop cycle 187. | html, css, vanilla-js | 2026-04-16 |
+| [bloom-filter-false-positive-lab](bloom-filter-false-positive-lab/) | Bloom Filter False Positive Lab — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [bloom-filter-network](bloom-filter-network/) | Bloom Filter Network — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [bloom-filter-playground](bloom-filter-playground/) | Bloom Filter Playground | html, css, vanilla-js | 2026-04-16 |
+| [bloom-filter-spam-demo](bloom-filter-spam-demo/) | Bloom Filter Spam Demo — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [bloom-filter-spam-shield](bloom-filter-spam-shield/) | Bloom Filter Spam Shield — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [bloom-filter-username-check](bloom-filter-username-check/) | Bloom Filter Username Check — Auto-generated bloom-filter visualization tool from hub-auto-loop cycle 287. | html, css, vanilla-js | 2026-04-16 |
+| [bloom-filter-visualizer](bloom-filter-visualizer/) | Bloom Filter Visualizer — Auto-generated bloom-filter visualization tool from hub-auto-loop cycle 2. | html, css, vanilla-js | 2026-04-16 |
+| [blue-green-deploy-cockpit](blue-green-deploy-cockpit/) | Blue Green Deploy Cockpit — Auto-generated blue-green-deploy visualization tool from hub-auto-loop cycle 272. | html, css, vanilla-js | 2026-04-16 |
+| [blue-green-deploy-simulator](blue-green-deploy-simulator/) | Blue Green Deploy Simulator — Auto-generated blue-green-deploy visualization tool from hub-auto-loop cycle 33. | html, css, vanilla-js | 2026-04-16 |
+| [blue-green-deploy-timeline](blue-green-deploy-timeline/) | Blue Green Deploy Timeline — Auto-generated blue-green-deploy visualization tool from hub-auto-loop cycle 272. | html, css, vanilla-js | 2026-04-16 |
+| [blue-green-health-dashboard](blue-green-health-dashboard/) | Blue Green Health Dashboard — Auto-generated blue-green-deploy visualization tool from hub-auto-loop cycle 220. | html, css, vanilla-js | 2026-04-16 |
+| [blue-green-traffic-flow](blue-green-traffic-flow/) | Blue Green Traffic Flow — Auto-generated blue-green-deploy visualization tool from hub-auto-loop cycle 59. | html, css, vanilla-js | 2026-04-16 |
+| [blue-green-traffic-shifter](blue-green-traffic-shifter/) | Blue Green Traffic Shifter — Auto-generated blue-green-deploy visualization tool from hub-auto-loop cycle 220. | html, css, vanilla-js | 2026-04-16 |
+| [bounded-context-mapper](bounded-context-mapper/) | Bounded Context Mapper — Auto-generated domain-driven visualization tool from hub-auto-loop cycle 266. | html, css, vanilla-js | 2026-04-16 |
+| [bulkhead-builder](bulkhead-builder/) | Bulkhead Builder — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [bulkhead-latency-lab](bulkhead-latency-lab/) | Bulkhead Latency Lab — Auto-generated bulkhead visualization tool from hub-auto-loop cycle 250. | html, css, vanilla-js | 2026-04-16 |
+| [bulkhead-load-dial](bulkhead-load-dial/) | Bulkhead Load Dial — Auto-generated bulkhead visualization tool from hub-auto-loop cycle 233. | html, css, vanilla-js | 2026-04-16 |
+| [bulkhead-monitor](bulkhead-monitor/) | Bulkhead Monitor — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [bulkhead-pattern](bulkhead-pattern/) | Bulkhead Pattern — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [bulkhead-pool-simulator](bulkhead-pool-simulator/) | Bulkhead Pool Simulator — Auto-generated bulkhead visualization tool from hub-auto-loop cycle 233. | html, css, vanilla-js | 2026-04-16 |
+| [bulkhead-ship](bulkhead-ship/) | Bulkhead Ship — Auto-generated bulkhead visualization tool from hub-auto-loop cycle 83. | html, css, vanilla-js | 2026-04-16 |
+| [bulkhead-ship-damage](bulkhead-ship-damage/) | Bulkhead Ship Damage — Auto-generated bulkhead visualization tool from hub-auto-loop cycle 250. | html, css, vanilla-js | 2026-04-16 |
+| [bulkhead-simulator](bulkhead-simulator/) | Bulkhead Simulator — Auto-generated bulkhead visualization tool from hub-auto-loop cycle 25. | html, css, vanilla-js | 2026-04-16 |
+| [cache-cluster-game](cache-cluster-game/) | Cache Cluster Game — Auto-generated consistent-hashing visualization tool from hub-auto-loop cycle 243. | html, css, vanilla-js | 2026-04-16 |
+| [canary-health-simulator](canary-health-simulator/) | Canary Health Simulator — Auto-generated canary-release visualization tool from hub-auto-loop cycle 306. | html, css, vanilla-js | 2026-04-16 |
+| [canary-in-the-coalmine](canary-in-the-coalmine/) | Canary In The Coalmine — Auto-generated canary-release visualization tool from hub-auto-loop cycle 294. | html, css, vanilla-js | 2026-04-16 |
+| [canary-release-conductor](canary-release-conductor/) | Canary Release Conductor — Auto-generated canary-release visualization tool from hub-auto-loop cycle 294. | html, css, vanilla-js | 2026-04-16 |
+| [canary-release-dashboard](canary-release-dashboard/) | Canary Release Dashboard — Auto-generated canary-release visualization tool from hub-auto-loop cycle 80. | html, css, vanilla-js | 2026-04-16 |
+| [canary-release-rollback-sim](canary-release-rollback-sim/) | Canary Release Rollback Sim — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [canary-release-rollout-sim](canary-release-rollout-sim/) | Canary Release Rollout Sim | html, css, vanilla-js | 2026-04-16 |
+| [canary-release-simulator](canary-release-simulator/) | Canary Release Simulator — Auto-generated canary-release visualization tool from hub-auto-loop cycle 201. | html, css, vanilla-js | 2026-04-16 |
+| [canary-release-timeline](canary-release-timeline/) | Canary Release Timeline — Auto-generated canary-release visualization tool from hub-auto-loop cycle 6. | html, css, vanilla-js | 2026-04-16 |
+| [canary-release-traffic-flow](canary-release-traffic-flow/) | Canary Release Traffic Flow | html, css, vanilla-js | 2026-04-16 |
+| [canary-release-traffic-shifter](canary-release-traffic-shifter/) | Canary Release Traffic Shifter — Auto-generated canary-release visualization tool from hub-auto-loop cycle 38. | html, css, vanilla-js | 2026-04-16 |
+| [canary-traffic-shifter](canary-traffic-shifter/) | Canary Traffic Shifter — Auto-generated canary-release visualization tool from hub-auto-loop cycle 306. | html, css, vanilla-js | 2026-04-16 |
+| [cdc-conflict-resolver](cdc-conflict-resolver/) | Cdc Conflict Resolver — Auto-generated cdc visualization tool from hub-auto-loop cycle 226. | html, css, vanilla-js | 2026-04-16 |
+| [cdc-pipeline-builder](cdc-pipeline-builder/) | Cdc Pipeline Builder — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [cdc-pipeline-monitor](cdc-pipeline-monitor/) | Cdc Pipeline Monitor — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [cdc-replay-theater](cdc-replay-theater/) | Cdc Replay Theater — Auto-generated cdc visualization tool from hub-auto-loop cycle 289. | html, css, vanilla-js | 2026-04-16 |
+| [cdc-replay-timeline](cdc-replay-timeline/) | Cdc Replay Timeline — Auto-generated cdc visualization tool from hub-auto-loop cycle 226. | html, css, vanilla-js | 2026-04-16 |
+| [cdc-stream-monitor](cdc-stream-monitor/) | Cdc Stream Monitor — Auto-generated cdc visualization tool from hub-auto-loop cycle 20. | html, css, vanilla-js | 2026-04-16 |
+| [cdc-stream-visualizer](cdc-stream-visualizer/) | Cdc Stream Visualizer — Auto-generated cdc visualization tool from hub-auto-loop cycle 183. | html, css, vanilla-js | 2026-04-16 |
+| [cdc-table-diff](cdc-table-diff/) | Cdc Table Diff — Auto-generated cdc visualization tool from hub-auto-loop cycle 69. | html, css, vanilla-js | 2026-04-16 |
+| [cdc-topology-map](cdc-topology-map/) | Cdc Topology Map — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [cdc-topology-weaver](cdc-topology-weaver/) | Cdc Topology Weaver — Auto-generated cdc visualization tool from hub-auto-loop cycle 289. | html, css, vanilla-js | 2026-04-16 |
+| [chaos-blast-radius](chaos-blast-radius/) | Chaos Blast Radius — Auto-generated chaos-engineering visualization tool from hub-auto-loop cycle 23. | html, css, vanilla-js | 2026-04-16 |
+| [chaos-blast-radius-simulator](chaos-blast-radius-simulator/) | Chaos Blast Radius Simulator — Auto-generated chaos-engineering visualization tool from hub-auto-loop cycle 224. | html, css, vanilla-js | 2026-04-16 |
+| [chaos-experiment-deck](chaos-experiment-deck/) | Chaos Experiment Deck — Auto-generated chaos-engineering visualization tool from hub-auto-loop cycle 224. | html, css, vanilla-js | 2026-04-16 |
+| [chaos-fault-injector](chaos-fault-injector/) | Chaos Fault Injector — Auto-generated chaos-engineering visualization tool from hub-auto-loop cycle 9. | html, css, vanilla-js | 2026-04-16 |
+| [chaos-gameday-board](chaos-gameday-board/) | Chaos Gameday Board — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [chaos-gameday-sim](chaos-gameday-sim/) | Chaos Gameday Sim | html, css, vanilla-js | 2026-04-16 |
+| [chaos-gameday-timeline](chaos-gameday-timeline/) | Chaos Gameday Timeline — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [chaos-monkey-dashboard](chaos-monkey-dashboard/) | Chaos Monkey Dashboard — Auto-generated chaos-engineering visualization tool from hub-auto-loop cycle 57. | html, css, vanilla-js | 2026-04-16 |
+| [chaos-monkey-simulator](chaos-monkey-simulator/) | Chaos Monkey Simulator — Auto-generated chaos-engineering visualization tool from hub-auto-loop cycle 181. | html, css, vanilla-js | 2026-04-16 |
+| [chaos-resilience-matrix](chaos-resilience-matrix/) | Chaos Resilience Matrix — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [chaos-slo-burn-monitor](chaos-slo-burn-monitor/) | Chaos Slo Burn Monitor — Auto-generated chaos-engineering visualization tool from hub-auto-loop cycle 224. | html, css, vanilla-js | 2026-04-16 |
+| [circuit-breaker-dashboard](circuit-breaker-dashboard/) | Circuit Breaker Dashboard — Auto-generated circuit-breaker visualization tool from hub-auto-loop cycle 19. | html, css, vanilla-js | 2026-04-16 |
+| [circuit-breaker-flow](circuit-breaker-flow/) | Circuit Breaker Flow — Auto-generated circuit-breaker visualization tool from hub-auto-loop cycle 74. | html, css, vanilla-js | 2026-04-16 |
+| [circuit-breaker-grid](circuit-breaker-grid/) | Circuit Breaker Grid — Auto-generated circuit-breaker visualization tool from hub-auto-loop cycle 283. | html, css, vanilla-js | 2026-04-16 |
+| [circuit-breaker-panel](circuit-breaker-panel/) | Circuit Breaker Panel — Auto-generated circuit-breaker visualization tool from hub-auto-loop cycle 297. | html, css, vanilla-js | 2026-04-16 |
+| [circuit-breaker-puzzle](circuit-breaker-puzzle/) | Circuit Breaker Puzzle — Auto-generated circuit-breaker visualization tool from hub-auto-loop cycle 221. | html, css, vanilla-js | 2026-04-16 |
+| [circuit-breaker-race](circuit-breaker-race/) | Circuit Breaker Race — Auto-generated circuit-breaker visualization tool from hub-auto-loop cycle 297. | html, css, vanilla-js | 2026-04-16 |
+| [circuit-breaker-simulator](circuit-breaker-simulator/) | Circuit Breaker Simulator — Auto-generated circuit-breaker visualization tool from hub-auto-loop cycle 3. | html, css, vanilla-js | 2026-04-16 |
+| [circuit-breaker-timeline](circuit-breaker-timeline/) | Circuit Breaker Timeline | html, css, vanilla-js | 2026-04-16 |
+| [circuit-breaker-visualizer](circuit-breaker-visualizer/) | Circuit Breaker Visualizer — Auto-generated circuit-breaker visualization tool from hub-auto-loop cycle 170. | html, css, vanilla-js | 2026-04-16 |
+| [command-query-bus](command-query-bus/) | Command Query Bus — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [command-query-journal](command-query-journal/) | Command Query Journal — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [command-query-monitor](command-query-monitor/) | Command Query Monitor — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [command-query-pipeline](command-query-pipeline/) | Command Query Pipeline — Auto-generated command-query visualization tool from hub-auto-loop cycle 45. | html, css, vanilla-js | 2026-04-16 |
+| [command-query-separation](command-query-separation/) | Command Query Separation — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [command-query-separator](command-query-separator/) | Command Query Separator — Auto-generated command-query visualization tool from hub-auto-loop cycle 175. | html, css, vanilla-js | 2026-04-16 |
+| [command-query-timeline](command-query-timeline/) | Command Query Timeline — Auto-generated command-query visualization tool from hub-auto-loop cycle 207. | html, css, vanilla-js | 2026-04-16 |
+| [connection-pool-bubbles](connection-pool-bubbles/) | Connection Pool Bubbles — Auto-generated connection-pool visualization tool from hub-auto-loop cycle 78. | html, css, vanilla-js | 2026-04-16 |
+| [connection-pool-config-lab](connection-pool-config-lab/) | Connection Pool Config Lab — Auto-generated connection-pool visualization tool from hub-auto-loop cycle 265. | html, css, vanilla-js | 2026-04-16 |
+| [connection-pool-lifecycle](connection-pool-lifecycle/) | Connection Pool Lifecycle — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [connection-pool-monitor](connection-pool-monitor/) | Connection Pool Monitor — Auto-generated connection-pool visualization tool from hub-auto-loop cycle 37. | html, css, vanilla-js | 2026-04-16 |
+| [connection-pool-sizer](connection-pool-sizer/) | Connection Pool Sizer — Auto-generated connection-pool visualization tool from hub-auto-loop cycle 240. | html, css, vanilla-js | 2026-04-16 |
+| [connection-pool-tuner](connection-pool-tuner/) | Connection Pool Tuner — Auto-generated connection-pool visualization tool from hub-auto-loop cycle 190. | html, css, vanilla-js | 2026-04-16 |
+| [connection-pool-tycoon](connection-pool-tycoon/) | Connection Pool Tycoon — Auto-generated connection-pool visualization tool from hub-auto-loop cycle 265. | html, css, vanilla-js | 2026-04-16 |
+| [connection-pool-visualizer](connection-pool-visualizer/) | Connection Pool Visualizer — Auto-generated connection-pool visualization tool from hub-auto-loop cycle 240. | html, css, vanilla-js | 2026-04-16 |
+| [consistent-hash-ring](consistent-hash-ring/) | Consistent Hash Ring — Auto-generated load-balancer visualization tool from hub-auto-loop cycle 303. | html, css, vanilla-js | 2026-04-16 |
+| [consistent-hashing-load](consistent-hashing-load/) | Consistent Hashing Load — Auto-generated consistent-hashing visualization tool from hub-auto-loop cycle 188. | html, css, vanilla-js | 2026-04-16 |
+| [consistent-hashing-load-test](consistent-hashing-load-test/) | Consistent Hashing Load Test — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [consistent-hashing-migration](consistent-hashing-migration/) | Consistent Hashing Migration — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [consistent-hashing-ring](consistent-hashing-ring/) | Consistent Hashing Ring — Auto-generated consistent-hashing visualization tool from hub-auto-loop cycle 21. | html, css, vanilla-js | 2026-04-16 |
+| [conveyor-belt-jam](conveyor-belt-jam/) | Conveyor Belt Jam — Auto-generated backpressure visualization tool from hub-auto-loop cycle 268. | html, css, vanilla-js | 2026-04-16 |
+| [cqrs-command-arena](cqrs-command-arena/) | Cqrs Command Arena — Auto-generated cqrs visualization tool from hub-auto-loop cycle 222. | html, css, vanilla-js | 2026-04-16 |
+| [cqrs-command-query-split](cqrs-command-query-split/) | Cqrs Command Query Split — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [cqrs-command-stream](cqrs-command-stream/) | Cqrs Command Stream — Auto-generated cqrs visualization tool from hub-auto-loop cycle 304. | html, css, vanilla-js | 2026-04-16 |
+| [cqrs-event-flow](cqrs-event-flow/) | Cqrs Event Flow — Auto-generated cqrs visualization tool from hub-auto-loop cycle 172. | html, css, vanilla-js | 2026-04-16 |
+| [cqrs-event-replay](cqrs-event-replay/) | Cqrs Event Replay — Auto-generated cqrs visualization tool from hub-auto-loop cycle 222. | html, css, vanilla-js | 2026-04-16 |
+| [cqrs-event-sourcing-replay](cqrs-event-sourcing-replay/) | Cqrs Event Sourcing Replay — Auto-generated cqrs visualization tool from hub-auto-loop cycle 304. | html, css, vanilla-js | 2026-04-16 |
+| [cqrs-flow-simulator](cqrs-flow-simulator/) | Cqrs Flow Simulator — Auto-generated command-query visualization tool from hub-auto-loop cycle 273. | html, css, vanilla-js | 2026-04-16 |
+| [cqrs-flow-visualizer](cqrs-flow-visualizer/) | Cqrs Flow Visualizer — Auto-generated cqrs visualization tool from hub-auto-loop cycle 222. | html, css, vanilla-js | 2026-04-16 |
+| [cqrs-latency-monitor](cqrs-latency-monitor/) | Cqrs Latency Monitor — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [cqrs-projection-lab](cqrs-projection-lab/) | Cqrs Projection Lab — Auto-generated event-sourcing visualization tool from hub-auto-loop cycle 246. | html, css, vanilla-js | 2026-04-16 |
+| [cqrs-read-model-racer](cqrs-read-model-racer/) | Cqrs Read Model Racer — Auto-generated cqrs visualization tool from hub-auto-loop cycle 304. | html, css, vanilla-js | 2026-04-16 |
+| [crdt-counter-cluster](crdt-counter-cluster/) | Crdt Counter Cluster — Auto-generated crdt visualization tool from hub-auto-loop cycle 242. | html, css, vanilla-js | 2026-04-16 |
+| [crdt-counter-sync](crdt-counter-sync/) | Crdt Counter Sync — Auto-generated crdt visualization tool from hub-auto-loop cycle 260. | html, css, vanilla-js | 2026-04-16 |
+| [crdt-lww-editor](crdt-lww-editor/) | Crdt Lww Editor — Auto-generated crdt visualization tool from hub-auto-loop cycle 260. | html, css, vanilla-js | 2026-04-16 |
+| [crdt-or-set-garden](crdt-or-set-garden/) | Crdt Or Set Garden — Auto-generated crdt visualization tool from hub-auto-loop cycle 242. | html, css, vanilla-js | 2026-04-16 |
+| [crdt-orset-graph](crdt-orset-graph/) | Crdt Orset Graph — Auto-generated crdt visualization tool from hub-auto-loop cycle 260. | html, css, vanilla-js | 2026-04-16 |
+| [crdt-text-weaver](crdt-text-weaver/) | Crdt Text Weaver — Auto-generated crdt visualization tool from hub-auto-loop cycle 242. | html, css, vanilla-js | 2026-04-16 |
+| [cron-explainer](cron-explainer/) | Cron Explainer — Spring `@Scheduled`, Quartz, and Kubernetes CronJobs all speak *almost* the same cron dialect, but 5-field (standard), 6-field (Quartz with seconds), and 7-field (Quartz with optional year) diverge on subtle edges. "Does `0 */2 * * 1-5` fire at 12pm on Saturday?" is a question that takes four tabs and a unit test to answer. This tool takes the expression, parses it, and shows (a) English, (b) the next ten firing times, (c) a one-year heatmap of firing density. | html, js, css | 2026-04-16 |
+| [data-pipeline-builder](data-pipeline-builder/) | Data Pipeline Builder — Auto-generated data-pipeline visualization tool from hub-auto-loop cycle 237. | html, css, vanilla-js | 2026-04-16 |
+| [data-pipeline-flow](data-pipeline-flow/) | Data Pipeline Flow — Auto-generated data-pipeline visualization tool from hub-auto-loop cycle 237. | html, css, vanilla-js | 2026-04-16 |
+| [data-pipeline-monitor](data-pipeline-monitor/) | Data Pipeline Monitor — Auto-generated data-pipeline visualization tool from hub-auto-loop cycle 237. | html, css, vanilla-js | 2026-04-16 |
+| [ddd-aggregate-lifecycle](ddd-aggregate-lifecycle/) | Ddd Aggregate Lifecycle — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [ddd-bounded-context-map](ddd-bounded-context-map/) | Ddd Bounded Context Map — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [ddd-ubiquitous-language-graph](ddd-ubiquitous-language-graph/) | Ddd Ubiquitous Language Graph — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [dead-letter-puzzle](dead-letter-puzzle/) | Dead Letter Puzzle — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [distributed-lock](distributed-lock/) | Distributed Lock — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [distributed-lock-visualizer](distributed-lock-visualizer/) | Distributed Lock Visualizer — Animated simulation of MongoDB and Redis distributed lock patterns with 5 failure scenarios — showcases distributed locking, re-check flag, and TTL jitter skills. | html, css, vanilla-js, canvas | 2026-04-16 |
+| [dlq-autopsy-report](dlq-autopsy-report/) | Dlq Autopsy Report — Auto-generated dead-letter-queue visualization tool from hub-auto-loop cycle 302. | html, css, vanilla-js | 2026-04-16 |
+| [dlq-autopsy-table](dlq-autopsy-table/) | Dlq Autopsy Table — Auto-generated dead-letter-queue visualization tool from hub-auto-loop cycle 75. | html, css, vanilla-js | 2026-04-16 |
+| [dlq-flow-visualizer](dlq-flow-visualizer/) | Dlq Flow Visualizer — Auto-generated dead-letter-queue visualization tool from hub-auto-loop cycle 2. | html, css, vanilla-js | 2026-04-16 |
+| [dlq-graveyard](dlq-graveyard/) | Dlq Graveyard — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [dlq-heatmap-monitor](dlq-heatmap-monitor/) | Dlq Heatmap Monitor — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [dlq-pulse-monitor](dlq-pulse-monitor/) | Dlq Pulse Monitor — Auto-generated dead-letter-queue visualization tool from hub-auto-loop cycle 200. | html, css, vanilla-js | 2026-04-16 |
+| [dlq-retry-arena](dlq-retry-arena/) | Dlq Retry Arena — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [dlq-topology-map](dlq-topology-map/) | Dlq Topology Map — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [dlq-triage-console](dlq-triage-console/) | Dlq Triage Console — Auto-generated dead-letter-queue visualization tool from hub-auto-loop cycle 278. | html, css, vanilla-js | 2026-04-16 |
+| [domain-driven-aggregate-builder](domain-driven-aggregate-builder/) | Domain Driven Aggregate Builder — Auto-generated domain-driven visualization tool from hub-auto-loop cycle 193. | html, css, vanilla-js | 2026-04-16 |
+| [domain-driven-aggregate-explorer](domain-driven-aggregate-explorer/) | Domain Driven Aggregate Explorer — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [domain-driven-aggregate-flow](domain-driven-aggregate-flow/) | Domain Driven Aggregate Flow — Auto-generated domain-driven visualization tool from hub-auto-loop cycle 236. | html, css, vanilla-js | 2026-04-16 |
+| [domain-driven-aggregate-lifecycle](domain-driven-aggregate-lifecycle/) | Domain Driven Aggregate Lifecycle — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [domain-driven-bounded-context-map](domain-driven-bounded-context-map/) | Domain Driven Bounded Context Map — Auto-generated domain-driven visualization tool from hub-auto-loop cycle 29. | html, css, vanilla-js | 2026-04-16 |
+| [domain-driven-context-map](domain-driven-context-map/) | Domain Driven Context Map — Auto-generated domain-driven visualization tool from hub-auto-loop cycle 63. | html, css, vanilla-js | 2026-04-16 |
+| [domain-driven-event-storm](domain-driven-event-storm/) | Domain Driven Event Storm — Auto-generated domain-driven visualization tool from hub-auto-loop cycle 236. | html, css, vanilla-js | 2026-04-16 |
+| [domain-driven-explorer](domain-driven-explorer/) | Domain Driven Explorer — Auto-generated domain-driven visualization tool from hub-auto-loop cycle 236. | html, css, vanilla-js | 2026-04-16 |
+| [domain-driven-ubiquitous-language](domain-driven-ubiquitous-language/) | Domain Driven Ubiquitous Language — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [entropy-dice](entropy-dice/) | Entropy Dice — Auto-generated chaos-engineering visualization tool from hub-auto-loop cycle 277. | html, css, vanilla-js | 2026-04-16 |
+| [etl-dashboard](etl-dashboard/) | Etl Dashboard — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [etl-data-flow](etl-data-flow/) | Etl Data Flow — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [etl-data-profiler](etl-data-profiler/) | Etl Data Profiler — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [etl-data-quality-radar](etl-data-quality-radar/) | Etl Data Quality Radar — Auto-generated etl visualization tool from hub-auto-loop cycle 271. | html, css, vanilla-js | 2026-04-16 |
+| [etl-job-monitor](etl-job-monitor/) | Etl Job Monitor — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [etl-job-scheduler](etl-job-scheduler/) | Etl Job Scheduler — Auto-generated data-pipeline visualization tool from hub-auto-loop cycle 249. | html, css, vanilla-js | 2026-04-16 |
+| [etl-lineage-map](etl-lineage-map/) | Etl Lineage Map — Auto-generated etl visualization tool from hub-auto-loop cycle 299. | html, css, vanilla-js | 2026-04-16 |
+| [etl-pipeline-flow](etl-pipeline-flow/) | Etl Pipeline Flow — Auto-generated etl visualization tool from hub-auto-loop cycle 53. | html, css, vanilla-js | 2026-04-16 |
+| [etl-pipeline-visualizer](etl-pipeline-visualizer/) | Etl Pipeline Visualizer — Auto-generated etl visualization tool from hub-auto-loop cycle 210. | html, css, vanilla-js | 2026-04-16 |
+| [etl-pipeline-viz](etl-pipeline-viz/) | Etl Pipeline Viz — Auto-generated etl visualization tool from hub-auto-loop cycle 24. | html, css, vanilla-js | 2026-04-16 |
+| [etl-rule-builder](etl-rule-builder/) | Etl Rule Builder — Auto-generated etl visualization tool from hub-auto-loop cycle 299. | html, css, vanilla-js | 2026-04-16 |
+| [etl-throughput-monitor](etl-throughput-monitor/) | Etl Throughput Monitor — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [etl-transform-playground](etl-transform-playground/) | Etl Transform Playground — Auto-generated etl visualization tool from hub-auto-loop cycle 271. | html, css, vanilla-js | 2026-04-16 |
+| [event-bus-lab](event-bus-lab/) | Event Bus Lab — Auto-generated pub-sub visualization tool from hub-auto-loop cycle 225. | html, css, vanilla-js | 2026-04-16 |
+| [event-ledger-replay](event-ledger-replay/) | Event Ledger Replay — Auto-generated event-sourcing visualization tool from hub-auto-loop cycle 246. | html, css, vanilla-js | 2026-04-16 |
+| [event-replay-timeline](event-replay-timeline/) | Event Replay Timeline — Auto-generated event-sourcing visualization tool from hub-auto-loop cycle 232. | html, css, vanilla-js | 2026-04-16 |
+| [event-sourced-counter](event-sourced-counter/) | Event Sourced Counter — Auto-generated cqrs visualization tool from hub-auto-loop cycle 256. | html, css, vanilla-js | 2026-04-16 |
+| [event-sourced-ledger](event-sourced-ledger/) | Event Sourced Ledger — Auto-generated event-sourcing visualization tool from hub-auto-loop cycle 232. | html, css, vanilla-js | 2026-04-16 |
+| [event-sourcing-aggregate](event-sourcing-aggregate/) | Event Sourcing Aggregate — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [event-sourcing-bank](event-sourcing-bank/) | Event Sourcing Bank — Auto-generated event-sourcing visualization tool from hub-auto-loop cycle 8. | html, css, vanilla-js | 2026-04-16 |
+| [event-sourcing-canvas](event-sourcing-canvas/) | Event Sourcing Canvas — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [event-sourcing-flow](event-sourcing-flow/) | Event Sourcing Flow — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [event-sourcing-ledger](event-sourcing-ledger/) | Event Sourcing Ledger — Auto-generated event-sourcing visualization tool from hub-auto-loop cycle 79. | html, css, vanilla-js | 2026-04-16 |
+| [event-sourcing-replay](event-sourcing-replay/) | Event Sourcing Replay | html, css, vanilla-js | 2026-04-16 |
+| [event-sourcing-stream](event-sourcing-stream/) | Event Sourcing Stream — Auto-generated event-sourcing visualization tool from hub-auto-loop cycle 173. | html, css, vanilla-js | 2026-04-16 |
+| [event-sourcing-timeline](event-sourcing-timeline/) | Event Sourcing Timeline — Auto-generated event-sourcing visualization tool from hub-auto-loop cycle 26. | html, css, vanilla-js | 2026-04-16 |
+| [fault-injection-dashboard](fault-injection-dashboard/) | Fault Injection Dashboard — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [feature-flag-ab-experiment](feature-flag-ab-experiment/) | Feature Flag Ab Experiment — Auto-generated feature-flags visualization tool from hub-auto-loop cycle 255. | html, css, vanilla-js | 2026-04-16 |
+| [feature-flag-dependency-graph](feature-flag-dependency-graph/) | Feature Flag Dependency Graph — Auto-generated feature-flags visualization tool from hub-auto-loop cycle 255. | html, css, vanilla-js | 2026-04-16 |
+| [feature-flag-rollout-simulator](feature-flag-rollout-simulator/) | Feature Flag Rollout Simulator — Auto-generated feature-flags visualization tool from hub-auto-loop cycle 255. | html, css, vanilla-js | 2026-04-16 |
+| [feature-flags-ab-test-dashboard](feature-flags-ab-test-dashboard/) | Feature Flags Ab Test Dashboard — Auto-generated feature-flags visualization tool from hub-auto-loop cycle 230. | html, css, vanilla-js | 2026-04-16 |
+| [feature-flags-dependency-graph](feature-flags-dependency-graph/) | Feature Flags Dependency Graph — Auto-generated feature-flags visualization tool from hub-auto-loop cycle 230. | html, css, vanilla-js | 2026-04-16 |
+| [feature-flags-rollout-simulator](feature-flags-rollout-simulator/) | Feature Flags Rollout Simulator — Auto-generated feature-flags visualization tool from hub-auto-loop cycle 230. | html, css, vanilla-js | 2026-04-16 |
+| [flow-valve-simulator](flow-valve-simulator/) | Flow Valve Simulator — Auto-generated backpressure visualization tool from hub-auto-loop cycle 268. | html, css, vanilla-js | 2026-04-16 |
+| [fsm-playground](fsm-playground/) | Fsm Playground — Auto-generated finite-state-machine visualization tool from hub-auto-loop cycle 205. | html, css, vanilla-js | 2026-04-16 |
+| [fsm-regex-matcher](fsm-regex-matcher/) | Fsm Regex Matcher — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [fsm-regex-tester](fsm-regex-tester/) | Fsm Regex Tester — Auto-generated finite-state-machine visualization tool from hub-auto-loop cycle 67. | html, css, vanilla-js | 2026-04-16 |
+| [fsm-state-designer](fsm-state-designer/) | Fsm State Designer — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [fsm-traffic-controller](fsm-traffic-controller/) | Fsm Traffic Controller — Auto-generated finite-state-machine visualization tool from hub-auto-loop cycle 192. | html, css, vanilla-js | 2026-04-16 |
+| [fsm-traffic-light](fsm-traffic-light/) | Fsm Traffic Light — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [fsm-traffic-sim](fsm-traffic-sim/) | Fsm Traffic Sim — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [fsm-visual-simulator](fsm-visual-simulator/) | Fsm Visual Simulator — Auto-generated finite-state-machine visualization tool from hub-auto-loop cycle 43. | html, css, vanilla-js | 2026-04-16 |
+| [gacha-simulator](gacha-simulator/) | Gacha Simulator Arena — Interactive gacha/loot box simulator with soft/hard pity, character collection, and turn-based combat — showcases 3 game-system skills. | html, css, vanilla-js | 2026-04-16 |
+| [gameday-scenario-runner](gameday-scenario-runner/) | Gameday Scenario Runner — Auto-generated chaos-engineering visualization tool from hub-auto-loop cycle 277. | html, css, vanilla-js | 2026-04-16 |
+| [graphql-query-builder](graphql-query-builder/) | Graphql Query Builder — Auto-generated graphql visualization tool from hub-auto-loop cycle 292. | html, css, vanilla-js | 2026-04-16 |
+| [graphql-query-playground](graphql-query-playground/) | Graphql Query Playground — Auto-generated graphql visualization tool from hub-auto-loop cycle 238. | html, css, vanilla-js | 2026-04-16 |
+| [graphql-resolver-flow](graphql-resolver-flow/) | Graphql Resolver Flow — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [graphql-schema-galaxy](graphql-schema-galaxy/) | Graphql Schema Galaxy — Auto-generated graphql visualization tool from hub-auto-loop cycle 178. | html, css, vanilla-js | 2026-04-16 |
+| [graphql-schema-graph](graphql-schema-graph/) | Graphql Schema Graph — Auto-generated graphql visualization tool from hub-auto-loop cycle 292. | html, css, vanilla-js | 2026-04-16 |
+| [graphql-schema-visualizer](graphql-schema-visualizer/) | Graphql Schema Visualizer — Auto-generated graphql visualization tool from hub-auto-loop cycle 238. | html, css, vanilla-js | 2026-04-16 |
+| [graphql-subscription-feed](graphql-subscription-feed/) | Graphql Subscription Feed — Auto-generated graphql visualization tool from hub-auto-loop cycle 292. | html, css, vanilla-js | 2026-04-16 |
+| [graphql-subscription-monitor](graphql-subscription-monitor/) | Graphql Subscription Monitor — Auto-generated graphql visualization tool from hub-auto-loop cycle 238. | html, css, vanilla-js | 2026-04-16 |
+| [hash-ring-visualizer](hash-ring-visualizer/) | Hash Ring Visualizer — Auto-generated consistent-hashing visualization tool from hub-auto-loop cycle 243. | html, css, vanilla-js | 2026-04-16 |
+| [health-check-dashboard](health-check-dashboard/) | Health Check Dashboard — Auto-generated load-balancer visualization tool from hub-auto-loop cycle 270. | html, css, vanilla-js | 2026-04-16 |
+| [health-check-matrix](health-check-matrix/) | Health Check Matrix — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [health-check-monitor](health-check-monitor/) | Health Check Monitor — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [health-check-orbit](health-check-orbit/) | Health Check Orbit — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [health-check-pulse](health-check-pulse/) | Health Check Pulse — Auto-generated health-check visualization tool from hub-auto-loop cycle 184. | html, css, vanilla-js | 2026-04-16 |
+| [health-check-radar](health-check-radar/) | Health Check Radar — Auto-generated health-check visualization tool from hub-auto-loop cycle 239. | html, css, vanilla-js | 2026-04-16 |
+| [health-check-timeline](health-check-timeline/) | Health Check Timeline — Auto-generated health-check visualization tool from hub-auto-loop cycle 239. | html, css, vanilla-js | 2026-04-16 |
+| [health-check-vitals](health-check-vitals/) | Health Check Vitals — Auto-generated health-check visualization tool from hub-auto-loop cycle 239. | html, css, vanilla-js | 2026-04-16 |
+| [heartbeat-monitor](heartbeat-monitor/) | Heartbeat Monitor — Auto-generated health-check visualization tool from hub-auto-loop cycle 48. | html, css, vanilla-js | 2026-04-16 |
+| [hex-arch-builder](hex-arch-builder/) | Hex Arch Builder — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [hex-arch-dependency-flow](hex-arch-dependency-flow/) | Hex Arch Dependency Flow — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [hex-arch-dependency-map](hex-arch-dependency-map/) | Hex Arch Dependency Map — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [hex-arch-flow-sim](hex-arch-flow-sim/) | Hex Arch Flow Sim — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [hex-arch-flow-simulator](hex-arch-flow-simulator/) | Hex Arch Flow Simulator — Auto-generated hexagonal-architecture visualization tool from hub-auto-loop cycle 39. | html, css, vanilla-js | 2026-04-16 |
+| [hex-arch-layer-builder](hex-arch-layer-builder/) | Hex Arch Layer Builder — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [hex-arch-layer-explorer](hex-arch-layer-explorer/) | Hex Arch Layer Explorer — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [hex-arch-port-adapter-sim](hex-arch-port-adapter-sim/) | Hex Arch Port Adapter Sim — Auto-generated hexagonal-architecture visualization tool from hub-auto-loop cycle 196. | html, css, vanilla-js | 2026-04-16 |
+| [hex-arch-visualizer](hex-arch-visualizer/) | Hex Arch Visualizer — Auto-generated hexagonal-architecture visualization tool from hub-auto-loop cycle 206. | html, css, vanilla-js | 2026-04-16 |
+| [hexagonal-dependency-inverter](hexagonal-dependency-inverter/) | Hexagonal Dependency Inverter — Auto-generated hexagonal-architecture visualization tool from hub-auto-loop cycle 274. | html, css, vanilla-js | 2026-04-16 |
+| [hexagonal-ports-adapters-playground](hexagonal-ports-adapters-playground/) | Hexagonal Ports Adapters Playground — Auto-generated hexagonal-architecture visualization tool from hub-auto-loop cycle 274. | html, css, vanilla-js | 2026-04-16 |
+| [hexagonal-request-tracer](hexagonal-request-tracer/) | Hexagonal Request Tracer — Auto-generated hexagonal-architecture visualization tool from hub-auto-loop cycle 274. | html, css, vanilla-js | 2026-04-16 |
+| [http-method-idempotency-quiz](http-method-idempotency-quiz/) | Http Method Idempotency Quiz — Auto-generated idempotency visualization tool from hub-auto-loop cycle 267. | html, css, vanilla-js | 2026-04-16 |
+| [idempotency-battle](idempotency-battle/) | Idempotency Battle | html, css, vanilla-js | 2026-04-16 |
+| [idempotency-heatmap](idempotency-heatmap/) | Idempotency Heatmap — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [idempotency-key-vault](idempotency-key-vault/) | Idempotency Key Vault — Auto-generated idempotency visualization tool from hub-auto-loop cycle 34. | html, css, vanilla-js | 2026-04-16 |
+| [idempotency-proof](idempotency-proof/) | Idempotency Proof — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [idempotency-proof-canvas](idempotency-proof-canvas/) | Idempotency Proof Canvas — Auto-generated idempotency visualization tool from hub-auto-loop cycle 4. | html, css, vanilla-js | 2026-04-16 |
+| [idempotency-replay-lab](idempotency-replay-lab/) | Idempotency Replay Lab — Auto-generated idempotency visualization tool from hub-auto-loop cycle 185. | html, css, vanilla-js | 2026-04-16 |
+| [idempotency-sandbox](idempotency-sandbox/) | Idempotency Sandbox — Auto-generated idempotency visualization tool from hub-auto-loop cycle 82. | html, css, vanilla-js | 2026-04-16 |
+| [idempotency-state-machine](idempotency-state-machine/) | Idempotency State Machine — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [idempotency-visualizer](idempotency-visualizer/) | Idempotency Visualizer — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [idempotent-function-lab](idempotent-function-lab/) | Idempotent Function Lab — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [idempotent-function-playground](idempotent-function-playground/) | Idempotent Function Playground — Auto-generated idempotency visualization tool from hub-auto-loop cycle 227. | html, css, vanilla-js | 2026-04-16 |
+| [idempotent-state-machine](idempotent-state-machine/) | Idempotent State Machine — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [json-diff-tree](json-diff-tree/) | JSON Diff Tree — API response regressions are common, and diffing pretty-printed JSON by eyeball sucks. `jq`-based diffs flatten structure; git diff doesn't understand key reorder. This is a two-pane browser tool: paste two JSON blobs, get a collapsible structural diff with per-path *added / removed / changed* badges, an ignore-key filter, and a one-click *copy as JSON Patch* (RFC 6902) button. | html, js, css | 2026-04-16 |
+| [jwt-token-inspector](jwt-token-inspector/) | Jwt Token Inspector — Auto-generated oauth visualization tool from hub-auto-loop cycle 247. | html, css, vanilla-js | 2026-04-16 |
+| [kafka-topology](kafka-topology/) | Kafka Topology — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [kafka-topology-designer](kafka-topology-designer/) | Kafka Topology Designer — The hub has 15+ Kafka skills but no visual surface for them. This canvas lets you sketch Kafka architectures with drag-and-drop components, see how they connect, and reference the relevant skills for each pattern. | html, css, js, svg | 2026-04-16 |
+| [knowledge-flashcards](knowledge-flashcards/) | Knowledge Flashcards — The Pitfall Quiz tests recognition (multiple choice). Flashcards build recall — you see the title and must remember the full explanation before flipping. SM-2 spaced repetition ensures you review cards just before you'd forget them. | html, css, js | 2026-04-16 |
+| [lb-algorithm-race](lb-algorithm-race/) | Lb Algorithm Race — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [lb-health-dashboard](lb-health-dashboard/) | Lb Health Dashboard — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [lb-traffic-flow](lb-traffic-flow/) | Lb Traffic Flow — Auto-generated load-balancer visualization tool from hub-auto-loop cycle 179. | html, css, vanilla-js | 2026-04-16 |
+| [leaky-bucket-playground](leaky-bucket-playground/) | Leaky Bucket Playground — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [load-balancer-algorithm-race](load-balancer-algorithm-race/) | Load Balancer Algorithm Race — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [load-balancer-arena](load-balancer-arena/) | Load Balancer Arena — Auto-generated load-balancer visualization tool from hub-auto-loop cycle 211. | html, css, vanilla-js | 2026-04-16 |
+| [load-balancer-dashboard](load-balancer-dashboard/) | Load Balancer Dashboard — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [load-balancer-health-dashboard](load-balancer-health-dashboard/) | Load Balancer Health Dashboard — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [load-balancer-sim](load-balancer-sim/) | Load Balancer Sim — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [load-balancer-simulator](load-balancer-simulator/) | Load Balancer Simulator — Auto-generated load-balancer visualization tool from hub-auto-loop cycle 36. | html, css, vanilla-js | 2026-04-16 |
+| [load-balancer-visualizer](load-balancer-visualizer/) | Load Balancer Visualizer — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [log-aggregation-heatmap](log-aggregation-heatmap/) | Log Aggregation Heatmap — Auto-generated log-aggregation visualization tool from hub-auto-loop cycle 258. | html, css, vanilla-js | 2026-04-16 |
+| [log-funnel-analyzer](log-funnel-analyzer/) | Log Funnel Analyzer — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [log-heatmap-grid](log-heatmap-grid/) | Log Heatmap Grid — Auto-generated log-aggregation visualization tool from hub-auto-loop cycle 202. | html, css, vanilla-js | 2026-04-16 |
+| [log-pattern-heatmap](log-pattern-heatmap/) | Log Pattern Heatmap — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [log-pipeline-flow](log-pipeline-flow/) | Log Pipeline Flow — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [log-query-console](log-query-console/) | Log Query Console — Auto-generated log-aggregation visualization tool from hub-auto-loop cycle 258. | html, css, vanilla-js | 2026-04-16 |
+| [log-stream-monitor](log-stream-monitor/) | Log Stream Monitor — Auto-generated log-aggregation visualization tool from hub-auto-loop cycle 27. | html, css, vanilla-js | 2026-04-16 |
+| [log-stream-river](log-stream-river/) | Log Stream River — Auto-generated log-aggregation visualization tool from hub-auto-loop cycle 258. | html, css, vanilla-js | 2026-04-16 |
+| [log-stream-waterfall](log-stream-waterfall/) | Log Stream Waterfall — Auto-generated log-aggregation visualization tool from hub-auto-loop cycle 194. | html, css, vanilla-js | 2026-04-16 |
+| [log-topology-ring](log-topology-ring/) | Log Topology Ring — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [materialized-view-builder](materialized-view-builder/) | Materialized View Builder — Auto-generated materialized-view visualization tool from hub-auto-loop cycle 223. | html, css, vanilla-js | 2026-04-16 |
+| [materialized-view-cache-game](materialized-view-cache-game/) | Materialized View Cache Game — Auto-generated materialized-view visualization tool from hub-auto-loop cycle 223. | html, css, vanilla-js | 2026-04-16 |
+| [materialized-view-dag](materialized-view-dag/) | Materialized View Dag — Auto-generated materialized-view visualization tool from hub-auto-loop cycle 58. | html, css, vanilla-js | 2026-04-16 |
+| [materialized-view-graph](materialized-view-graph/) | Materialized View Graph — Auto-generated materialized-view visualization tool from hub-auto-loop cycle 261. | html, css, vanilla-js | 2026-04-16 |
+| [materialized-view-query-diff](materialized-view-query-diff/) | Materialized View Query Diff — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [materialized-view-query-planner](materialized-view-query-planner/) | Materialized View Query Planner — Auto-generated materialized-view visualization tool from hub-auto-loop cycle 301. | html, css, vanilla-js | 2026-04-16 |
+| [materialized-view-query-race](materialized-view-query-race/) | Materialized View Query Race — Auto-generated materialized-view visualization tool from hub-auto-loop cycle 261. | html, css, vanilla-js | 2026-04-16 |
+| [materialized-view-refresh-monitor](materialized-view-refresh-monitor/) | Materialized View Refresh Monitor — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [materialized-view-refresh-simulator](materialized-view-refresh-simulator/) | Materialized View Refresh Simulator — Auto-generated materialized-view visualization tool from hub-auto-loop cycle 261. | html, css, vanilla-js | 2026-04-16 |
+| [materialized-view-refresh-timeline](materialized-view-refresh-timeline/) | Materialized View Refresh Timeline — Auto-generated materialized-view visualization tool from hub-auto-loop cycle 223. | html, css, vanilla-js | 2026-04-16 |
+| [materialized-view-staleness-dashboard](materialized-view-staleness-dashboard/) | Materialized View Staleness Dashboard — Auto-generated materialized-view visualization tool from hub-auto-loop cycle 301. | html, css, vanilla-js | 2026-04-16 |
+| [mcp-playground](mcp-playground/) | Mcp Playground — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [mcp-protocol-playground](mcp-protocol-playground/) | MCP Protocol Playground — The Model Context Protocol (MCP) is rapidly becoming the standard for AI tool integration, but designing and testing tool schemas currently requires switching between docs, JSON editors, and test scripts. This playground combines schema editing, validation, and simulation in a single browser IDE. | html, js, css | 2026-04-16 |
+| [mesh-policy-composer](mesh-policy-composer/) | Mesh Policy Composer — Auto-generated service-mesh visualization tool from hub-auto-loop cycle 275. | html, css, vanilla-js | 2026-04-16 |
+| [mesh-traffic-visualizer](mesh-traffic-visualizer/) | Mesh Traffic Visualizer — Auto-generated service-mesh visualization tool from hub-auto-loop cycle 275. | html, css, vanilla-js | 2026-04-16 |
+| [message-flow-orchestra](message-flow-orchestra/) | Message Flow Orchestra — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [message-queue-conveyor](message-queue-conveyor/) | Message Queue Conveyor — Auto-generated message-queue visualization tool from hub-auto-loop cycle 219. | html, css, vanilla-js | 2026-04-16 |
+| [message-queue-flow](message-queue-flow/) | Message Queue Flow — Auto-generated message-queue visualization tool from hub-auto-loop cycle 76. | html, css, vanilla-js | 2026-04-16 |
+| [message-queue-monitor](message-queue-monitor/) | Message Queue Monitor — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [message-queue-priority-heap](message-queue-priority-heap/) | Message Queue Priority Heap — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [message-queue-pub-sub-grid](message-queue-pub-sub-grid/) | Message Queue Pub Sub Grid — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [message-queue-sandbox](message-queue-sandbox/) | Message Queue Sandbox — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [mv-dependency-graph](mv-dependency-graph/) | Mv Dependency Graph — Auto-generated materialized-view visualization tool from hub-auto-loop cycle 4. | html, css, vanilla-js | 2026-04-16 |
+| [mv-freshness-monitor](mv-freshness-monitor/) | Mv Freshness Monitor — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [mv-query-planner](mv-query-planner/) | Mv Query Planner — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [network-health-radar](network-health-radar/) | Network Health Radar — Auto-generated health-check visualization tool from hub-auto-loop cycle 286. | html, css, vanilla-js | 2026-04-16 |
+| [oauth-flow-visualizer](oauth-flow-visualizer/) | Oauth Flow Visualizer — Auto-generated oauth visualization tool from hub-auto-loop cycle 49. | html, css, vanilla-js | 2026-04-16 |
+| [oauth-scope-playground](oauth-scope-playground/) | Oauth Scope Playground — Auto-generated oauth visualization tool from hub-auto-loop cycle 203. | html, css, vanilla-js | 2026-04-16 |
+| [oauth-scope-simulator](oauth-scope-simulator/) | Oauth Scope Simulator — Auto-generated oauth visualization tool from hub-auto-loop cycle 247. | html, css, vanilla-js | 2026-04-16 |
+| [oauth-token-inspector](oauth-token-inspector/) | Oauth Token Inspector — Auto-generated oauth visualization tool from hub-auto-loop cycle 50. | html, css, vanilla-js | 2026-04-16 |
+| [object-storage-bucket-viz](object-storage-bucket-viz/) | Object Storage Bucket Viz — Auto-generated object-storage visualization tool from hub-auto-loop cycle 54. | html, css, vanilla-js | 2026-04-16 |
+| [object-storage-cost-simulator](object-storage-cost-simulator/) | Object Storage Cost Simulator — Auto-generated object-storage visualization tool from hub-auto-loop cycle 253. | html, css, vanilla-js | 2026-04-16 |
+| [object-storage-explorer](object-storage-explorer/) | Object Storage Explorer — Auto-generated object-storage visualization tool from hub-auto-loop cycle 253. | html, css, vanilla-js | 2026-04-16 |
+| [object-storage-flow](object-storage-flow/) | Object Storage Flow — Auto-generated object-storage visualization tool from hub-auto-loop cycle 199. | html, css, vanilla-js | 2026-04-16 |
+| [object-storage-galaxy](object-storage-galaxy/) | Object Storage Galaxy — Auto-generated object-storage visualization tool from hub-auto-loop cycle 1. | html, css, vanilla-js | 2026-04-16 |
+| [object-storage-latency-monitor](object-storage-latency-monitor/) | Object Storage Latency Monitor — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [object-storage-lifecycle-sim](object-storage-lifecycle-sim/) | Object Storage Lifecycle Sim — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [object-storage-replication-viz](object-storage-replication-viz/) | Object Storage Replication Viz — Auto-generated object-storage visualization tool from hub-auto-loop cycle 253. | html, css, vanilla-js | 2026-04-16 |
+| [object-storage-terminal](object-storage-terminal/) | Object Storage Terminal — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [object-storage-treemap](object-storage-treemap/) | Object Storage Treemap — Auto-generated object-storage visualization tool from hub-auto-loop cycle 176. | html, css, vanilla-js | 2026-04-16 |
+| [outbox-flow-simulator](outbox-flow-simulator/) | Outbox Flow Simulator — Auto-generated outbox-pattern visualization tool from hub-auto-loop cycle 44. | html, css, vanilla-js | 2026-04-16 |
+| [outbox-pattern-dashboard](outbox-pattern-dashboard/) | Outbox Pattern Dashboard — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [outbox-pattern-flow](outbox-pattern-flow/) | Outbox Pattern Flow — Auto-generated outbox-pattern visualization tool from hub-auto-loop cycle 62. | html, css, vanilla-js | 2026-04-16 |
+| [outbox-pattern-inspector](outbox-pattern-inspector/) | Outbox Pattern Inspector — Auto-generated outbox-pattern visualization tool from hub-auto-loop cycle 241. | html, css, vanilla-js | 2026-04-16 |
+| [outbox-pattern-lab](outbox-pattern-lab/) | Outbox Pattern Lab — Auto-generated outbox-pattern visualization tool from hub-auto-loop cycle 262. | html, css, vanilla-js | 2026-04-16 |
+| [outbox-pattern-pipeline](outbox-pattern-pipeline/) | Outbox Pattern Pipeline — Auto-generated outbox-pattern visualization tool from hub-auto-loop cycle 262. | html, css, vanilla-js | 2026-04-16 |
+| [outbox-pattern-race](outbox-pattern-race/) | Outbox Pattern Race — Auto-generated outbox-pattern visualization tool from hub-auto-loop cycle 241. | html, css, vanilla-js | 2026-04-16 |
+| [outbox-pattern-simulator](outbox-pattern-simulator/) | Outbox Pattern Simulator — Auto-generated outbox-pattern visualization tool from hub-auto-loop cycle 241. | html, css, vanilla-js | 2026-04-16 |
+| [outbox-pattern-timeline](outbox-pattern-timeline/) | Outbox Pattern Timeline — Auto-generated outbox-pattern visualization tool from hub-auto-loop cycle 262. | html, css, vanilla-js | 2026-04-16 |
+| [outbox-relay-visualizer](outbox-relay-visualizer/) | Outbox Relay Visualizer — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [pipe-pressure-game](pipe-pressure-game/) | Pipe Pressure Game — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [pipeline-dag-builder](pipeline-dag-builder/) | Pipeline Dag Builder — Auto-generated data-pipeline visualization tool from hub-auto-loop cycle 70. | html, css, vanilla-js | 2026-04-16 |
+| [pipeline-flow-monitor](pipeline-flow-monitor/) | Pipeline Flow Monitor — Auto-generated data-pipeline visualization tool from hub-auto-loop cycle 35. | html, css, vanilla-js | 2026-04-16 |
+| [pipeline-flow-visualizer](pipeline-flow-visualizer/) | Pipeline Flow Visualizer — Auto-generated data-pipeline visualization tool from hub-auto-loop cycle 249. | html, css, vanilla-js | 2026-04-16 |
+| [pipeline-pressure-lab](pipeline-pressure-lab/) | Pipeline Pressure Lab — Auto-generated backpressure visualization tool from hub-auto-loop cycle 298. | html, css, vanilla-js | 2026-04-16 |
+| [pipeline-throughput-dashboard](pipeline-throughput-dashboard/) | Pipeline Throughput Dashboard — Auto-generated data-pipeline visualization tool from hub-auto-loop cycle 189. | html, css, vanilla-js | 2026-04-16 |
+| [pitfall-quiz](pitfall-quiz/) | Pitfall Quiz — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [pitfall-quiz-arena](pitfall-quiz-arena/) | Pitfall Quiz Arena — The pitfall and architecture knowledge entries are the most actionable content in the hub but have zero discoverability. Gamification makes them sticky — wrong answers reveal the full explanation, turning mistakes into learning moments. | html, css, js | 2026-04-16 |
+| [priority-queue-puzzle](priority-queue-puzzle/) | Priority Queue Puzzle — Auto-generated message-queue visualization tool from hub-auto-loop cycle 264. | html, css, vanilla-js | 2026-04-16 |
+| [projection-race](projection-race/) | Projection Race — Auto-generated event-sourcing visualization tool from hub-auto-loop cycle 232. | html, css, vanilla-js | 2026-04-16 |
+| [pub-sub-constellation](pub-sub-constellation/) | Pub Sub Constellation — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [pub-sub-event-bus-lab](pub-sub-event-bus-lab/) | Pub Sub Event Bus Lab — Auto-generated pub-sub visualization tool from hub-auto-loop cycle 254. | html, css, vanilla-js | 2026-04-16 |
+| [pub-sub-flow-canvas](pub-sub-flow-canvas/) | Pub Sub Flow Canvas — Auto-generated pub-sub visualization tool from hub-auto-loop cycle 46. | html, css, vanilla-js | 2026-04-16 |
+| [pub-sub-galaxy](pub-sub-galaxy/) | Pub Sub Galaxy — Auto-generated pub-sub visualization tool from hub-auto-loop cycle 177. | html, css, vanilla-js | 2026-04-16 |
+| [pub-sub-heartbeat](pub-sub-heartbeat/) | Pub Sub Heartbeat — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [pub-sub-newsroom](pub-sub-newsroom/) | Pub Sub Newsroom — Auto-generated pub-sub visualization tool from hub-auto-loop cycle 254. | html, css, vanilla-js | 2026-04-16 |
+| [pub-sub-radio-tower](pub-sub-radio-tower/) | Pub Sub Radio Tower — Auto-generated pub-sub visualization tool from hub-auto-loop cycle 254. | html, css, vanilla-js | 2026-04-16 |
+| [pub-sub-sandbox](pub-sub-sandbox/) | Pub Sub Sandbox — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [pub-sub-topic-board](pub-sub-topic-board/) | Pub Sub Topic Board — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [query-playground](query-playground/) | Query Playground — Auto-generated command-query visualization tool from hub-auto-loop cycle 273. | html, css, vanilla-js | 2026-04-16 |
+| [queue-conductor](queue-conductor/) | Queue Conductor — Auto-generated message-queue visualization tool from hub-auto-loop cycle 264. | html, css, vanilla-js | 2026-04-16 |
+| [queue-monitor-dashboard](queue-monitor-dashboard/) | Queue Monitor Dashboard — Auto-generated message-queue visualization tool from hub-auto-loop cycle 180. | html, css, vanilla-js | 2026-04-16 |
+| [raft-consensus-quiz](raft-consensus-quiz/) | Raft Consensus Quiz — Auto-generated raft-consensus visualization tool from hub-auto-loop cycle 217. | html, css, vanilla-js | 2026-04-16 |
+| [raft-election-arena](raft-election-arena/) | Raft Election Arena — Auto-generated raft-consensus visualization tool from hub-auto-loop cycle 1. | html, css, vanilla-js | 2026-04-16 |
+| [raft-leader-election](raft-leader-election/) | Raft Leader Election — Auto-generated raft-consensus visualization tool from hub-auto-loop cycle 64. | html, css, vanilla-js | 2026-04-16 |
+| [raft-log-replication](raft-log-replication/) | Raft Log Replication | html, css, vanilla-js | 2026-04-16 |
+| [raft-partition-lab](raft-partition-lab/) | Raft Partition Lab | html, css, vanilla-js | 2026-04-16 |
+| [raft-state-machine](raft-state-machine/) | Raft State Machine — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [raft-state-timeline](raft-state-timeline/) | Raft State Timeline — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [raft-term-timeline](raft-term-timeline/) | Raft Term Timeline — Auto-generated raft-consensus visualization tool from hub-auto-loop cycle 281. | html, css, vanilla-js | 2026-04-16 |
+| [rate-limiter-bucket](rate-limiter-bucket/) | Rate Limiter Bucket — Auto-generated rate-limiter visualization tool from hub-auto-loop cycle 208. | html, css, vanilla-js | 2026-04-16 |
+| [rate-limiter-dashboard](rate-limiter-dashboard/) | Rate Limiter Dashboard — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [rate-limiter-playground](rate-limiter-playground/) | Rate Limiter Playground — Auto-generated rate-limiter visualization tool from hub-auto-loop cycle 72. | html, css, vanilla-js | 2026-04-16 |
+| [rate-limiter-visualizer](rate-limiter-visualizer/) | Rate Limiter Visualizer — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [reactive-stream-juggler](reactive-stream-juggler/) | Reactive Stream Juggler — Auto-generated backpressure visualization tool from hub-auto-loop cycle 298. | html, css, vanilla-js | 2026-04-16 |
+| [reactive-stream-lab](reactive-stream-lab/) | Reactive Stream Lab — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [reactive-stream-window](reactive-stream-window/) | Reactive Stream Window — Auto-generated backpressure visualization tool from hub-auto-loop cycle 268. | html, css, vanilla-js | 2026-04-16 |
+| [read-replica-consistency-simulator](read-replica-consistency-simulator/) | Read Replica Consistency Simulator — Auto-generated read-replica visualization tool from hub-auto-loop cycle 280. | html, css, vanilla-js | 2026-04-16 |
+| [read-replica-lag-monitor](read-replica-lag-monitor/) | Read Replica Lag Monitor — Auto-generated read-replica visualization tool from hub-auto-loop cycle 280. | html, css, vanilla-js | 2026-04-16 |
+| [read-replica-loadbalancer](read-replica-loadbalancer/) | Read Replica Loadbalancer — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [read-replica-router-playground](read-replica-router-playground/) | Read Replica Router Playground — Auto-generated read-replica visualization tool from hub-auto-loop cycle 280. | html, css, vanilla-js | 2026-04-16 |
+| [read-replica-topology](read-replica-topology/) | Read Replica Topology — Auto-generated read-replica visualization tool from hub-auto-loop cycle 204. | html, css, vanilla-js | 2026-04-16 |
+| [read-write-split-lab](read-write-split-lab/) | Read Write Split Lab — Auto-generated cqrs visualization tool from hub-auto-loop cycle 256. | html, css, vanilla-js | 2026-04-16 |
+| [rebalance-simulator](rebalance-simulator/) | Rebalance Simulator — Auto-generated consistent-hashing visualization tool from hub-auto-loop cycle 257. | html, css, vanilla-js | 2026-04-16 |
+| [regex-fsm-visualizer](regex-fsm-visualizer/) | Regex Fsm Visualizer — Auto-generated finite-state-machine visualization tool from hub-auto-loop cycle 252. | html, css, vanilla-js | 2026-04-16 |
+| [retention-policy-simulator](retention-policy-simulator/) | Retention Policy Simulator — Auto-generated time-series-db visualization tool from hub-auto-loop cycle 244. | html, css, vanilla-js | 2026-04-16 |
+| [retry-budget-monitor](retry-budget-monitor/) | Retry Budget Monitor — Auto-generated retry-strategy visualization tool from hub-auto-loop cycle 285. | html, css, vanilla-js | 2026-04-16 |
+| [retry-circuit-dashboard](retry-circuit-dashboard/) | Retry Circuit Dashboard — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [retry-policy-playground](retry-policy-playground/) | Retry Policy Playground — Auto-generated retry-strategy visualization tool from hub-auto-loop cycle 229. | html, css, vanilla-js | 2026-04-16 |
+| [retry-race-game](retry-race-game/) | Retry Race Game — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [retry-storm-simulator](retry-storm-simulator/) | Retry Storm Simulator — Auto-generated retry-strategy visualization tool from hub-auto-loop cycle 285. | html, css, vanilla-js | 2026-04-16 |
+| [retry-strategy-battle](retry-strategy-battle/) | Retry Strategy Battle — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [retry-strategy-composer](retry-strategy-composer/) | Retry Strategy Composer — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [retry-strategy-explorer](retry-strategy-explorer/) | Retry Strategy Explorer — Auto-generated retry-strategy visualization tool from hub-auto-loop cycle 229. | html, css, vanilla-js | 2026-04-16 |
+| [retry-strategy-lab](retry-strategy-lab/) | Retry Strategy Lab — Auto-generated retry-strategy visualization tool from hub-auto-loop cycle 285. | html, css, vanilla-js | 2026-04-16 |
+| [retry-strategy-playground](retry-strategy-playground/) | Retry Strategy Playground — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [retry-strategy-simulator](retry-strategy-simulator/) | Retry Strategy Simulator — Auto-generated retry-strategy visualization tool from hub-auto-loop cycle 52. | html, css, vanilla-js | 2026-04-16 |
+| [retry-strategy-timeline](retry-strategy-timeline/) | Retry Strategy Timeline — Auto-generated retry-strategy visualization tool from hub-auto-loop cycle 174. | html, css, vanilla-js | 2026-04-16 |
+| [retry-strategy-visualizer](retry-strategy-visualizer/) | Retry Strategy Visualizer — Auto-generated retry-strategy visualization tool from hub-auto-loop cycle 31. | html, css, vanilla-js | 2026-04-16 |
+| [saga-choreography-simulator](saga-choreography-simulator/) | Saga Choreography Simulator — Auto-generated saga-pattern visualization tool from hub-auto-loop cycle 234. | html, css, vanilla-js | 2026-04-16 |
+| [saga-choreography-swarm](saga-choreography-swarm/) | Saga Choreography Swarm — Auto-generated saga-pattern visualization tool from hub-auto-loop cycle 251. | html, css, vanilla-js | 2026-04-16 |
+| [saga-compensation-chain](saga-compensation-chain/) | Saga Compensation Chain — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [saga-compensation-ledger](saga-compensation-ledger/) | Saga Compensation Ledger — Auto-generated saga-pattern visualization tool from hub-auto-loop cycle 251. | html, css, vanilla-js | 2026-04-16 |
+| [saga-orchestrator-flow](saga-orchestrator-flow/) | Saga Orchestrator Flow — Auto-generated saga-pattern visualization tool from hub-auto-loop cycle 234. | html, css, vanilla-js | 2026-04-16 |
+| [saga-orchestrator-sim](saga-orchestrator-sim/) | Saga Orchestrator Sim — Auto-generated saga-pattern visualization tool from hub-auto-loop cycle 30. | html, css, vanilla-js | 2026-04-16 |
+| [saga-pattern-orchestrator](saga-pattern-orchestrator/) | Saga Pattern Orchestrator — Auto-generated saga-pattern visualization tool from hub-auto-loop cycle 61. | html, css, vanilla-js | 2026-04-16 |
+| [saga-pattern-simulator](saga-pattern-simulator/) | Saga Pattern Simulator | html, css, vanilla-js | 2026-04-16 |
+| [saga-pattern-timeline](saga-pattern-timeline/) | Saga Pattern Timeline — Auto-generated saga-pattern visualization tool from hub-auto-loop cycle 11. | html, css, vanilla-js | 2026-04-16 |
+| [saga-timeline-debugger](saga-timeline-debugger/) | Saga Timeline Debugger — Auto-generated saga-pattern visualization tool from hub-auto-loop cycle 234. | html, css, vanilla-js | 2026-04-16 |
+| [saga-timeline-viewer](saga-timeline-viewer/) | Saga Timeline Viewer — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [schema-compat-checker](schema-compat-checker/) | Schema Compat Checker — Auto-generated schema-registry visualization tool from hub-auto-loop cycle 305. | html, css, vanilla-js | 2026-04-16 |
+| [schema-compat-matrix](schema-compat-matrix/) | Schema Compat Matrix — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [schema-compatibility-checker](schema-compatibility-checker/) | Schema Compatibility Checker — Auto-generated schema-registry visualization tool from hub-auto-loop cycle 195. | html, css, vanilla-js | 2026-04-16 |
+| [schema-compatibility-matrix](schema-compatibility-matrix/) | Schema Compatibility Matrix — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [schema-evolution-timeline](schema-evolution-timeline/) | Schema Evolution Timeline — Auto-generated schema-registry visualization tool from hub-auto-loop cycle 209. | html, css, vanilla-js | 2026-04-16 |
+| [schema-registry-explorer](schema-registry-explorer/) | Schema Registry Explorer — Auto-generated schema-registry visualization tool from hub-auto-loop cycle 32. | html, css, vanilla-js | 2026-04-16 |
+| [schema-registry-graph](schema-registry-graph/) | Schema Registry Graph — Auto-generated schema-registry visualization tool from hub-auto-loop cycle 305. | html, css, vanilla-js | 2026-04-16 |
+| [schema-version-timeline](schema-version-timeline/) | Schema Version Timeline — Auto-generated schema-registry visualization tool from hub-auto-loop cycle 81. | html, css, vanilla-js | 2026-04-16 |
+| [separation-visualizer](separation-visualizer/) | Separation Visualizer — Auto-generated command-query visualization tool from hub-auto-loop cycle 273. | html, css, vanilla-js | 2026-04-16 |
+| [service-graph-topology](service-graph-topology/) | Service Graph Topology — Auto-generated distributed-tracing visualization tool from hub-auto-loop cycle 290. | html, css, vanilla-js | 2026-04-16 |
+| [service-mesh-circuit-breaker](service-mesh-circuit-breaker/) | Service Mesh Circuit Breaker — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [service-mesh-policy-simulator](service-mesh-policy-simulator/) | Service Mesh Policy Simulator — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [service-mesh-topology](service-mesh-topology/) | Service Mesh Topology — Auto-generated service-mesh visualization tool from hub-auto-loop cycle 68. | html, css, vanilla-js | 2026-04-16 |
+| [service-mesh-traffic](service-mesh-traffic/) | Service Mesh Traffic — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [service-mesh-traffic-visualizer](service-mesh-traffic-visualizer/) | Service Mesh Traffic Visualizer — Auto-generated service-mesh visualization tool from hub-auto-loop cycle 215. | html, css, vanilla-js | 2026-04-16 |
+| [service-pulse-monitor](service-pulse-monitor/) | Service Pulse Monitor — Auto-generated health-check visualization tool from hub-auto-loop cycle 286. | html, css, vanilla-js | 2026-04-16 |
+| [service-topology](service-topology/) | Service Topology — Auto-generated distributed-tracing visualization tool from hub-auto-loop cycle 66. | html, css, vanilla-js | 2026-04-16 |
+| [service-topology-map](service-topology-map/) | Service Topology Map — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [shard-flow-visualizer](shard-flow-visualizer/) | Shard Flow Visualizer — Auto-generated database-sharding visualization tool from hub-auto-loop cycle 18. | html, css, vanilla-js | 2026-04-16 |
+| [shard-health-monitor](shard-health-monitor/) | Shard Health Monitor — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [shard-rebalancer](shard-rebalancer/) | Shard Rebalancer — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [shard-rebalancer-sim](shard-rebalancer-sim/) | Shard Rebalancer Sim — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [shard-ring-router](shard-ring-router/) | Shard Ring Router — Auto-generated database-sharding visualization tool from hub-auto-loop cycle 51. | html, css, vanilla-js | 2026-04-16 |
+| [shard-router-visualizer](shard-router-visualizer/) | Shard Router Visualizer — Auto-generated database-sharding visualization tool from hub-auto-loop cycle 214. | html, css, vanilla-js | 2026-04-16 |
+| [shard-traffic-simulator](shard-traffic-simulator/) | Shard Traffic Simulator — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [ship-bulkhead-flood](ship-bulkhead-flood/) | Ship Bulkhead Flood — Auto-generated bulkhead visualization tool from hub-auto-loop cycle 233. | html, css, vanilla-js | 2026-04-16 |
+| [sidecar-proxy-config-lab](sidecar-proxy-config-lab/) | Sidecar Proxy Config Lab — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [sidecar-proxy-dashboard](sidecar-proxy-dashboard/) | Sidecar Proxy Dashboard — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [sidecar-proxy-explorer](sidecar-proxy-explorer/) | Sidecar Proxy Explorer — Auto-generated sidecar-proxy visualization tool from hub-auto-loop cycle 276. | html, css, vanilla-js | 2026-04-16 |
+| [sidecar-proxy-flow](sidecar-proxy-flow/) | Sidecar Proxy Flow — Auto-generated sidecar-proxy visualization tool from hub-auto-loop cycle 216. | html, css, vanilla-js | 2026-04-16 |
+| [sidecar-proxy-latency-scope](sidecar-proxy-latency-scope/) | Sidecar Proxy Latency Scope — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [sidecar-proxy-playground](sidecar-proxy-playground/) | Sidecar Proxy Playground — Auto-generated service-mesh visualization tool from hub-auto-loop cycle 275. | html, css, vanilla-js | 2026-04-16 |
+| [sidecar-proxy-policy-lab](sidecar-proxy-policy-lab/) | Sidecar Proxy Policy Lab — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [sidecar-proxy-topology](sidecar-proxy-topology/) | Sidecar Proxy Topology — Auto-generated sidecar-proxy visualization tool from hub-auto-loop cycle 47. | html, css, vanilla-js | 2026-04-16 |
+| [sidecar-proxy-traffic-flow](sidecar-proxy-traffic-flow/) | Sidecar Proxy Traffic Flow — Auto-generated sidecar-proxy visualization tool from hub-auto-loop cycle 171. | html, css, vanilla-js | 2026-04-16 |
+| [sidecar-proxy-traffic-sim](sidecar-proxy-traffic-sim/) | Sidecar Proxy Traffic Sim — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [skill-breeder](skill-breeder/) | Skill Breeder — `skill-multiplier` runs the loop unattended and explodes the population \u2014 fun, but you can't *curate*. Breeder is the manual counterpart: you pick the parents, you inspect the draft, you decide whether it joins the pool. Accepted children become breedable with any other entry (including a prior child), so the propagation is still infinite \u2014 it's just steered by a human. Use it when you want to ask "what would X crossed with Y look like?" and iterate. | node, html, js, css | 2026-04-16 |
+| [skill-cookbook](skill-cookbook/) | Skill Cookbook — `skill-tryout` tests routing of *one* skill at a time. Cookbook answers "which skills work *together*?" — the combinatorial view that was missing. Instead of browsing 240 skills individually, describe your problem and get a ready-made recipe. | html, css, js | 2026-04-16 |
+| [skill-diff](skill-diff/) | Skill Diff — The hub gains and loses skills constantly — but there's no release-notes surface. You can `git log`, but a raw log doesn't tell you *which slug* changed or *how its description/triggers/tags differ*. This tool diffs two refs of a hub working copy and shows per-slug added / modified / removed cards with the frontmatter delta expanded inline. Good for audit trails and curation. | node, html, js | 2026-04-16 |
+| [skill-doctor](skill-doctor/) | Skill Doctor — A skills-hub working copy with 200+ entries drifts silently: a `SKILL.md` with no `description`, a knowledge entry whose folder disagrees with its `category`, two skills with the same `name`, `content.md` referenced but missing. No tool was enforcing the shape. This is a zero-dep Node CLI that lints every `SKILL.md` and `.claude/knowledge/*/*.md` and returns a non-zero exit code when errors exist — CI/pre-commit ready. | node, cli | 2026-04-16 |
+| [skill-graph](skill-graph/) | Skill Graph — `skills-explorer` lets you search by keyword, but the hub is also a web of *relationships* — skills that share tags, entries extracted from the same source project, patterns that cluster around specific domains. A flat list hides the clustering. This is a zero-dep browser-based force-directed graph that makes those relationships visible and navigable. | node, html, svg, js | 2026-04-16 |
+| [skill-multiplier](skill-multiplier/) | Skill Multiplier — The hub holds ~430 entries today, but it has always grown by human authorship. What if every skill + knowledge pair is already a latent *third* skill waiting to be synthesized? This tool runs a generational loop: Gen 0 = the live hub, every tick picks two parents (weighted by tag/category overlap, with a mutation chance), deterministically synthesizes a child `SKILL.md` draft, and drops it back into the pool as a Gen-1 entry. The next tick can pair a Gen-1 child with an original — so children beget children. Watch the population double, triple, keep going. | node, html, js, css | 2026-04-16 |
+| [skill-reactor](skill-reactor/) | Skill Reactor — `skill-multiplier` is stochastic \u2014 fun, but the children feel arbitrary. `skill-breeder` is hand-curated \u2014 precise, but slow. Reactor sits between: you declare **reaction rules** (e.g. `category=kafka + tag=tenant \u2192 new skill`), and the engine fires them against the entire pool every tick. Newly produced children re-enter the pool and can satisfy other rules, which is how the propagation stays infinite without becoming noise. Think Conway's Game of Life, but for skills. | node, html, js, css | 2026-04-16 |
+| [skill-stats](skill-stats/) | Skill Stats — `skills-explorer` shows *what* is in the hub; `skill-graph` shows *how* entries relate. This shows *what the hub is made of in aggregate* — category balance, tag frequency, which source projects contributed the most patterns, how much of the corpus has `content.md` vs only `SKILL.md`. Useful for curating: are we bloated on `workflow` entries? Is `lucida-measurement` overrepresented? Which tags have become synonymous with garbage? | node, html, svg, js | 2026-04-16 |
+| [skill-timeline](skill-timeline/) | Skill Timeline — `skills-explorer` lets you search the hub; `skill-graph` shows relationships; `skill-stats` shows aggregates. None of them answer *when did what change*, or *which entries have been thrashed*. This tool walks `git log` on a skills-hub working copy and renders a GitHub-style commit heatmap plus a top-churned leaderboard — the "drift over time" view that was missing. | node, html, svg, js | 2026-04-16 |
+| [skill-tryout](skill-tryout/) | Skill Tryout — A skill is only useful if it gets discovered. `description` and `triggers` are the only signals Claude uses to route a query, but no one measures how well those signals actually work. This is a browser REPL: paste a sentence, see which skills rank highest via TF-IDF across description + triggers (3× boost) + tags (2× boost) + slug/name. Lets you find skills whose triggers are too narrow, too broad, or worse — entirely absent. | node, html, js | 2026-04-16 |
+| [skills-explorer](skills-explorer/) | Skills Explorer — A single working copy of `kjuhwa/skills-hub` can accumulate hundreds of skills and knowledge entries (this one has 217 + 213 = 430). Reading them one `SKILL.md` at a time doesn't scale — you need a browseable catalog with fuzzy search. This tool turns any local checkout of the hub into an instantly-searchable dashboard, zero dependencies, offline. | node, html, js, css | 2026-04-16 |
+| [sliding-window-lab](sliding-window-lab/) | Sliding Window Lab — Auto-generated rate-limiter visualization tool from hub-auto-loop cycle 291. | html, css, vanilla-js | 2026-04-16 |
+| [sliding-window-monitor](sliding-window-monitor/) | Sliding Window Monitor — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [span-flame](span-flame/) | Span Flame — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [span-flame-chart](span-flame-chart/) | Span Flame Chart — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [span-latency-heatmap](span-latency-heatmap/) | Span Latency Heatmap — Auto-generated distributed-tracing visualization tool from hub-auto-loop cycle 290. | html, css, vanilla-js | 2026-04-16 |
+| [spring-starter-wizard](spring-starter-wizard/) | Spring Boot Starter Wizard — 115 backend skills are overwhelming. This wizard is the "what do I need?" entry point — pick your requirements from 6 categories and get a curated, ordered skill recipe with implementation dependencies resolved. | html, css, js | 2026-04-16 |
+| [starter-wizard](starter-wizard/) | Starter Wizard — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [strangler-fig-ecosystem](strangler-fig-ecosystem/) | Strangler Fig Ecosystem — Auto-generated strangler-fig visualization tool from hub-auto-loop cycle 5. | html, css, vanilla-js | 2026-04-16 |
+| [strangler-fig-garden](strangler-fig-garden/) | Strangler Fig Garden — Auto-generated strangler-fig visualization tool from hub-auto-loop cycle 263. | html, css, vanilla-js | 2026-04-16 |
+| [strangler-fig-growth](strangler-fig-growth/) | Strangler Fig Growth — Auto-generated strangler-fig visualization tool from hub-auto-loop cycle 22. | html, css, vanilla-js | 2026-04-16 |
+| [strangler-fig-growth-sim](strangler-fig-growth-sim/) | Strangler Fig Growth Sim | html, css, vanilla-js | 2026-04-16 |
+| [strangler-fig-migration](strangler-fig-migration/) | Strangler Fig Migration | html, css, vanilla-js | 2026-04-16 |
+| [strangler-fig-migration-simulator](strangler-fig-migration-simulator/) | Strangler Fig Migration Simulator — Auto-generated strangler-fig visualization tool from hub-auto-loop cycle 307. | html, css, vanilla-js | 2026-04-16 |
+| [strangler-fig-migrator](strangler-fig-migrator/) | Strangler Fig Migrator — Auto-generated strangler-fig visualization tool from hub-auto-loop cycle 245. | html, css, vanilla-js | 2026-04-16 |
+| [strangler-fig-route-router](strangler-fig-route-router/) | Strangler Fig Route Router — Auto-generated strangler-fig visualization tool from hub-auto-loop cycle 307. | html, css, vanilla-js | 2026-04-16 |
+| [strangler-fig-simulator](strangler-fig-simulator/) | Strangler Fig Simulator — Auto-generated strangler-fig visualization tool from hub-auto-loop cycle 56. | html, css, vanilla-js | 2026-04-16 |
+| [strangler-fig-timeline](strangler-fig-timeline/) | Strangler Fig Timeline — Auto-generated strangler-fig visualization tool from hub-auto-loop cycle 263. | html, css, vanilla-js | 2026-04-16 |
+| [strangler-fig-traffic-splitter](strangler-fig-traffic-splitter/) | Strangler Fig Traffic Splitter — Auto-generated strangler-fig visualization tool from hub-auto-loop cycle 245. | html, css, vanilla-js | 2026-04-16 |
+| [strangler-fig-vine-grower](strangler-fig-vine-grower/) | Strangler Fig Vine Grower — Auto-generated strangler-fig visualization tool from hub-auto-loop cycle 307. | html, css, vanilla-js | 2026-04-16 |
+| [stream-throughput-monitor](stream-throughput-monitor/) | Stream Throughput Monitor — Auto-generated data-pipeline visualization tool from hub-auto-loop cycle 249. | html, css, vanilla-js | 2026-04-16 |
+| [supervision-tree-viz](supervision-tree-viz/) | Supervision Tree Viz — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [supervisor-tree-playground](supervisor-tree-playground/) | Supervisor Tree Playground — Auto-generated actor-model visualization tool from hub-auto-loop cycle 300. | html, css, vanilla-js | 2026-04-16 |
+| [system-vitals-ring](system-vitals-ring/) | System Vitals Ring — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [tcp-window-sim](tcp-window-sim/) | Tcp Window Sim — Auto-generated backpressure visualization tool from hub-auto-loop cycle 298. | html, css, vanilla-js | 2026-04-16 |
+| [tech-radar](tech-radar/) | Tech Radar — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [tech-trends-radar](tech-trends-radar/) | Tech Trends Radar 2025-2026 — ThoughtWorks식 인터랙티브 기술 레이더 — 43개 기술의 Adopt/Trial/Assess/Hold 포지셔닝을 한눈에 | html, css, js, svg | 2026-04-16 |
+| [time-series-db-explorer](time-series-db-explorer/) | Time Series Db Explorer — Auto-generated time-series-db visualization tool from hub-auto-loop cycle 244. | html, css, vanilla-js | 2026-04-16 |
+| [time-travel-tree](time-travel-tree/) | Time Travel Tree — Auto-generated event-sourcing visualization tool from hub-auto-loop cycle 246. | html, css, vanilla-js | 2026-04-16 |
+| [tiny-regex-lab](tiny-regex-lab/) | Tiny Regex Lab — Regex debugging is a daily pain, and every online playground is ad-heavy, cloud-hosted, and logs your input. This is a single-file browser tool — no server, no network, per-group color highlighting, a preset library of common patterns, and URL-hash sharing so you can paste a link into chat without a backend. | html, js, css | 2026-04-16 |
+| [token-bucket-visualizer](token-bucket-visualizer/) | Token Bucket Visualizer — Auto-generated rate-limiter visualization tool from hub-auto-loop cycle 7. | html, css, vanilla-js | 2026-04-16 |
+| [topic-pubsub-monitor](topic-pubsub-monitor/) | Topic Pubsub Monitor — Auto-generated message-queue visualization tool from hub-auto-loop cycle 264. | html, css, vanilla-js | 2026-04-16 |
+| [topic-river](topic-river/) | Topic River — Auto-generated pub-sub visualization tool from hub-auto-loop cycle 225. | html, css, vanilla-js | 2026-04-16 |
+| [trace-waterfall](trace-waterfall/) | Trace Waterfall — Auto-generated distributed-tracing visualization tool from hub-auto-loop cycle 41. | html, css, vanilla-js | 2026-04-16 |
+| [trace-waterfall-inspector](trace-waterfall-inspector/) | Trace Waterfall Inspector — Auto-generated distributed-tracing visualization tool from hub-auto-loop cycle 290. | html, css, vanilla-js | 2026-04-16 |
+| [trace-waterfall-viewer](trace-waterfall-viewer/) | Trace Waterfall Viewer — Auto-generated distributed-tracing visualization tool from hub-auto-loop cycle 197. | html, css, vanilla-js | 2026-04-16 |
+| [traffic-light-fsm](traffic-light-fsm/) | Traffic Light Fsm — Auto-generated finite-state-machine visualization tool from hub-auto-loop cycle 252. | html, css, vanilla-js | 2026-04-16 |
+| [trend-heatmap](trend-heatmap/) | Trend Heatmap — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [trend-heatmap-dashboard](trend-heatmap-dashboard/) | Trend Heatmap Dashboard — 36개 기술의 28개월간(2024.01–2026.04) 인기도 변화를 히트맵으로 시각화 — 어떤 트렌드가 지속되고 어떤 것이 사라졌는지 한눈에 파악 | html, css, js | 2026-04-16 |
+| [tsdb-ingest-simulator](tsdb-ingest-simulator/) | Tsdb Ingest Simulator — Auto-generated time-series-db visualization tool from hub-auto-loop cycle 282. | html, css, vanilla-js | 2026-04-16 |
+| [tsdb-ingestion-monitor](tsdb-ingestion-monitor/) | Tsdb Ingestion Monitor | html, css, vanilla-js | 2026-04-16 |
+| [tsdb-live-dashboard](tsdb-live-dashboard/) | Tsdb Live Dashboard — Auto-generated time-series-db visualization tool from hub-auto-loop cycle 5. | html, css, vanilla-js | 2026-04-16 |
+| [tsdb-live-monitor](tsdb-live-monitor/) | Tsdb Live Monitor — Auto-generated time-series-db visualization tool from hub-auto-loop cycle 77. | html, css, vanilla-js | 2026-04-16 |
+| [tsdb-query-explorer](tsdb-query-explorer/) | Tsdb Query Explorer — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [tsdb-query-playground](tsdb-query-playground/) | Tsdb Query Playground — Auto-generated time-series-db visualization tool from hub-auto-loop cycle 7. | html, css, vanilla-js | 2026-04-16 |
+| [tsdb-query-repl](tsdb-query-repl/) | Tsdb Query Repl — Auto-generated time-series-db visualization tool from hub-auto-loop cycle 282. | html, css, vanilla-js | 2026-04-16 |
+| [tsdb-query-sandbox](tsdb-query-sandbox/) | Tsdb Query Sandbox — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [tsdb-retention-planner](tsdb-retention-planner/) | Tsdb Retention Planner — Auto-generated time-series-db visualization tool from hub-auto-loop cycle 182. | html, css, vanilla-js | 2026-04-16 |
+| [tsdb-retention-sim](tsdb-retention-sim/) | Tsdb Retention Sim — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [tsdb-retention-visualizer](tsdb-retention-visualizer/) | Tsdb Retention Visualizer | html, css, vanilla-js | 2026-04-16 |
+| [ubiquitous-language-glossary](ubiquitous-language-glossary/) | Ubiquitous Language Glossary — Auto-generated domain-driven visualization tool from hub-auto-loop cycle 266. | html, css, vanilla-js | 2026-04-16 |
+| [ubiquitous-language-miner](ubiquitous-language-miner/) | Ubiquitous Language Miner — Auto-generated domain-driven visualization tool from hub-auto-loop cycle 296. | html, css, vanilla-js | 2026-04-16 |
+| [uptime-heatmap](uptime-heatmap/) | Uptime Heatmap — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [vending-machine-fsm](vending-machine-fsm/) | Vending Machine Fsm — Auto-generated finite-state-machine visualization tool from hub-auto-loop cycle 252. | html, css, vanilla-js | 2026-04-16 |
+| [vibe-canvas](vibe-canvas/) | Vibe Canvas — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [vibe-coding-canvas](vibe-coding-canvas/) | Vibe Coding Canvas — "Vibe coding" — describing what you want in natural language and getting working UI — is the hottest trend of 2025. This canvas lets you type component descriptions in Korean or English and instantly see a live preview with generated HTML/CSS code. No AI API needed — pure template-based pattern matching. | html, js, css | 2026-04-16 |
+| [vital-signs-checkup](vital-signs-checkup/) | Vital Signs Checkup — Auto-generated health-check visualization tool from hub-auto-loop cycle 286. | html, css, vanilla-js | 2026-04-16 |
+| [vnode-load-balancer](vnode-load-balancer/) | Vnode Load Balancer — Auto-generated consistent-hashing visualization tool from hub-auto-loop cycle 257. | html, css, vanilla-js | 2026-04-16 |
+| [websocket-arena](websocket-arena/) | Websocket Arena | html, css, vanilla-js | 2026-04-16 |
+| [websocket-chat-sim](websocket-chat-sim/) | Websocket Chat Sim — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [websocket-chat-simulator](websocket-chat-simulator/) | Websocket Chat Simulator — Auto-generated websocket visualization tool from hub-auto-loop cycle 259. | html, css, vanilla-js | 2026-04-16 |
+| [websocket-chat-swarm](websocket-chat-swarm/) | Websocket Chat Swarm — Auto-generated websocket visualization tool from hub-auto-loop cycle 228. | html, css, vanilla-js | 2026-04-16 |
+| [websocket-flow](websocket-flow/) | Websocket Flow — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [websocket-frame-inspector](websocket-frame-inspector/) | Websocket Frame Inspector — Auto-generated websocket visualization tool from hub-auto-loop cycle 228. | html, css, vanilla-js | 2026-04-16 |
+| [websocket-frames](websocket-frames/) | Websocket Frames — Auto-generated websocket visualization tool from hub-auto-loop cycle 10. | html, css, vanilla-js | 2026-04-16 |
+| [websocket-handshake-visualizer](websocket-handshake-visualizer/) | Websocket Handshake Visualizer — Auto-generated websocket visualization tool from hub-auto-loop cycle 259. | html, css, vanilla-js | 2026-04-16 |
+| [websocket-pulse](websocket-pulse/) | Websocket Pulse — Auto-generated websocket visualization tool from hub-auto-loop cycle 55. | html, css, vanilla-js | 2026-04-16 |
+| [websocket-pulse-monitor](websocket-pulse-monitor/) | Websocket Pulse Monitor — Auto-generated websocket visualization tool from hub-auto-loop cycle 228. | html, css, vanilla-js | 2026-04-16 |
+| [ws-chat-simulator](ws-chat-simulator/) | Ws Chat Simulator — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [ws-handshake-anatomy](ws-handshake-anatomy/) | Ws Handshake Anatomy — Auto-generated distributed systems visualization tool. | html, css, vanilla-js | 2026-04-17 |
+| [ws-packet-visualizer](ws-packet-visualizer/) | Ws Packet Visualizer — Auto-generated websocket visualization tool from hub-auto-loop cycle 6. | html, css, vanilla-js | 2026-04-16 |
 
 ## Adding an example
 
-Use the `/example_add <slug>` slash command from a working copy that contains the artifact. It will:
+Use the `/hub-publish-example <slug>` slash command. It will:
 
-1. Copy the selected files into `example/<slug>/`
+1. Copy files into `example/<slug>/`
 2. Generate `README.md` and `manifest.json`
 3. Branch, commit, push, and open a PR
 4. Update this catalog
-
-Duplication check: `/make_something` invokes `/example_list` first to avoid rebuilding something already here.


### PR DESCRIPTION
Complete catalog with all 542 examples from manifest.json