### PR TITLE
Publish 2 pitfall knowledge entries (2026-04-17 session)

### DIFF
--- a/knowledge/pitfall/python-regex-dotall-spans-java-method-blocks.md
+++ b/knowledge/pitfall/python-regex-dotall-spans-java-method-blocks.md
@@ -1,0 +1,56 @@
+---
+name: python-regex-dotall-spans-java-method-blocks
+description: Python re.sub에서 DOTALL + .*? 로 Java 메서드를 batch 편집하면 non-greedy여도 인접 메서드 블록을 건너뛰어 잘못된 위치에 annotation이 삽입된다
+category: pitfall
+tags:
+  - python
+  - regex
+  - java
+  - annotation-batch
+  - swagger-ai-optimization
+---
+
+# python-regex-dotall-spans-java-method-blocks
+
+`@Operation` / `@PostMapping` 에 `@Extension` 을 대량으로 붙이려고 Python 정규식을 돌렸는데, 의도한 엔드포인트가 아닌 **바로 윗/아래 엔드포인트**에 확장이 붙는다. re.subn 호출 결과의 교체 건수는 맞게 나오고 빌드도 성공하지만, 랜딩 위치가 어긋나 **엔드포인트·param 매핑이 뒤집힌 오염 데이터**가 된다. 증상이 미묘해서 스펙 JSON을 열어 cross-check 하기 전까지는 발견하기 어렵다. 실전 사례: `ConfigurationController`에서 `/conf-info/{confId}/resource-info` 에 `x-resolver(param=confId)` 를 붙이려 했는데, 바로 뒤에 있는 `/os-types` 엔드포인트 앞에 삽입됐다. 빌드는 green, x-resolver count는 +1 증가, 그러나 landing은 틀린 endpoint.
+
+원인은 `re.DOTALL` 과 `.*?` 조합이다. 아래 같은 패턴에서:
+
+```python
+pat = re.compile(
+    r'security = \{@SecurityRequirement\(name = "bearerAuth"\)\}\)\n(\s*)'
+    r'@PostMapping\((".*?\{' + path_var + r'\}.*?")\)',
+    re.DOTALL,
+)
+```
+
+`(".*?\{confId\}.*?")` 는 non-greedy 지만 `re.DOTALL` 때문에 `.` 이 개행도 매치한다. 엔진의 동작은 (1) "가장 왼쪽에서 시작하는 첫 매치"를 찾고 (2) 주어진 제약을 만족할 때까지 non-greedy로 확장한다. 여러 엔드포인트가 연속으로 `security = ...) / @PostMapping(...)` 쌍을 이루는 경우, 앞쪽 엔드포인트의 security 닫는 괄호에서 시작해서 뒤쪽 엔드포인트의 `@PostMapping("/conf-info/{confId}/...")` 까지 **중간 엔드포인트를 통째로 뛰어넘어** 단일 매치로 포획한다. 결과적으로 교체 문자열이 앞쪽 엔드포인트의 @Operation 뒤에 붙어버린다. 간단히 말해 **"security 닫는 괄호"와 "path-param 포함 PostMapping" 사이 거리가 멀면 `.*?` 가 블록 경계를 무시하고 점프한다.**
+
+대응은 세 가지다. 첫째, **path 문자열 전체를 리터럴로 고정**. `re.escape(path)` 로 path의 모든 부분을 포함시키고 `.*?` 는 제거한다:
+
+```python
+path = '/conf-info/{confId}/resource-info'
+escaped = re.escape(path)
+pat = re.compile(
+    r'security = \{@SecurityRequirement\(name = "bearerAuth"\)\}\)\n(\s*)'
+    r'@PostMapping\((path = )?"' + escaped + r'"\)',
+    re.DOTALL,
+)
+```
+
+둘째, **각 endpoint를 개별 패턴으로 한 번씩 호출** — 한 번의 re.sub로 모든 endpoint를 잡지 말고 endpoint 수만큼 루프 돌리기. 셋째, **DOTALL 끄기** — `.` 가 개행을 매치하지 않게 해서 single-line 범위 내에서만 매치. 단, `@PostMapping(path = "...")` 이 여러 줄로 쪼개진 포매팅에서는 실패하므로 주의.
+
+검증은 반드시 사후 감사로. 빌드 성공만으로는 랜딩 오염을 잡을 수 없다. spec 재추출 후 `x-resolver.param` 이 실제 path의 path-param 중 하나인지 교차 검증하는 스크립트를 돌린다:
+
+```python
+import json, re
+s = json.load(open('docs/swagger-after.json', encoding='utf-8'))
+for p, ms in s['paths'].items():
+    path_params = re.findall(r'\{([^}]+)\}', p)
+    for m, op in ms.items():
+        xr = op.get('x-resolver')
+        if xr and xr.get('param') and xr['param'] not in path_params:
+            print(f'DRIFT: [{m}] {p} x-resolver.param={xr["param"]} vs path_params={path_params}')
+```
+
+한 줄 교훈: **DOTALL + `.*?` 는 "가장 짧은 매치"를 보장하지만 "가장 가까운 블록 내" 매치를 보장하지는 않는다.** Batch 편집은 path/operationId 같은 **unique anchor** 를 반드시 패턴에 포함시킬 것.

--- a/knowledge/pitfall/springdoc-dto-schema-orphan-when-unexposed.md
+++ b/knowledge/pitfall/springdoc-dto-schema-orphan-when-unexposed.md
@@ -1,0 +1,30 @@
+---
+name: springdoc-dto-schema-orphan-when-unexposed
+description: springdoc는 컨트롤러 시그니처를 walk하므로 ApiResponseData<Object> 반환 DTO에 달린 @Schema·x-lookup은 스펙에 반영되지 않는다
+category: pitfall
+tags:
+  - springdoc
+  - openapi
+  - java
+  - schema
+  - swagger-ai-optimization
+---
+
+# springdoc-dto-schema-orphan-when-unexposed
+
+DTO 필드에 `@Schema(description, example, extensions = @Extension(...))` 를 꼼꼼히 달았는데 `/v3/api-docs`(또는 저장한 `swagger-after.json`)을 확인하면 해당 DTO가 `components.schemas` 에 **아예 없거나 빈 `{}`** 로 노출된다. x-lookup, x-enum 등 확장이 전부 무시된 것처럼 보인다. 빌드는 성공하고 Swagger UI만 봐도 모양이 그럴듯해서 금방 알아채기 어렵다.
+
+원인은 `springdoc-openapi` 의 walker 구조다. springdoc는 컨트롤러 메서드의 `@RequestBody` 파라미터 타입과 **반환 타입**을 시작점으로 타입 그래프를 walk 하며 스키마를 수집한다. Lucida 도메인 프로젝트에서 흔한 `public ApiResponseData<Object> xxx(...)` 시그니처는 반환 타입이 `Object` 로 지워져 있어 walker가 내부 `ApiResponseData.createSuccess(X)` 의 실제 타입을 추적하지 못한다. 이 경로로만 사용되는 DTO는 컨트롤러 어디에도 참조되지 않으므로 **아무리 annotation 을 달아도 스펙에 절대 등장하지 않는다.** 실전 사례: `ConfigurationDto.groupId` 에 `x-lookup` 을 걸었지만 `components.schemas.ConfigurationDto` 자체가 스펙에 존재하지 않아 100% 무효였고, 같은 내용을 실제 엔드포인트 응답 경로에 포함된 `HostInformationDto.groupId` 로 옮기고서야 노출됐다.
+
+대응은 **annotation 대량 투하 전 스펙 노출 여부 선검증**이다. 타겟 필드 이름(`groupId` 등)으로 spec JSON을 검색해서 실제로 노출된 DTO 이름을 먼저 추린다:
+
+```python
+import json
+s = json.load(open('docs/swagger-after.json', encoding='utf-8'))
+target_field = 'groupId'
+for n, sc in s.get('components', {}).get('schemas', {}).items():
+    if target_field in (sc.get('properties') or {}):
+        print(f'exposed: {n}')
+```
+
+노출 안 된 DTO에 annotation 다는 작업은 "미래를 위한 문서화"는 될지언정 **현 스펙 품질 개선에는 기여 0** 이다. ROI 관점에서는 (1) 노출된 DTO에만 annotation 투자, (2) 노출 안 된 DTO는 Phase 5-B 수준(시그니처 실체화 또는 `@Schema(implementation=MarkerDto.class)` 마커 노출)을 선행한 뒤에 annotation을 붙인다. 체크리스트 3항: 컨트롤러 반환 타입이 `ApiResponseData<Object>`인가 → `@Schema(implementation=...)` 마커 노출이 있나 → 스펙 JSON에서 해당 DTO가 `properties: {...}` 로 채워졌나. 세 가지를 모두 확인한 뒤 annotation 투하.

--- a/registry.json
+++ b/registry.json
@@ -3862,6 +3862,50 @@
         "sirius"
       ],
       "extracted_at": "2026-04-16"
+    },
+    "springdoc-dto-schema-orphan-when-unexposed": {
+      "category": "pitfall",
+      "scope": "global",
+      "path": "~/.claude/skills-hub/knowledge/pitfall/springdoc-dto-schema-orphan-when-unexposed.md",
+      "source": {
+        "kind": "commit",
+        "ref": "729ad3af82bb278b9083600d5caefe9c10702608"
+      },
+      "confidence": "high",
+      "linked_skills": [
+        "swagger-ai-optimization"
+      ],
+      "tags": [
+        "springdoc",
+        "openapi",
+        "java",
+        "schema",
+        "swagger-ai-optimization"
+      ],
+      "extracted_at": "2026-04-17"
+    },
+    "python-regex-dotall-spans-java-method-blocks": {
+      "category": "pitfall",
+      "scope": "global",
+      "path": "~/.claude/skills-hub/knowledge/pitfall/python-regex-dotall-spans-java-method-blocks.md",
+      "source": {
+        "kind": "commit",
+        "ref": "88dff45a5adff6cbbc56f2757c1559d5981bc161"
+      },
+      "confidence": "high",
+      "linked_skills": [
+        "swagger-ai-optimization",
+        "bucket-parallel-java-annotation-dispatch",
+        "parallel-bulk-annotation"
+      ],
+      "tags": [
+        "python",
+        "regex",
+        "java",
+        "annotation-batch",
+        "swagger-ai-optimization"
+      ],
+      "extracted_at": "2026-04-17"
     }
   }
 }


### PR DESCRIPTION
## Knowledge

- **[pitfall] springdoc-dto-schema-orphan-when-unexposed** — `ApiResponseData<Object>` 반환 컨트롤러는 springdoc walker가 DTO 그래프를 추적하지 못해 `@Schema`·x-lookup 등 annotation이 스펙에 반영되지 않는다. 투입 전 스펙 노출 여부 선검증 필수.
- **[pitfall] python-regex-dotall-spans-java-method-blocks** — `re.DOTALL + .*?` 는 non-greedy 여도 인접 Java 메서드 블록을 건너뛰어 잘못된 엔드포인트에 annotation이 삽입된다. path 리터럴 고정과 사후 coverage 감사로 회귀 차단.

## Skills

(없음 — `swagger-ai-optimization` Part C는 이전 릴리스에 포함됨)

## Cross-links

두 knowledge 모두 `swagger-ai-optimization` 스킬에 linked. 두 번째 entry는 `bucket-parallel-java-annotation-dispatch`, `parallel-bulk-annotation` 과도 연결.

## Source

- Project: `lucida-domain-sms` (develop-10.2.4_3 branch)
- Session: 2026-04-17, Polestar API 스펙 확장 요청서 4.3.2 / 4.4.1 확산 작업
- 작업 중 발견: (1) `ConfigurationDto.groupId` 에 x-lookup 달았으나 스펙 미노출 → `HostInformationDto.groupId` 로 이전. (2) Python re.sub 로 x-resolver batch 적용 시 `/conf-info/{confId}/...` 용 확장이 `/os-types` 앞에 잘못 삽입돼 회귀. 두 건 모두 수정 완료, coverage 19/19·12/12·8/8 달성.