### PR TITLE
example(auto-hub-loop): v2 rewrite — Recipe panel + full inventory + phase status

### DIFF
--- a/example/hub-tools/auto-hub-loop/README.md
+++ b/example/hub-tools/auto-hub-loop/README.md
@@ -1,21 +1,25 @@
 # Hub Auto-Loop Dashboard
 
-> **Why.** Fully automated pipeline that generates apps, publishes to skills-hub, extracts skills/knowledge, and loops — with a real-time web dashboard for monitoring.
+> **Why.** Fully automated pipeline that generates apps, publishes to skills-hub, extracts skills/knowledge, and loops — with a live web dashboard proving the hub is actually being leveraged each cycle.
 
 ## Features
 
-- **Automated Pipeline** — generate → build → publish → merge → extract → publish-sk → install → loop
-- **Web Dashboard** — real-time SSE-based UI showing pipeline phases, apps built, skills acquired, log stream
-- **Claude CLI Integration** — uses `claude -p` via `execFile` for creative code generation and pattern extraction
-- **Git Automation** — branch creation, PR, auto-merge, all handled programmatically
-- **50 Keywords** — distributed systems concepts pool for infinite variety
+- **7-phase pipeline** — generate → build → publish → merge → extract → publish-sk → install → loop (all automated, auto-merged)
+- **Evocative 10–20 word themes** — each cycle picks a random phrase like "Midnight cartographers chart constellations drifting across velvet skies" instead of bare keywords. Unlocks creative variety from Claude.
+- **FULL hub inventory in prompt** — every cycle scans all 300+ skills and 300+ knowledge entries from the hub, embeds them into Claude's prompt, and requires 100+ citations spread across 3 generated apps.
+- **Live Recipe panel** — right-side panel shows, in real time, which skills/knowledge Claude cited this cycle (up to 200 skills + 100 knowledge). Click any item to open a modal showing the full SKILL.md / knowledge .md content.
+- **Status strip** — top bar shows current phase (n/7), phase elapsed time (live MM:SS), and the cycle's theme phrase with gradient glow.
+- **Run Once / Start Loop** — either drive one complete cycle and stop, or run continuously.
+- **Real-time SSE log stream** with color-coded levels and auto-scrolling panel.
+- **Apps built / Skills acquired** panels showing every artifact produced with links to merged PRs.
 
 ## File structure
 
 ```
 auto-hub-loop/
-  server.js     — HTTP server + SSE + 7-phase orchestration engine (744 lines)
-  index.html    — Dashboard with pipeline strip, app/skill panels, log stream (294 lines)
+  server.js     — HTTP server + SSE + 7-phase orchestration engine (~1300 lines)
+  index.html    — Dashboard: pipeline strip, status bar, apps list, recipe panel, log stream, hub-item modal (~900 lines)
+  manifest.json — Hub metadata
 ```
 
 ## Usage
@@ -23,14 +27,52 @@ auto-hub-loop/
 ```bash
 node server.js
 # open http://localhost:8917
-# click "Start Loop"
+# click "Start Loop" or "Run Once"
 ```
+
+### Pipeline phases
+
+Each cycle runs these phases in sequence:
+
+1. **Generate Ideas** — Claude produces 3 distinct app ideas (visualization + simulation + tool) from a random theme phrase
+2. **Build Apps** — parse and write files to `NN-slug/` directories, validate JS syntax
+3. **Publish PRs** — git branch + commit + push + `gh pr create` for each app (3 PRs)
+4. **Auto-Merge** — `gh pr merge --merge` for each PR
+5. **Extract Skills** — Claude analyzes the built apps for NEW, genuine patterns (ignoring templated `-visualization-pattern` slugs)
+6. **Publish S/K** — single PR with all extracted skills + knowledge, auto-merged
+7. **Install All** — copy new items into `~/.claude/skills/` and `.claude/knowledge/`
+
+### Key technical tricks
+
+- **Large-prompt stdin redirect** — prompts with 300+ skill descriptions exceed argv limits. Server writes prompt to a temp file, then spawns `claude -p < tmpfile` via shell redirect (avoids ENAMETOOLONG on Windows, stdin-pipe propagation bugs on Windows cmd).
+- **OMC hook isolation** — child Claude process runs with `DISABLE_OMC=1`, `OMC_SKIP_HOOKS=*`, `CLAUDE_DISABLE_SESSION_HOOKS=1` env to prevent autopilot hooks from hijacking output into side channels.
+- **Recipe extraction** — after apps are built, the server scans the Claude output for all known skill/knowledge names (regex word-boundary + backtick match) and broadcasts the matched list via SSE.
+- **Duplicate-aware extraction** — extraction phase tells Claude to skip names already in the repo and bans templated suffixes, forcing genuinely new patterns each cycle.
 
 ## Stack
 
-`node` · `html` · `css` · `vanilla-js` — zero external dependencies, 1,038 lines
+`node` · `html` · `css` · `vanilla-js` — zero external dependencies, ~2200 lines total
+
+## Skills applied
+
+| Skill | Used for |
+|---|---|
+| `stdin-redirect-cli-large-prompts` | >30KB prompt delivery via temp file + shell redirect |
+| `full-inventory-over-sampling-prompt` | Passing all 300+ hub items to Claude instead of sampling |
+| `parallel-build-sequential-publish` | Build locally in batch, publish to git one at a time |
+| `zero-dep-dark-html-app` | Dashboard scaffold |
+
+## Knowledge respected
+
+| Knowledge | Why |
+|---|---|
+| `dashboard-decoration-vs-evidence` | Replaced animated character with Recipe panel showing actual cited skills |
+| `single-keyword-formulaic-llm-output` | Themes are 10–20 word phrases, not single words |
+| `batch-pr-conflict-recovery` | Per-PR flow avoids catalog README edits to prevent merge conflicts |
+| `flat-vs-categorized-folder-structure` | Publishes to `example/<category>/<slug>/` not flat |
 
 ## Provenance
 
-- Built by Claude Code via `/hub-make` on 2026-04-16
+- Built iteratively by Claude Code via `/hub-make` across multiple sessions in 2026-04-16 and 2026-04-17
 - Source working copy: `D:/22_TEST/test/17-auto-hub-loop`
+- This is v2 — significant rewrite since initial publish (PR #111)

--- a/example/hub-tools/auto-hub-loop/index.html
+++ b/example/hub-tools/auto-hub-loop/index.html
@@ -20,6 +20,8 @@ header .controls{margin-left:auto;display:flex;gap:8px;align-items:center}
 .btn-go{background:var(--accent);color:#0f1117}.btn-go:hover{filter:brightness(1.1)}
 .btn-go:disabled{opacity:.4;cursor:not-allowed}
 .btn-stop{background:var(--danger);color:#fff}.btn-stop:hover{filter:brightness(1.1)}
+.btn-once{background:var(--accent2);color:#fff}.btn-once:hover{filter:brightness(1.1)}
+.btn-once:disabled{opacity:.4;cursor:not-allowed}
 .btn-stop:disabled{opacity:.4;cursor:not-allowed}
 .status-pill{font-size:11px;padding:3px 10px;border-radius:99px;font-weight:600;text-transform:uppercase}
 .status-idle{background:#2e3344;color:var(--dim)}
@@ -51,12 +53,36 @@ main{flex:1;display:grid;grid-template-columns:1fr 1fr;grid-template-rows:auto 4
 .phase-arrow{color:var(--border);font-size:16px;margin:0 4px;transition:color .3s}
 .phase-arrow.flowing{color:var(--accent);animation:arrowFlow 1.5s ease-in-out infinite}
 @keyframes arrowFlow{0%,100%{opacity:.4;transform:translateX(0)}50%{opacity:1;transform:translateX(3px)}}
-.cycle-badge{margin-left:auto;font-size:20px;font-weight:700;color:var(--accent);font-variant-numeric:tabular-nums}
+.cycle-badge{font-size:20px;font-weight:700;color:var(--accent);font-variant-numeric:tabular-nums}
+.keyword-chip{margin-left:auto;display:inline-flex;align-items:center;gap:6px;padding:5px 14px;border-radius:99px;background:linear-gradient(90deg,#818cf840,#f472b640);border:1.5px solid var(--accent2);font-size:13px;font-weight:700;color:#fff;text-transform:lowercase;animation:keywordPulse 2s ease-in-out infinite;box-shadow:0 0 12px rgba(129,140,248,.3)}
+.keyword-chip.hidden{display:none}
+.keyword-chip .keyword-icon{font-size:12px}
+.keyword-chip #keywordText{color:var(--text);font-family:'Cascadia Code','Fira Code',monospace;letter-spacing:.5px}
+@keyframes keywordPulse{0%,100%{box-shadow:0 0 0 0 #818cf830}50%{box-shadow:0 0 10px 2px #818cf840}}
 .cycle-label{font-size:11px;color:var(--dim);margin-right:4px}
 
 /* Activity canvas */
-.activity-strip{grid-column:1/3;height:48px;background:var(--surface);position:relative;overflow:hidden}
-.activity-strip canvas{width:100%;height:100%}
+.activity-strip{grid-column:1/3;height:48px;background:linear-gradient(90deg,var(--surface),var(--surface2),var(--surface));display:flex;align-items:center;padding:0 24px;gap:20px;border-top:1px solid var(--border);border-bottom:1px solid var(--border)}
+.status-slot{display:flex;flex-direction:column;justify-content:center;gap:2px;min-width:0}
+.status-elapsed{flex:0 0 auto}
+.status-phase{flex:0 0 auto}
+.status-theme{flex:1;min-width:0;overflow:hidden}
+.status-label{font-size:9px;font-weight:700;letter-spacing:1.2px;color:var(--dim);text-transform:uppercase;display:flex;align-items:center;gap:4px}
+.status-label #phaseIndex{color:var(--accent);font-variant-numeric:tabular-nums}
+.status-value{font-family:'Cascadia Code','Fira Code',monospace;font-size:13px;font-weight:700;color:var(--text);line-height:1.2;font-variant-numeric:tabular-nums;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.status-elapsed .status-value{color:var(--accent)}
+.status-phase .status-value{color:var(--accent2);text-transform:uppercase;letter-spacing:.5px}
+.status-theme .status-value{color:transparent;background:linear-gradient(90deg,var(--accent) 0%,var(--accent2) 50%,#f472b6 100%);-webkit-background-clip:text;background-clip:text;font-size:12px;font-weight:600;letter-spacing:.3px;animation:kwGlow 3s ease-in-out infinite;white-space:normal;line-height:1.25;max-height:2.5em;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical}
+.status-divider{width:1px;height:32px;background:linear-gradient(180deg,transparent,var(--border),transparent);flex-shrink:0}
+.status-value.swap{animation:kwGlow 3s ease-in-out infinite,valueSwap .4s ease-out}
+@keyframes valueSwap{0%{opacity:0;transform:translateY(4px)}100%{opacity:1;transform:translateY(0)}}
+.activity-keyword{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;gap:16px;pointer-events:none;z-index:2}
+.activity-keyword .kw-prefix{font-family:'Cascadia Code','Fira Code',monospace;font-size:10px;color:var(--dim);letter-spacing:2px;text-transform:uppercase}
+.activity-keyword .kw-word{font-family:'Cascadia Code','Fira Code',monospace;font-size:14px;font-weight:700;letter-spacing:.5px;background:linear-gradient(90deg,var(--accent) 0%,var(--accent2) 50%,#f472b6 100%);-webkit-background-clip:text;background-clip:text;color:transparent;animation:kwGlow 2.5s ease-in-out infinite;position:relative;max-width:80%;text-align:center;line-height:1.3;text-transform:none}
+/* pseudo-element dashes removed — phrase is long */
+@keyframes kwGlow{0%,100%{text-shadow:0 0 10px rgba(129,140,248,.4)}50%{text-shadow:0 0 30px rgba(244,114,182,.7),0 0 15px rgba(110,231,183,.5)}}
+.activity-keyword.swap .kw-word{animation:kwSwap .4s ease-out,kwGlow 2.5s ease-in-out infinite .4s}
+@keyframes kwSwap{0%{opacity:0;transform:translateY(10px) scale(.8)}60%{opacity:1;transform:translateY(-2px) scale(1.1)}100%{transform:translateY(0) scale(1)}}
 
 /* Apps list */
 .app-row{display:flex;align-items:center;gap:8px;padding:6px 8px;border-radius:4px;font-size:12px;border-bottom:1px solid var(--border)}
@@ -81,8 +107,157 @@ main{flex:1;display:grid;grid-template-columns:1fr 1fr;grid-template-rows:auto 4
 .log-panel{font-family:'Cascadia Code','Fira Code',monospace;position:relative}
 
 /* Visualization panel */
-.viz-panel{background:var(--surface);position:relative;overflow:hidden}
-.viz-panel canvas{width:100%;height:100%}
+.viz-panel{background:linear-gradient(180deg,#151824 0%,var(--surface) 70%);position:relative;overflow:hidden;display:flex;flex-direction:column;padding:14px 16px;gap:10px}
+/* Recipe panel */
+.recipe-header{flex-shrink:0;padding:8px 12px;background:linear-gradient(90deg,#818cf815,#f472b615);border:1px solid var(--border);border-radius:6px}
+.recipe-theme{font-family:'Cascadia Code','Fira Code',monospace;font-size:11px;color:var(--accent2);line-height:1.5;font-style:italic;text-align:center}
+.recipe-body{flex:1;display:flex;flex-direction:column;gap:10px;overflow:hidden}
+.recipe-section{background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:10px 12px;flex:1;display:flex;flex-direction:column;min-height:0}
+.recipe-section-title{display:flex;align-items:center;gap:6px;font-size:11px;font-weight:700;color:var(--accent);text-transform:uppercase;letter-spacing:.5px;margin-bottom:8px;flex-shrink:0}
+.recipe-icon{font-size:13px}
+.recipe-count{margin-left:auto;background:var(--surface2);color:var(--dim);padding:1px 8px;border-radius:99px;font-size:10px;text-transform:none;letter-spacing:0}
+.recipe-list{flex:1;overflow-y:auto;overflow-x:hidden;display:flex;flex-direction:column;gap:3px;min-height:0}
+.recipe-empty{color:var(--dim);font-size:11px;font-style:italic;text-align:center;padding:12px}
+.recipe-item{display:flex;align-items:center;gap:8px;padding:4px 8px;background:var(--surface2);border-radius:4px;font-size:11px;animation:recipeItemIn .3s ease-out;transition:background .2s,box-shadow .2s;cursor:pointer;min-width:0}
+.recipe-item:hover{background:var(--border);box-shadow:inset 2px 0 0 var(--accent2)}
+.recipe-item:active{background:var(--surface2);transform:scale(.98)}
+.recipe-item-name{min-width:0;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+/* Hub Item Modal */
+.hub-item-modal{position:fixed;inset:0;background:rgba(0,0,0,.7);display:none;align-items:center;justify-content:center;z-index:1000;backdrop-filter:blur(4px)}
+.hub-item-modal.visible{display:flex;animation:modalFadeIn .2s ease-out}
+@keyframes modalFadeIn{from{opacity:0}to{opacity:1}}
+.hub-item-content{background:var(--surface);border:1px solid var(--border);border-radius:10px;width:min(800px,90vw);max-height:85vh;display:flex;flex-direction:column;overflow:hidden;box-shadow:0 20px 60px rgba(0,0,0,.5)}
+.hub-item-header{display:flex;align-items:center;gap:12px;padding:14px 18px;background:var(--surface2);border-bottom:1px solid var(--border);flex-shrink:0}
+.hub-item-kind{font-size:10px;font-weight:700;letter-spacing:1px;padding:3px 10px;border-radius:4px;text-transform:uppercase}
+.hub-item-kind.skill{background:#818cf830;color:var(--accent2)}
+.hub-item-kind.knowledge{background:#38bdf830;color:var(--info)}
+.hub-item-title-name{flex:1;font-family:'Cascadia Code','Fira Code',monospace;font-size:14px;font-weight:600;color:var(--text)}
+.hub-item-close{background:none;border:none;color:var(--dim);font-size:24px;cursor:pointer;padding:0 8px;line-height:1;transition:color .15s}
+.hub-item-close:hover{color:var(--danger)}
+.hub-item-path{padding:6px 18px;font-family:'Cascadia Code','Fira Code',monospace;font-size:10px;color:var(--dim);background:var(--bg);border-bottom:1px solid var(--border);flex-shrink:0}
+.hub-item-body{margin:0;padding:18px;font-family:'Cascadia Code','Fira Code',monospace;font-size:12px;line-height:1.6;color:var(--text);overflow-y:auto;flex:1;white-space:pre-wrap;word-break:break-word;background:var(--bg)}
+@keyframes recipeItemIn{from{opacity:0;transform:translateX(-8px)}to{opacity:1;transform:translateX(0)}}
+.recipe-item-bullet{width:5px;height:5px;border-radius:50%;background:var(--accent);flex-shrink:0}
+.recipe-item-bullet.knowledge{background:var(--info)}
+.recipe-item-name{font-family:'Cascadia Code','Fira Code',monospace;color:var(--text);font-weight:500}
+.recipe-item-cat{margin-left:auto;font-size:9px;color:var(--dim);background:var(--bg);padding:1px 6px;border-radius:3px;text-transform:uppercase;letter-spacing:.5px}
+.recipe-footer{flex-shrink:0;padding:6px 12px;font-size:10px;color:var(--dim);text-align:center;border-top:1px dashed var(--border)}
+.recipe-pool-stat b{color:var(--accent);font-variant-numeric:tabular-nums}
+.hidden{display:none !important}
+/* Pixel scene backdrop */
+.pixel-scene{position:absolute;inset:0;z-index:1}
+.pixel-sky{position:absolute;top:0;left:0;right:0;height:65%;background:linear-gradient(180deg,#1e1b4b 0%,#312e81 50%,#4c1d95 100%);image-rendering:pixelated}
+.pixel-sky::before{content:'';position:absolute;inset:0;background-image:
+  radial-gradient(circle 2px at 12% 20%, #fef3c7 100%, transparent 100%),
+  radial-gradient(circle 2px at 28% 40%, #fef3c7 100%, transparent 100%),
+  radial-gradient(circle 2px at 45% 15%, #fef3c7 100%, transparent 100%),
+  radial-gradient(circle 2px at 62% 35%, #a5b4fc 100%, transparent 100%),
+  radial-gradient(circle 2px at 78% 22%, #fef3c7 100%, transparent 100%),
+  radial-gradient(circle 2px at 88% 50%, #fbcfe8 100%, transparent 100%),
+  radial-gradient(circle 2px at 15% 55%, #c7d2fe 100%, transparent 100%),
+  radial-gradient(circle 2px at 35% 60%, #fef3c7 100%, transparent 100%);
+  animation:twinkle 3s steps(2) infinite;image-rendering:pixelated}
+@keyframes twinkle{0%,100%{opacity:.9}50%{opacity:.3}}
+.pixel-window{position:absolute;top:12%;right:10%;width:28%;height:36%;background:
+  linear-gradient(180deg,#60a5fa 0%,#3b82f6 60%,#1e40af 100%);
+  border:4px solid #1f2937;box-shadow:inset 0 0 0 2px #374151, inset 0 0 0 4px #111827;image-rendering:pixelated}
+.pixel-window::before{content:'';position:absolute;top:0;left:50%;width:2px;height:100%;background:#1f2937;transform:translateX(-1px)}
+.pixel-window::after{content:'';position:absolute;top:50%;left:0;width:100%;height:2px;background:#1f2937;transform:translateY(-1px)}
+.pixel-floor{position:absolute;bottom:0;left:0;right:0;height:35%;background:
+  repeating-linear-gradient(90deg, #1f2937 0, #1f2937 32px, #111827 32px, #111827 34px),
+  linear-gradient(180deg, #374151 0%, #1f2937 20px, #111827 100%);
+  background-blend-mode:multiply;image-rendering:pixelated;border-top:3px solid #6ee7b7;box-shadow:0 -4px 0 rgba(110,231,183,.2)}
+.pixel-floor::before{content:'';position:absolute;top:0;left:0;right:0;height:30px;background:repeating-linear-gradient(0deg,transparent 0,transparent 6px,rgba(110,231,183,.08) 6px,rgba(110,231,183,.08) 8px)}
+.pixel-wall-grid{position:absolute;inset:0;pointer-events:none;background-image:
+  linear-gradient(rgba(110,231,183,.04) 1px, transparent 1px),
+  linear-gradient(90deg, rgba(110,231,183,.04) 1px, transparent 1px);
+  background-size:16px 16px;image-rendering:pixelated}
+.agent-label{position:absolute;top:10px;left:12px;font-size:10px;color:var(--dim);font-weight:600;text-transform:uppercase;letter-spacing:.5px;display:flex;align-items:center;gap:6px}
+.agent-label::before{content:'';width:6px;height:6px;border-radius:50%;background:var(--accent);animation:pulse 1.5s infinite}
+.speech-bubble{position:absolute;top:14%;left:50%;transform:translateX(-50%);background:var(--surface2);border:1px solid var(--border);color:var(--text);padding:6px 12px;border-radius:12px;font-size:11px;font-weight:500;white-space:nowrap;opacity:0;transition:opacity .3s;max-width:90%;text-align:center}
+.speech-bubble::after{content:'';position:absolute;bottom:-6px;left:50%;transform:translateX(-50%);width:0;height:0;border-left:6px solid transparent;border-right:6px solid transparent;border-top:6px solid var(--surface2)}
+.speech-bubble.visible{opacity:1}
+.speech-bubble .emoji{margin-right:4px}
+.agent-idle-status{position:absolute;bottom:12px;right:14px;font-size:10px;color:var(--dim);font-variant-numeric:tabular-nums}
+/* Pixel-art Agent Character */
+.agent-img-wrap{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:60%;max-width:360px;aspect-ratio:1;display:flex;align-items:center;justify-content:center;pointer-events:none;z-index:5;transition:width .5s ease}
+.agent-img-wrap.trio{width:95%;max-width:560px;gap:2%}
+.agent-img-wrap.trio .agent-character{width:30%;height:auto}
+.agent-img-wrap.trio .agent-character.extra{animation-name:idleWalk}
+.agent-character{
+  width:48px;height:48px;
+  background-image:url('move.jpg');
+  background-repeat:no-repeat;
+  background-position:0 0;
+  image-rendering:pixelated;
+  image-rendering:crisp-edges;
+  transform:scale(4.5);
+  transform-origin:center center;
+  animation:spriteWalk 1.1s steps(12) infinite;
+  filter:drop-shadow(1px 2px 0 rgba(0,0,0,.4));
+}
+.agent-img-wrap.trio .agent-character{transform:scale(3)}
+@keyframes spriteWalk{
+  from{background-position-x:0}
+  to{background-position-x:-576px}
+}
+/* Phase-specific sprite rows (background-position-y) and speeds */
+.agent .agent-character{background-position-y:0}
+.agent.thinking .agent-character{background-position-y:-48px;animation-duration:1.6s}
+.agent.working  .agent-character{background-position-y:-96px;animation-duration:.55s}
+.agent.sending  .agent-character{background-position-y:-144px;animation-duration:.7s}
+.agent.reading  .agent-character{background-position-y:-192px;animation-duration:1.4s}
+.agent.installing .agent-character{background-position-y:-240px;animation-duration:.8s}
+.agent.celebrating .agent-character{background-position-y:-288px;animation-duration:.5s}
+/* Character color variants per agent identity */
+.agent-character[data-hue="0"]{filter:drop-shadow(1px 2px 0 rgba(0,0,0,.4))}
+.agent-character[data-hue="30"]{filter:hue-rotate(30deg) saturate(1.15) drop-shadow(1px 2px 0 rgba(0,0,0,.4))}
+.agent-character[data-hue="70"]{filter:hue-rotate(70deg) saturate(1.1) drop-shadow(1px 2px 0 rgba(0,0,0,.4))}
+.agent-character[data-hue="140"]{filter:hue-rotate(140deg) saturate(1.2) drop-shadow(1px 2px 0 rgba(0,0,0,.4))}
+.agent-character[data-hue="180"]{filter:hue-rotate(180deg) saturate(1.1) drop-shadow(1px 2px 0 rgba(0,0,0,.4))}
+.agent-character[data-hue="220"]{filter:hue-rotate(220deg) saturate(1.15) drop-shadow(1px 2px 0 rgba(0,0,0,.4))}
+.agent-character[data-hue="280"]{filter:hue-rotate(280deg) saturate(1.1) drop-shadow(1px 2px 0 rgba(0,0,0,.4))}
+/* Name tag under each agent */
+.agent-character{position:relative}
+.agent-name-tag{position:absolute;bottom:-16px;left:50%;transform:translateX(-50%);font-size:9px;font-weight:700;letter-spacing:.5px;color:var(--text);background:var(--surface);padding:2px 6px;border-radius:3px;border:1px solid var(--border);white-space:nowrap;z-index:6;pointer-events:none}
+.agent-img-wrap.trio .agent-name-tag{bottom:-12px;font-size:8px}
+/* Extra motion layered on top via wrapper */
+.agent-img-wrap{animation:charBob 1.1s steps(4) infinite}
+@keyframes charBob{0%,100%{margin-top:0}50%{margin-top:-6px}}
+.agent.working .agent-img-wrap,.agent.working + .agent-img-wrap{animation-duration:.55s}
+.agent.celebrating .agent-img-wrap{animation:charJump .8s ease-out}
+@keyframes charJump{0%{transform:translate(-50%,-50%)}30%{transform:translate(-50%,calc(-50% - 40px))}60%{transform:translate(-50%,calc(-50% - 10px))}100%{transform:translate(-50%,-50%)}}
+/* Swap flash */
+.agent-character.swap{animation:spriteWalk 1.1s steps(12) infinite, flashIn .4s ease-out}
+@keyframes flashIn{0%{filter:brightness(2) drop-shadow(1px 2px 0 rgba(0,0,0,.4))}100%{filter:drop-shadow(1px 2px 0 rgba(0,0,0,.4))}}
+/* Ground shadow */
+.agent-img-wrap::after{
+  content:'';position:absolute;bottom:6%;left:50%;transform:translateX(-50%);
+  width:40%;height:10px;background:radial-gradient(ellipse,rgba(0,0,0,.5) 0%,transparent 70%);
+  animation:shadowBob 1.1s steps(4) infinite;z-index:-1;pointer-events:none;
+}
+.agent-img-wrap.trio::after{display:none}
+@keyframes shadowBob{0%,50%,100%{width:40%;opacity:.6}25%,75%{width:32%;opacity:.3}}
+/* Tool badge */
+.agent-tool-badge{position:absolute;top:-8%;right:-4%;width:56px;height:56px;display:flex;align-items:center;justify-content:center;font-size:32px;background:var(--surface);border:2px solid var(--accent);border-radius:50%;opacity:0;transform:scale(0);transition:all .3s cubic-bezier(.34,1.56,.64,1);box-shadow:0 4px 12px rgba(110,231,183,.4);animation:toolFloat 2s ease-in-out infinite}
+.agent-tool-badge.visible{opacity:1;transform:scale(1)}
+@keyframes toolFloat{0%,100%{transform:scale(1) translateY(0)}50%{transform:scale(1) translateY(-4px)}}
+/* Sparkle */
+.agent-sparkle{position:absolute;top:-4%;left:-4%;font-size:22px;opacity:0;transition:opacity .3s;pointer-events:none;animation:sparkleBlink 1.5s ease-in-out infinite}
+.agent-sparkle.visible{opacity:1}
+@keyframes sparkleBlink{0%,100%{transform:scale(1) rotate(0);opacity:.6}50%{transform:scale(1.2) rotate(20deg);opacity:1}}
+/* Antenna light (unused but kept harmless) */
+.agent-antenna-light{animation:antennaBlink 1.5s ease-in-out infinite}
+@keyframes antennaBlink{0%,100%{opacity:.4}50%{opacity:1}}
+/* Screen glow */
+.screen-content line{animation:codeScroll 4s linear infinite}
+@keyframes codeScroll{0%{opacity:0;transform:translateX(-2px)}10%{opacity:1}90%{opacity:1}100%{opacity:0;transform:translateX(2px)}}
+.screen-glow{animation:screenGlow 2s ease-in-out infinite}
+@keyframes screenGlow{0%,100%{opacity:.3}50%{opacity:.6}}
+/* Particles flying around */
+.agent-particle{opacity:0;transform-origin:center}
+.agent-particle.active{animation:particleFly 1.2s ease-out forwards}
+@keyframes particleFly{0%{opacity:1;transform:translate(0,0) scale(.5)}100%{opacity:0;transform:translate(var(--dx),var(--dy)) scale(1.2)}}
 .log-cursor{display:none;font-size:11px;padding:1px 0;line-height:1.5;color:var(--accent);animation:blink 1s step-end infinite}
 .log-cursor.active{display:block}
 @keyframes blink{0%,100%{opacity:1}50%{opacity:0}}
@@ -112,6 +287,7 @@ main{flex:1;display:grid;grid-template-columns:1fr 1fr;grid-template-rows:auto 4
   <span class="status-pill status-idle" id="statusPill">IDLE</span>
   <div class="controls">
     <button class="btn btn-go" id="btnStart" onclick="start()">Start Loop</button>
+    <button class="btn btn-once" id="btnOnce" onclick="runOnce()">Run Once</button>
     <button class="btn btn-stop" id="btnStop" onclick="stop()" disabled>Stop</button>
   </div>
 </header>
@@ -138,9 +314,24 @@ main{flex:1;display:grid;grid-template-columns:1fr 1fr;grid-template-rows:auto 4
     <span class="cycle-badge" id="cycleNum">0</span>
   </div>
 
-  <!-- Activity visualization -->
-  <div class="activity-strip">
-    <canvas id="activityCanvas"></canvas>
+  <!-- Status strip: elapsed / phase / theme -->
+  <div class="activity-strip" id="activityStrip">
+    <div class="status-slot status-elapsed">
+      <span class="status-label">ELAPSED</span>
+      <span class="status-value" id="phaseElapsed">00:00</span>
+    </div>
+    <div class="status-divider"></div>
+    <div class="status-slot status-phase">
+      <span class="status-label">PHASE <span id="phaseIndex">—/7</span></span>
+      <span class="status-value" id="phaseName">IDLE</span>
+    </div>
+    <div class="status-divider"></div>
+    <div class="status-slot status-theme">
+      <span class="status-label">✨ THEME</span>
+      <span class="status-value" id="kwWord">—</span>
+    </div>
+    <!-- Legacy wrap for compat (not used visually anymore) -->
+    <div class="activity-keyword" id="activityKeyword" style="display:none"></div>
   </div>
 
   <!-- Apps built -->
@@ -164,9 +355,34 @@ main{flex:1;display:grid;grid-template-columns:1fr 1fr;grid-template-rows:auto 4
     <div class="log-cursor" id="logCursor">_</div>
   </div>
 
-  <!-- Live visualization -->
+  <!-- Cycle Recipe panel -->
   <div class="viz-panel">
-    <canvas id="vizCanvas"></canvas>
+    <span class="agent-label">Cycle Recipe</span>
+    <div class="recipe-header">
+      <div class="recipe-theme" id="recipeTheme">Waiting for cycle start...</div>
+    </div>
+    <div class="recipe-body">
+      <div class="recipe-section">
+        <div class="recipe-section-title"><span class="recipe-icon">🎯</span> Applied Skills <span class="recipe-count" id="recipeAppliedCount">0</span></div>
+        <div class="recipe-list" id="recipeApplied"><div class="recipe-empty">— awaiting apps —</div></div>
+      </div>
+      <div class="recipe-section">
+        <div class="recipe-section-title"><span class="recipe-icon">⚠️</span> Respecting Knowledge <span class="recipe-count" id="recipeKnowledgeCount">0</span></div>
+        <div class="recipe-list" id="recipeKnowledge"><div class="recipe-empty">— awaiting apps —</div></div>
+      </div>
+      <div class="recipe-footer">
+        <span class="recipe-pool-stat">Pool scanned: <b id="recipePoolSkills">0</b> skills · <b id="recipePoolKnowledge">0</b> knowledge</span>
+      </div>
+    </div>
+    <!-- Legacy: hidden but kept for JS compatibility -->
+    <div class="speech-bubble hidden" id="speechBubble"><span class="emoji">💤</span>—</div>
+    <!-- Legacy hidden stubs (kept so old JS hooks don't throw) -->
+    <div class="agent-img-wrap hidden" id="agent" style="display:none">
+      <div class="agent-character" id="agentImg"></div>
+      <div class="agent-tool-badge" id="agentToolBadge"></div>
+      <div class="agent-sparkle" id="agentSparkle"></div>
+    </div>
+    <div class="agent-idle-status hidden" id="agentIdleStatus" style="display:none">Standby</div>
   </div>
 </main>
 
@@ -179,6 +395,19 @@ main{flex:1;display:grid;grid-template-columns:1fr 1fr;grid-template-rows:auto 4
   <div class="stat">Lines Generated: <b id="statLines">0</b></div>
 </div>
 
+<!-- Hub Item Preview Modal -->
+<div class="hub-item-modal" id="hubItemModal" onclick="if(event.target===this)closeHubItem()">
+  <div class="hub-item-content">
+    <div class="hub-item-header">
+      <span class="hub-item-kind skill" id="hubItemKind">SKILL</span>
+      <span class="hub-item-title-name" id="hubItemTitle">—</span>
+      <button class="hub-item-close" onclick="closeHubItem()">×</button>
+    </div>
+    <div class="hub-item-path" id="hubItemPath">—</div>
+    <pre class="hub-item-body" id="hubItemBody">...</pre>
+  </div>
+</div>
+
 <script>
 const API = '';
 let evtSource = null;
@@ -189,6 +418,16 @@ let isRunning = false;
 function start() {
   fetch(API + '/api/start', { method: 'POST' });
   document.getElementById('btnStart').disabled = true;
+  document.getElementById('btnOnce').disabled = true;
+  document.getElementById('btnStop').disabled = false;
+  startTime = Date.now();
+  connectSSE();
+}
+
+function runOnce() {
+  fetch(API + '/api/run-once', { method: 'POST' });
+  document.getElementById('btnStart').disabled = true;
+  document.getElementById('btnOnce').disabled = true;
   document.getElementById('btnStop').disabled = false;
   startTime = Date.now();
   connectSSE();
@@ -197,6 +436,7 @@ function start() {
 function stop() {
   fetch(API + '/api/stop', { method: 'POST' });
   document.getElementById('btnStart').disabled = false;
+  document.getElementById('btnOnce').disabled = false;
   document.getElementById('btnStop').disabled = true;
 }
 
@@ -217,7 +457,8 @@ function handleEvent(data) {
     case 'state': updateFullState(data); break;
     case 'log': addLog(data.level, data.message); break;
     case 'phase': setPhase(data.phase, data.status); break;
-    case 'cycle': setCycle(data.cycle); break;
+    case 'cycle': setCycle(data.cycle, data.keyword); break;
+    case 'recipe': renderRecipe(data); break;
     case 'app': addApp(data.app); break;
     case 'skill': addSkill(data.skill); break;
     case 'stats': updateStats(data.stats); break;
@@ -238,14 +479,97 @@ function setStatus(status) {
   });
   if (status === 'idle') {
     document.getElementById('btnStart').disabled = false;
+    document.getElementById('btnOnce').disabled = false;
     document.getElementById('btnStop').disabled = true;
     phaseStartTime = null;
   }
 }
 
-function setCycle(n) {
+function setCycle(n, keyword) {
   document.getElementById('cycleNum').textContent = n;
+  const kwWord = document.getElementById('kwWord');
+  if (kwWord && keyword) {
+    if (kwWord.textContent.trim() !== keyword) {
+      kwWord.textContent = keyword;
+      kwWord.classList.remove('swap');
+      void kwWord.offsetWidth;
+      kwWord.classList.add('swap');
+    }
+  } else if (kwWord && n === 0) {
+    kwWord.textContent = '—';
+  }
+  // Update recipe theme line
+  const theme = document.getElementById('recipeTheme');
+  if (theme && keyword) theme.textContent = `"${keyword}"`;
 }
+
+function renderRecipe(data) {
+  const theme = document.getElementById('recipeTheme');
+  if (theme && data.keyword) theme.textContent = `"${data.keyword}"`;
+  const applied = data.applied || [];
+  const knowledge = data.respecting || [];
+  const poolS = data.poolSkills || 0;
+  const poolK = data.poolKnowledge || 0;
+
+  const appliedEl = document.getElementById('recipeApplied');
+  const knowledgeEl = document.getElementById('recipeKnowledge');
+  document.getElementById('recipeAppliedCount').textContent = applied.length;
+  document.getElementById('recipeKnowledgeCount').textContent = knowledge.length;
+  document.getElementById('recipePoolSkills').textContent = poolS;
+  document.getElementById('recipePoolKnowledge').textContent = poolK;
+
+  if (applied.length === 0) {
+    appliedEl.innerHTML = '<div class="recipe-empty">— none cited —</div>';
+  } else {
+    appliedEl.innerHTML = applied.map(s => `
+      <div class="recipe-item" data-kind="skill" data-name="${s.name || s}" onclick="openHubItem('skill', '${s.name || s}')">
+        <span class="recipe-item-bullet"></span>
+        <span class="recipe-item-name">${s.name || s}</span>
+        ${s.category ? `<span class="recipe-item-cat">${s.category}</span>` : ''}
+      </div>`).join('');
+  }
+
+  if (knowledge.length === 0) {
+    knowledgeEl.innerHTML = '<div class="recipe-empty">— none cited —</div>';
+  } else {
+    knowledgeEl.innerHTML = knowledge.map(k => `
+      <div class="recipe-item" data-kind="knowledge" data-name="${k.name || k}" onclick="openHubItem('knowledge', '${k.name || k}')">
+        <span class="recipe-item-bullet knowledge"></span>
+        <span class="recipe-item-name">${k.name || k}</span>
+        ${k.category ? `<span class="recipe-item-cat">${k.category}</span>` : ''}
+      </div>`).join('');
+  }
+}
+
+async function openHubItem(kind, name) {
+  const modal = document.getElementById('hubItemModal');
+  const titleEl = document.getElementById('hubItemTitle');
+  const kindEl = document.getElementById('hubItemKind');
+  const pathEl = document.getElementById('hubItemPath');
+  const bodyEl = document.getElementById('hubItemBody');
+  titleEl.textContent = name;
+  kindEl.textContent = kind.toUpperCase();
+  kindEl.className = 'hub-item-kind ' + kind;
+  pathEl.textContent = 'loading...';
+  bodyEl.textContent = '...';
+  modal.classList.add('visible');
+  try {
+    const r = await fetch(`/api/hub-item?kind=${encodeURIComponent(kind)}&name=${encodeURIComponent(name)}`);
+    if (!r.ok) throw new Error('not found');
+    const data = await r.json();
+    pathEl.textContent = data.path;
+    bodyEl.textContent = data.content;
+  } catch (err) {
+    pathEl.textContent = '(error)';
+    bodyEl.textContent = `Failed to load: ${err.message}`;
+  }
+}
+function closeHubItem() {
+  document.getElementById('hubItemModal').classList.remove('visible');
+}
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') closeHubItem();
+});
 
 function setPhase(phase, status) {
   document.querySelectorAll('.phase').forEach(el => {
@@ -323,7 +647,7 @@ function updateStats(s) {
 
 function updateFullState(data) {
   setStatus(data.status);
-  setCycle(data.cycle || 0);
+  setCycle(data.cycle || 0, data.keyword);
   if (data.apps) data.apps.forEach(a => addApp(a));
   if (data.skills) data.skills.forEach(s => addSkill(s));
   if (data.stats) updateStats(data.stats);
@@ -362,346 +686,347 @@ setInterval(() => {
   }
 }, 1000);
 
-// === Activity canvas animation ===
-const canvas = document.getElementById('activityCanvas');
-const ctx = canvas.getContext('2d');
-let particles = [];
-let waveOffset = 0;
+// === Status strip: phase name, phase elapsed, phase index ===
+const PHASE_ORDER = ['generate','build','publish','merge','extract','publish-sk','install','loop'];
+const PHASE_LABELS = {
+  'generate':'Generate Ideas','build':'Build Apps','publish':'Publish PRs',
+  'merge':'Auto-Merge','extract':'Extract Skills','publish-sk':'Publish S/K',
+  'install':'Install All','loop':'Complete',
+};
+let currentPhaseKey = null;
+// phaseStartTime already declared above (line 414) — reuse it
 
-function resizeCanvas() {
-  canvas.width = canvas.parentElement.offsetWidth * devicePixelRatio;
-  canvas.height = canvas.parentElement.offsetHeight * devicePixelRatio;
-  ctx.scale(devicePixelRatio, devicePixelRatio);
+function updatePhaseElapsed() {
+  const el = document.getElementById('phaseElapsed');
+  if (!el) return;
+  if (!phaseStartTime) { el.textContent = '00:00'; return; }
+  const s = Math.floor((Date.now() - phaseStartTime) / 1000);
+  const m = String(Math.floor(s / 60)).padStart(2, '0');
+  const sec = String(s % 60).padStart(2, '0');
+  el.textContent = m + ':' + sec;
 }
-resizeCanvas();
-window.addEventListener('resize', resizeCanvas);
+setInterval(updatePhaseElapsed, 500);
 
-class Particle {
-  constructor() { this.reset(true); }
-  reset(init) {
-    this.x = init ? Math.random() * (canvas.width / devicePixelRatio) : -8;
-    this.y = (canvas.height / devicePixelRatio) / 2;
-    this.speed = 0.6 + Math.random() * 1.4;
-    this.size = 1.5 + Math.random() * 2.5;
-    this.opacity = 0.3 + Math.random() * 0.7;
-    this.hue = Math.random() > 0.7 ? 230 : 160; // accent green or accent2 purple
-    this.amp = 4 + Math.random() * 12;
-    this.freq = 0.01 + Math.random() * 0.02;
-    this.phase = Math.random() * Math.PI * 2;
-  }
-}
-
-function initParticles() {
-  particles = [];
-  for (let i = 0; i < 60; i++) particles.push(new Particle());
-}
-initParticles();
-
-function drawActivity() {
-  const w = canvas.width / devicePixelRatio;
-  const h = canvas.height / devicePixelRatio;
-  ctx.clearRect(0, 0, w, h);
-
-  if (!isRunning) {
-    // Idle: dim center line with slow pulse
-    const idleAlpha = 0.05 + 0.03 * Math.sin(Date.now() * 0.001);
-    ctx.strokeStyle = `rgba(110,231,183,${idleAlpha})`;
-    ctx.lineWidth = 1;
-    ctx.beginPath();
-    ctx.moveTo(0, h / 2);
-    ctx.lineTo(w, h / 2);
-    ctx.stroke();
-    requestAnimationFrame(drawActivity);
-    return;
-  }
-
-  waveOffset += 0.5;
-
-  // Background wave trail
-  ctx.strokeStyle = 'rgba(110,231,183,0.06)';
-  ctx.lineWidth = 1;
-  for (let j = 0; j < 3; j++) {
-    ctx.beginPath();
-    for (let x = 0; x < w; x += 2) {
-      const y = h / 2 + Math.sin((x + waveOffset * (1 + j * 0.3)) * 0.02 + j) * (6 + j * 4);
-      x === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
-    }
-    ctx.stroke();
-  }
-
-  // Particles
-  for (const p of particles) {
-    p.x += p.speed;
-    const yOff = Math.sin((p.x * p.freq) + p.phase + waveOffset * 0.02) * p.amp;
-    const drawY = p.y + yOff;
-
-    // Glow
-    const grad = ctx.createRadialGradient(p.x, drawY, 0, p.x, drawY, p.size * 3);
-    const hsl = p.hue === 160 ? '160,70%,70%' : '230,80%,72%';
-    grad.addColorStop(0, `hsla(${hsl},${p.opacity * 0.5})`);
-    grad.addColorStop(1, `hsla(${hsl},0)`);
-    ctx.fillStyle = grad;
-    ctx.beginPath();
-    ctx.arc(p.x, drawY, p.size * 3, 0, Math.PI * 2);
-    ctx.fill();
-
-    // Core dot
-    ctx.fillStyle = `hsla(${hsl},${p.opacity})`;
-    ctx.beginPath();
-    ctx.arc(p.x, drawY, p.size, 0, Math.PI * 2);
-    ctx.fill();
-
-    if (p.x > w + 10) p.reset(false);
-  }
-
-  requestAnimationFrame(drawActivity);
-}
-requestAnimationFrame(drawActivity);
-
-// === Network visualization canvas ===
-const vizCanvas = document.getElementById('vizCanvas');
-const vCtx = vizCanvas.getContext('2d');
-let vizW = 0, vizH = 0;
-const VIZ_PHASES = ['generate','build','publish','merge','extract','publish-sk','install','loop'];
-let vizActiveIdx = -1;
-let vizPulse = 0;
-let vizNodes = [], vizEdges = [], vizPackets = [], vizSparks = [];
-
-function resizeViz() {
-  vizW = vizCanvas.parentElement.offsetWidth;
-  vizH = vizCanvas.parentElement.offsetHeight;
-  vizCanvas.width = vizW * devicePixelRatio;
-  vizCanvas.height = vizH * devicePixelRatio;
-  vCtx.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
-  buildGraph();
-}
-
-function buildGraph() {
-  vizNodes = []; vizEdges = [];
-  const cx = vizW / 2, cy = vizH / 2;
-  const R = Math.min(vizW, vizH) * 0.35;
-  // Core
-  vizNodes.push({ x: cx, y: cy, bx: cx, by: cy, r: 18, type: 'core', label: 'HUB', idx: -1 });
-  // Phase ring
-  for (let i = 0; i < VIZ_PHASES.length; i++) {
-    const a = (i / VIZ_PHASES.length) * Math.PI * 2 - Math.PI / 2;
-    const nx = cx + Math.cos(a) * R, ny = cy + Math.sin(a) * R;
-    vizNodes.push({ x: nx, y: ny, bx: nx, by: ny, r: 11, type: 'phase', label: VIZ_PHASES[i], idx: i });
-    vizEdges.push({ a: 0, b: i + 1 });
-    if (i > 0) vizEdges.push({ a: i, b: i + 1 });
-  }
-  vizEdges.push({ a: VIZ_PHASES.length, b: 1 });
-  // Outer satellites — more, bigger, faster
-  for (let i = 0; i < 30; i++) {
-    const a = Math.random() * Math.PI * 2;
-    const d = R * (0.3 + Math.random() * 0.65);
-    const nx = cx + Math.cos(a) * d, ny = cy + Math.sin(a) * d;
-    const sp = 0.4 + Math.random() * 1.2;
-    vizNodes.push({ x: nx, y: ny, bx: nx, by: ny, r: 2.5 + Math.random() * 3.5, type: 'sat',
-      vx: (Math.random() - 0.5) * sp, vy: (Math.random() - 0.5) * sp, idx: -1 });
-    vizEdges.push({ a: vizNodes.length - 1, b: 1 + Math.floor(Math.random() * VIZ_PHASES.length) });
-    // Some satellites connect to each other
-    if (i > 0 && Math.random() < 0.4) {
-      vizEdges.push({ a: vizNodes.length - 1, b: vizNodes.length - 1 - Math.ceil(Math.random() * Math.min(i, 5)) });
-    }
-  }
-}
-
-// Hook into events
-const _origSetPhase = setPhase;
+// Hook into setPhase to update the strip
+const _origSetPhaseStrip = setPhase;
 setPhase = function(phase, status) {
-  _origSetPhase(phase, status);
-  vizActiveIdx = VIZ_PHASES.indexOf(phase);
-  vizPulse = 1.5;
-  // Burst sparks
-  const node = vizNodes[vizActiveIdx + 1];
-  if (node) for (let i = 0; i < 20; i++) {
-    const a = Math.random() * Math.PI * 2, sp = 2 + Math.random() * 5;
-    vizSparks.push({ x: node.x, y: node.y, vx: Math.cos(a)*sp, vy: Math.sin(a)*sp, life: 1, color: 'accent' });
-  }
-};
-const _origAddLog = addLog;
-addLog = function(level, msg) {
-  _origAddLog(level, msg);
-  vizPulse = Math.max(vizPulse, 0.8);
-  // Spawn data packets from core to active phase
-  if (vizActiveIdx >= 0) {
-    for (let i = 0; i < 3; i++) {
-      vizPackets.push({ from: 0, to: vizActiveIdx + 1, t: -i * 0.15, speed: 0.008 + Math.random() * 0.012,
-        size: 2 + Math.random() * 3, hue: level === 'error' ? 0 : level === 'warn' ? 45 : level === 'success' ? 160 : 230 });
+  _origSetPhaseStrip.call(this, phase, status);
+  const idx = PHASE_ORDER.indexOf(phase);
+  const phaseIdxEl = document.getElementById('phaseIndex');
+  const phaseNameEl = document.getElementById('phaseName');
+  if (idx >= 0) {
+    if (phaseIdxEl) phaseIdxEl.textContent = (idx + 1) + '/' + PHASE_ORDER.length;
+    if (phaseNameEl) {
+      phaseNameEl.textContent = PHASE_LABELS[phase] || phase.toUpperCase();
+      phaseNameEl.classList.remove('swap'); void phaseNameEl.offsetWidth; phaseNameEl.classList.add('swap');
+    }
+    if (phase !== currentPhaseKey) {
+      currentPhaseKey = phase;
+      phaseStartTime = Date.now();
     }
   }
 };
 
-resizeViz();
-window.addEventListener('resize', resizeViz);
-
-function drawViz() {
-  vCtx.clearRect(0, 0, vizW, vizH);
-  const t = Date.now() * 0.001;
-  vizPulse *= 0.96;
-
-  // === Move satellites ===
-  for (const n of vizNodes) {
-    if (n.type === 'sat') {
-      n.x += n.vx; n.y += n.vy;
-      if (n.x < 8 || n.x > vizW - 8) n.vx *= -1;
-      if (n.y < 8 || n.y > vizH - 8) n.vy *= -1;
-      if (Math.random() < 0.02) { n.vx += (Math.random()-.5)*.3; n.vy += (Math.random()-.5)*.3; }
-      const maxV = 1.5; n.vx = Math.max(-maxV, Math.min(maxV, n.vx)); n.vy = Math.max(-maxV, Math.min(maxV, n.vy));
-    }
-    if (n.type === 'phase') {
-      n.x = n.bx + Math.sin(t * 1.2 + n.idx * 1.5) * 5;
-      n.y = n.by + Math.cos(t * 0.9 + n.idx * 2.0) * 5;
-    }
-    if (n.type === 'core') {
-      n.r = 18 + Math.sin(t * 2) * 3 + vizPulse * 8;
-    }
+const _origSetStatusStrip = setStatus;
+setStatus = function(status) {
+  _origSetStatusStrip.call(this, status);
+  if (status === 'idle') {
+    currentPhaseKey = null;
+    phaseStartTime = null;
+    const phaseNameEl = document.getElementById('phaseName');
+    const phaseIdxEl = document.getElementById('phaseIndex');
+    if (phaseNameEl) phaseNameEl.textContent = 'IDLE';
+    if (phaseIdxEl) phaseIdxEl.textContent = '—/7';
   }
+};
 
-  // === Draw edges ===
-  for (const e of vizEdges) {
-    const na = vizNodes[e.a], nb = vizNodes[e.b];
-    const isHot = isRunning && (na.idx === vizActiveIdx || nb.idx === vizActiveIdx);
-    const alpha = isHot ? 0.35 + Math.sin(t * 4) * 0.1 : 0.06;
-    vCtx.strokeStyle = isHot ? `rgba(110,231,183,${alpha})` : `rgba(110,231,183,${alpha})`;
-    vCtx.lineWidth = isHot ? 2 : 0.5;
-    vCtx.beginPath(); vCtx.moveTo(na.x, na.y); vCtx.lineTo(nb.x, nb.y); vCtx.stroke();
+// === Agent Character Controller ===
+const agent = document.getElementById('agent');
+const speechBubble = document.getElementById('speechBubble');
+const idleStatus = document.getElementById('agentIdleStatus');
+const agentMouth = document.getElementById('agentMouth');
+const agentParticles = document.getElementById('agentParticles');
 
-    // Traveling dots on ALL edges when running
-    if (isRunning) {
-      const count = isHot ? 3 : 1;
-      for (let d = 0; d < count; d++) {
-        const prog = ((t * (isHot ? 0.6 : 0.2)) + e.a * 0.17 + d * 0.33) % 1;
-        const px = na.x + (nb.x - na.x) * prog;
-        const py = na.y + (nb.y - na.y) * prog;
-        const dotR = isHot ? 2.5 : 1.2;
-        const dotA = isHot ? 0.8 : 0.2;
-        vCtx.fillStyle = `rgba(110,231,183,${dotA})`;
-        vCtx.beginPath(); vCtx.arc(px, py, dotR, 0, Math.PI*2); vCtx.fill();
+// Single CSS sprite sheet (move.jpg) — rows are phase-specific animations.
+// Load sheet, chroma-key white pixels to transparent, inject as CSS background.
+(function preprocessSpriteSheet() {
+  const im = new Image();
+  im.onload = () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = im.naturalWidth;
+    canvas.height = im.naturalHeight;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(im, 0, 0);
+    const data = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    const d = data.data;
+    for (let i = 0; i < d.length; i += 4) {
+      // Make near-white pixels transparent
+      if (d[i] > 230 && d[i+1] > 230 && d[i+2] > 230) {
+        d[i+3] = 0;
       }
     }
-  }
+    ctx.putImageData(data, 0, 0);
+    const url = canvas.toDataURL('image/png');
+    // Apply to all agent-character elements (current + future)
+    const style = document.createElement('style');
+    style.textContent = `.agent-character{background-image:url(${url}) !important}`;
+    document.head.appendChild(style);
+  };
+  im.onerror = () => console.warn('move.jpg failed to load');
+  im.src = 'move.jpg';
+})();
 
-  // === Data packets ===
-  vizPackets = vizPackets.filter(p => {
-    p.t += p.speed;
-    if (p.t < 0) return true;
-    if (p.t > 1) return false;
-    const na = vizNodes[p.from], nb = vizNodes[p.to];
-    const px = na.x + (nb.x - na.x) * p.t;
-    const py = na.y + (nb.y - na.y) * p.t;
-    // Glow
-    const g = vCtx.createRadialGradient(px, py, 0, px, py, p.size * 5);
-    g.addColorStop(0, `hsla(${p.hue},80%,65%,0.5)`);
-    g.addColorStop(1, `hsla(${p.hue},80%,65%,0)`);
-    vCtx.fillStyle = g; vCtx.beginPath(); vCtx.arc(px, py, p.size * 5, 0, Math.PI*2); vCtx.fill();
-    // Core
-    vCtx.fillStyle = `hsla(${p.hue},80%,70%,0.9)`;
-    vCtx.beginPath(); vCtx.arc(px, py, p.size, 0, Math.PI*2); vCtx.fill();
-    // Trail
-    const trail = Math.max(0, p.t - p.speed * 5);
-    const tx = na.x + (nb.x - na.x) * trail;
-    const ty = na.y + (nb.y - na.y) * trail;
-    vCtx.strokeStyle = `hsla(${p.hue},80%,65%,0.3)`;
-    vCtx.lineWidth = p.size * 0.8;
-    vCtx.beginPath(); vCtx.moveTo(tx, ty); vCtx.lineTo(px, py); vCtx.stroke();
-    return true;
-  });
+// Named agents — each has a distinct color (hue) and role
+const AGENTS = {
+  IDEA:     { name: 'Aria',   hue: 280, role: 'Idea Forger' },      // Purple — creative
+  BUILDER:  { name: 'Blaze',  hue: 30,  role: 'Builder' },           // Orange — construction
+  PUBLISHER:{ name: 'Cielo',  hue: 220, role: 'Publisher' },         // Blue — shipping
+  MERGER:   { name: 'Mira',   hue: 140, role: 'Merger' },            // Green — merging
+  EXTRACTOR:{ name: 'Echo',   hue: 180, role: 'Analyst' },           // Cyan — analysis
+  ARCHIVIST:{ name: 'Sage',   hue: 70,  role: 'Archivist' },         // Lime — knowledge
+  INSTALLER:{ name: 'Pixel',  hue: 0,   role: 'Installer' },         // Default — systems
+};
 
-  // === Sparks ===
-  vizSparks = vizSparks.filter(s => {
-    s.x += s.vx; s.y += s.vy; s.vx *= 0.96; s.vy *= 0.96; s.life -= 0.025;
-    if (s.life <= 0) return false;
-    vCtx.fillStyle = s.color === 'accent' ? `rgba(110,231,183,${s.life})` : `rgba(129,140,248,${s.life})`;
-    vCtx.beginPath(); vCtx.arc(s.x, s.y, 2 * s.life, 0, Math.PI*2); vCtx.fill();
-    return true;
-  });
+const PHASE_PROFILES = {
+  'generate':   { class: 'thinking',    badge: '💡', text: '💡 Generating ideas...',     agents: [AGENTS.IDEA],                                      trio: false },
+  'build':      { class: 'working',     badge: '🔨', text: '🔨 Building apps...',        agents: [AGENTS.BUILDER, AGENTS.IDEA, AGENTS.EXTRACTOR],    trio: true  },
+  'publish':    { class: 'sending',     badge: '📤', text: '📤 Publishing PRs...',       agents: [AGENTS.PUBLISHER, AGENTS.BUILDER, AGENTS.MERGER],  trio: true  },
+  'merge':      { class: 'working',     badge: '🔀', text: '🔀 Merging branches...',     agents: [AGENTS.MERGER, AGENTS.PUBLISHER, AGENTS.BUILDER],  trio: true  },
+  'extract':    { class: 'reading',     badge: '🔍', text: '🔍 Extracting patterns...',  agents: [AGENTS.EXTRACTOR],                                 trio: false },
+  'publish-sk': { class: 'sending',     badge: '📚', text: '📚 Publishing skills...',    agents: [AGENTS.ARCHIVIST],                                 trio: false },
+  'install':    { class: 'installing',  badge: '📥', text: '📥 Installing skills...',    agents: [AGENTS.INSTALLER],                                 trio: false },
+  'loop':       { class: 'celebrating', badge: '✨', text: '✨ Cycle complete!',         agents: [AGENTS.IDEA],                                      trio: false },
+};
 
-  // === Draw nodes ===
-  for (let i = 0; i < vizNodes.length; i++) {
-    const n = vizNodes[i];
-    const isActive = n.idx === vizActiveIdx && isRunning;
+const IDLE_PHRASES = [
+  '💤 Standing by...',
+  '☕ Sipping coffee...',
+  '📖 Reading docs...',
+  '🎵 Humming a tune...',
+  '🧘 Meditating on code...',
+];
 
-    // Big glow
-    if (n.type !== 'sat') {
-      const gr = n.r * (isActive ? 5 : n.type === 'core' ? 4 : 2.5);
-      const grd = vCtx.createRadialGradient(n.x, n.y, 0, n.x, n.y, gr);
-      if (n.type === 'core') {
-        grd.addColorStop(0, `rgba(110,231,183,${0.2 + vizPulse * 0.3})`);
-      } else if (isActive) {
-        grd.addColorStop(0, 'rgba(110,231,183,0.35)');
-      } else {
-        grd.addColorStop(0, 'rgba(129,140,248,0.1)');
-      }
-      grd.addColorStop(1, 'rgba(0,0,0,0)');
-      vCtx.fillStyle = grd; vCtx.beginPath(); vCtx.arc(n.x, n.y, gr, 0, Math.PI*2); vCtx.fill();
-    }
+const agentWrap = document.getElementById('agent');
+const agentImg = document.getElementById('agentImg');
+const toolBadge = document.getElementById('agentToolBadge');
+const sparkle = document.getElementById('agentSparkle');
 
-    // Node body
-    if (n.type === 'core') {
-      vCtx.fillStyle = `rgba(110,231,183,${0.7 + vizPulse * 0.3})`;
-    } else if (n.type === 'phase') {
-      vCtx.fillStyle = isActive ? 'rgba(110,231,183,0.95)' : 'rgba(129,140,248,0.35)';
-    } else {
-      vCtx.fillStyle = `rgba(136,146,168,${0.15 + Math.sin(t*1.5 + i*0.7) * 0.1})`;
-    }
-    vCtx.beginPath(); vCtx.arc(n.x, n.y, n.r, 0, Math.PI*2); vCtx.fill();
+let currentImg = 'agent-a.jpg';
+let speechTimeout = null;
+let idleInterval = null;
 
-    // Active pulsing rings
-    if (isActive && n.type === 'phase') {
-      for (let r = 0; r < 3; r++) {
-        const rr = n.r + 6 + r * 8 + Math.sin(t * 3 + r) * 3;
-        vCtx.strokeStyle = `rgba(110,231,183,${0.4 - r * 0.12})`;
-        vCtx.lineWidth = 2 - r * 0.5;
-        vCtx.beginPath(); vCtx.arc(n.x, n.y, rr, 0, Math.PI*2); vCtx.stroke();
-      }
-    }
-
-    // Labels — bigger
-    if (n.type === 'core') {
-      vCtx.fillStyle = 'rgba(15,17,23,0.9)';
-      vCtx.font = 'bold 11px "Segoe UI", sans-serif';
-      vCtx.textAlign = 'center'; vCtx.textBaseline = 'middle';
-      vCtx.fillText('HUB', n.x, n.y);
-    } else if (n.type === 'phase') {
-      vCtx.fillStyle = isActive ? 'rgba(110,231,183,0.95)' : 'rgba(136,146,168,0.6)';
-      vCtx.font = `${isActive ? 'bold ' : ''}10px "Segoe UI", sans-serif`;
-      vCtx.textAlign = 'center';
-      vCtx.fillText(n.label, n.x, n.y + n.r + 14);
-    }
-  }
-
-  // === Orbiting particles around core ===
-  if (isRunning) {
-    const core = vizNodes[0];
-    for (let ring = 0; ring < 3; ring++) {
-      const orbitR = 30 + ring * 14 + Math.sin(t * 0.7 + ring) * 4;
-      const speed = (1.5 - ring * 0.3);
-      const count = 4 + ring * 2;
-      for (let i = 0; i < count; i++) {
-        const a = t * speed + (i * Math.PI * 2 / count) + ring * 0.5;
-        const ox = core.x + Math.cos(a) * orbitR;
-        const oy = core.y + Math.sin(a) * orbitR;
-        const pr = 2.5 - ring * 0.5;
-        vCtx.fillStyle = `rgba(110,231,183,${0.6 - ring * 0.15})`;
-        vCtx.beginPath(); vCtx.arc(ox, oy, pr, 0, Math.PI*2); vCtx.fill();
-      }
-    }
-  }
-
-  // === Background ambient particles (always active) ===
-  for (let i = 0; i < 15; i++) {
-    const px = (Math.sin(t * 0.3 + i * 47.3) * 0.5 + 0.5) * vizW;
-    const py = (Math.cos(t * 0.25 + i * 31.7) * 0.5 + 0.5) * vizH;
-    const pa = 0.04 + Math.sin(t + i * 2.3) * 0.03;
-    vCtx.fillStyle = `rgba(110,231,183,${pa})`;
-    vCtx.beginPath(); vCtx.arc(px, py, 1.5, 0, Math.PI*2); vCtx.fill();
-  }
-
-  requestAnimationFrame(drawViz);
+function clearAgentClasses() {
+  agentWrap.classList.remove('thinking','working','sending','reading','installing','celebrating','trio');
 }
-requestAnimationFrame(drawViz);
+
+function showSpeech(text) {
+  if (!speechBubble) return;
+  speechBubble.innerHTML = text.replace(/^(\S+)\s/, '<span class="emoji">$1</span>');
+  speechBubble.classList.add('visible');
+  clearTimeout(speechTimeout);
+}
+
+// Legacy flood-fill helper kept only in case of reuse; not called for sprite sheet.
+const processedCache = new Map();
+
+function removeBackground(srcUrl) {
+  if (processedCache.has(srcUrl)) return Promise.resolve(processedCache.get(srcUrl));
+  return new Promise((resolve) => {
+    const im = new Image();
+    im.crossOrigin = 'anonymous';
+    im.onload = () => {
+      const canvas = document.createElement('canvas');
+      const w = canvas.width = im.naturalWidth;
+      const h = canvas.height = im.naturalHeight;
+      const ctx = canvas.getContext('2d');
+      ctx.drawImage(im, 0, 0);
+      const imgData = ctx.getImageData(0, 0, w, h);
+      const d = imgData.data;
+
+      // Flood fill from 4 corners
+      const TOL = 42;        // color distance tolerance
+      const FEATHER = 14;    // alpha ramp distance for edges
+      const visited = new Uint8Array(w * h);
+      const stack = [];
+      const seedPoints = [[0,0],[w-1,0],[0,h-1],[w-1,h-1],[Math.floor(w/2),0],[Math.floor(w/2),h-1],[0,Math.floor(h/2)],[w-1,Math.floor(h/2)]];
+      const seedColors = seedPoints.map(([x,y]) => {
+        const i = (y*w + x)*4;
+        return [d[i], d[i+1], d[i+2]];
+      });
+
+      for (const [sx, sy] of seedPoints) stack.push(sx, sy);
+
+      while (stack.length) {
+        const y = stack.pop();
+        const x = stack.pop();
+        if (x < 0 || y < 0 || x >= w || y >= h) continue;
+        const idx = y*w + x;
+        if (visited[idx]) continue;
+        const pi = idx * 4;
+        const r = d[pi], g = d[pi+1], b = d[pi+2];
+        // Check if any seed color is close enough
+        let isBg = false;
+        for (const [sr, sg, sb] of seedColors) {
+          const dist = Math.abs(r-sr) + Math.abs(g-sg) + Math.abs(b-sb);
+          if (dist < TOL * 3) { isBg = true; break; }
+        }
+        if (!isBg) continue;
+        visited[idx] = 1;
+        d[pi+3] = 0;  // transparent
+        stack.push(x+1, y, x-1, y, x, y+1, x, y-1);
+      }
+
+      // Feather edges: semi-transparent for pixels near transparent ones
+      const out = new Uint8ClampedArray(d);
+      for (let y = 1; y < h-1; y++) {
+        for (let x = 1; x < w-1; x++) {
+          const idx = y*w + x;
+          if (visited[idx]) continue;
+          const pi = idx*4;
+          if (d[pi+3] === 0) continue;
+          let nearBg = 0;
+          for (let dy = -1; dy <= 1; dy++) for (let dx = -1; dx <= 1; dx++) {
+            if (dx === 0 && dy === 0) continue;
+            if (visited[(y+dy)*w + (x+dx)]) nearBg++;
+          }
+          if (nearBg > 0) out[pi+3] = Math.max(0, 255 - nearBg * 80);
+        }
+      }
+      imgData.data.set(out);
+      ctx.putImageData(imgData, 0, 0);
+
+      const url = canvas.toDataURL('image/png');
+      processedCache.set(srcUrl, url);
+      resolve(url);
+    };
+    im.onerror = () => resolve(srcUrl); // fallback to original
+    im.src = srcUrl;
+  });
+}
+
+function setImage() {
+  // Sprite sheet driven by CSS; trigger swap flash animation only
+  agentImg.classList.remove('swap');
+  void agentImg.offsetWidth;
+  agentImg.classList.add('swap');
+}
+
+function renderTrio(on, agentList) {
+  document.querySelectorAll('.agent-character.extra').forEach(el => el.remove());
+  document.querySelectorAll('.agent-name-tag[data-extra-for]').forEach(el => el.remove());
+  if (on) {
+    agentWrap.classList.add('trio');
+    // Primary already rendered on agentImg — add 2 more for agents[1] and agents[2]
+    for (let i = 1; i < Math.min(3, agentList.length); i++) {
+      const div = document.createElement('div');
+      div.className = 'agent-character extra';
+      div.style.animationDelay = (0.15 * i) + 's';
+      div.setAttribute('data-hue', String(agentList[i].hue));
+      div.dataset.tagId = 'extra-' + i;
+      agentWrap.appendChild(div);
+      // Name tag for this extra
+      const tag = document.createElement('div');
+      tag.className = 'agent-name-tag';
+      tag.dataset.extraFor = 'extra-' + i;
+      tag.textContent = agentList[i].name;
+      agentWrap.appendChild(tag);
+    }
+  } else {
+    agentWrap.classList.remove('trio');
+  }
+}
+
+function applyAgentIdentity(el, agent) {
+  if (!agent) return;
+  el.setAttribute('data-hue', String(agent.hue));
+  // Ensure name tag exists
+  let tag = el.parentElement && el.parentElement.querySelector('.agent-name-tag.main-' + (el.classList.contains('extra') ? el.dataset.tagId : 'primary'));
+  if (!tag) {
+    tag = document.createElement('div');
+    tag.className = 'agent-name-tag';
+    if (el.classList.contains('extra')) {
+      tag.dataset.extraFor = el.dataset.tagId || '';
+      el.parentElement.appendChild(tag);
+    } else {
+      agentWrap.appendChild(tag);
+    }
+  }
+  tag.textContent = agent.name;
+}
+
+function clearNameTags() {
+  document.querySelectorAll('.agent-name-tag').forEach(el => el.remove());
+}
+
+function setAgentPhase(phase) {
+  const profile = PHASE_PROFILES[phase];
+  if (!profile) return;
+  clearInterval(idleInterval); idleInterval = null;
+
+  clearAgentClasses();
+  clearNameTags();
+  if (profile.class) agentWrap.classList.add(profile.class);
+
+  // Primary agent (first in list)
+  const primary = profile.agents[0];
+  applyAgentIdentity(agentImg, primary);
+
+  // Flash swap on the sprite
+  setImage();
+
+  // Trio mode for build/publish/merge — use the 3 agents from profile
+  renderTrio(!!profile.trio, profile.agents);
+
+  // Tool badge emoji
+  if (toolBadge) {
+    toolBadge.textContent = profile.badge;
+    toolBadge.classList.add('visible');
+  }
+  // Sparkle for celebrate
+  if (sparkle) {
+    sparkle.textContent = phase === 'loop' ? '🎉' : '✨';
+    sparkle.classList.toggle('visible', phase === 'loop' || phase === 'generate');
+  }
+
+  showSpeech(profile.text);
+
+  if (idleStatus) idleStatus.textContent = phase.toUpperCase().replace('-',' ');
+}
+
+function goIdle() {
+  clearAgentClasses();
+  clearNameTags();
+  document.querySelectorAll('.agent-character.extra').forEach(el => el.remove());
+  if (toolBadge) toolBadge.classList.remove('visible');
+  if (sparkle) sparkle.classList.remove('visible');
+  if (idleStatus) idleStatus.textContent = 'Standby';
+  applyAgentIdentity(agentImg, AGENTS.IDEA); // default agent
+  setImage();
+
+  let idx = 0;
+  showSpeech(IDLE_PHRASES[0]);
+  idleInterval = setInterval(() => {
+    idx = (idx + 1) % IDLE_PHRASES.length;
+    showSpeech(IDLE_PHRASES[idx]);
+  }, 5000);
+}
+
+// Hook into setPhase
+const _origSetPhaseAgent = setPhase;
+setPhase = function(phase, status) {
+  _origSetPhaseAgent.call(this, phase, status);
+  setAgentPhase(phase);
+};
+
+// Hook into status changes for idle
+const _origSetStatusAgent = setStatus;
+setStatus = function(status) {
+  _origSetStatusAgent.call(this, status);
+  if (status === 'idle') goIdle();
+};
+
+// Start in idle mode
+goIdle();
 
 // Auto-connect on load
 fetch(API + '/api/state').then(r => r.json()).then(handleEvent).catch(() => {});

--- a/example/hub-tools/auto-hub-loop/server.js
+++ b/example/hub-tools/auto-hub-loop/server.js
@@ -18,6 +18,7 @@ const REGISTRY_PATH = toSlash(path.join(process.env.HOME || process.env.USERPROF
 const state = {
   status: 'idle',    // idle | running | stopping | error
   cycle: 0,
+  currentKeyword: null,
   phase: null,
   apps: [],
   skills: [],
@@ -25,6 +26,7 @@ const state = {
   stats: { apps: 0, skills: 0, knowledge: 0, prs: 0, lines: 0 },
   startTime: null,
   stopRequested: false,
+  runOnce: false,    // single-cycle mode
 };
 
 // ── SSE Clients ──
@@ -44,57 +46,89 @@ function log(level, message) {
 }
 
 // ── Random Keywords ──
-const KEYWORDS = [
-  'websocket', 'oauth', 'graphql', 'cqrs', 'event-sourcing', 'rate-limiter',
-  'circuit-breaker', 'saga-pattern', 'blue-green-deploy', 'feature-flags',
-  'chaos-engineering', 'load-balancer', 'service-mesh', 'api-versioning',
-  'data-pipeline', 'etl', 'cdc', 'outbox-pattern', 'idempotency',
-  'bloom-filter', 'consistent-hashing', 'raft-consensus', 'crdt',
-  'backpressure', 'bulkhead', 'sidecar-proxy', 'canary-release',
-  'database-sharding', 'read-replica', 'materialized-view',
-  'command-query', 'domain-driven', 'hexagonal-architecture',
-  'finite-state-machine', 'actor-model', 'pub-sub', 'message-queue',
-  'connection-pool', 'object-storage', 'time-series-db',
-  'log-aggregation', 'distributed-tracing', 'health-check',
-  'retry-strategy', 'dead-letter-queue', 'schema-registry',
-  'api-gateway-pattern', 'bff-pattern', 'strangler-fig',
+// Fallback pool (10-20 word evocative themes)
+const KEYWORD_FALLBACK = [
+  'A cozy lighthouse keeper decodes midnight signals drifting across the stormy ocean horizon',
+  'Tiny garden gnomes orchestrate a symphony while moonflowers bloom and fireflies weave patterns',
+  'Ancient librarians sort whispered secrets into glowing tomes within a floating crystal archive',
+  'Travelers trade constellations at a bustling skybound market above the clouds at dawn',
+  'Forest spirits knit paths of moss while cartographers chart their shifting territories by lantern',
+  'Dreamers assemble mechanical butterflies and launch them through windows into a neon alley',
+  'A patient cartographer redraws coastlines as tides whisper forgotten names beneath silver moonlight',
+  'Cooks braid ribbons of steam into recipes recorded by a curious mouse wearing spectacles',
+  'Wanderers stitch patchwork quilts from discarded dreams beside a bonfire near an obsidian lake',
 ];
 const KEYWORD_TO_CATEGORY = {
-  'websocket': 'websocket', 'oauth': 'auth', 'graphql': 'graphql',
-  'cqrs': 'event-driven', 'event-sourcing': 'event-driven', 'rate-limiter': 'rate-limiting',
-  'circuit-breaker': 'circuit-breaker', 'saga-pattern': 'event-driven',
-  'blue-green-deploy': 'deployment', 'feature-flags': 'feature-flags',
-  'chaos-engineering': 'chaos-engineering', 'load-balancer': 'load-balancing',
-  'service-mesh': 'architecture', 'api-versioning': 'api-patterns',
-  'data-pipeline': 'data-pipeline', 'etl': 'data-pipeline', 'cdc': 'data-pipeline',
-  'outbox-pattern': 'event-driven', 'idempotency': 'idempotency',
-  'bloom-filter': 'algorithms', 'consistent-hashing': 'load-balancing',
-  'raft-consensus': 'consensus', 'crdt': 'consensus',
-  'backpressure': 'resilience', 'bulkhead': 'resilience',
-  'sidecar-proxy': 'architecture', 'canary-release': 'deployment',
-  'database-sharding': 'storage', 'read-replica': 'storage',
-  'materialized-view': 'caching', 'command-query': 'event-driven',
-  'domain-driven': 'ddd', 'hexagonal-architecture': 'architecture',
-  'finite-state-machine': 'algorithms', 'actor-model': 'actor-model',
-  'pub-sub': 'messaging', 'message-queue': 'messaging',
-  'connection-pool': 'concurrency', 'object-storage': 'storage',
-  'time-series-db': 'storage', 'log-aggregation': 'observability',
-  'distributed-tracing': 'observability', 'health-check': 'observability',
-  'retry-strategy': 'resilience', 'dead-letter-queue': 'messaging',
-  'schema-registry': 'schema', 'api-gateway-pattern': 'api-patterns',
-  'bff-pattern': 'api-patterns', 'strangler-fig': 'deployment',
+  // Nouns → thematic categories
+  'garden': 'interactive', 'ocean': 'interactive', 'forest': 'interactive',
+  'city': 'interactive', 'galaxy': 'interactive',
+  'library': 'hub-tools', 'museum': 'hub-tools',
+  'kitchen': 'interactive', 'factory': 'interactive', 'workshop': 'interactive',
+  // Verbs → action categories
+  'explore': 'interactive', 'discover': 'interactive', 'navigate': 'interactive',
+  'create': 'interactive', 'compose': 'interactive',
+  'simulate': 'algorithms', 'visualize': 'interactive',
+  'analyze': 'algorithms', 'transform': 'algorithms',
+  'connect': 'messaging',
 };
 
 function categoryForKeyword(kw) {
-  return KEYWORD_TO_CATEGORY[kw] || 'misc';
+  if (!kw) return 'misc';
+  if (KEYWORD_TO_CATEGORY[kw]) return KEYWORD_TO_CATEGORY[kw];
+  // Substring match — scan phrase for known keyword
+  const lower = kw.toLowerCase();
+  for (const [k, cat] of Object.entries(KEYWORD_TO_CATEGORY)) {
+    if (lower.includes(k)) return cat;
+  }
+  // Fallback keyword → category hints based on phrase content
+  const hints = [
+    [['garden','forest','ocean','galaxy','moon','sky','lighthouse','cave','river','mountain'], 'interactive'],
+    [['library','archive','tome','book','map','cartograph'], 'hub-tools'],
+    [['trade','market','orchestrate','assemble','weave','knit','stitch'], 'interactive'],
+    [['analyze','decode','pattern','signal','chart'], 'algorithms'],
+    [['whisper','connect','message','send','transmit'], 'messaging'],
+  ];
+  for (const [words, cat] of hints) {
+    for (const w of words) {
+      if (lower.includes(w)) return cat;
+    }
+  }
+  return 'misc';
 }
 
 const usedKeywords = new Set();
 
-function pickKeyword() {
-  const available = KEYWORDS.filter(k => !usedKeywords.has(k));
-  if (available.length === 0) { usedKeywords.clear(); return pickKeyword(); }
-  const kw = available[Math.floor(Math.random() * available.length)];
+async function pickKeyword() {
+  const recent = [...usedKeywords].slice(-5).join(' | ') || '(none)';
+  const prompt = `Generate ONE random evocative theme phrase (10 to 20 English words) suitable as a creative theme for a set of 3 interactive HTML visualization apps.
+
+Constraints:
+- Must be 10-20 words total (count carefully)
+- Mix nouns and verbs — concrete, sensory, evocative
+- Describe a scene, activity, or concept (not a product)
+- Must NOT repeat these recent themes: ${recent}
+- No technical jargon (no "api", "database", "server", "framework", etc.)
+- Examples of good themes:
+  - "A cozy lighthouse keeper decodes midnight signals drifting across the stormy ocean horizon"
+  - "Tiny garden gnomes orchestrate a symphony while moonflowers bloom and fireflies weave patterns"
+  - "Ancient librarians sort whispered secrets into glowing tomes within a floating crystal archive"
+
+Output ONLY the phrase, no quotes, no explanation, nothing else.`;
+
+  try {
+    const raw = await askClaude(prompt, 60000);
+    const phrase = raw.trim().replace(/^["']|["']$/g, '');
+    const wordCount = phrase.split(/\s+/).filter(Boolean).length;
+    if (phrase && wordCount >= 8 && wordCount <= 25 && !usedKeywords.has(phrase)) {
+      usedKeywords.add(phrase);
+      return phrase;
+    }
+  } catch {}
+
+  // Fallback: pick from the local pool
+  const available = KEYWORD_FALLBACK.filter(k => !usedKeywords.has(k));
+  const pool = available.length > 0 ? available : KEYWORD_FALLBACK;
+  const kw = pool[Math.floor(Math.random() * pool.length)];
   usedKeywords.add(kw);
   return kw;
 }
@@ -120,12 +154,36 @@ function shellSync(cmd, opts = {}) {
 }
 
 // ── Claude CLI Helper ──
-async function askClaude(prompt, timeout = 300000) {
-  const { execFile } = require('child_process');
+async function askClaude(prompt, timeout = 900000) {
+  const { spawn } = require('child_process');
+  // Write prompt to a temp file and pipe via shell redirect — avoids argv length limits AND stdin propagation issues
+  const tmpFile = path.join(require('os').tmpdir(), `claude-prompt-${Date.now()}-${Math.random().toString(36).slice(2,8)}.txt`);
+  fs.writeFileSync(tmpFile, prompt, 'utf8');
+
   return new Promise((resolve, reject) => {
-    execFile('claude', ['-p', prompt], { maxBuffer: 50 * 1024 * 1024, timeout }, (err, stdout, stderr) => {
-      if (err) reject(new Error(err.message.split('\n')[0]));
-      else resolve((stdout || '').trim());
+    // Use shell redirect `< file` so claude's stdin comes from the file
+    const cmd = process.platform === 'win32'
+      ? `claude -p < "${tmpFile.replace(/\\/g, '/')}"`
+      : `claude -p < "${tmpFile}"`;
+    const child = spawn(cmd, [], {
+      shell: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, DISABLE_OMC: '1', OMC_SKIP_HOOKS: '*', CLAUDE_DISABLE_SESSION_HOOKS: '1' },
+    });
+    let stdout = ''; let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill();
+      try { fs.unlinkSync(tmpFile); } catch {}
+      reject(new Error('askClaude timeout'));
+    }, timeout);
+    child.stdout.on('data', (d) => { stdout += d.toString(); });
+    child.stderr.on('data', (d) => { stderr += d.toString(); });
+    child.on('error', (err) => { clearTimeout(timer); try { fs.unlinkSync(tmpFile); } catch {}; reject(err); });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      try { fs.unlinkSync(tmpFile); } catch {}
+      if (code !== 0) reject(new Error(`claude exited ${code}: ${stderr.split('\n')[0]}`));
+      else resolve(stdout.trim());
     });
   });
 }
@@ -154,41 +212,177 @@ function getNextProjectNum() {
   return last + 1;
 }
 
+// Remote sampling helpers
+function listExistingSkillNames() {
+  try {
+    const skillsDir = path.join(SKILLS_HUB, 'skills');
+    if (!fs.existsSync(skillsDir)) return [];
+    const names = [];
+    for (const cat of fs.readdirSync(skillsDir)) {
+      const catPath = path.join(skillsDir, cat);
+      if (!fs.statSync(catPath).isDirectory()) continue;
+      for (const name of fs.readdirSync(catPath)) {
+        if (fs.existsSync(path.join(catPath, name, 'SKILL.md'))) names.push(name);
+      }
+    }
+    return names;
+  } catch { return []; }
+}
+
+function listExistingKnowledgeNames() {
+  try {
+    const kDir = path.join(SKILLS_HUB, 'knowledge');
+    if (!fs.existsSync(kDir)) return [];
+    const names = [];
+    for (const cat of fs.readdirSync(kDir)) {
+      const catPath = path.join(kDir, cat);
+      if (!fs.statSync(catPath).isDirectory()) continue;
+      for (const f of fs.readdirSync(catPath)) {
+        if (f.endsWith('.md')) names.push(f.replace(/\.md$/, ''));
+      }
+    }
+    return names;
+  } catch { return []; }
+}
+
+function sampleRandom(arr, n) {
+  const pool = [...arr]; const out = [];
+  while (out.length < n && pool.length > 0) {
+    const idx = Math.floor(Math.random() * pool.length);
+    out.push(pool[idx]); pool.splice(idx, 1);
+  }
+  return out;
+}
+
+function sampleSkillsWithMeta(n) {
+  const skillsDir = path.join(SKILLS_HUB, 'skills');
+  if (!fs.existsSync(skillsDir)) return [];
+  const all = [];
+  try {
+    for (const cat of fs.readdirSync(skillsDir)) {
+      const catPath = path.join(skillsDir, cat);
+      if (!fs.statSync(catPath).isDirectory()) continue;
+      for (const name of fs.readdirSync(catPath)) {
+        const f = path.join(catPath, name, 'SKILL.md');
+        if (!fs.existsSync(f)) continue;
+        try {
+          const txt = fs.readFileSync(f, 'utf8');
+          const desc = (txt.match(/^description:\s*(.+)$/m)?.[1] || '').trim();
+          all.push({ name, category: cat, description: desc });
+        } catch {}
+      }
+    }
+  } catch {}
+  return sampleRandom(all, n);
+}
+
+function sampleKnowledgeWithMeta(n) {
+  const kDir = path.join(SKILLS_HUB, 'knowledge');
+  if (!fs.existsSync(kDir)) return [];
+  const all = [];
+  try {
+    for (const cat of fs.readdirSync(kDir)) {
+      const catPath = path.join(kDir, cat);
+      if (!fs.statSync(catPath).isDirectory()) continue;
+      for (const f of fs.readdirSync(catPath).filter(x => x.endsWith('.md'))) {
+        try {
+          const txt = fs.readFileSync(path.join(catPath, f), 'utf8');
+          const desc = (txt.match(/^description:\s*(.+)$/m)?.[1] || '').trim();
+          all.push({ name: f.replace(/\.md$/, ''), category: cat, description: desc });
+        } catch {}
+      }
+    }
+  } catch {}
+  return sampleRandom(all, n);
+}
+
 // ╔══════════════════════════════════════════════════════════════╗
 // ║  PIPELINE PHASES                                             ║
 // ╚══════════════════════════════════════════════════════════════╝
 
 async function phaseGenerate(keyword) {
   setPhase('generate');
-  log('phase', `Phase 1: Generate 3 app ideas for "${keyword}"`);
+  log('phase', `Phase 1: Generate 3 distinct app ideas for "${keyword}"`);
 
-  const prompt = `You are a creative developer. Generate exactly 3 unique zero-dependency HTML app ideas about "${keyword}".
+  // Include FULL hub inventory (name + description only) — Claude selects relevant ones
+  const allSkills = sampleSkillsWithMeta(1000);       // effectively all
+  const allKnowledge = sampleKnowledgeWithMeta(1000);
+  const skillsBlock = allSkills.length > 0
+    ? allSkills.map(s => `  - \`${s.name}\` (${s.category}): ${s.description || ''}`).join('\n')
+    : '  (no skills available)';
+  const knowBlock = allKnowledge.length > 0
+    ? allKnowledge.map(k => `  - \`${k.name}\` (${k.category}): ${k.description || ''}`).join('\n')
+    : '  (no knowledge available)';
 
-For EACH app, output the COMPLETE source code in this EXACT format:
+  log('info', `Inventory: ${allSkills.length} skills + ${allKnowledge.length} knowledge available`);
 
-===FILE:app-name/index.html===
-(complete HTML file)
+  const prompt = `You are a creative developer mimicking the /hub-make workflow. The theme keyword is "${keyword}".
+
+FULL hub inventory below (300+ skills + 300+ knowledge entries).
+
+CRITICAL — WIDE UTILIZATION IS THE POINT:
+- Scan the ENTIRE inventory. Cite a MINIMUM of **100 skill/knowledge entries total across the 3 apps** (combined). More is better.
+- Each app's features list MUST reference 30+ skills by their exact backtick name, e.g. \`canvas-chromakey-bg-removal\`, \`kafka-batch-consumer-partition-tuning\`.
+- Include a dedicated "## Skills applied" section in each app's README-style commentary naming all cited skills.
+- Include a "## Knowledge respected" section naming relevant pitfalls/decisions.
+- Don't force nonsense — pick skills that PLAUSIBLY apply to this theme (theme is loose; almost every skill has a metaphorical angle: rate-limiters → tide rhythm, distributed-lock → territorial claim, etc).
+- Quality of application doesn't matter as much as breadth of acknowledgment. The hub's purpose is to surface patterns; this cycle proves the pool is being scanned.
+
+Available skills (${allSkills.length} total):
+${skillsBlock}
+
+Relevant knowledge/pitfalls to respect (${allKnowledge.length} total):
+${knowBlock}
+
+
+Generate exactly 3 apps that take this theme from THREE FUNDAMENTALLY DIFFERENT ANGLES (not 3 variations of the same idea):
+
+  App 1: a VISUALIZATION/EXPLORER — interactive view over generated data (graph, map, timeline, canvas scene)
+  App 2: a SIMULATION/GAME — stateful mechanic with user agency (physics, turn-based, rhythm, puzzle)
+  App 3: a TOOL/CALCULATOR — practical utility (converter, generator, analyzer, composer)
+
+Creative naming rules:
+- Each app name must be EVOCATIVE and UNIQUE — do NOT use the pattern "<keyword>-explorer" or "<keyword>-dashboard"
+- Combine the keyword metaphorically with a distinctive word (e.g. "${keyword}-atlas", "whispering-<keyword>", "<keyword>-kaleidoscope", "echo-<keyword>")
+- Kebab-case, 2–4 words
+
+Output format — for each of the 3 apps, emit EXACTLY this block, in order:
+
+===APP===
+name: <kebab-case-name>
+title: <Human Readable Title>
+why: <one-sentence motivation, 10-20 words>
+features:
+- <feature bullet 1>
+- <feature bullet 2>
+- <feature bullet 3>
+stack: html, css, vanilla-js
+===FILE:index.html===
+<complete HTML>
 ===END===
-
-===FILE:app-name/style.css===
-(complete CSS file)
+===FILE:style.css===
+<complete CSS>
 ===END===
-
-===FILE:app-name/app.js===
-(complete JS file)
+===FILE:app.js===
+<complete JS>
 ===END===
+===END-APP===
 
-Requirements:
-- Each app must be a DIFFERENT creative take on "${keyword}"
-- Use kebab-case for app-name (e.g. "${keyword}-explorer")
-- Dark theme: bg #0f1117, surface #1a1d27, accent #6ee7b7
-- Zero dependencies, vanilla JS only
-- Each app should be 150-400 lines total across all 3 files
-- Must be immediately functional when opened in a browser
-- Include simulated/mock data so the app is interactive on load
-- Use canvas or SVG for visualizations where appropriate
+Technical requirements:
+- Dark theme: --bg #0f1117, --surface #1a1d27, --accent #6ee7b7 (use CSS variables)
+- Zero dependencies, vanilla JS only, no external scripts
+- 200–450 lines total per app
+- Immediately interactive on load with meaningful simulated/mock data
+- Use canvas or SVG where visualization helps
+- Modern UX: hover states, transitions, keyboard shortcuts where natural
 
-Output ONLY the file blocks, no other text.`;
+CRITICAL OUTPUT RULES:
+- Output the three complete APP blocks INLINE in this single text response
+- DO NOT use any tools, file writes, or side channels — return ALL code as text in the response body
+- DO NOT summarize, confirm, or describe what you delivered — just emit the blocks
+- DO NOT wrap in code fences (\`\`\`) — emit the raw ===APP=== markers
+- If you catch yourself writing "The apps were delivered above" or similar — STOP and restart with just the blocks
+- The response MUST start with "===APP===" and end with "===END-APP===", nothing else`;
 
   const response = await askClaude(prompt, 600000);
   return response;
@@ -201,69 +395,152 @@ async function phaseBuild(claudeOutput, keyword, cycleNum) {
   const builtApps = [];
   const num = getNextProjectNum();
 
-  // Parse files from Claude output
-  const fileRegex = /===FILE:(.+?)===\n([\s\S]*?)===END===/g;
-  const filesByApp = {};
-  let match;
-  while ((match = fileRegex.exec(claudeOutput)) !== null) {
-    const filePath = match[1].trim();
-    const content = match[2].trim();
-    const appName = filePath.split('/')[0];
-    if (!filesByApp[appName]) filesByApp[appName] = [];
-    filesByApp[appName].push({ path: filePath, content });
+  // Parse structured ===APP=== blocks with metadata + nested ===FILE=== blocks
+  const appBlockRegex = /===APP===\n([\s\S]*?)===END-APP===/g;
+  const parsedApps = [];
+  let m;
+  while ((m = appBlockRegex.exec(claudeOutput)) !== null) {
+    const block = m[1];
+    // Extract metadata (before first ===FILE===)
+    const metaEnd = block.indexOf('===FILE:');
+    const meta = metaEnd >= 0 ? block.slice(0, metaEnd) : block;
+    const name = (meta.match(/^\s*name:\s*(.+)$/m)?.[1] || '').trim();
+    const title = (meta.match(/^\s*title:\s*(.+)$/m)?.[1] || '').trim();
+    const why = (meta.match(/^\s*why:\s*(.+)$/m)?.[1] || '').trim();
+    const stack = (meta.match(/^\s*stack:\s*(.+)$/m)?.[1] || 'html, css, vanilla-js').trim();
+    const featuresBlock = meta.match(/features:\s*\n([\s\S]*?)(?=\n(?:stack|===|$))/i);
+    const features = featuresBlock ? featuresBlock[1].split('\n').map(l => l.replace(/^\s*-\s*/, '').trim()).filter(Boolean) : [];
+
+    // Extract files
+    const fileRegex = /===FILE:(.+?)===\n([\s\S]*?)===END===/g;
+    const files = [];
+    let fm;
+    while ((fm = fileRegex.exec(block)) !== null) {
+      files.push({ path: fm[1].trim(), content: fm[2].trim() });
+    }
+
+    if (name && files.length > 0) {
+      parsedApps.push({ name, title, why, stack, features, files });
+    }
   }
 
-  const appNames = Object.keys(filesByApp);
-  if (appNames.length === 0) {
-    // Fallback: try to extract code blocks
-    log('warn', 'No ===FILE:=== markers found, trying code block extraction');
+  // Fallback: legacy ===FILE:app-name/...=== format
+  if (parsedApps.length === 0) {
+    log('warn', 'No ===APP=== blocks found, trying legacy parser');
+    const legacyRegex = /===FILE:(.+?)===\n([\s\S]*?)===END===/g;
+    const byApp = {};
+    let lm;
+    while ((lm = legacyRegex.exec(claudeOutput)) !== null) {
+      const p = lm[1].trim();
+      const content = lm[2].trim();
+      const appName = p.includes('/') ? p.split('/')[0] : null;
+      if (!appName) continue;
+      if (!byApp[appName]) byApp[appName] = [];
+      byApp[appName].push({ path: p.replace(`${appName}/`, ''), content });
+    }
+    for (const [name, files] of Object.entries(byApp)) {
+      parsedApps.push({ name, title: '', why: '', stack: 'html, css, vanilla-js', features: [], files });
+    }
+  }
+
+  if (parsedApps.length === 0) {
+    log('error', 'Parsed 0 apps from Claude output');
+    // Dump response to a log file for inspection
+    try {
+      const dumpFile = path.join(__dirname, `.debug-claude-cycle${cycleNum}.txt`);
+      fs.writeFileSync(dumpFile, claudeOutput || '(empty response)', 'utf8');
+      log('info', `Response dumped to ${dumpFile} (${(claudeOutput||'').length} chars)`);
+      // Log first 300 chars so we can see format
+      const preview = (claudeOutput || '').slice(0, 300).replace(/\n/g, ' | ');
+      log('info', `Preview: ${preview}`);
+    } catch {}
     return builtApps;
   }
 
   let appIdx = 0;
-  for (const appName of appNames.slice(0, 3)) {
+  for (const app of parsedApps.slice(0, 3)) {
     const projNum = String(num + appIdx).padStart(2, '0');
-    const projDir = path.join(WORK_DIR, `${projNum}-${appName}`);
+    const projDir = path.join(WORK_DIR, `${projNum}-${app.name}`);
     fs.mkdirSync(projDir, { recursive: true });
 
     let totalLines = 0;
-    for (const file of filesByApp[appName]) {
-      const relPath = file.path.replace(`${appName}/`, '');
-      const fullPath = path.join(projDir, relPath);
+    for (const file of app.files) {
+      const fullPath = path.join(projDir, file.path);
       fs.mkdirSync(path.dirname(fullPath), { recursive: true });
       fs.writeFileSync(fullPath, file.content, 'utf8');
       totalLines += file.content.split('\n').length;
     }
 
-    // Validate JS syntax
+    // Validate JS
     const jsFile = path.join(projDir, 'app.js');
     let valid = true;
     if (fs.existsSync(jsFile)) {
-      try {
-        shellSync(`node --check "${jsFile}"`);
-      } catch {
-        log('warn', `${appName}: JS syntax error, skipping validation`);
-        valid = false;
-      }
+      try { shellSync(`node --check "${jsFile}"`); }
+      catch { log('warn', `${app.name}: JS syntax error`); valid = false; }
     }
 
-    const app = {
-      name: appName,
-      dir: `${projNum}-${appName}`,
+    const title = app.title || app.name.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+    const built = {
+      name: app.name,
+      dir: `${projNum}-${app.name}`,
       cycle: cycleNum,
       lines: totalLines,
       status: 'built',
       keyword,
       valid,
+      title,
+      why: app.why || `Interactive ${keyword} experience.`,
+      features: app.features || [],
+      stack: app.stack,
     };
-    builtApps.push(app);
-    state.apps.push(app);
+    builtApps.push(built);
+    state.apps.push(built);
     state.stats.apps++;
     state.stats.lines += totalLines;
-    broadcast({ type: 'app', app });
+    broadcast({ type: 'app', app: built });
     broadcast({ type: 'stats', stats: state.stats });
-    log('success', `Built: ${app.dir} (${totalLines} lines)`);
+    log('success', `Built: ${built.dir} (${totalLines} lines) — ${title}`);
     appIdx++;
+  }
+
+  // Extract cited skills/knowledge from Claude output for the Recipe panel
+  try {
+    const allSkillNames = listExistingSkillNames();
+    const allKnowNames = listExistingKnowledgeNames();
+    // Build {name:category} lookup once
+    const skillCat = {};
+    for (const s of sampleSkillsWithMeta(9999)) skillCat[s.name] = s.category;
+    const knowCat = {};
+    for (const k of sampleKnowledgeWithMeta(9999)) knowCat[k.name] = k.category;
+
+    const bigText = (claudeOutput || '') + ' ' + builtApps.map(a => (a.features || []).join(' ') + ' ' + (a.why || '')).join(' ');
+    const appliedSet = new Set();
+    const respectingSet = new Set();
+
+    for (const name of allSkillNames) {
+      // Look for backtick or whole-word match
+      const re = new RegExp('`' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '`|\\b' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b', 'i');
+      if (re.test(bigText)) appliedSet.add(name);
+    }
+    for (const name of allKnowNames) {
+      const re = new RegExp('`' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '`|\\b' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b', 'i');
+      if (re.test(bigText)) respectingSet.add(name);
+    }
+
+    const applied = [...appliedSet].slice(0, 200).map(n => ({ name: n, category: skillCat[n] || 'misc' }));
+    const respecting = [...respectingSet].slice(0, 100).map(n => ({ name: n, category: knowCat[n] || 'misc' }));
+
+    broadcast({
+      type: 'recipe',
+      keyword,
+      applied,
+      respecting,
+      poolSkills: allSkillNames.length,
+      poolKnowledge: allKnowNames.length,
+    });
+    log('info', `Recipe: cited ${applied.length} skills + ${respecting.length} knowledge (pool: ${allSkillNames.length}/${allKnowNames.length})`);
+  } catch (err) {
+    log('warn', `Recipe extract failed: ${err.message.split('\n')[0]}`);
   }
 
   return builtApps;
@@ -313,18 +590,65 @@ async function phasePublish(apps, cycleNum) {
       const exDir = exDirNative; // for manifest/readme writes below
 
       // Write manifest
+      const title = app.title || slug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+      const stackArr = (app.stack || 'html, css, vanilla-js').split(',').map(s => s.trim()).filter(Boolean);
       const manifest = {
         slug,
-        title: slug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase()),
-        stack: ['html', 'css', 'vanilla-js'],
+        title,
+        stack: stackArr,
         created_at: new Date().toISOString(),
         source_project: app.dir,
         author: 'kjuhwa@nkia.co.kr',
+        keyword: app.keyword,
+        cycle: cycleNum,
       };
       fs.writeFileSync(path.join(exDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
 
-      // Write README
-      const readme = `# ${manifest.title}\n\n> **Why.** Auto-generated ${app.keyword} visualization tool from hub-auto-loop cycle ${cycleNum}.\n\n## Usage\n\nOpen \`index.html\` in any browser.\n\n## Stack\n\n\`html\` · \`css\` · \`vanilla-js\` — zero dependencies, ${app.lines} lines\n\n## Provenance\n\n- Auto-generated by hub-auto-loop cycle ${cycleNum} on ${new Date().toISOString().split('T')[0]}\n`;
+      // Rich README matching /hub-make output style
+      const why = app.why || `Interactive ${app.keyword} experience.`;
+      const features = (app.features && app.features.length > 0) ? app.features : [
+        `Themed around "${app.keyword}"`,
+        'Dark-theme UI with keyboard and pointer interactions',
+        'Self-contained, no build step',
+      ];
+      const readme = [
+        `# ${title}`,
+        '',
+        `> **Why.** ${why}`,
+        '',
+        '## Features',
+        '',
+        ...features.map(f => `- ${f}`),
+        '',
+        '## File structure',
+        '',
+        '```',
+        `${slug}/`,
+        '  index.html    — shell, markup, inline SVG where used',
+        '  style.css     — dark-theme styling and animations',
+        '  app.js        — interactions, simulated data, render loop',
+        '  manifest.json — hub metadata',
+        '```',
+        '',
+        '## Usage',
+        '',
+        '```bash',
+        '# any static file server works',
+        'python -m http.server 8080',
+        '# or open index.html directly in a browser',
+        '```',
+        '',
+        '## Stack',
+        '',
+        `${stackArr.map(s => '`' + s + '`').join(' · ')} — zero dependencies, ${app.lines} lines`,
+        '',
+        '## Provenance',
+        '',
+        `- Generated by auto-hub-loop cycle ${cycleNum} on ${new Date().toISOString().split('T')[0]}`,
+        `- Theme keyword: \`${app.keyword}\``,
+        `- Source working copy: \`${app.dir}\``,
+        '',
+      ].join('\n');
       fs.writeFileSync(path.join(exDir, 'README.md'), readme);
 
       // Commit + push (skip README catalog update to avoid merge conflicts)
@@ -388,38 +712,56 @@ async function phaseExtract(apps, cycleNum) {
   const appNames = apps.map(a => a.name).join(', ');
   const keyword = apps[0]?.keyword || 'general';
 
-  const prompt = `Analyze these 3 apps built about "${keyword}" (names: ${appNames}) and extract reusable patterns.
+  // Sample existing skill/knowledge names to avoid template duplicates
+  const existingSkills = listExistingSkillNames().slice(0, 200);
+  const existingKnowledge = listExistingKnowledgeNames().slice(0, 100);
 
-Output EXACTLY in this format (2 skills + 1 knowledge entry):
+  const prompt = `You built 3 apps this cycle about "${keyword}" (names: ${appNames}).
 
-===SKILL:1===
-name: ${keyword}-visualization-pattern
-category: design
-description: (one line)
-content: (2-3 paragraphs of the reusable pattern)
+Your task: identify genuinely NEW, REUSABLE patterns that emerged during the build — NOT the obvious "${keyword}-visualization-pattern" template. Quality over quantity.
+
+Rules:
+1. Emit ZERO to THREE skills/knowledge entries — only what truly generalizes beyond this cycle.
+2. DO NOT use names already in the repo (these exist): ${existingSkills.slice(0, 60).join(', ')}, ...
+3. Avoid naming patterns like "${keyword}-visualization-pattern", "${keyword}-data-simulation", "${keyword}-implementation-pitfall" — too templated.
+4. Name each entry descriptively based on the SPECIFIC pattern (e.g. "canvas-spatial-grid-renderer", "simulation-tick-event-queue", "react-less-pixel-sprite-swap"). The name should be evocative + specific.
+5. Categories available: design, workflow, arch, ai, backend, frontend, algorithms, misc (pick best fit, not default).
+6. Knowledge types: pitfall, decision, workflow, reference.
+7. If the cycle didn't produce anything interesting beyond generic patterns, output just "===NONE===" and skip entries.
+
+Output format — emit entries as needed (in any mix, any count):
+
+===SKILL===
+name: <descriptive-kebab-case>
+category: <one of above>
+description: (one line summary)
+content: (2-3 paragraphs explaining the reusable pattern, with code-like examples)
 ===END===
 
-===SKILL:2===
-name: ${keyword}-data-simulation
-category: workflow
+===KNOWLEDGE===
+name: <descriptive-kebab-case>
+category: <pitfall|decision|workflow|reference>
 description: (one line)
-content: (2-3 paragraphs of the reusable pattern)
+content: (2-3 paragraphs explaining the specific lesson)
 ===END===
 
-===KNOWLEDGE:1===
-name: ${keyword}-implementation-pitfall
-category: pitfall
-description: (one line)
-content: (2-3 paragraphs about what can go wrong)
-===END===
-
-Be specific to "${keyword}" domain. No generic content.`;
+Output ONLY blocks that describe real patterns. Empty output is valid. No preamble.`;
 
   try {
     const response = await askClaude(prompt, 300000);
 
-    // Parse skills
-    const skillRegex = /===SKILL:\d+===\n([\s\S]*?)===END===/g;
+    // Short-circuit: NONE means Claude decided nothing is worth extracting
+    if (/===NONE===/i.test(response)) {
+      log('info', 'No new patterns this cycle (Claude returned NONE)');
+    }
+
+    const existingSkillSet = new Set(existingSkills);
+    const existingKnowSet = new Set(existingKnowledge);
+    const banned = ['visualization-pattern','data-simulation','implementation-pitfall'];
+    const isTemplated = (n) => banned.some(b => n.endsWith('-' + b));
+
+    // Parse skills (new format: ===SKILL=== no number)
+    const skillRegex = /===SKILL===\n([\s\S]*?)===END===/g;
     let m;
     while ((m = skillRegex.exec(response)) !== null) {
       const block = m[1];
@@ -428,17 +770,19 @@ Be specific to "${keyword}" domain. No generic content.`;
       const description = (block.match(/description:\s*(.+)/)?.[1] || '').trim();
       const content = (block.match(/content:\s*([\s\S]*?)$/)?.[1] || '').trim();
 
-      if (name) {
-        extracted.skills.push({ name, category, description, content });
-        state.skills.push({ name, category, type: 'skill', cycle: cycleNum });
-        state.stats.skills++;
-        broadcast({ type: 'skill', skill: { name, category, type: 'skill' } });
-        log('success', `Extracted skill: ${name} (${category})`);
-      }
+      if (!name) continue;
+      if (existingSkillSet.has(name)) { log('warn', `Skipped duplicate skill: ${name}`); continue; }
+      if (isTemplated(name)) { log('warn', `Skipped templated name: ${name}`); continue; }
+
+      extracted.skills.push({ name, category, description, content });
+      state.skills.push({ name, category, type: 'skill', cycle: cycleNum });
+      state.stats.skills++;
+      broadcast({ type: 'skill', skill: { name, category, type: 'skill' } });
+      log('success', `Extracted skill: ${name} (${category})`);
     }
 
     // Parse knowledge
-    const knowRegex = /===KNOWLEDGE:\d+===\n([\s\S]*?)===END===/g;
+    const knowRegex = /===KNOWLEDGE===\n([\s\S]*?)===END===/g;
     while ((m = knowRegex.exec(response)) !== null) {
       const block = m[1];
       const name = (block.match(/name:\s*(.+)/)?.[1] || '').trim();
@@ -446,13 +790,19 @@ Be specific to "${keyword}" domain. No generic content.`;
       const description = (block.match(/description:\s*(.+)/)?.[1] || '').trim();
       const content = (block.match(/content:\s*([\s\S]*?)$/)?.[1] || '').trim();
 
-      if (name) {
-        extracted.knowledge.push({ name, category, description, content });
-        state.knowledge.push({ name, category, type: 'knowledge', cycle: cycleNum });
-        state.stats.knowledge++;
-        broadcast({ type: 'skill', skill: { name, category, type: 'knowledge' } });
-        log('success', `Extracted knowledge: ${name} (${category})`);
-      }
+      if (!name) continue;
+      if (existingKnowSet.has(name)) { log('warn', `Skipped duplicate knowledge: ${name}`); continue; }
+      if (isTemplated(name)) { log('warn', `Skipped templated name: ${name}`); continue; }
+
+      extracted.knowledge.push({ name, category, description, content });
+      state.knowledge.push({ name, category, type: 'knowledge', cycle: cycleNum });
+      state.stats.knowledge++;
+      broadcast({ type: 'skill', skill: { name, category, type: 'knowledge' } });
+      log('success', `Extracted knowledge: ${name} (${category})`);
+    }
+
+    if (extracted.skills.length === 0 && extracted.knowledge.length === 0) {
+      log('info', 'Extraction yielded nothing new — quality over quantity');
     }
   } catch (err) {
     log('error', `Extract failed: ${err.message.split('\n')[0]}`);
@@ -615,10 +965,11 @@ function setPhase(phase) {
 async function runCycle() {
   state.cycle++;
   const cycleNum = state.cycle;
-  broadcast({ type: 'cycle', cycle: cycleNum });
   log('phase', `═══ CYCLE ${cycleNum} START ═══`);
 
-  const keyword = pickKeyword();
+  const keyword = await pickKeyword();
+  state.currentKeyword = keyword;
+  broadcast({ type: 'cycle', cycle: cycleNum, keyword });
   log('info', `Keyword: "${keyword}"`);
 
   try {
@@ -686,6 +1037,12 @@ async function mainLoop() {
 
     if (state.stopRequested) break;
 
+    // Single-cycle mode: exit after first cycle
+    if (state.runOnce) {
+      log('phase', '═══ Single run complete — stopping ═══');
+      break;
+    }
+
     // Brief pause between cycles
     log('info', 'Next cycle in 10 seconds...');
     await new Promise(r => setTimeout(r, 10000));
@@ -715,6 +1072,18 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  // Static image/asset serving
+  if (/\.(jpg|jpeg|png|gif|webp|svg)$/i.test(url.pathname)) {
+    const fp = path.join(__dirname, decodeURIComponent(url.pathname.replace(/^\//, '')));
+    if (fp.startsWith(__dirname) && fs.existsSync(fp)) {
+      const ext = path.extname(fp).slice(1).toLowerCase();
+      const mime = { jpg:'image/jpeg', jpeg:'image/jpeg', png:'image/png', gif:'image/gif', webp:'image/webp', svg:'image/svg+xml' }[ext] || 'application/octet-stream';
+      res.writeHead(200, { 'Content-Type': mime, 'Cache-Control': 'public, max-age=3600' });
+      res.end(fs.readFileSync(fp));
+      return;
+    }
+  }
+
   // SSE
   if (url.pathname === '/events') {
     res.writeHead(200, {
@@ -733,6 +1102,7 @@ const server = http.createServer((req, res) => {
       type: 'state',
       status: state.status,
       cycle: state.cycle,
+      keyword: state.currentKeyword,
       apps: state.apps.slice(-20),
       skills: [...state.skills, ...state.knowledge].slice(-20),
       stats: state.stats,
@@ -746,12 +1116,42 @@ const server = http.createServer((req, res) => {
   }
 
   // API: state
+  // Serve hub item content (skill or knowledge) for click-to-preview
+  if (url.pathname === '/api/hub-item') {
+    const kind = url.searchParams.get('kind'); // 'skill' or 'knowledge'
+    const name = url.searchParams.get('name');
+    if (!kind || !name || !/^[a-z0-9-]+$/.test(name)) {
+      res.writeHead(400, { 'Content-Type': 'application/json' }); res.end('{"error":"bad request"}'); return;
+    }
+    let content = null, foundPath = null;
+    try {
+      if (kind === 'skill') {
+        const root = path.join(SKILLS_HUB, 'skills');
+        for (const cat of fs.readdirSync(root)) {
+          const f = path.join(root, cat, name, 'SKILL.md');
+          if (fs.existsSync(f)) { content = fs.readFileSync(f, 'utf8'); foundPath = `skills/${cat}/${name}/SKILL.md`; break; }
+        }
+      } else if (kind === 'knowledge') {
+        const root = path.join(SKILLS_HUB, 'knowledge');
+        for (const cat of fs.readdirSync(root)) {
+          const f = path.join(root, cat, `${name}.md`);
+          if (fs.existsSync(f)) { content = fs.readFileSync(f, 'utf8'); foundPath = `knowledge/${cat}/${name}.md`; break; }
+        }
+      }
+    } catch {}
+    if (!content) { res.writeHead(404, { 'Content-Type': 'application/json' }); res.end('{"error":"not found"}'); return; }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ name, kind, path: foundPath, content }));
+    return;
+  }
+
   if (url.pathname === '/api/state') {
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({
       type: 'state',
       status: state.status,
       cycle: state.cycle,
+      keyword: state.currentKeyword,
       apps: state.apps.slice(-50),
       skills: [...state.skills, ...state.knowledge].slice(-50),
       stats: state.stats,
@@ -763,10 +1163,22 @@ const server = http.createServer((req, res) => {
   // API: start
   if (url.pathname === '/api/start' && req.method === 'POST') {
     if (state.status !== 'running') {
+      state.runOnce = false;
       mainLoop().catch(err => log('error', err.message));
     }
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  // Run single cycle then stop
+  if (url.pathname === '/api/run-once' && req.method === 'POST') {
+    if (state.status !== 'running') {
+      state.runOnce = true;
+      mainLoop().catch(err => log('error', err.message));
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, mode: 'run-once' }));
     return;
   }
 


### PR DESCRIPTION
Significant v2 iteration of the auto-hub-loop example.

### Major changes vs v1 (PR #111)

- **Themes**: 10-20 word evocative phrases instead of single keywords
- **Prompting**: FULL 300+ skill + 300+ knowledge inventory injected per cycle (was: random sample of 6+3)
- **Dashboard**: Animated character → **Cycle Recipe panel** with clickable skill/knowledge items opening a modal with the full .md content
- **Status bar**: Particle canvas → clean 3-slot strip (ELAPSED / PHASE n/7 / THEME)
- **CLI piping**: Switched to temp-file + shell redirect to bypass argv ENAMETOOLONG + Windows stdin-pipe propagation bugs
- **Isolation**: Child Claude process uses DISABLE_OMC/OMC_SKIP_HOOKS env vars to prevent autopilot hijacking
- **Extraction**: Duplicate-aware, templated-name-banned to force genuinely new patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)