### PR TITLE
Publish 2 skills + 2 knowledge (session 2026-04-17 part 3)

### DIFF
--- a/knowledge/pitfall/arbitrary-display-caps-hide-signal.md
+++ b/knowledge/pitfall/arbitrary-display-caps-hide-signal.md
@@ -1,0 +1,58 @@
+---
+name: arbitrary-display-caps-hide-signal
+description: Hardcoded `slice(0, N)` display limits in UI code silently cap counts below actual data, making users distrust the pipeline even when it works correctly
+category: pitfall
+tags:
+  - ui
+  - dashboards
+  - monitoring
+  - debugging
+---
+
+# Arbitrary Display Caps Hide Signal
+
+## The failure
+
+You build a pipeline that scans 300 items and cites 120 of them. The dashboard renders the list with `slice(0, 20)` because "nobody wants to see 120 items at once." User sees 20, assumes only 20 were cited, and reports: "the system says 120 but only shows 20 — which one is the lie?"
+
+The code isn't lying — the **display layer is lying on the data layer's behalf** by arbitrarily truncating before the user sees the full picture.
+
+## Why it happens
+
+Dashboards grow incrementally. Early in development you test with 5 items and add `slice(0, 20)` as "defense against pathological inputs." Later the real data is 120 items. The slice stays because nobody remembers it's there. The count header says "120 cited" (correct), but the rendered list shows 20 (capped). The user either:
+
+- Assumes the system is broken
+- Counts the visible items and concludes the header is wrong
+- Loses trust in the whole dashboard
+
+## When caps are legitimate
+
+Caps are fine when:
+
+- The UI is bandwidth-limited (e.g., mobile, embedded display, terminal width)
+- There's a visible "Show more / Show all" affordance matching the actual count
+- The cap is explicitly tied to what the data layer produced (e.g., "top 10 by relevance" — not "first 10 arbitrarily")
+- A companion metric shows the true count prominently (e.g., "Showing 20 of 120 cited")
+
+Caps are **not** fine when:
+
+- The cap was written for a smaller dataset and never revisited
+- The cap silently hides items with no UI signal that truncation occurred
+- The user's trust model assumes "what I see is what was processed"
+
+## The rule
+
+Before adding `.slice(0, N)` to a render path, ask:
+
+1. Is N tied to something meaningful (screen size, pagination, perf budget)?
+2. If the full count exceeds N, is the truncation visible to the user?
+3. Would a cautious user, looking at the dashboard alone, be able to tell the list was truncated?
+
+If any answer is no, either remove the cap or add a "Showing N of M" footer. Prefer the former — modern browsers handle thousands of list items without issue, and users almost always want to see all data by default.
+
+## This project
+
+- The Cycle Recipe panel had `slice(0, 20)` on applied skills and `slice(0, 10)` on knowledge, coded early when Claude was citing 2–5 items per cycle
+- After raising the prompt to "cite 100+ skills," Claude actually did — 120+ matches in the regex — but the UI kept showing 20
+- User immediately noticed: "it says 120 but only shows 20?" — classic symptom
+- Fix: raise caps to 200/100 (effectively unbounded for expected input) and rely on browser to handle the rendering

--- a/knowledge/pitfall/child-claude-inherits-parent-hooks.md
+++ b/knowledge/pitfall/child-claude-inherits-parent-hooks.md
@@ -1,0 +1,71 @@
+---
+name: child-claude-inherits-parent-hooks
+description: When spawning Claude CLI from a Node process, the child inherits OMC/session hooks that can hijack the output into side-channels — you only see a confirmation string
+category: pitfall
+tags:
+  - claude-cli
+  - subprocess
+  - hooks
+  - orchestration
+---
+
+# Child Claude Inherits Parent Hooks — Output Gets Hijacked
+
+## The symptom
+
+You spawn `claude -p` from a Node orchestrator with a clear prompt asking for structured output blocks (`===APP===`, etc.). The child process returns `code 0` with a response like:
+
+> `Autopilot state set to active: false. The three creative apps (app-a, app-b, app-c) were delivered above.`
+
+No structured blocks. The "delivered above" is a lie — the child Claude genuinely produced the content, but some hook intercepted it and routed it through a side channel (tool calls, file writes, session state) that your `claude -p` invocation can't observe.
+
+## Why it happens
+
+`claude` inherits environment and config from the shell that spawned it. If the parent shell has OMC (oh-my-claudecode) or similar hooks active — `SessionStart`, autopilot hooks, `UserPromptSubmit` handlers — they run inside the child too. Any of them can:
+
+- Rewrite the prompt before Claude sees it
+- Detect "autopilot loop" keywords and enter a different execution mode
+- Write output to session state instead of stdout
+- Complete silently with a bland confirmation message
+
+## Fix: env-var isolation
+
+Spawn the child with hooks explicitly disabled:
+
+```js
+const child = spawn(cmd, [], {
+  shell: true,
+  stdio: ['ignore', 'pipe', 'pipe'],
+  env: {
+    ...process.env,
+    DISABLE_OMC: '1',
+    OMC_SKIP_HOOKS: '*',
+    CLAUDE_DISABLE_SESSION_HOOKS: '1',
+  },
+});
+```
+
+This ensures the child Claude sees only the prompt you sent, produces inline text output, and doesn't try to be "clever" about routing the response.
+
+## Why not just `--bare`?
+
+`claude --bare` is tempting — it skips hooks, plugins, auto-memory, keychain reads. But it also disables OAuth/keychain authentication. If the user is logged in via OAuth (no `ANTHROPIC_API_KEY` env var set), `--bare` fails with `Not logged in`. Env-var hook suppression keeps auth working while still stopping hooks.
+
+## Why not reinforce via prompt?
+
+You might try: *"Do not use tools. Do not summarize. Output blocks inline."* This helps but is unreliable — if a `UserPromptSubmit` hook has already rewritten your prompt before Claude sees it, your instructions never reach the model. Env isolation is the actual fix; prompt guardrails are belt-and-suspenders.
+
+## How to detect this happened
+
+Your response is surprisingly short (few hundred bytes) and contains meta-phrases like:
+- "was delivered above"
+- "Autopilot state"
+- "completed successfully"
+- "Files written to ..."
+
+None of those belong in a raw text-generation response. When you see them, check for parent-process hooks first, before blaming the prompt or the model.
+
+## Related
+
+- Keep a debug dump of Claude's raw output whenever parsing fails (`fs.writeFileSync(dumpFile, response)`) — the only way to diagnose these issues is to see what actually came back.
+- Document env vars your orchestrator sets at the top of the server file so future maintainers don't `unset` them thinking they're stale config.

--- a/skills/design/click-to-inspect-corpus-from-dashboard/SKILL.md
+++ b/skills/design/click-to-inspect-corpus-from-dashboard/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: click-to-inspect-corpus-from-dashboard
+description: Make every corpus item (skill, doc, reference) clickable in a dashboard and open its source .md content in a modal via a server endpoint
+category: design
+triggers:
+  - skill preview modal
+  - inspect corpus item
+  - dashboard item drilldown
+  - clickable reference list
+tags:
+  - dashboard
+  - ux
+  - modal
+  - sse
+version: 1.0.0
+---
+
+# Click to Inspect Corpus From Dashboard
+
+A dashboard that lists references from a corpus (skills, knowledge entries, docs, datasets) often ends up read-only — you see names but can't drill into content. The fix is cheap and high-value: add a server endpoint that serves the raw source file by slug, render the list items as clickable, and open a minimal modal with the content.
+
+## Pattern
+
+### 1. Server endpoint — path-safe lookup
+
+```js
+if (url.pathname === '/api/hub-item') {
+  const kind = url.searchParams.get('kind');   // 'skill' | 'knowledge'
+  const name = url.searchParams.get('name');
+  if (!/^[a-z0-9-]+$/.test(name)) return res.writeHead(400).end();
+
+  const root = path.join(CORPUS_DIR, kind === 'skill' ? 'skills' : 'knowledge');
+  // Auto-walk subcategories — don't require caller to know the category
+  for (const cat of fs.readdirSync(root)) {
+    const file = kind === 'skill'
+      ? path.join(root, cat, name, 'SKILL.md')
+      : path.join(root, cat, `${name}.md`);
+    if (fs.existsSync(file)) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ name, kind, path: file, content: fs.readFileSync(file, 'utf8') }));
+      return;
+    }
+  }
+  res.writeHead(404).end();
+}
+```
+
+### 2. Client — make items clickable and fetch on click
+
+```js
+// When rendering the list
+el.innerHTML = items.map(x => `
+  <div class="item" onclick="openItem('${kind}', '${x.name}')">
+    <span class="bullet"></span>
+    <span class="name">${x.name}</span>
+  </div>`).join('');
+
+async function openItem(kind, name) {
+  showModal();
+  const r = await fetch(`/api/hub-item?kind=${kind}&name=${name}`);
+  const data = await r.json();
+  document.getElementById('modalPath').textContent = data.path;
+  document.getElementById('modalBody').textContent = data.content;
+}
+```
+
+### 3. Modal — plain `<pre>` is enough
+
+For technical corpora, raw markdown in a monospace `<pre>` is the right call. Markdown rendering adds complexity (dependency or parser code) for little gain — users of a skills/knowledge dashboard are already reading raw .md elsewhere, consistency wins over prettiness.
+
+```html
+<div class="modal" id="m" onclick="if(event.target===this)close()">
+  <div class="content">
+    <header>
+      <span class="kind-badge">SKILL</span>
+      <span class="title" id="modalTitle"></span>
+      <button onclick="close()">×</button>
+    </header>
+    <div class="path" id="modalPath"></div>
+    <pre class="body" id="modalBody"></pre>
+  </div>
+</div>
+```
+
+## Why this matters
+
+Before clickable items: the list is proof that the corpus was scanned, nothing more. Users have to `cat` files or open the repo in a browser to verify a cited item even exists with the right content.
+
+After clickable items: one click confirms the item is real, shows its full content, and builds trust that the system is using what it says it's using. Especially valuable for automated pipelines where users question whether the "300 skills cited" are actually backed by real files.
+
+## Design notes
+
+- **Path safety**: regex-validate `name` before filesystem lookup (`^[a-z0-9-]+$`). Never interpolate directly.
+- **Auto-walk categories**: the caller shouldn't have to know which category folder an item lives in — walk them all and stop at first hit. Small corpora make this fast enough.
+- **Escape closing**: ESC key + outside-click + explicit × button are all cheap and users expect all three.
+- **Cache rule**: don't cache responses — the dashboard is live and the corpus may change during a session.
+
+## Generalization
+
+Applies to any dashboard rendering references to files you own:
+- Config editor showing which config files are loaded → click to view source
+- Log viewer citing source locations → click to open the file at that line
+- Test runner showing which fixtures are used → click to see the fixture content
+- API doc listing example payloads → click to see the full example

--- a/skills/design/layout-stable-hover-via-inset-shadow/SKILL.md
+++ b/skills/design/layout-stable-hover-via-inset-shadow/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: layout-stable-hover-via-inset-shadow
+description: Replace transform-based hover effects (translate, scale) with inset box-shadow to avoid layout shifts and horizontal-scrollbar flicker
+category: design
+triggers:
+  - hover causes scrollbar
+  - hover layout shift
+  - translate hover flicker
+  - scrollbar flashes on hover
+tags:
+  - css
+  - hover
+  - scrollbar
+  - layout
+version: 1.0.0
+---
+
+# Layout-Stable Hover via Inset Shadow
+
+Transform-based hover effects like `transform: translateX(2px)` look tasteful on a single button but break lists inside scrollable containers. Each item's hover overflows its parent horizontally, the browser flashes a horizontal scrollbar, which shifts the vertical scrollbar, which moves the hovered item out from under the cursor — flicker loop.
+
+## The anti-pattern
+
+```css
+.list-item {
+  transition: all .2s;
+}
+.list-item:hover {
+  transform: translateX(2px);   /* ← overflows parent */
+  box-shadow: 0 0 0 1px var(--accent);
+}
+```
+
+Inside a container with bounded width, every hover triggers:
+1. Item moves 2px right
+2. Right edge overflows parent
+3. Browser adds horizontal scrollbar
+4. Vertical scrollbar narrows/moves
+5. Item under cursor is no longer hovered
+6. Scrollbar disappears
+7. Repeat — visible flicker
+
+## The fix
+
+Use an effect that **doesn't change layout**:
+
+```css
+.list-item {
+  min-width: 0;            /* allow text ellipsis */
+  transition: background .2s, box-shadow .2s;   /* explicit, not 'all' */
+}
+.list-item:hover {
+  background: var(--hover-bg);
+  box-shadow: inset 2px 0 0 var(--accent);   /* painted inside, no overflow */
+}
+.list-item-name {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.list-container {
+  overflow-x: hidden;      /* defense in depth */
+}
+```
+
+Key changes:
+
+- **`box-shadow: inset`** paints *inside* the element's box, so it doesn't add to scroll width.
+- **Explicit transition properties** (`background, box-shadow`) instead of `all` — prevents re-triggering on any unrelated property.
+- **`overflow-x: hidden` on container** — defense in depth against future hover changes that forget this rule.
+- **`min-width: 0` on flex children** — required to let `text-overflow: ellipsis` actually truncate inside a flex layout.
+
+## When transforms are still fine
+
+Transform-based hovers are fine when:
+- The item has room to grow (e.g. padding or margin buffers on all sides ≥ transform distance)
+- The container has `overflow: visible` and doesn't scroll
+- The transform is a `scale()` at origin center (no edge overflow)
+
+They're only bad inside tight scrollable containers.
+
+## Related pitfalls
+
+- `transition: all` re-fires on any computed property change — scope transitions explicitly.
+- `:active` using `transform: scale(.98)` is usually fine because it's brief and mouse is already held.
+- Animated `margin-left/right` also causes reflow; stick to inset shadows or absolutely-positioned overlays for decoration.


### PR DESCRIPTION
## Skills

- `design/click-to-inspect-corpus-from-dashboard` v1.0.0 — server endpoint + modal for clicking corpus items
- `design/layout-stable-hover-via-inset-shadow` v1.0.0 — hover effects without scrollbar flicker

## Knowledge

- `pitfall/child-claude-inherits-parent-hooks` (high) — env var isolation for spawned Claude
- `pitfall/arbitrary-display-caps-hide-signal` (medium) — hardcoded slice() breaks user trust

## Source

Session 2026-04-17 part 3 — Recipe panel redesign + hover flicker debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)