### PR TITLE
cleanup: reindex index.json (354 -> 748)

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,706 +1,5126 @@
 [
   {
-    "name": "actor-model-data-simulation",
-    "slug": "actor-model-data-simulation",
-    "category": "workflow",
-    "description": "Simulate actor system behavior using timer-driven state mutation with probabilistic failure injection and staged restart recovery.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "actor model data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/actor-model-data-simulation",
-    "has_content": false
+    "kind": "knowledge",
+    "name": "actuator-path-dual-compatibility",
+    "slug": "actuator-path-dual-compatibility",
+    "category": "api",
+    "description": "Actuator endpoints must respond at both /actuator/** and /actuator/{appName}/** for deployment compatibility.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/api/actuator-path-dual-compatibility.md",
+    "has_content": true
   },
   {
-    "name": "actor-model-visualization-pattern",
-    "slug": "actor-model-visualization-pattern",
-    "category": "design",
-    "description": "Render actor systems using layered visual encoding — shape for identity, color for health state, animation for message activity, and spatial layout for hierarchy.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "actor model visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/actor-model-visualization-pattern",
-    "has_content": false
+    "kind": "knowledge",
+    "name": "claude-code-routines-cloud-automation-model",
+    "slug": "claude-code-routines-cloud-automation-model",
+    "category": "api",
+    "description": "Claude Code Routines (research preview) are saved cloud sessions — prompt + repos + connectors + environment — triggered by schedule, HTTP POST, or GitHub events. One routine can combine all three. Daily run cap per account; branch pushes restricted to `claude/*` by default.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/api/claude-code-routines-cloud-automation-model.md",
+    "has_content": true
   },
   {
-    "name": "adaptive-strategy-hot-swap",
-    "slug": "adaptive-strategy-hot-swap",
+    "kind": "knowledge",
+    "name": "confid-vs-resourceid-routing",
+    "slug": "confid-vs-resourceid-routing",
+    "category": "api",
+    "description": "Queries support both `configIds` (tenant/policy scope) and `resourceId` (agent scope); filter routes to different Mongo match fields",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/api/confid-vs-resourceid-routing.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "endpoint-service-dual-pattern",
+    "slug": "endpoint-service-dual-pattern",
+    "category": "api",
+    "description": "Two coexisting API service patterns — factory functions (apmServices) and direct functional exports (alarmService) — with centralized endpoint constants",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/api/endpoint-service-dual-pattern.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "es-xpack-transport-vs-rest-ssl",
+    "slug": "es-xpack-transport-vs-rest-ssl",
+    "category": "api",
+    "description": "Elasticsearch transport SSL and REST SSL are independent X-Pack configs; enabling one does not enable the other",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/api/es-xpack-transport-vs-rest-ssl.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "kafka-avro-change-flag-contract",
+    "slug": "kafka-avro-change-flag-contract",
+    "category": "api",
+    "description": "Every Configuration-domain Avro event carries an `actionType` enum (INSERT/UPDATE/DELETE) plus boolean change flags per mutable section (e.g. `parentChanged`, `tagFiltersChanged`, `configurationsChanged`) rather than full before/after payloads.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/api/kafka-avro-change-flag-contract.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "kafka-organization-id-record-header",
+    "slug": "kafka-organization-id-record-header",
+    "category": "api",
+    "description": "Place organizationId (tenant) in the Kafka record header, not only in the payload — downstream consumers route by header before deserializing.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/api/kafka-organization-id-record-header.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "live-chart-timestamp-normalization",
+    "slug": "live-chart-timestamp-normalization",
+    "category": "api",
+    "description": "LIVE charts accept `normalizeTimestamp` + `normalizeIntervalMs` to align per-agent millisecond offsets into a single x-axis",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/api/live-chart-timestamp-normalization.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "stomp-heartbeat-10s-bidirectional",
+    "slug": "stomp-heartbeat-10s-bidirectional",
+    "category": "api",
+    "description": "STOMP broker heartbeat set to 10s/10s (client↔server) is a reasonable default for detecting dead WebSocket sessions within ~20s",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/api/stomp-heartbeat-10s-bidirectional.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "timeselector-mode-interval-range-mapping",
+    "slug": "timeselector-mode-interval-range-mapping",
+    "category": "api",
+    "description": "Clients send a `mode` enum (RAW..YEAR); the server maps it to a (bin-interval, query-range) pair and picks the right pre-aggregated collection",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/api/timeselector-mode-interval-range-mapping.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "xlog-extended-transaction-trace-with-compression",
+    "slug": "xlog-extended-transaction-trace-with-compression",
+    "category": "api",
+    "description": "XLog is scouter's per-request transaction trace format — hierarchical typed steps stored as compressed binary, indexed by end-time, with flat metadata for server-side filtering",
+    "tags": [
+      "xlog",
+      "tracing",
+      "apm",
+      "format",
+      "scouter"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/api/xlog-extended-transaction-trace-with-compression.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "additive-registry-schema-versioning",
+    "slug": "additive-registry-schema-versioning",
     "category": "arch",
-    "description": "Periodically re-evaluate candidate strategies/policies against recent data, swap the active one only when a weighted composite score beats the incumbent by a hysteresis threshold — prevents flapping while staying adaptive.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/arch/adaptive-strategy-hot-swap",
-    "has_content": true
-  },
-  {
-    "name": "ag-grid-cell-renderer-pattern",
-    "slug": "ag-grid-cell-renderer-pattern",
-    "category": "frontend",
-    "description": "Structured AG-Grid custom cell renderer catalog with typed column definitions and category-based organization",
-    "tags": [],
-    "triggers": [
-      "ag-grid",
-      "cell renderer",
-      "grid column",
-      "custom renderer",
-      "grid cell"
+    "description": "JSON registry 진화는 version bump + 새 키 empty container + 첫 쓰기 시 자동 마이그레이션으로 하라",
+    "tags": [
+      "registry",
+      "schema",
+      "versioning",
+      "migration",
+      "backwards-compat"
     ],
-    "version": "1.0.0",
-    "path": "skills/frontend/ag-grid-cell-renderer-pattern",
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/additive-registry-schema-versioning.md",
     "has_content": true
   },
   {
-    "name": "ag-grid-custom-filter-system",
-    "slug": "ag-grid-custom-filter-system",
-    "category": "design",
-    "description": "ag-grid Enterprise wrapper with GridContext provider, custom filter components (Boolean, Number, DateRange, SelectMulti), and pagination state management",
+    "kind": "knowledge",
+    "name": "agent-memory-binding-vs-recall",
+    "slug": "agent-memory-binding-vs-recall",
+    "category": "arch",
+    "description": "Agent memory systems that ace retrieval benchmarks still fail operationally because stored skills aren't *bound* to the episodes that validated them. Fix is a memory bundle — skill record + episode record + bidirectional link — returned together on recall.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/agent-memory-binding-vs-recall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "annotation-driven-authz-via-function-id",
+    "slug": "annotation-driven-authz-via-function-id",
+    "category": "arch",
+    "description": "Controllers declare required capability with a method-level enum annotation; an interceptor enforces it against JWT-derived roles",
+    "tags": [
+      "authorization",
+      "jwt",
+      "annotation",
+      "interceptor",
+      "rbac"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/annotation-driven-authz-via-function-id.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "archon-deterministic-ai-coding-harness",
+    "slug": "archon-deterministic-ai-coding-harness",
+    "category": "arch",
+    "description": "Archon enforces deterministic AI-assisted coding by encoding workflows as YAML DAGs — deterministic nodes (tests, git ops) bracket AI-driven nodes (plan, implement, review), each run isolated in its own git worktree. The pattern generalizes beyond Archon itself.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/archon-deterministic-ai-coding-harness.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "assumeutxo-snapshot-chainstate-phases",
+    "slug": "assumeutxo-snapshot-chainstate-phases",
+    "category": "arch",
+    "description": "(Blockchain-specific) Multi-chainstate snapshot validation — active chainstate syncs from a trusted-but-unverified UTXO snapshot while a background chainstate validates the snapshot's base, with a phased state machine for clean cutover.",
+    "tags": [
+      "blockchain",
+      "utxo",
+      "snapshot",
+      "bitcoin",
+      "phased-validation"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/assumeutxo-snapshot-chainstate-phases.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "bilingual-user-facing-strings",
+    "slug": "bilingual-user-facing-strings",
+    "category": "arch",
+    "description": "A bilingual_str struct carrying both original and translated forms lets GUI show translated text while logs/stderr keep the original — no locale branching in business code.",
+    "tags": [
+      "cpp",
+      "i18n",
+      "localization",
+      "logging",
+      "ui"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/bilingual-user-facing-strings.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "boilerplate-generated-business-logic-manual",
+    "slug": "boilerplate-generated-business-logic-manual",
+    "category": "arch",
+    "description": "Split AI codegen scope along the boilerplate/business-logic line — AI produces skeletons, humans fill domain rules",
+    "tags": [
+      "codegen",
+      "hexagonal",
+      "scope",
+      "ai-automation",
+      "skeleton"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/boilerplate-generated-business-logic-manual.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "claude-plugin-skill-md-is-sufficient",
+    "slug": "claude-plugin-skill-md-is-sufficient",
+    "category": "arch",
+    "description": "스킬 = SKILL.md 하나. 코드, 빌드, 의존성, 스크립트 없이도 완전히 동작한다.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/claude-plugin-skill-md-is-sufficient.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "commons-logging-exclusion-strategy",
+    "slug": "commons-logging-exclusion-strategy",
+    "category": "arch",
+    "description": "Globally exclude commons-logging, log4j, and slf4j-log4j12 in Gradle so SLF4J+Logback is the only logging backend on the classpath",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/commons-logging-exclusion-strategy.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "data-patch-package-for-migrations",
+    "slug": "data-patch-package-for-migrations",
+    "category": "arch",
+    "description": "One-off data patches (backfills, embedded→referenced splits, field additions) are grouped under a `patch` package so they're isolated from day-to-day service code and easy to audit/remove after a release.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/data-patch-package-for-migrations.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "domain-registry-plus-projects-yaml",
+    "slug": "domain-registry-plus-projects-yaml",
+    "category": "arch",
+    "description": "Central domain registry + per-user path map for multi-repo codegen",
+    "tags": [
+      "multi-repo",
+      "codegen",
+      "routing",
+      "registry",
+      "local-config"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/domain-registry-plus-projects-yaml.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "dual-design-token-pipeline-arch",
+    "slug": "dual-design-token-pipeline-arch",
+    "category": "arch",
+    "description": "Project runs two parallel design token pipelines — legacy SD v3→SCSS for sirius/Ant Design and modern SD v5→CSS @theme for AI Portal/Tailwind v4",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/dual-design-token-pipeline-arch.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "dual-redis-lock-vs-access-control",
+    "slug": "dual-redis-lock-vs-access-control",
+    "category": "arch",
+    "description": "The service connects to two separate Redis instances: Lock Control (default port 6399) and Access Control (default port 6389). They are not interchangeable.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/dual-redis-lock-vs-access-control.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "duckdb-vectorized-analytical-execution",
+    "slug": "duckdb-vectorized-analytical-execution",
+    "category": "arch",
+    "description": "DuckDB's design has five separable pillars — vectorized execution, pipelined operators, explicit memory + grouped aggregation, ART indexing, and a dedicated query rewriter — distinguishing it from row-at-a-time OLTP engines.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/duckdb-vectorized-analytical-execution.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "env-override-last-wins-chain",
+    "slug": "env-override-last-wins-chain",
+    "category": "arch",
+    "description": "Environment variables resolve across four sources with \"last wins\" precedence.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/env-override-last-wins-chain.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "event-driven-init-wait-for-services",
+    "slug": "event-driven-init-wait-for-services",
+    "category": "arch",
+    "description": "Initialization work is deferred until leader status and dependent-service readiness are confirmed via a `@WaitForServices` event listener",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/event-driven-init-wait-for-services.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "gradle-avro-plugin-config",
+    "slug": "gradle-avro-plugin-config",
+    "category": "arch",
+    "description": "davidmc24 avro-gradle-plugin config — createSetters=false + fieldVisibility=PRIVATE enforces immutable generated event schemas",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/gradle-avro-plugin-config.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "hierarchical-agents-md-catalog",
+    "slug": "hierarchical-agents-md-catalog",
+    "category": "arch",
+    "description": "루트 AGENTS.md(프로젝트 개요) + `skills/AGENTS.md`(스킬 카탈로그) 2계층 구조. 하위는 상위를 `<!-- Parent: ../AGENTS.md -->` 주석으로 가리킨다.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/hierarchical-agents-md-catalog.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "interface-abstraction-for-modularity",
+    "slug": "interface-abstraction-for-modularity",
+    "category": "arch",
+    "description": "Pure-virtual C++ interfaces in a dedicated src/interfaces/ directory decouple modules without symbol-level coupling, and enable IPC code generation later.",
+    "tags": [
+      "cpp",
+      "architecture",
+      "modularity",
+      "ipc",
+      "dependency-inversion"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/interface-abstraction-for-modularity.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "jar-task-disabled-bootjar-only",
+    "slug": "jar-task-disabled-bootjar-only",
+    "category": "arch",
+    "description": "Gradle `jar` task is disabled so only `bootJar` produces an artifact — CI/Docker consumers never receive an ambiguous plain JAR",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/jar-task-disabled-bootjar-only.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "jvm-module-opens-java21-spring-kafka",
+    "slug": "jvm-module-opens-java21-spring-kafka",
+    "category": "arch",
+    "description": "Java 21 runs Spring Boot + Kafka/MongoDB clients under strict module access; two --add-opens flags are required or reflective serializers fail at runtime.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/jvm-module-opens-java21-spring-kafka.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "k-git-tag-registry-versioning",
+    "slug": "k-git-tag-registry-versioning",
+    "category": "arch",
+    "description": "Git tag를 semver registry로 쓰면 별도 version manifest 없이 rollback·pinning을 얻는다",
+    "tags": [
+      "git",
+      "versioning",
+      "registry",
+      "rollback",
+      "semver"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/k-git-tag-registry-versioning.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "kafka-1h-topic-and-nonmetric-pool",
+    "slug": "kafka-1h-topic-and-nonmetric-pool",
+    "category": "arch",
+    "description": "Raw alarm path uses a 1-hour-retention Kafka topic and a dedicated non-metric thread pool — isolates alarm latency from batch ingest",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/kafka-1h-topic-and-nonmetric-pool.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "kafka-avro-schedule-event-chain",
+    "slug": "kafka-avro-schedule-event-chain",
+    "category": "arch",
+    "description": "Collection scheduling decouples Kafka ingress from per-DBMS handlers via four typed BlockingQueues",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/kafka-avro-schedule-event-chain.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "kafka-avro-schema-registry-env-topology",
+    "slug": "kafka-avro-schema-registry-env-topology",
+    "category": "arch",
+    "description": "Kafka uses Avro + Confluent Schema Registry; partition and replication counts are environment-driven.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/kafka-avro-schema-registry-env-topology.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "kafka-partition-topology-design",
+    "slug": "kafka-partition-topology-design",
+    "category": "arch",
+    "description": "Asymmetric Kafka partition counts per topic (high for hot-path, default for admin topics) match volume and concurrency needs without over-provisioning",
+    "tags": [
+      "kafka",
+      "partition",
+      "topology",
+      "throughput",
+      "concurrency"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/kafka-partition-topology-design.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "live-mode-aggregation-exceptions",
+    "slug": "live-mode-aggregation-exceptions",
+    "category": "arch",
+    "description": "LIVE mode reads raw data by default, but equalizer / multi-resource / TopN charts still aggregate raw at query time",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/live-mode-aggregation-exceptions.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "llm-tool-calling-mxn-wire-format-problem",
+    "slug": "llm-tool-calling-mxn-wire-format-problem",
+    "category": "arch",
+    "description": "Open-source LLMs each encode tool calls in a different wire format (special tokens, XML, channel notation, JSON blocks), so M inference apps × N models = M×N parsers. Fix is declarative tool-call specs shipped with the model and consumed by both grammar engines and parsers.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/llm-tool-calling-mxn-wire-format-problem.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "lucida-framework-gate-annotations",
+    "slug": "lucida-framework-gate-annotations",
+    "category": "arch",
+    "description": "Internal framework (lucida-framework-*) uses opt-in annotations (@EnabledMessage, @EnableDataExport, @EnableSchedule, @EnableCommand) on the Application class to gate auto-config; omitting one silently disables the feature.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/lucida-framework-gate-annotations.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "lucida-ui-design-token-reference",
+    "slug": "lucida-ui-design-token-reference",
+    "category": "arch",
+    "description": "lucida-ui 프로젝트의 실제 디자인 토큰 값 참조표 — 팔레트, 시맨틱, 사이즈, 타이포, 컴포넌트 스타일",
+    "tags": [
+      "lucida-ui",
+      "nds",
+      "design-token",
+      "sirius",
+      "scss",
+      "figma"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/lucida-ui-design-token-reference.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mf-cross-remote-import-forbidden",
+    "slug": "mf-cross-remote-import-forbidden",
+    "category": "arch",
+    "description": "In a Module Federation monorepo with per-remote webpack aliases, remotes must not import from sibling remotes directly — share code through `shared/` or through MF exposes.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/mf-cross-remote-import-forbidden.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mf-expose-requires-memoryrouter-wrapper",
+    "slug": "mf-expose-requires-memoryrouter-wrapper",
+    "category": "arch",
+    "description": "Components exposed via Module Federation that use react-router hooks must be wrapped in MemoryRouter at the expose boundary, not BrowserRouter and not a full-app router wrapper.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/mf-expose-requires-memoryrouter-wrapper.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mf-shared-singleton-config",
+    "slug": "mf-shared-singleton-config",
+    "category": "arch",
+    "description": "227 shared dependencies configured as Webpack Module Federation singletons with strict versioning; react-router-dom intentionally excluded",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/mf-shared-singleton-config.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mongodb-aggregated-stats-as-views",
+    "slug": "mongodb-aggregated-stats-as-views",
+    "category": "arch",
+    "description": "Precomputed hour/day statistics exposed as MongoDB read-only views instead of physical collections to simplify reads and keep them consistent with source",
+    "tags": [
+      "mongodb",
+      "views",
+      "aggregation",
+      "time-series"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/mongodb-aggregated-stats-as-views.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "multi-domain-split-via-domain-mapping",
+    "slug": "multi-domain-split-via-domain-mapping",
+    "category": "arch",
+    "description": "Split multi-domain screens via a domain-mapping manifest — one OpenAPI file per owning domain",
+    "tags": [
+      "multi-domain",
+      "openapi",
+      "ownership",
+      "parallel-dev",
+      "cross-domain"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/multi-domain-split-via-domain-mapping.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "multi-layer-css-architecture",
+    "slug": "multi-layer-css-architecture",
+    "category": "arch",
+    "description": "Four-layer CSS architecture — SCSS (sirius design system), LESS (Ant Design vars), Tailwind v4 (AI Portal with scope isolation), plain CSS — each with distinct webpack rules and toolchains",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/multi-layer-css-architecture.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "multiprocess-architecture-via-ipc",
+    "slug": "multiprocess-architecture-via-ipc",
+    "category": "arch",
+    "description": "Decompose a monolith into cooperating processes by defining interfaces in a neutral schema language (Cap'n Proto), then codegen client/server proxies that preserve the original C++ interface shape.",
+    "tags": [
+      "ipc",
+      "capnp",
+      "architecture",
+      "process-isolation",
+      "codegen"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/multiprocess-architecture-via-ipc.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "nfs-backed-volumes-for-docker-swarm",
+    "slug": "nfs-backed-volumes-for-docker-swarm",
+    "category": "arch",
+    "description": "Cross-node Docker Swarm persistence via a single NFS share mounted at the same host path on every swarm node",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/nfs-backed-volumes-for-docker-swarm.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-ai-slop-cleaner",
+    "slug": "oh-my-claudecode-ai-slop-cleaner",
+    "category": "arch",
+    "description": "OMC implements \\\"ai-slop-cleaner\\\" as: Clean AI-generated code slop with a regression-safe, deletion-first workflow and optional reviewer-only mode",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "ai-slop-cleaner"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-ai-slop-cleaner.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-ask",
+    "slug": "oh-my-claudecode-ask",
+    "category": "arch",
+    "description": "OMC implements \\\"ask\\\" as: Process-first advisor routing for Claude, Codex, or Gemini via `omc ask`, with artifact capture and no raw CLI assembly",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "ask"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-ask.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-autopilot",
+    "slug": "oh-my-claudecode-autopilot",
+    "category": "arch",
+    "description": "OMC implements \\\"autopilot\\\" as: Full autonomous execution from idea to working code",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "autopilot"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-autopilot.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-cancel",
+    "slug": "oh-my-claudecode-cancel",
+    "category": "arch",
+    "description": "OMC implements \\\"cancel\\\" as: Cancel any active OMC mode (autopilot, ralph, ultrawork, ultraqa, swarm, ultrapilot, pipeline, team)",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "cancel"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-cancel.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-ccg",
+    "slug": "oh-my-claudecode-ccg",
+    "category": "arch",
+    "description": "OMC implements \\\"ccg\\\" as: Claude-Codex-Gemini tri-model orchestration via /ask codex + /ask gemini, then Claude synthesizes results",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "ccg"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-ccg.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-configure-notifications",
+    "slug": "oh-my-claudecode-configure-notifications",
+    "category": "arch",
+    "description": "OMC implements \\\"configure-notifications\\\" as: Configure notification integrations (Telegram, Discord, Slack) via natural language",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "configure-notifications"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-configure-notifications.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-debug",
+    "slug": "oh-my-claudecode-debug",
+    "category": "arch",
+    "description": "OMC implements \\\"debug\\\" as: Diagnose the current OMC session or repo state using logs, traces, state, and focused reproduction",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "debug"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-debug.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-deep-dive",
+    "slug": "oh-my-claudecode-deep-dive",
+    "category": "arch",
+    "description": "OMC implements \\\"deep-dive\\\" as: 2-stage pipeline: trace (causal investigation) -> deep-interview (requirements crystallization) with 3-point injection",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "deep-dive"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-deep-dive.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-deep-interview",
+    "slug": "oh-my-claudecode-deep-interview",
+    "category": "arch",
+    "description": "OMC implements \\\"deep-interview\\\" as: Socratic deep interview with mathematical ambiguity gating before autonomous execution",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "deep-interview"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-deep-interview.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-deepinit",
+    "slug": "oh-my-claudecode-deepinit",
+    "category": "arch",
+    "description": "OMC implements \\\"deepinit\\\" as: Deep codebase initialization with hierarchical AGENTS.md documentation",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "deepinit"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-deepinit.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-external-context",
+    "slug": "oh-my-claudecode-external-context",
+    "category": "arch",
+    "description": "OMC implements \\\"external-context\\\" as: Invoke parallel document-specialist agents for external web searches and documentation lookup",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "external-context"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-external-context.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-hud",
+    "slug": "oh-my-claudecode-hud",
+    "category": "arch",
+    "description": "OMC implements \\\"hud\\\" as: Configure HUD display options (layout, presets, display elements)",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "hud"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-hud.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-learner",
+    "slug": "oh-my-claudecode-learner",
+    "category": "arch",
+    "description": "OMC implements \\\"learner\\\" as: Extract a learned skill from the current conversation",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "learner"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-learner.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-mcp-setup",
+    "slug": "oh-my-claudecode-mcp-setup",
+    "category": "arch",
+    "description": "OMC implements \\\"mcp-setup\\\" as: Configure popular MCP servers for enhanced agent capabilities",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "mcp-setup"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-mcp-setup.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-omc-doctor",
+    "slug": "oh-my-claudecode-omc-doctor",
+    "category": "arch",
+    "description": "OMC implements \\\"omc-doctor\\\" as: Diagnose and fix oh-my-claudecode installation issues",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "omc-doctor"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-omc-doctor.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-omc-reference",
+    "slug": "oh-my-claudecode-omc-reference",
+    "category": "arch",
+    "description": "OMC implements \\\"omc-reference\\\" as: OMC agent catalog, available tools, team pipeline routing, commit protocol, and skills registry. Auto-loads when delegating to agents, using OMC tools, orchestrating teams, making commits, or invoking skills.",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "omc-reference"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-omc-reference.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-omc-setup",
+    "slug": "oh-my-claudecode-omc-setup",
+    "category": "arch",
+    "description": "OMC implements \\\"omc-setup\\\" as: Install or refresh oh-my-claudecode for plugin, npm, and local-dev setups from the canonical setup flow",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "omc-setup"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-omc-setup.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-omc-teams",
+    "slug": "oh-my-claudecode-omc-teams",
+    "category": "arch",
+    "description": "OMC implements \\\"omc-teams\\\" as: CLI-team runtime for claude, codex, or gemini workers in tmux panes when you need process-based parallel execution",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "omc-teams"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-omc-teams.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-plan",
+    "slug": "oh-my-claudecode-plan",
+    "category": "arch",
+    "description": "OMC implements \\\"plan\\\" as: Strategic planning with optional interview workflow",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "plan"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-plan.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-project-session-manager",
+    "slug": "oh-my-claudecode-project-session-manager",
+    "category": "arch",
+    "description": "OMC implements \\\"project-session-manager\\\" as: Worktree-first dev environment manager for issues, PRs, and features with optional tmux sessions",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "project-session-manager"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-project-session-manager.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-ralph",
+    "slug": "oh-my-claudecode-ralph",
+    "category": "arch",
+    "description": "OMC implements \\\"ralph\\\" as: Self-referential loop until task completion with configurable verification reviewer",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "ralph"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-ralph.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-ralplan",
+    "slug": "oh-my-claudecode-ralplan",
+    "category": "arch",
+    "description": "OMC implements \\\"ralplan\\\" as: Consensus planning entrypoint that auto-gates vague ralph/autopilot/team requests before execution",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "ralplan"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-ralplan.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-release",
+    "slug": "oh-my-claudecode-release",
+    "category": "arch",
+    "description": "OMC implements \\\"release\\\" as: Generic release assistant — analyzes repo release rules, caches them in .omc/RELEASE_RULE.md, then guides the release",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "release"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-release.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-remember",
+    "slug": "oh-my-claudecode-remember",
+    "category": "arch",
+    "description": "OMC implements \\\"remember\\\" as: Review reusable project knowledge and decide what belongs in project memory, notepad, or durable docs",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "remember"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-remember.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-sciomc",
+    "slug": "oh-my-claudecode-sciomc",
+    "category": "arch",
+    "description": "OMC implements \\\"sciomc\\\" as: Orchestrate parallel scientist agents for comprehensive analysis with AUTO mode",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "sciomc"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-sciomc.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-self-improve",
+    "slug": "oh-my-claudecode-self-improve",
+    "category": "arch",
+    "description": "OMC implements \\\"self-improve\\\" as: Autonomous evolutionary code improvement engine with tournament selection",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "self-improve"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-self-improve.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-setup",
+    "slug": "oh-my-claudecode-setup",
+    "category": "arch",
+    "description": "OMC implements \\\"setup\\\" as: Use first for install/update routing — sends setup, doctor, or MCP requests to the correct OMC setup flow",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "setup"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-setup.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-skill",
+    "slug": "oh-my-claudecode-skill",
+    "category": "arch",
+    "description": "OMC implements \\\"skill\\\" as: Manage local skills - list, add, remove, search, edit, setup wizard",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "skill"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-skill.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-skillify",
+    "slug": "oh-my-claudecode-skillify",
+    "category": "arch",
+    "description": "OMC implements \\\"skillify\\\" as: Turn a repeatable workflow from the current session into a reusable OMC skill draft",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "skillify"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-skillify.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-team",
+    "slug": "oh-my-claudecode-team",
+    "category": "arch",
+    "description": "OMC implements \\\"team\\\" as: N coordinated agents on shared task list using Claude Code native teams",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "team"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-team.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-trace",
+    "slug": "oh-my-claudecode-trace",
+    "category": "arch",
+    "description": "OMC implements \\\"trace\\\" as: Evidence-driven tracing lane that orchestrates competing tracer hypotheses in Claude built-in team mode",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "trace"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-trace.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-ultraqa",
+    "slug": "oh-my-claudecode-ultraqa",
+    "category": "arch",
+    "description": "OMC implements \\\"ultraqa\\\" as: QA cycling workflow - test, verify, fix, repeat until goal met",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "ultraqa"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-ultraqa.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-ultrawork",
+    "slug": "oh-my-claudecode-ultrawork",
+    "category": "arch",
+    "description": "OMC implements \\\"ultrawork\\\" as: Parallel execution engine for high-throughput task completion",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "ultrawork"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-ultrawork.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-verify",
+    "slug": "oh-my-claudecode-verify",
+    "category": "arch",
+    "description": "OMC implements \\\"verify\\\" as: Verify that a change really works before you claim completion",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "verify"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-verify.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-visual-verdict",
+    "slug": "oh-my-claudecode-visual-verdict",
+    "category": "arch",
+    "description": "OMC implements \\\"visual-verdict\\\" as: Structured visual QA verdict for screenshot-to-reference comparisons",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "visual-verdict"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-visual-verdict.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-wiki",
+    "slug": "oh-my-claudecode-wiki",
+    "category": "arch",
+    "description": "OMC implements \\\"wiki\\\" as: LLM Wiki — persistent markdown knowledge base that compounds across sessions (Karpathy model)",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "wiki"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-wiki.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oh-my-claudecode-writer-memory",
+    "slug": "oh-my-claudecode-writer-memory",
+    "category": "arch",
+    "description": "OMC implements \\\"writer-memory\\\" as: Agentic memory system for writers - track characters, relationships, scenes, and themes",
+    "tags": [
+      "external-reference",
+      "oh-my-claudecode",
+      "omc",
+      "workflow",
+      "writer-memory"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/oh-my-claudecode-writer-memory.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "openapi-as-single-fe-be-contract",
+    "slug": "openapi-as-single-fe-be-contract",
+    "category": "arch",
+    "description": "Use OpenAPI 3.0 as the only intermediate artifact between planning and codegen; both FE and BE generators consume the same file",
+    "tags": [
+      "openapi",
+      "contract",
+      "codegen",
+      "fe-be-alignment",
+      "interop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/openapi-as-single-fe-be-contract.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "plugin-architecture-runtime-vs-startup-loading",
+    "slug": "plugin-architecture-runtime-vs-startup-loading",
+    "category": "arch",
+    "description": "Scouter server loads hot-reloadable script plugins (.plug files) for alerts/filters and compiled JAR plugins for stateful data handlers (sinks, connection-pool-heavy integrations)",
+    "tags": [
+      "plugin",
+      "extensibility",
+      "scouter"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/plugin-architecture-runtime-vs-startup-loading.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "polymorphic-metadata-via-enum-switch",
+    "slug": "polymorphic-metadata-via-enum-switch",
+    "category": "arch",
+    "description": "Store heterogeneous domain payloads under one field as raw Document, then deserialize with Gson chosen by an enum discriminator",
+    "tags": [
+      "polymorphism",
+      "bson",
+      "gson",
+      "mongodb",
+      "discriminator",
+      "content-type"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/polymorphic-metadata-via-enum-switch.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "port-out-no-optional-raise-in-adapter",
+    "slug": "port-out-no-optional-raise-in-adapter",
+    "category": "arch",
+    "description": "In hexagonal codegen, single-record lookups should raise a domain exception inside the Adapter rather than return `Optional<T>` from the Port-Out interface",
+    "tags": [
+      "hexagonal",
+      "port-out",
+      "optional",
+      "exception-handling",
+      "error-code"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/port-out-no-optional-raise-in-adapter.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "published-vs-realtime-view-pages",
+    "slug": "published-vs-realtime-view-pages",
+    "category": "arch",
+    "description": "PublishedViewPage renders a frozen deploy snapshot; RealTimeViewPage renders the live editable dashboard",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/published-vs-realtime-view-pages.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "redis-change-counter-for-versioning-trigger",
+    "slug": "redis-change-counter-for-versioning-trigger",
+    "category": "arch",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/redis-change-counter-for-versioning-trigger.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "scouter-three-tier-architecture",
+    "slug": "scouter-three-tier-architecture",
+    "category": "arch",
+    "description": "Scouter APM enforces strict agent → server → client separation, with an optional standalone HTTP webapp for horizontal scaling of query load",
+    "tags": [
+      "apm",
+      "architecture",
+      "tiered",
+      "scouter"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/scouter-three-tier-architecture.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "scss-css-variable-theme-system",
+    "slug": "scss-css-variable-theme-system",
+    "category": "arch",
+    "description": "Architecture decision — SCSS + CSS custom properties + data-theme attribute for dark/light theming in a large React monorepo",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/scss-css-variable-theme-system.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "shallow-clone-mktemp-cleanup-pattern",
+    "slug": "shallow-clone-mktemp-cleanup-pattern",
+    "category": "arch",
+    "description": "publish/install/원격 목록 조회처럼 원격 git repo를 만질 때는 `mktemp -d → git clone --depth 1 → 작업 → rm -rf`. 작업 디렉토리를 오염시키지 않는다.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/shallow-clone-mktemp-cleanup-pattern.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "sirius-component-taxonomy",
+    "slug": "sirius-component-taxonomy",
+    "category": "arch",
+    "description": "Sirius design system (@nkia/sirius) organizes 200+ components into 5 categories — data-display, data-entry, feedback, layout, navigation",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/sirius-component-taxonomy.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "sirius-wraps-antd-design-system",
+    "slug": "sirius-wraps-antd-design-system",
+    "category": "arch",
+    "description": "Sirius design system wraps Ant Design components instead of replacing them — rationale, extension pattern, and upgrade implications",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/sirius-wraps-antd-design-system.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "tenant-context-per-request-interceptor",
+    "slug": "tenant-context-per-request-interceptor",
+    "category": "arch",
+    "description": "Extract tenant id from JWT/header in preHandle, store in ThreadLocal, clear in afterCompletion to isolate multi-tenant data access",
+    "tags": [
+      "multi-tenancy",
+      "thread-local",
+      "spring-mvc",
+      "interceptor",
+      "mongodb"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/tenant-context-per-request-interceptor.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "wait-for-services-eureka-startup-init",
+    "slug": "wait-for-services-eureka-startup-init",
+    "category": "arch",
+    "description": "Defer schema/index/data bootstrap until named services report ready in discovery, with bounded exponential backoff and leader election",
+    "tags": [
+      "startup",
+      "service-discovery",
+      "eureka",
+      "zookeeper",
+      "leader-election",
+      "event-driven"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/wait-for-services-eureka-startup-init.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "widget-is-frozen-group-snapshot",
+    "slug": "widget-is-frozen-group-snapshot",
+    "category": "arch",
+    "description": "Widgets are snapshots of a group at save time; later edits to the source group do not propagate",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/widget-is-frozen-group-snapshot.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "yorkie-team-server-split",
+    "slug": "yorkie-team-server-split",
+    "category": "arch",
+    "description": "Yorkie holds live canvas state; the team server holds metadata (projects, assets, datasources) — never mix",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/yorkie-team-server-split.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "actuator-endpoints-skip-auth-by-design",
+    "slug": "actuator-endpoints-skip-auth-by-design",
+    "category": "decision",
+    "description": "In a monitoring collector, target-level BASIC/BEARER auth is stored but intentionally NOT applied when calling /actuator/health and /actuator/metrics.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/actuator-endpoints-skip-auth-by-design.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "admin-role-disabled-secretkey",
+    "slug": "admin-role-disabled-secretkey",
+    "category": "decision",
+    "description": "Default `admins` role is disabled and the shared `SecretKey` was removed from `config.properties` — never re-enable without a per-install key",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/admin-role-disabled-secretkey.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "alarm-raw-over-1min-aggregate",
+    "slug": "alarm-raw-over-1min-aggregate",
+    "category": "decision",
+    "description": "Alarm judgement reads raw metrics, not 1-minute aggregates — accuracy over storage cost",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/alarm-raw-over-1min-aggregate.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "always-pr-branch-never-direct-push",
+    "slug": "always-pr-branch-never-direct-push",
+    "category": "decision",
+    "description": "Always create a feature branch and PR for shared repos — never push directly to main, even for 'obvious' additions",
+    "tags": [
+      "git",
+      "pr",
+      "workflow",
+      "shared-repo",
+      "review"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/always-pr-branch-never-direct-push.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "assume-semantics-for-compiler-hints",
+    "slug": "assume-semantics-for-compiler-hints",
+    "category": "decision",
+    "description": "Three-tier assertion strategy (Assert / CHECK_NONFATAL / Assume) separates fatal invariants from recoverable logic bugs and pure compiler hints.",
+    "tags": [
+      "cpp",
+      "assertions",
+      "invariants",
+      "design"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/assume-semantics-for-compiler-hints.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "avro-private-fields-no-setters",
+    "slug": "avro-private-fields-no-setters",
+    "category": "decision",
+    "description": "Avro-generated classes are configured with `fieldVisibility=PRIVATE` and `createSetters=false` to enforce immutability on event payloads",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/avro-private-fields-no-setters.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "cache-even-when-enable-false",
+    "slug": "cache-even-when-enable-false",
+    "category": "decision",
+    "description": "Notification configs with `enable=false` are still loaded into the cache manager rather than skipped, so toggling enable on/off doesn't require a cache reload",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/cache-even-when-enable-false.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "caveats-absence-confidence-cap",
+    "slug": "caveats-absence-confidence-cap",
+    "category": "decision",
+    "description": "반증 조건(Counter/Caveats)이 비어 있는 knowledge는 confidence 최대 medium으로 강등한다 — 미확인 = 과신 위험",
+    "tags": [
+      "calibration",
+      "confidence",
+      "falsifiability",
+      "knowledge-quality"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/caveats-absence-confidence-cap.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "circular-dependency-detection-script",
+    "slug": "circular-dependency-detection-script",
+    "category": "decision",
+    "description": "A small Python script that parses #include directives across the tree and reports the shortest cycle in the module graph — cheap CI gate against architectural decay.",
+    "tags": [
+      "cpp",
+      "build",
+      "dependencies",
+      "tooling",
+      "ci"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/circular-dependency-detection-script.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "confid-only-query-over-resource-tuple",
+    "slug": "confid-only-query-over-resource-tuple",
+    "category": "decision",
+    "description": "Performance queries key off `confId` (config id) whenever available, falling back to (resourceType, resourceName) only when confId is absent",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/confid-only-query-over-resource-tuple.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "copy-naming-suffix-numbered",
+    "slug": "copy-naming-suffix-numbered",
+    "category": "decision",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/copy-naming-suffix-numbered.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "cors-allow-credentials-star-origin",
+    "slug": "cors-allow-credentials-star-origin",
+    "category": "decision",
+    "description": "서비스 레벨 allowCredentials=true + allowedOriginPatterns(\"*\") 유지 — 엣지(Traefik/Istio)에서 CORS를 제어하는 아키텍처 전제",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/cors-allow-credentials-star-origin.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "csp-frame-ancestors-required",
+    "slug": "csp-frame-ancestors-required",
+    "category": "decision",
+    "description": "Send a Content-Security-Policy header (including `frame-ancestors`) on every response to block clickjacking",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/csp-frame-ancestors-required.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "dashboard-decoration-vs-evidence",
+    "slug": "dashboard-decoration-vs-evidence",
+    "category": "decision",
+    "description": "When designing monitoring dashboards for automation pipelines, prioritize visible evidence of system behavior over decorative animations",
+    "tags": [
+      "ui",
+      "dashboards",
+      "monitoring",
+      "automation"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/dashboard-decoration-vs-evidence.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "dataavro-json-wrapper-pattern",
+    "slug": "dataavro-json-wrapper-pattern",
+    "category": "decision",
+    "description": "여러 이벤트 타입마다 Avro 스키마를 만들지 않고 DataAvro{jsonData,jsonDataClass} 하나로 통일 — TCM 선례 채택",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/dataavro-json-wrapper-pattern.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "do-not-ask-planners-for-api-design",
+    "slug": "do-not-ask-planners-for-api-design",
+    "category": "decision",
+    "description": "Product planners own screens and UX, not endpoint shapes — push API design to AI extraction + developer review instead of template-driven planner input",
+    "tags": [
+      "planning-doc",
+      "api-design",
+      "role-boundary",
+      "ai-extraction",
+      "review-gate"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/do-not-ask-planners-for-api-design.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "drawer-over-modal",
+    "slug": "drawer-over-modal",
+    "category": "decision",
+    "description": "Decision to use side drawers (463 files) instead of centered modals (10 usages) as the primary overlay pattern",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/drawer-over-modal.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "existing-code-patterns-over-standard-rules",
+    "slug": "existing-code-patterns-over-standard-rules",
+    "category": "decision",
+    "description": "When generating into an established repo, mirror the repo's existing style first; apply the written standard only when the repo is empty or silent",
+    "tags": [
+      "codegen",
+      "style-matching",
+      "convention",
+      "rulebook",
+      "hexagonal"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/existing-code-patterns-over-standard-rules.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "fifth-normal-form-join-dependency-tradeoff",
+    "slug": "fifth-normal-form-join-dependency-tradeoff",
+    "category": "decision",
+    "description": "5NF catches join dependencies that 4NF/BCNF miss, but in practice you rarely reason about it directly — design from business entities, recognize AB-BC-AC triangles vs ABC+D stars, and let 5NF fall out.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/fifth-normal-form-join-dependency-tradeoff.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "flat-vs-categorized-folder-structure",
+    "slug": "flat-vs-categorized-folder-structure",
+    "category": "decision",
+    "description": "When a content folder crosses ~100 entries, flat structure becomes unnavigable — categorize into ~15–30 semantic buckets even if the tool doesn't require it",
+    "tags": [
+      "directory-structure",
+      "scalability",
+      "content-organization"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/flat-vs-categorized-folder-structure.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "god-controller-split-by-resource",
+    "slug": "god-controller-split-by-resource",
+    "category": "decision",
+    "description": "Split an oversized controller along URL sub-resource boundaries (one controller per sub-path like /page, /widget, /file) and keep the common @RequestMapping prefix — clearer per-class responsibility without breaking the external API surface.",
+    "tags": [
+      "refactor",
+      "controller",
+      "srp",
+      "spring"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/god-controller-split-by-resource.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "hub-soft-delete-via-frontmatter-flag",
+    "slug": "hub-soft-delete-via-frontmatter-flag",
+    "category": "decision",
+    "description": "Skills-hub retires low-value entries via an `archived: true` frontmatter flag — never via file deletion. Installers and sync commands skip archived entries; git history remains intact for auditability and un-archive.",
+    "tags": [
+      "skills-hub",
+      "archive",
+      "soft-delete",
+      "frontmatter",
+      "decision"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/hub-soft-delete-via-frontmatter-flag.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "hyperloglog-for-unique-user-counting",
+    "slug": "hyperloglog-for-unique-user-counting",
+    "category": "decision",
+    "description": "Scouter uses HyperLogLog (Clearspring stream-lib) to estimate recent and daily unique user counts with ~100 bytes of memory and ~2% error, avoiding O(n) hash sets",
+    "tags": [
+      "hyperloglog",
+      "cardinality",
+      "decision",
+      "scouter"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/hyperloglog-for-unique-user-counting.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "jacoco-exclude-business-layers",
+    "slug": "jacoco-exclude-business-layers",
+    "category": "decision",
+    "description": "In this project's Jacoco config, nearly every layer (service, repository, dto, entity, kafka, config, constants, helper, exception, schedule, provider) is excluded from coverage measurement — only controllers/business orchestration code is measured.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/jacoco-exclude-business-layers.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "jacoco-sonar-exclusion-policy",
+    "slug": "jacoco-sonar-exclusion-policy",
+    "category": "decision",
+    "description": "Single exclusion list drives Jacoco + Sonar + test excludes; generated/boilerplate code never counts toward coverage",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/jacoco-sonar-exclusion-policy.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "jacoco-sonar-exclusion-rationale",
+    "slug": "jacoco-sonar-exclusion-rationale",
+    "category": "decision",
+    "description": "Classes under config/, dto/, entity/, kafka/, avro/, exception/, advice/, schedule/, service/websocket/, and generated Q-classes are excluded from Jacoco coverage gates. Only business logic (routers, guards, services) is measured.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/jacoco-sonar-exclusion-rationale.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "java-21-upgrade-rationale",
+    "slug": "java-21-upgrade-rationale",
+    "category": "decision",
+    "description": "Java 17 → 21 + Spring Boot 3.5.x upgrade rationale and required Gradle/JVM flag adjustments",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/java-21-upgrade-rationale.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "jest-coverage-80-threshold",
+    "slug": "jest-coverage-80-threshold",
+    "category": "decision",
+    "description": "Global Jest coverage threshold is 80% on branches, functions, lines, and statements",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/jest-coverage-80-threshold.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "json-clone-reducer-state-constraint",
+    "slug": "json-clone-reducer-state-constraint",
+    "category": "decision",
+    "description": "`JSON.parse(JSON.stringify(state))` is sufficient for pure-reducer immutability only when state is JSON-safe — it silently drops `Date`, `Map`, `Set`, `RegExp`, functions, and `undefined`.",
+    "tags": [
+      "canvas",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/json-clone-reducer-state-constraint.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "jwt-stateless-refresh-24h-default",
+    "slug": "jwt-stateless-refresh-24h-default",
+    "category": "decision",
+    "description": "JWT stateless auth with 1h access / 24h refresh token defaults, both env-tunable.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/jwt-stateless-refresh-24h-default.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "k-kafka-message-header-metadata",
+    "slug": "k-kafka-message-header-metadata",
+    "category": "decision",
+    "description": "멀티테넌트 Kafka routing 메타는 payload 대신 RecordHeader에 두어 business schema 오염을 막는다",
+    "tags": [
+      "kafka",
+      "multi-tenant",
+      "routing",
+      "message-schema"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/k-kafka-message-header-metadata.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "kafka-batch-size-timeout-tuning",
+    "slug": "kafka-batch-size-timeout-tuning",
+    "category": "decision",
+    "description": "Lowering Spring Kafka max-poll-records (e.g. 200→10) on heavy-processing consumers prevents max.poll.interval.ms timeouts and rebalance storms",
+    "tags": [
+      "kafka",
+      "spring-kafka",
+      "max-poll-records",
+      "max-poll-interval-ms",
+      "rebalance"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/kafka-batch-size-timeout-tuning.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "large-range-query-raw-collections",
+    "slug": "large-range-query-raw-collections",
+    "category": "decision",
+    "description": "For long time-range analytics over day-partitioned data, query the daily raw collections directly rather than going through an aggregated view to avoid query timeouts.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/large-range-query-raw-collections.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "less-antd-theme-only",
+    "slug": "less-antd-theme-only",
+    "category": "decision",
+    "description": "LESS files (71 total) and less-loader exist solely for Ant Design modifyVars theming — LESS is not a general-purpose styling choice in this project",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/less-antd-theme-only.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "license-apply-window-15d",
+    "slug": "license-apply-window-15d",
+    "category": "decision",
+    "description": "Issued licenses must be applied within 15 days; expired licenses are immutable.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/license-apply-window-15d.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "measurement-batch-send-per-config",
+    "slug": "measurement-batch-send-per-config",
+    "category": "decision",
+    "description": "Send one bundled Kafka message per target per tick containing all metrics, instead of one message per (target, metric).",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/measurement-batch-send-per-config.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "node-npm-pin-matches-jenkins",
+    "slug": "node-npm-pin-matches-jenkins",
+    "category": "decision",
+    "description": "UI build is pinned to Node 24.6.0 + npm 11.5.1 to match the Jenkins build environment",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/node-npm-pin-matches-jenkins.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "organization-soft-delete-grace-period",
+    "slug": "organization-soft-delete-grace-period",
+    "category": "decision",
+    "description": "Organization deletion uses a 30-day grace period before permanent removal (DELETE_ORGANIZATION_INTERVAL_DAYS).",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/organization-soft-delete-grace-period.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "planning-doc-in-issue-description",
+    "slug": "planning-doc-in-issue-description",
+    "category": "decision",
+    "description": "For AI pipelines that read planning docs from issue trackers, favor putting the full markdown in the issue description over wiki-link indirection",
+    "tags": [
+      "issue-tracker",
+      "planning-doc",
+      "redmine",
+      "ai-ingestion",
+      "single-source"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/planning-doc-in-issue-description.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "plugin-repo-scope-generic-skills-only",
+    "slug": "plugin-repo-scope-generic-skills-only",
+    "category": "decision",
+    "description": "nkia-skills 같은 공용 플러그인에는 범용 스킬만. 프로젝트 특화 스킬은 각 프로젝트의 `.claude/skills/`에 둔다.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/plugin-repo-scope-generic-skills-only.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "postgres-version-rolling-support",
+    "slug": "postgres-version-rolling-support",
+    "category": "decision",
+    "description": "Roll PostgreSQL major-version support forward incrementally (9.x → 18) rather than pinning one LTS",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/postgres-version-rolling-support.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "prefer-static-import-over-constant-inheritance",
+    "slug": "prefer-static-import-over-constant-inheritance",
+    "category": "decision",
+    "description": "Access shared constants via `import static SomeConstants.*` instead of `extends SomeConstants` — inheritance for constants pollutes the single-inheritance slot, leaks protected visibility, and makes subclasses nonsensically \\\"is-a\\\" a constants bag.",
+    "tags": [
+      "java",
+      "refactor",
+      "anti-pattern",
+      "constants"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/prefer-static-import-over-constant-inheritance.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "push-local-removed-use-doc-update",
+    "slug": "push-local-removed-use-doc-update",
+    "category": "decision",
+    "description": "pushLocalChangesIntoRemote and its action-mapping helpers were removed; mutate Yorkie via doc.update directly",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/push-local-removed-use-doc-update.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "query-manager-version-conversion-fallback",
+    "slug": "query-manager-version-conversion-fallback",
+    "category": "decision",
+    "description": "Unknown target RDBMS versions fall back to a documented default bucket rather than erroring, keeping collection alive",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/query-manager-version-conversion-fallback.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "rcp-desktop-client-design-rationale-vs-saas-web",
+    "slug": "rcp-desktop-client-design-rationale-vs-saas-web",
+    "category": "decision",
+    "description": "Scouter chose an Eclipse RCP desktop client over a browser UI to enable high-throughput binary streams, local caching, and real-time drill-down without HTTP/JSON overhead",
+    "tags": [
+      "rcp",
+      "desktop",
+      "decision",
+      "apm",
+      "scouter"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/rcp-desktop-client-design-rationale-vs-saas-web.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "recoil-over-redux",
+    "slug": "recoil-over-redux",
+    "category": "decision",
+    "description": "Decision to use Recoil atoms (2697 usages, 53 store files) as sole state management instead of Redux in a 25-remote MFA monorepo",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/recoil-over-redux.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "resource-mount-unmount-use-jar-defaults",
+    "slug": "resource-mount-unmount-use-jar-defaults",
+    "category": "decision",
+    "description": "Don't bind-mount i18n/exception/menu resource files into Spring Boot containers; let the jar ship its own defaults",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/resource-mount-unmount-use-jar-defaults.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "save-child-only-when-changed",
+    "slug": "save-child-only-when-changed",
+    "category": "decision",
+    "description": "When reconciling parent→child configurations, persistence is conditional on \"new\" or \"resourceName/tags changed\". Unconditional save caused unnecessary write load and spurious change events.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/save-child-only-when-changed.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "scatter-topic-1min-retention",
+    "slug": "scatter-topic-1min-retention",
+    "category": "decision",
+    "description": "Per-tenant scatter-plot/summary topics use 60s retention; metric-history topics use the cluster default. Class-of-data drives retention, not tenant.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/scatter-topic-1min-retention.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "skill-registry-vs-skill-config-split",
+    "slug": "skill-registry-vs-skill-config-split",
+    "category": "decision",
+    "description": "원격 저장소 정보는 `.claude/skill-registry.yaml`, 스킬별 런타임 옵션(출력 경로 등)은 `.claude/skill-config.yaml`. 파일 단위로 관심사 분리.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/skill-registry-vs-skill-config-split.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "stub-in-service-unblocks-fe-parallelism",
+    "slug": "stub-in-service-unblocks-fe-parallelism",
+    "category": "decision",
+    "description": "Emit stub return values inside generated Service methods (tagged `// STUB:`) so FE can connect to a live BE without waiting on business logic",
+    "tags": [
+      "codegen",
+      "stub",
+      "fe-be-parallelism",
+      "hexagonal",
+      "service-layer"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/stub-in-service-unblocks-fe-parallelism.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "system-notification-shared-with-2fa-and-password-find",
+    "slug": "system-notification-shared-with-2fa-and-password-find",
+    "category": "decision",
+    "description": "The `system_notification` config (SMTP/SMS credentials) is intentionally shared between 2FA and password-find flows rather than duplicated per flow",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/system-notification-shared-with-2fa-and-password-find.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "tabular-metric-excluded-from-list",
+    "slug": "tabular-metric-excluded-from-list",
+    "category": "decision",
+    "description": "TABULAR measurement type is intentionally excluded from searchable metric-definition list endpoints",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/tabular-metric-excluded-from-list.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "tag-values-separate-collection",
+    "slug": "tag-values-separate-collection",
+    "category": "decision",
+    "description": "TagValueInfo's `values` array was extracted from the parent tag document into a separate `tag_value_detail` collection to bound document size and index cost.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/tag-values-separate-collection.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "tomcat-request-timeout-1h-for-oz-report",
+    "slug": "tomcat-request-timeout-1h-for-oz-report",
+    "category": "decision",
+    "description": "Report-generation services should raise Tomcat connection/read timeout to ~1 hour because export of large OZ/Jasper reports is genuinely long-running",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/tomcat-request-timeout-1h-for-oz-report.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "triple-styling-paradigm-coexistence",
+    "slug": "triple-styling-paradigm-coexistence",
+    "category": "decision",
+    "description": "Why Tailwind CSS, SCSS modules, and styled-components coexist in the same codebase — migration path, isolation needs, and legacy constraints",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/triple-styling-paradigm-coexistence.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "typed-wikilinks-for-llm-knowledge-base",
+    "slug": "typed-wikilinks-for-llm-knowledge-base",
+    "category": "decision",
+    "description": "Flat `[[wikilinks]]` carry one bit of information. For an LLM-facing knowledge base, tag every link with a relationship type (supersedes, contradicts, causes, supports) so the graph is queryable rather than just traversable.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/typed-wikilinks-for-llm-knowledge-base.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "udp-for-throughput-tcp-for-reliability",
+    "slug": "udp-for-throughput-tcp-for-reliability",
+    "category": "decision",
+    "description": "Scouter streams periodic metrics over UDP (lossy but cheap) and reserves TCP for config fetch, agent registration, and XLog profile uploads that demand delivery guarantees",
+    "tags": [
+      "network",
+      "udp",
+      "tcp",
+      "decision",
+      "apm"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/udp-for-throughput-tcp-for-reliability.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "variable-length-integer-encoding-for-metrics-bandwidth",
+    "slug": "variable-length-integer-encoding-for-metrics-bandwidth",
+    "category": "decision",
+    "description": "Scouter's DataOutputX uses 3-byte (INT3) and 5-byte (LONG5) integer encodings to shrink UDP metric packs by 20-40% when most values fit within 24 / 40 bits",
+    "tags": [
+      "varint",
+      "encoding",
+      "perf",
+      "decision",
+      "scouter"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/variable-length-integer-encoding-for-metrics-bandwidth.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "vllm-kv-cache-fp8-with-mtp",
+    "slug": "vllm-kv-cache-fp8-with-mtp",
+    "category": "decision",
+    "description": "vLLM serving chose fp8_e4m3 KV cache + prefix caching + MTP speculative decoding for Qwen3.5 throughput",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/vllm-kv-cache-fp8-with-mtp.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "account-lockout-configurable-threshold",
+    "slug": "account-lockout-configurable-threshold",
+    "category": "domain",
+    "description": "Failed-login counter locks the account after a configurable threshold (ACCOUNT_LOCKOUT, default 10).",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/domain/account-lockout-configurable-threshold.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "encrypted-pii-decode-on-export",
+    "slug": "encrypted-pii-decode-on-export",
+    "category": "domain",
+    "description": "PII fields (phone, email) are stored encrypted; only decrypted for explicit export/API response, never for logs.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/domain/encrypted-pii-decode-on-export.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mongodb-exclude-system-databases",
+    "slug": "mongodb-exclude-system-databases",
+    "category": "domain",
+    "description": "When enumerating tenant databases in a shared MongoDB cluster, filter out admin/config/local plus third-party DBs (yorkie-meta, migration) to avoid touching shared state",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/domain/mongodb-exclude-system-databases.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mysql-mariadb-performance-schema-detection",
+    "slug": "mysql-mariadb-performance-schema-detection",
+    "category": "domain",
+    "description": "MySQL/MariaDB metric availability depends on per-instance Performance Schema state; detect at runtime, don't assume",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/domain/mysql-mariadb-performance-schema-detection.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "one-default-template-per-type-rule",
+    "slug": "one-default-template-per-type-rule",
+    "category": "domain",
+    "description": "Exactly one default message template may exist per notification type; creating a second default is rejected, but editing the existing default is allowed",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/domain/one-default-template-per-type-rule.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "period-interval-naming-convention",
+    "slug": "period-interval-naming-convention",
+    "category": "domain",
+    "description": "Period.Mode names encode both unit and multiplier (MIN_15, MONTH_2); monthly modes densify at 24h, not the unit itself",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/domain/period-interval-naming-convention.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "pims-write-requires-dryrun-confirm",
+    "slug": "pims-write-requires-dryrun-confirm",
+    "category": "domain",
+    "description": "PIMS 시간 기록/제출/일괄 갱신 등 모든 쓰기 API는 미리보기 → 사용자 확인 → 재시도 가능한 실행 플로우를 반드시 거친다. `--dry-run`은 API 쓰기 호출 자체가 금지.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/domain/pims-write-requires-dryrun-confirm.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "root-span-error-propagation",
+    "slug": "root-span-error-propagation",
+    "category": "domain",
+    "description": "A trace's root-span isError flag must aggregate descendant span errors; otherwise scatter and list views disagree about which traces errored.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/domain/root-span-error-propagation.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "topresource-immediate-generation-invariant",
+    "slug": "topresource-immediate-generation-invariant",
+    "category": "domain",
+    "description": "In report immediate-generation, the topResource flag decides whether to query by resource-id (fast path) or the full conf-id set (slow path)",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/domain/topresource-immediate-generation-invariant.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "actor-model-implementation-pitfall",
+    "slug": "actor-model-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Shared mutable state and blocking calls silently break actor-model guarantees",
+    "tags": [
+      "actor",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/actor-model-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "actuator-metric-call-aggressive-timeout",
+    "slug": "actuator-metric-call-aggressive-timeout",
+    "category": "pitfall",
+    "description": "Use aggressive HTTP timeouts (100ms–1s) for /actuator/health and /actuator/metrics polling, but keep long timeouts for /actuator/threaddump and /actuator/heapdump — mixing them stalls the collector.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/actuator-metric-call-aggressive-timeout.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "ai-guess-mark-and-review-checklist",
+    "slug": "ai-guess-mark-and-review-checklist",
+    "category": "pitfall",
+    "description": "When AI fills gaps the source doc doesn't specify, annotate the guess inline and output a review checklist alongside the artifact",
+    "tags": [
+      "ai-inference",
+      "uncertainty",
+      "review",
+      "openapi-extraction",
+      "transparency"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/ai-guess-mark-and-review-checklist.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "anonymize-examples-in-skill-docs",
+    "slug": "anonymize-examples-in-skill-docs",
+    "category": "pitfall",
+    "description": "실사 티켓 번호·실명·프로젝트명이 예시에 들어가면 보안 감사에서 지적됨. 공용 repo 기준 모든 예시는 익명 더미여야 한다.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/anonymize-examples-in-skill-docs.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "api-gateway-pattern-implementation-pitfall",
+    "slug": "api-gateway-pattern-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Conflating gateway-added latency with backend latency and letting rate-limit state leak across gateway replicas",
+    "tags": [
+      "api",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/api-gateway-pattern-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "api-versioning-implementation-pitfall",
+    "slug": "api-versioning-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common traps when building API version visualizations: off-by-one lifecycle states, diff semantic loss, and traffic share math",
+    "tags": [
+      "api",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/api-versioning-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "arbitrary-display-caps-hide-signal",
+    "slug": "arbitrary-display-caps-hide-signal",
+    "category": "pitfall",
+    "description": "Hardcoded `slice(0, N)` display limits in UI code silently cap counts below actual data, making users distrust the pipeline even when it works correctly",
+    "tags": [
+      "ui",
+      "dashboards",
+      "monitoring",
+      "debugging"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/arbitrary-display-caps-hide-signal.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "asm-based-classloader-instrumentation-caveats",
+    "slug": "asm-based-classloader-instrumentation-caveats",
+    "category": "pitfall",
+    "description": "ASM-based JVM agents miss Java 8+ lambda forms, annotation-processor classes, and Spring proxies unless explicitly handled; misses manifest as XLog gaps or skipped trace points",
+    "tags": [
+      "asm",
+      "pitfall",
+      "instrumentation",
+      "lambda",
+      "jvm"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/asm-based-classloader-instrumentation-caveats.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "audit-changed-prev-after-field-swap-bug",
+    "slug": "audit-changed-prev-after-field-swap-bug",
+    "category": "pitfall",
+    "description": "Audit diff logic had before/after swapped — iterating the wrong doc and putting the wrong value into changedPrev corrupted the audit trail silently",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/audit-changed-prev-after-field-swap-bug.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "auto-default-until-user-edit-dataset-flag",
+    "slug": "auto-default-until-user-edit-dataset-flag",
+    "category": "pitfall",
+    "description": "Track whether a prefilled form field is still \"auto\" via a dataset flag so regeneration doesn't clobber user edits.",
+    "tags": [
+      "fnv1a",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/auto-default-until-user-edit-dataset-flag.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "auto-lock-must-not-bump-lastEditedTime",
+    "slug": "auto-lock-must-not-bump-lastEditedTime",
+    "category": "pitfall",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/auto-lock-must-not-bump-lastEditedTime.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "backpressure-implementation-pitfall",
+    "slug": "backpressure-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Conflating rate limiting with backpressure hides the upstream feedback loop that defines it",
+    "tags": [
+      "backpressure",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/backpressure-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "bff-pattern-implementation-pitfall",
+    "slug": "bff-pattern-implementation-pitfall",
+    "category": "pitfall",
+    "description": "BFFs silently become distributed monoliths when teams share one BFF across clients or let it accumulate business logic",
+    "tags": [
+      "bff",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/bff-pattern-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "binsize-zero-fallback-to-one",
+    "slug": "binsize-zero-fallback-to-one",
+    "category": "pitfall",
+    "description": "Substitute binSize=1 whenever the computed interval is 0 in MongoDB time-bucket aggregation",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/binsize-zero-fallback-to-one.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "bloom-filter-implementation-pitfall",
+    "slug": "bloom-filter-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Hash independence, bit-array indexing, and removal semantics are the common breakage points",
+    "tags": [
+      "bloom",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/bloom-filter-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "blue-green-deploy-implementation-pitfall",
+    "slug": "blue-green-deploy-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common modeling mistakes when visualizing blue-green cutovers — instant flip, color-coded active state, ignored drain phase",
+    "tags": [
+      "blue",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/blue-green-deploy-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "bulkhead-implementation-pitfall",
+    "slug": "bulkhead-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common mistakes that silently defeat bulkhead isolation in visualizations and real systems",
+    "tags": [
+      "bulkhead",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/bulkhead-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "canary-release-implementation-pitfall",
+    "slug": "canary-release-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common traps when modeling canary releases — low-volume gate noise, symmetric SLOs, and instant weight shifts",
+    "tags": [
+      "canary",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/canary-release-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "canvas-event-coord-devicepixel-rescale",
+    "slug": "canvas-event-coord-devicepixel-rescale",
+    "category": "pitfall",
+    "description": "Pointer coords on a responsive canvas must be rescaled by `canvas.width / rect.width` — using raw `clientX - rect.left` mis-hits whenever CSS size differs from the backing store size.",
+    "tags": [
+      "canvas",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/canvas-event-coord-devicepixel-rescale.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "catalina-urlencoder-internal-api",
+    "slug": "catalina-urlencoder-internal-api",
+    "category": "pitfall",
+    "description": "org.apache.catalina.util.URLEncoder는 톰캣 내부 API — 컨테이너 교체/버전업에 깨지기 쉽다. java.net.URLEncoder 또는 Spring UriUtils 사용",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/catalina-urlencoder-internal-api.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "cdc-implementation-pitfall",
+    "slug": "cdc-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common CDC mistakes: losing position state, mishandling tombstones, and breaking transaction boundaries",
+    "tags": [
+      "cdc",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/cdc-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "chaos-engineering-implementation-pitfall",
+    "slug": "chaos-engineering-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common mistakes when building chaos-engineering tooling that make it unsafe or untrustworthy",
+    "tags": [
+      "chaos",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/chaos-engineering-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "child-claude-inherits-parent-hooks",
+    "slug": "child-claude-inherits-parent-hooks",
+    "category": "pitfall",
+    "description": "When spawning Claude CLI from a Node process, the child inherits OMC/session hooks that can hijack the output into side-channels — you only see a confirmation string",
+    "tags": [
+      "claude-cli",
+      "subprocess",
+      "hooks",
+      "orchestration"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/child-claude-inherits-parent-hooks.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "circuit-breaker-implementation-pitfall",
+    "slug": "circuit-breaker-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common bugs when implementing the HALF_OPEN probe state and failure window accounting",
+    "tags": [
+      "circuit",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/circuit-breaker-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "classifier-both-verdict-self-reference",
+    "slug": "classifier-both-verdict-self-reference",
+    "category": "pitfall",
+    "description": "LLM classifier의 both-verdict에 suggested_links를 허용하면 자기 자신을 가리키는 self-link가 나온다 — 링크는 post-process에서 붙일 것",
+    "tags": [
+      "llm",
+      "classifier",
+      "schema",
+      "post-processing",
+      "linking"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/classifier-both-verdict-self-reference.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "claude-plugin-marketplace-owner-required",
+    "slug": "claude-plugin-marketplace-owner-required",
+    "category": "pitfall",
+    "description": "플러그인 설치 스키마 오류: marketplace.json 최상위에 `owner` 객체 없으면 플러그인 설치가 실패.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/claude-plugin-marketplace-owner-required.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "command-query-implementation-pitfall",
+    "slug": "command-query-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common traps when building CQRS command-query separation apps — leaky reads, sync assumptions, and unbounded projections",
+    "tags": [
+      "command",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/command-query-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "common-alarm-policy-init-gotcha",
+    "slug": "common-alarm-policy-init-gotcha",
+    "category": "pitfall",
+    "description": "Policy loader that \"only runs on first boot if records exist\" silently skips later-added policies for tenants that started empty",
+    "tags": [
+      "initialization",
+      "bootstrap",
+      "tenant",
+      "policy-loader",
+      "silent-failure"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/common-alarm-policy-init-gotcha.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "compare-counts-exclude-added-deleted",
+    "slug": "compare-counts-exclude-added-deleted",
+    "category": "pitfall",
+    "description": "An earlier query filtered change-count by `latest` / `added` / `deleted` flags, which silently dropped newly-added resources from the \"number of changes between two points in time\" metric.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/compare-counts-exclude-added-deleted.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "composite-alarm-all-deleted-npe",
+    "slug": "composite-alarm-all-deleted-npe",
+    "category": "pitfall",
+    "description": "Composite/aggregated monitors must validate their child set before reducing — empty aggregation throws NPE",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/composite-alarm-all-deleted-npe.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "conf-info-may-lack-resource-type",
+    "slug": "conf-info-may-lack-resource-type",
+    "category": "pitfall",
+    "description": "The `conf_info` collection is NOT guaranteed to carry `resourceType` for every metric; criteria builders must tolerate missing field",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/conf-info-may-lack-resource-type.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "connection-pool-implementation-pitfall",
+    "slug": "connection-pool-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common errors when modeling or implementing connection pool visualizers, simulators, and config labs",
+    "tags": [
+      "connection",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/connection-pool-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "consistent-hashing-implementation-pitfall",
+    "slug": "consistent-hashing-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common correctness and distribution pitfalls when implementing consistent hashing rings and virtual nodes",
+    "tags": [
+      "consistent",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/consistent-hashing-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "cqrs-implementation-pitfall",
+    "slug": "cqrs-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Treating CQRS as \"just split read/write DBs\" and ignoring projector idempotency, ordering, and rebuild cost.",
+    "tags": [
+      "cqrs",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/cqrs-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "crdt-implementation-pitfall",
+    "slug": "crdt-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common CRDT bugs: naive LWW tiebreaking, OR-Set tag reuse, and counter double-counting on replay",
+    "tags": [
+      "crdt",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/crdt-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "crypto-randomuuid-requires-secure-context",
+    "slug": "crypto-randomuuid-requires-secure-context",
+    "category": "pitfall",
+    "description": "`crypto.randomUUID()` is only defined in secure contexts (HTTPS or localhost); plain-HTTP dev or intranet deployments need an explicit UUID fallback.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/crypto-randomuuid-requires-secure-context.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "data-pipeline-implementation-pitfall",
+    "slug": "data-pipeline-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common mistakes that make pipeline visualizations look broken, lie about state, or degrade at scale",
+    "tags": [
+      "data",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/data-pipeline-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "database-sharding-implementation-pitfall",
+    "slug": "database-sharding-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Modulo sharding's rebalance cost trap and virtual node undersizing cause visualizers to mislead operators about real-world behavior",
+    "tags": [
+      "database",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/database-sharding-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "dead-letter-queue-implementation-pitfall",
+    "slug": "dead-letter-queue-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common failure modes when building DLQ tooling: replay loops, payload loss, and silent growth",
+    "tags": [
+      "dead",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/dead-letter-queue-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "distributed-tracing-implementation-pitfall",
+    "slug": "distributed-tracing-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Clock skew, orphan spans, and sampling bias break tracing visualizations in ways that look like UI bugs",
+    "tags": [
+      "distributed",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/distributed-tracing-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "docker-engine-29-requires-traefik-upgrade",
+    "slug": "docker-engine-29-requires-traefik-upgrade",
+    "category": "pitfall",
+    "description": "Docker Engine 29.x raises the minimum client API to 1.44, breaking older Traefik versions that pin an older API",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/docker-engine-29-requires-traefik-upgrade.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "domain-driven-implementation-pitfall",
+    "slug": "domain-driven-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common failure modes when building tools that model bounded contexts, aggregates, and ubiquitous language",
+    "tags": [
+      "domain",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/domain-driven-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "enum-notnull-comparison-pitfall",
+    "slug": "enum-notnull-comparison-pitfall",
+    "category": "pitfall",
+    "description": "In Java, comparing an enum field with `==` without a null guard NPEs on the left operand; prefer constant-on-the-left or an explicit @NotNull contract",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/enum-notnull-comparison-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "enum-whitelist-blocks-time-based-sqli",
+    "slug": "enum-whitelist-blocks-time-based-sqli",
+    "category": "pitfall",
+    "description": "Validate user-supplied identifiers (metric aliases, column names, value-type keys) against a known definition/enum before they reach any query builder — string-only sinks are still injectable",
+    "tags": [
+      "security",
+      "sql-injection",
+      "mongodb",
+      "validation",
+      "zap"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/enum-whitelist-blocks-time-based-sqli.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "etl-implementation-pitfall",
+    "slug": "etl-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common failures when building ETL visualization UIs that feel wrong to data engineers",
+    "tags": [
+      "etl",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/etl-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "event-sourcing-implementation-pitfall",
+    "slug": "event-sourcing-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Schema evolution and non-deterministic projections break replay guarantees",
+    "tags": [
+      "event",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/event-sourcing-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "executor-agent-bash-permission",
+    "slug": "executor-agent-bash-permission",
+    "category": "pitfall",
+    "description": "Executor sub-agents may not have Bash tool permissions, causing git/shell operations to fail silently",
+    "tags": [
+      "agents",
+      "permissions",
+      "bash",
+      "git",
+      "publishing"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/executor-agent-bash-permission.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "feature-flags-implementation-pitfall",
+    "slug": "feature-flags-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common correctness traps when building feature-flag rollout, dependency, and A/B UIs",
+    "tags": [
+      "feature",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/feature-flags-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "finite-state-machine-implementation-pitfall",
+    "slug": "finite-state-machine-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common FSM bugs: undefined-transition silent no-ops, guard side effects, and async timer drift during state changes.",
+    "tags": [
+      "finite",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/finite-state-machine-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "gh-pr-create-race-with-auto-merge",
+    "slug": "gh-pr-create-race-with-auto-merge",
+    "category": "pitfall",
+    "description": "On repos with auto-merge enabled, `gh pr create` can fail with \\\"No commits between main and <branch>\\\" because the PR was already created AND merged by automation in the time between `git push` and `gh pr create`. Detect this by checking `git merge-base --is-ancestor <branch> origin/main` before assuming failure.",
+    "tags": [
+      "gh-cli",
+      "pull-request",
+      "auto-merge",
+      "race-condition",
+      "pitfall"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/gh-pr-create-race-with-auto-merge.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "graphql-implementation-pitfall",
+    "slug": "graphql-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common failures when rendering schemas, building queries, and handling subscription streams in GraphQL UIs",
+    "tags": [
+      "graphql",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/graphql-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "gridfs-template-upload-data-loss-pitfall",
+    "slug": "gridfs-template-upload-data-loss-pitfall",
+    "category": "pitfall",
+    "description": "MongoDB GridFS uploads can silently drop file bytes if the bucket/db selection or stream flush is wrong — always verify metadata size equals input size",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/gridfs-template-upload-data-loss-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "health-check-implementation-pitfall",
+    "slug": "health-check-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common failure modes when building health-check systems: self-check blind spots, probe-induced load, and stale-cache green lies",
+    "tags": [
+      "health",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/health-check-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "hexagonal-architecture-implementation-pitfall",
+    "slug": "hexagonal-architecture-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Ports become leaky DTO pass-throughs and adapters accumulate domain logic, collapsing the hexagon into layered architecture",
+    "tags": [
+      "hexagonal",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/hexagonal-architecture-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "hibernate-date-format-lowercase",
+    "slug": "hibernate-date-format-lowercase",
+    "category": "pitfall",
+    "description": "Use lowercase `yyyy` for calendar year — `YYYY` is ISO week-year and produces wrong values near Jan 1 / Dec 31",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/hibernate-date-format-lowercase.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "history-view-yearly-partition-pitfall",
+    "slug": "history-view-yearly-partition-pitfall",
+    "category": "pitfall",
+    "description": "A history/reporting view or materialized collection created with a year-bounded clause silently stops returning rows when the calendar year rolls over",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/history-view-yearly-partition-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "hub-scan-must-exclude-external-imports",
+    "slug": "hub-scan-must-exclude-external-imports",
+    "category": "pitfall",
+    "description": "Any cross-corpus heuristic scan (/hub-refactor, /hub-condense, /hub-cleanup) that modifies entries must exclude externally-imported content by default, or it will propose changes that diverge from upstream and break /hub-sync.",
+    "tags": [
+      "skills-hub",
+      "heuristic",
+      "external-import",
+      "upstream-fidelity",
+      "pitfall"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/hub-scan-must-exclude-external-imports.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "idempotency-implementation-pitfall",
+    "slug": "idempotency-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common failure modes when implementing idempotency keys — race conditions, improper scope, and caching the wrong response.",
+    "tags": [
+      "idempotency",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/idempotency-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "injectmocks-generics-type-erasure",
+    "slug": "injectmocks-generics-type-erasure",
+    "category": "pitfall",
+    "description": "@InjectMocks가 제네릭 필드에 Mock을 주입할 때 타입 소거로 잘못된 후보를 고르는 flaky 원인",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/injectmocks-generics-type-erasure.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "ipv6-colon-detection-edge",
+    "slug": "ipv6-colon-detection-edge",
+    "category": "pitfall",
+    "description": "Detecting IPv6 by colon count breaks on compressed notation — use a regex character class",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/ipv6-colon-detection-edge.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "jackson-version-pinning-2.17.1",
+    "slug": "jackson-version-pinning-2.17.1",
+    "category": "pitfall",
+    "description": "Jackson must be pinned via Gradle resolutionStrategy across all com.fasterxml.jackson.* groups to avoid NoSuchMethodError from transitive version drift",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/jackson-version-pinning-2.17.1.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "jdbc-template-var-xml-escape-bypass",
+    "slug": "jdbc-template-var-xml-escape-bypass",
+    "category": "pitfall",
+    "description": "When the template engine XML-escapes values but the downstream channel is raw SQL / plain text, the escaped `&amp; &lt; &gt;` leaks into stored data",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/jdbc-template-var-xml-escape-bypass.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "k8s-clusterrole-aggregation-npe",
+    "slug": "k8s-clusterrole-aggregation-npe",
+    "category": "pitfall",
+    "description": "ClusterRole `aggregationRule` and its `clusterRoleSelectors` are both nullable — iterate only after null-check",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/k8s-clusterrole-aggregation-npe.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "kafka-consumer-group-id-hostname-not-timezone",
+    "slug": "kafka-consumer-group-id-hostname-not-timezone",
+    "category": "pitfall",
+    "description": "Kafka consumer group-id must derive from a stable node identifier (hostname), never from a timezone/locale string — a silent typo will split consumers into unintended groups.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/kafka-consumer-group-id-hostname-not-timezone.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "kafka-error-handling-deserializer-fallback",
+    "slug": "kafka-error-handling-deserializer-fallback",
+    "category": "pitfall",
+    "description": "Wrap Avro/JSON deserializers in ErrorHandlingDeserializer so a single bad record doesn't poison the consumer and crash-loop the container",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/kafka-error-handling-deserializer-fallback.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "kafka-sticky-partitioner-key-null",
+    "slug": "kafka-sticky-partitioner-key-null",
+    "category": "pitfall",
+    "description": "ProducerRecord key=null일 때 Sticky Partitioner가 batch.size 동안 한 파티션에 몰리는 성질 — 소규모 환경에서 Pod 분산 안 보이는 원인",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/kafka-sticky-partitioner-key-null.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "konva-center-coord-system",
+    "slug": "konva-center-coord-system",
+    "category": "pitfall",
+    "description": "Konva node coordinates can be center-based; when converting to top-left boxes subtract half width/height",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/konva-center-coord-system.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "lantern-implementation-pitfall",
+    "slug": "lantern-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common failure modes when building lantern visualizations: additive-blend saturation, flicker desync, and ember leak",
+    "tags": [
+      "lantern",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/lantern-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "latest-availability-deletion-risk",
+    "slug": "latest-availability-deletion-risk",
+    "category": "pitfall",
+    "description": "Latest-availability collection can lose data when upstream source is stale but not actually missing",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/latest-availability-deletion-risk.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "lean-verification-spec-coverage-gap",
+    "slug": "lean-verification-spec-coverage-gap",
+    "category": "pitfall",
+    "description": "Formal proofs cover exactly what the spec formalizes — untrusted parsers and the language runtime, which are usually *not* in the spec, routinely contain the bugs a \"proven correct\" library claims to have eliminated.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/lean-verification-spec-coverage-gap.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "legacy-datasource-naming",
+    "slug": "legacy-datasource-naming",
+    "category": "pitfall",
+    "description": "`dataSource` / `dataSourceFilter` in the codebase actually mean data-pipeline-select and data-pipeline-filter — not datasource",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/legacy-datasource-naming.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "load-balancer-implementation-pitfall",
+    "slug": "load-balancer-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common bugs when implementing load balancer algorithms in a simulation, especially consistent hashing and least-connections",
+    "tags": [
+      "load",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/load-balancer-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "log-aggregation-implementation-pitfall",
+    "slug": "log-aggregation-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common failure modes when building log aggregation visualizations: memory blowup, scroll jank, and meaningless heatmaps",
+    "tags": [
+      "log",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/log-aggregation-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "materialized-view-implementation-pitfall",
+    "slug": "materialized-view-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common mistakes when visualizing or simulating materialized-view refresh semantics",
+    "tags": [
+      "materialized",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/materialized-view-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "message-queue-implementation-pitfall",
+    "slug": "message-queue-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common correctness bugs when implementing queue semantics in browser-based demos",
+    "tags": [
+      "message",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/message-queue-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mf-select-unstable-options-infinite-loop",
+    "slug": "mf-select-unstable-options-infinite-loop",
+    "category": "pitfall",
+    "description": "Custom Select/Dropdown components that accept an `options` array and diff it by reference can infinite-loop when consumed across a Module Federation boundary; prefer pure HTML selects or stabilize the array.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/mf-select-unstable-options-infinite-loop.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mongo-direct-connection-flag",
+    "slug": "mongo-direct-connection-flag",
+    "category": "pitfall",
+    "description": "MongoDB datasource connectionString requires directConnection=true in this deployment",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/mongo-direct-connection-flag.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mongo-timeseries-forced-hint-kills-pushdown",
+    "slug": "mongo-timeseries-forced-hint-kills-pushdown",
+    "category": "pitfall",
+    "description": "Forcing `hint(indexName)` on a MongoDB time-series aggregation bypasses the optimizer's bucket-index rewrite — the plan scans every bucket with `control.min/max.timestamp = [MinKey, MaxKey]` instead of honoring the timestamp predicate.",
+    "tags": [
+      "mongodb",
+      "time-series",
+      "query-hint",
+      "query-optimization"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/mongo-timeseries-forced-hint-kills-pushdown.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mongo-timeseries-match-split-for-pushdown",
+    "slug": "mongo-timeseries-match-split-for-pushdown",
+    "category": "pitfall",
+    "description": "On MongoDB time-series collections, combining timestamp range + metadata filters in a single `$match` disables bucket-level push-down — split into two sequential `$match` stages (timestamp first, metadata second) so the optimizer can synthesize `control.*.timestamp` bounds.",
+    "tags": [
+      "mongodb",
+      "time-series",
+      "query-optimization",
+      "aggregation"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/mongo-timeseries-match-split-for-pushdown.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mongo-timeseries-view-pushdown-broken-8_2_3",
+    "slug": "mongo-timeseries-view-pushdown-broken-8_2_3",
+    "category": "pitfall",
+    "description": "On MongoDB 8.2.3, aggregations run against a view whose source is a time-series collection lose the timestamp bucket-index push-down — hot queries must target the base collection directly. Retest after server upgrades.",
+    "tags": [
+      "mongodb",
+      "time-series",
+      "view",
+      "aggregation",
+      "version-specific"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/mongo-timeseries-view-pushdown-broken-8_2_3.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mongodb-changestream-resubscribe",
+    "slug": "mongodb-changestream-resubscribe",
+    "category": "pitfall",
+    "description": "MongoDB change streams do not self-heal after network hiccups or replica-set elections; must be explicitly stopped and restarted to resume receiving events",
+    "tags": [
+      "mongodb",
+      "changestream",
+      "resilience",
+      "reconnect",
+      "resumetoken"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/mongodb-changestream-resubscribe.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mongodb-compound-index-on-views",
+    "slug": "mongodb-compound-index-on-views",
+    "category": "pitfall",
+    "description": "Spring Data @CompoundIndex annotations on a view-backed @Document class are silently ignored — the annotation must live on the collection-backed class or the collection stays unindexed.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/mongodb-compound-index-on-views.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mongodb-documentreference-lazy-removal",
+    "slug": "mongodb-documentreference-lazy-removal",
+    "category": "pitfall",
+    "description": "Spring Data MongoDB @DocumentReference (even with lazy=true) triggers N+1 queries on bulk reads; replace with explicit $lookup aggregation",
+    "tags": [
+      "mongodb",
+      "spring-data",
+      "documentreference",
+      "n-plus-one",
+      "aggregation",
+      "lookup"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/mongodb-documentreference-lazy-removal.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mongodb-field-name-underscore-to-dot",
+    "slug": "mongodb-field-name-underscore-to-dot",
+    "category": "pitfall",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/mongodb-field-name-underscore-to-dot.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mongodb-single-node-directconnection",
+    "slug": "mongodb-single-node-directconnection",
+    "category": "pitfall",
+    "description": "MongoDB clients must pass directConnection=true when connecting to a single-node replSet, otherwise they hang on primary discovery",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/mongodb-single-node-directconnection.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mongodb-string-id-field-type-mapping",
+    "slug": "mongodb-string-id-field-type-mapping",
+    "category": "pitfall",
+    "description": "Spring Data MongoDB coerces 24-char-hex @Id String values to ObjectId unless @Field(targetType = FieldType.STRING) is set",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/mongodb-string-id-field-type-mapping.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oauth-implementation-pitfall",
+    "slug": "oauth-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common mistakes when building OAuth visualizers and educational tools that misrepresent the protocol",
+    "tags": [
+      "oauth",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/oauth-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "object-storage-implementation-pitfall",
+    "slug": "object-storage-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common mistakes when modeling object storage semantics in visualizations and simulators",
+    "tags": [
+      "object",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/object-storage-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "outbox-pattern-implementation-pitfall",
+    "slug": "outbox-pattern-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common outbox implementation failures around ordering, stuck rows, and at-least-once semantics",
+    "tags": [
+      "outbox",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/outbox-pattern-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oz-license-file-placement-flip-flop",
+    "slug": "oz-license-file-placement-flip-flop",
+    "category": "pitfall",
+    "description": "Vendor engines (OZ Report, Crystal, Jasper-Pro) often hard-code license file search paths — pin the path in the image and document it, or you will ship it broken repeatedly",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/oz-license-file-placement-flip-flop.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "page-map-returns-new-instance",
+    "slug": "page-map-returns-new-instance",
+    "category": "pitfall",
+    "description": "Spring Data Page는 불변 — Page.map()은 새 인스턴스를 반환하므로 호출 결과를 반드시 재할당해야 한다",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/page-map-returns-new-instance.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "pixel-smooth-style-mismatch",
+    "slug": "pixel-smooth-style-mismatch",
+    "category": "pitfall",
+    "description": "Mixing pixel-art character with smooth vector illustration creates jarring visual mismatch — both layers need the same aesthetic",
+    "tags": [
+      "design",
+      "pixel-art",
+      "visual-language",
+      "consistency"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/pixel-smooth-style-mismatch.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "policy-edit-saveraw-loss",
+    "slug": "policy-edit-saveraw-loss",
+    "category": "pitfall",
+    "description": "Editing a common collection policy can silently drop individual `saveRaw`/interval settings if not re-applied",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/policy-edit-saveraw-loss.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "pub-sub-implementation-pitfall",
+    "slug": "pub-sub-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Synchronous in-loop dispatch causes slow subscribers to block publishers and starve fast ones",
+    "tags": [
+      "pub",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/pub-sub-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "python-regex-dotall-spans-java-method-blocks",
+    "slug": "python-regex-dotall-spans-java-method-blocks",
+    "category": "pitfall",
+    "description": "Python re.sub에서 DOTALL + .*? 로 Java 메서드를 batch 편집하면 non-greedy여도 인접 메서드 블록을 건너뛰어 잘못된 위치에 annotation이 삽입된다",
+    "tags": [
+      "python",
+      "regex",
+      "java",
+      "annotation-batch",
+      "swagger-ai-optimization"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/python-regex-dotall-spans-java-method-blocks.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "raft-consensus-implementation-pitfall",
+    "slug": "raft-consensus-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common correctness bugs when modeling or implementing Raft, especially around term handling and commit safety",
+    "tags": [
+      "raft",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/raft-consensus-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "rate-limiter-implementation-pitfall",
+    "slug": "rate-limiter-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common correctness bugs in rate limiter algorithms that only surface under specific traffic patterns",
+    "tags": [
+      "rate",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/rate-limiter-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "read-replica-implementation-pitfall",
+    "slug": "read-replica-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common mistakes when modeling read-replica lag, routing, and consistency guarantees in a simulator",
+    "tags": [
+      "read",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/read-replica-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "refresh-token-do-not-regenerate",
+    "slug": "refresh-token-do-not-regenerate",
+    "category": "pitfall",
+    "description": "A refresh call must issue a new ACCESS token only, never a new refresh token.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/refresh-token-do-not-regenerate.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "registry-json-dict-not-list",
+    "slug": "registry-json-dict-not-list",
+    "category": "pitfall",
+    "description": "skills-hub registry.json stores skills and knowledge as dicts keyed by name, not arrays — list.append() fails silently or throws",
+    "tags": [
+      "registry",
+      "json",
+      "data-structure",
+      "skills-hub"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/registry-json-dict-not-list.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "retry-strategy-implementation-pitfall",
+    "slug": "retry-strategy-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common failure modes when building retry strategy demos: unbounded growth, jitter miscalculation, and thundering herd blind spots",
+    "tags": [
+      "retry",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/retry-strategy-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "saga-pattern-implementation-pitfall",
+    "slug": "saga-pattern-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common saga failures around non-compensatable pivot steps, lost compensations, and non-idempotent retries",
+    "tags": [
+      "saga",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/saga-pattern-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "schema-registry-implementation-pitfall",
+    "slug": "schema-registry-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common mistakes when modeling compatibility checks and version semantics in registry tools",
+    "tags": [
+      "schema",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/schema-registry-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "serial-pipeline-failure-compounding",
+    "slug": "serial-pipeline-failure-compounding",
+    "category": "pitfall",
+    "description": "N-stage serial AI pipeline success = product of per-stage success rates; prefer developer-invoked skills at each boundary",
+    "tags": [
+      "pipeline",
+      "reliability",
+      "ai-automation",
+      "skill-boundary",
+      "review-gate"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/serial-pipeline-failure-compounding.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "service-mesh-implementation-pitfall",
+    "slug": "service-mesh-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common traps when building service mesh tooling: stale config, identity confusion, and sidecar startup races",
+    "tags": [
+      "service",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/service-mesh-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "shared-repo-sequential-branching",
+    "slug": "shared-repo-sequential-branching",
+    "category": "pitfall",
+    "description": "Git operations on a shared repo clone must be sequential — parallel branch creation causes working tree conflicts",
+    "tags": [
+      "git",
+      "parallel",
+      "branching",
+      "skills-hub"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/shared-repo-sequential-branching.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "sibling-scoped-name-uniqueness",
+    "slug": "sibling-scoped-name-uniqueness",
+    "category": "pitfall",
+    "description": "A global unique index on group `name` was present and had to be dropped; uniqueness is correct only within the same parent.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/sibling-scoped-name-uniqueness.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "sidecar-proxy-implementation-pitfall",
+    "slug": "sidecar-proxy-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common sidecar-proxy modeling mistakes that break the mental model and produce misleading metrics.",
+    "tags": [
+      "sidecar",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/sidecar-proxy-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "simpledateformat-not-thread-safe",
+    "slug": "simpledateformat-not-thread-safe",
+    "category": "pitfall",
+    "description": "SimpleDateFormat은 스레드 안전하지 않아 공유 인스턴스 사용 시 포맷 깨짐/예외 발생 — java.time.DateTimeFormatter로 교체",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/simpledateformat-not-thread-safe.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "single-keyword-formulaic-llm-output",
+    "slug": "single-keyword-formulaic-llm-output",
+    "category": "pitfall",
+    "description": "A single-word theme given to an LLM produces formulaic, generic output — evocative 10–20 word phrases unlock variety",
+    "tags": [
+      "llm",
+      "prompt-engineering",
+      "creativity",
+      "theme-design"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/single-keyword-formulaic-llm-output.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "skill-md-plus-content-md-body-counting",
+    "slug": "skill-md-plus-content-md-body-counting",
+    "category": "pitfall",
+    "description": "Heuristic scanners that compute body_lines from SKILL.md alone will flag every frontmatter-only skill (body in content.md) as a perma-stub. Always sum SKILL.md body + content.md body for size-based conditions.",
+    "tags": [
+      "skills-hub",
+      "body-size",
+      "heuristic",
+      "content-md",
+      "pitfall"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/skill-md-plus-content-md-body-counting.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "skip-schedule-if-previous-running",
+    "slug": "skip-schedule-if-previous-running",
+    "category": "pitfall",
+    "description": "When a periodic tick arrives and the previous execution for the same job is still running, skip the new tick — never queue it.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/skip-schedule-if-previous-running.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "snmp-ifindex-not-stable",
+    "slug": "snmp-ifindex-not-stable",
+    "category": "pitfall",
+    "description": "SNMP `ifIndex` can change across device reboot/reconfig — never use it as a stable identifier",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/snmp-ifindex-not-stable.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "sonar-token-hardcoded-build-gradle",
+    "slug": "sonar-token-hardcoded-build-gradle",
+    "category": "pitfall",
+    "description": "Hardcoded SonarQube login token in build.gradle plus `allowInsecureProtocol = true` on an internal Nexus are two common DevSecOps anti-patterns to fix together",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/sonar-token-hardcoded-build-gradle.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "span-hash-determinism",
+    "slug": "span-hash-determinism",
+    "category": "pitfall",
+    "description": "Span-dedup hash must be deterministic and stable; changing the hash definition produces duplicate rows during rollout and poisons historical joins.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/span-hash-determinism.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "span-lifetime-safety-documentation",
+    "slug": "span-lifetime-safety-documentation",
+    "category": "pitfall",
+    "description": "std::span is a non-owning view — common C++20 hazards (dangling temporaries, vector realloc, implicit construction from rvalues) and the safe usage patterns that avoid UB.",
+    "tags": [
+      "cpp20",
+      "span",
+      "lifetime",
+      "ub",
+      "undefined-behavior"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/span-lifetime-safety-documentation.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "spec-excluded-from-jest",
+    "slug": "spec-excluded-from-jest",
+    "category": "pitfall",
+    "description": ".spec.ts files are excluded from the Jest runner in this project — only .test.ts is discovered",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/spec-excluded-from-jest.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "springdoc-dto-schema-orphan-when-unexposed",
+    "slug": "springdoc-dto-schema-orphan-when-unexposed",
+    "category": "pitfall",
+    "description": "springdoc는 컨트롤러 시그니처를 walk하므로 ApiResponseData<Object> 반환 DTO에 달린 @Schema·x-lookup은 스펙에 반영되지 않는다",
+    "tags": [
+      "springdoc",
+      "openapi",
+      "java",
+      "schema",
+      "swagger-ai-optimization"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/springdoc-dto-schema-orphan-when-unexposed.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "sql-hash-unsigned-integer",
+    "slug": "sql-hash-unsigned-integer",
+    "category": "pitfall",
+    "description": "MySQL/MariaDB SQL digest hashes fit in an unsigned 32-bit range but arrive as signed Java int — negatives are legal and must not be dropped",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/sql-hash-unsigned-integer.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "sql-text-null-check-session-history-consistency",
+    "slug": "sql-text-null-check-session-history-consistency",
+    "category": "pitfall",
+    "description": "Session history rows must omit sqlHash and queryTime when SQL text is missing, else they orphan in downstream joins",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/sql-text-null-check-session-history-consistency.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "sqlserver-sqltextinfo-index-constraint",
+    "slug": "sqlserver-sqltextinfo-index-constraint",
+    "category": "pitfall",
+    "description": "Do not put a unique index on sqlHash for SQL Server text-info collection — duplicates are legitimate",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/sqlserver-sqltextinfo-index-constraint.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "static-value-injection-race-condition",
+    "slug": "static-value-injection-race-condition",
+    "category": "pitfall",
+    "description": "static 필드에 @Value 주입은 setter 호출 타이밍과 멀티스레드 가시성으로 레이스 컨디션을 유발 — 인스턴스 필드로 직접 주입하라",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/static-value-injection-race-condition.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "strangler-fig-implementation-pitfall",
+    "slug": "strangler-fig-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common failure modes when building strangler-fig migration tooling: premature legacy retirement, shadow drift, dependency blindness",
+    "tags": [
+      "strangler",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/strangler-fig-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "subagent-permission-denial-fallback",
+    "slug": "subagent-permission-denial-fallback",
+    "category": "pitfall",
+    "description": "Claude Code subagents (Agent tool) cannot obtain Write/Bash permissions independently — if user hasn't pre-granted them, all 3 agents fail and you must build directly",
+    "tags": [
+      "claude-code",
+      "subagent",
+      "permissions",
+      "agent-tool",
+      "parallel"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/subagent-permission-denial-fallback.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "tailwind-mfa-css-isolation-pitfalls",
+    "slug": "tailwind-mfa-css-isolation-pitfalls",
+    "category": "pitfall",
+    "description": "CSS isolation failures when using Tailwind CSS in Module Federation — preflight leaks, portal scope loss, postcss-prefix-selector parse errors",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/tailwind-mfa-css-isolation-pitfalls.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "tenant-context-clear-after-completion",
+    "slug": "tenant-context-clear-after-completion",
+    "category": "pitfall",
+    "description": "Multi-tenant thread-locals must be cleared in a HandlerInterceptor `afterCompletion`, regardless of request outcome",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/tenant-context-clear-after-completion.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "tenant-flag-over-name-detection",
+    "slug": "tenant-flag-over-name-detection",
+    "category": "pitfall",
+    "description": "Identify special/system tenants by a boolean flag on the entity, never by matching on name.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/tenant-flag-over-name-detection.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "testcontainers-springboot-cache-conflict",
+    "slug": "testcontainers-springboot-cache-conflict",
+    "category": "pitfall",
+    "description": "@Testcontainers + @SpringBootTest 컨텍스트 캐싱 충돌 — @DynamicPropertySource + static start() 패턴으로 대체",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/testcontainers-springboot-cache-conflict.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "time-series-db-implementation-pitfall",
+    "slug": "time-series-db-implementation-pitfall",
+    "category": "pitfall",
+    "description": "TSDB tools frequently corrupt their own UX by misusing timestamp precision, time zones, and rollup boundaries.",
+    "tags": [
+      "time",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/time-series-db-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "time-unit-consistency-us-ms-ns",
+    "slug": "time-unit-consistency-us-ms-ns",
+    "category": "pitfall",
+    "description": "Mixed time units (ns/μs/ms) across OTLP ingestion, storage, filters, and UI are a recurring high-severity bug class — pick one canonical internal unit and convert only at edges.",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/time-unit-consistency-us-ms-ns.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "top-bottom-widest-collection-range",
+    "slug": "top-bottom-widest-collection-range",
+    "category": "pitfall",
+    "description": "For Top/Bottom selection queries, pick the collection whose bin granularity covers the widest range, not the finest-grained one",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/top-bottom-widest-collection-range.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "topn-unwind-match-to-filter",
+    "slug": "topn-unwind-match-to-filter",
+    "category": "pitfall",
+    "description": "TopN Mongo pipeline using `$unwind`+`$match` explodes documents; push predicate into `$filter` first",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/topn-unwind-match-to-filter.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "trace-context-async-execution-propagation",
+    "slug": "trace-context-async-execution-propagation",
+    "category": "pitfall",
+    "description": "Thread-local trace context is lost across executor.submit / reactor.flatMap boundaries; scouter injects bytecode wrappers around async entry points to capture and restore it",
+    "tags": [
+      "async",
+      "tracing",
+      "pitfall",
+      "jvm",
+      "scouter"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/trace-context-async-execution-propagation.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "traefik-2.11-requires-explicit-idletimeout",
+    "slug": "traefik-2.11-requires-explicit-idletimeout",
+    "category": "pitfall",
+    "description": "Traefik 2.11 silently drops idle backend connections without an explicit idleTimeout on the entrypoint/serversTransport",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/traefik-2.11-requires-explicit-idletimeout.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "udp-receiver-needs-large-socket-buffer",
+    "slug": "udp-receiver-needs-large-socket-buffer",
+    "category": "pitfall",
+    "description": "UDP collectors behind Traefik/containers must raise SO_RCVBUF well above the 8KB default or drop packets under burst load",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/udp-receiver-needs-large-socket-buffer.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "unit-enum-silent-filter",
+    "slug": "unit-enum-silent-filter",
+    "category": "pitfall",
+    "description": "When metric rows are filtered out because their `unit` is not defined in a Java enum, the symptom is \"items missing from the list UI\" — no error, no log — and the root cause is upstream data adding units faster than the enum is updated",
+    "tags": [
+      "enum",
+      "silent-drop",
+      "defensive-coding",
+      "observability"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/unit-enum-silent-filter.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "user-sql-source-requires-select-only-and-readonly",
+    "slug": "user-sql-source-requires-select-only-and-readonly",
+    "category": "pitfall",
+    "description": "When a feature lets end-users paste raw SQL for display, no single guard is enough — layer four defenses: SELECT-only keyword allow-list, token-aware destructive-keyword blocklist, JDBC `setReadOnly(true)`, and `setQueryTimeout` + `setMaxRows` caps.",
+    "tags": [
+      "security",
+      "jdbc",
+      "user-input",
+      "data-source"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/user-sql-source-requires-select-only-and-readonly.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "websocket-implementation-pitfall",
+    "slug": "websocket-implementation-pitfall",
+    "category": "pitfall",
+    "description": "Common WebSocket mistakes: missing masking, ignored close codes, no heartbeat, reconnect storms",
+    "tags": [
+      "websocket",
+      "auto-loop"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/websocket-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "widget-high-prop-count-debt",
+    "slug": "widget-high-prop-count-debt",
+    "category": "pitfall",
+    "description": "Dashboard CardChart components accumulate 100+ props making them hard to maintain, version, and test — known tech debt with no current mitigation",
+    "tags": [],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/widget-high-prop-count-debt.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "windows-python-utf8-explicit",
+    "slug": "windows-python-utf8-explicit",
+    "category": "pitfall",
+    "description": "On Windows, Python defaults to cp949/cp1252 locale encoding — all file I/O on UTF-8 content (JSON with em-dashes, CJK text) must specify encoding='utf-8' explicitly",
+    "tags": [
+      "windows",
+      "python",
+      "encoding",
+      "utf-8",
+      "cp949"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/windows-python-utf8-explicit.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "yaml-block-scalar-frontmatter-parsing",
+    "slug": "yaml-block-scalar-frontmatter-parsing",
+    "category": "pitfall",
+    "description": "Regex-based frontmatter parsers that treat every `key: value` line as a scalar will collapse `description: |` (YAML block scalar) to the single character `|`, causing downstream metadata-empty heuristics to over-fire on fully-written entries.",
+    "tags": [
+      "yaml",
+      "frontmatter",
+      "parser",
+      "heuristic",
+      "pitfall"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/yaml-block-scalar-frontmatter-parsing.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "batch-pr-conflict-recovery",
+    "slug": "batch-pr-conflict-recovery",
+    "category": "workflow",
+    "description": "When N auto-generated PRs all touch the same catalog file and serially conflict, close them all and batch-cherry-pick the content into one PR",
+    "tags": [
+      "git",
+      "github",
+      "automation",
+      "conflict-resolution"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/workflow/batch-pr-conflict-recovery.md",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "autoplan",
+    "slug": "autoplan",
+    "category": "",
+    "description": "|",
     "tags": [],
     "triggers": [],
     "version": "1.0.0",
-    "path": "skills/design/ag-grid-custom-filter-system",
+    "path": "skills/cli/gstack/autoplan",
     "has_content": false
   },
   {
+    "kind": "skill",
+    "name": "benchmark",
+    "slug": "benchmark",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/benchmark",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "browse",
+    "slug": "browse",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.1.0",
+    "path": "skills/cli/gstack/browse",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "canary",
+    "slug": "canary",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/canary",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "careful",
+    "slug": "careful",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "0.1.0",
+    "path": "skills/cli/gstack/careful",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "checkpoint",
+    "slug": "checkpoint",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/checkpoint",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "codex",
+    "slug": "codex",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/codex",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "cso",
+    "slug": "cso",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/cli/gstack/cso",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "design-consultation",
+    "slug": "design-consultation",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/design-consultation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "design-html",
+    "slug": "design-html",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/design-html",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "design-review",
+    "slug": "design-review",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/cli/gstack/design-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "design-shotgun",
+    "slug": "design-shotgun",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/design-shotgun",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "devex-review",
+    "slug": "devex-review",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/devex-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "document-release",
+    "slug": "document-release",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/document-release",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "freeze",
+    "slug": "freeze",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "0.1.0",
+    "path": "skills/cli/gstack/freeze",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "gstack-openclaw-ceo-review",
+    "slug": "gstack-openclaw-ceo-review",
+    "category": "",
+    "description": "CEO/founder-mode plan review. Rethink the problem, find the 10-star product, challenge premises, expand scope when it creates a better product. Four modes: SCOPE EXPANSION (dream big), SELECTIVE EXPANSION (hold scope + cherry-pick), HOLD SCOPE (maximum rigor), SCOPE REDUCTION (strip to essentials). Use when asked to review a plan, challenge this, CEO review, poke holes, think bigger, or expand scope.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/openclaw/skills/gstack-openclaw-ceo-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "gstack-openclaw-investigate",
+    "slug": "gstack-openclaw-investigate",
+    "category": "",
+    "description": "Systematic debugging with root cause investigation. Four phases: investigate, analyze, hypothesize, implement. Iron Law: no fixes without root cause. Use when asked to debug, fix a bug, investigate an error, or root cause analysis. Proactively use when user reports errors, stack traces, unexpected behavior, or says something stopped working.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/openclaw/skills/gstack-openclaw-investigate",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "gstack-openclaw-office-hours",
+    "slug": "gstack-openclaw-office-hours",
+    "category": "",
+    "description": "Product interrogation with six forcing questions. Two modes: startup diagnostic (demand reality, status quo, desperate specificity, narrowest wedge, observation, future-fit) and builder brainstorm. Use when asked to brainstorm, \"is this worth building\", \"I have an idea\", \"office hours\", or \"help me think through this\". Proactively use when user describes a new product idea or wants to think through design decisions before any code is written.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/openclaw/skills/gstack-openclaw-office-hours",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "gstack-openclaw-retro",
+    "slug": "gstack-openclaw-retro",
+    "category": "",
+    "description": "Weekly engineering retrospective. Analyzes commit history, work patterns, and code quality metrics with persistent history and trend tracking. Team-aware with per-person contributions, praise, and growth areas. Use when asked for weekly retro, what shipped this week, or engineering retrospective.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/openclaw/skills/gstack-openclaw-retro",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "gstack-upgrade",
+    "slug": "gstack-upgrade",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.1.0",
+    "path": "skills/cli/gstack/gstack-upgrade",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "guard",
+    "slug": "guard",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "0.1.0",
+    "path": "skills/cli/gstack/guard",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "health",
+    "slug": "health",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/health",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "investigate",
+    "slug": "investigate",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/investigate",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "land-and-deploy",
+    "slug": "land-and-deploy",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/land-and-deploy",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "learn",
+    "slug": "learn",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/learn",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "office-hours",
+    "slug": "office-hours",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/cli/gstack/office-hours",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "open-gstack-browser",
+    "slug": "open-gstack-browser",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "0.2.0",
+    "path": "skills/cli/gstack/open-gstack-browser",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "pair-agent",
+    "slug": "pair-agent",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "0.1.0",
+    "path": "skills/cli/gstack/pair-agent",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "plan-ceo-review",
+    "slug": "plan-ceo-review",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/plan-ceo-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "plan-design-review",
+    "slug": "plan-design-review",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/cli/gstack/plan-design-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "plan-devex-review",
+    "slug": "plan-devex-review",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/cli/gstack/plan-devex-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "plan-eng-review",
+    "slug": "plan-eng-review",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/plan-eng-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "qa",
+    "slug": "qa",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/cli/gstack/qa",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "qa-only",
+    "slug": "qa-only",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/qa-only",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "retro",
+    "slug": "retro",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/cli/gstack/retro",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "review",
+    "slug": "review",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "setup-browser-cookies",
+    "slug": "setup-browser-cookies",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/setup-browser-cookies",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "setup-deploy",
+    "slug": "setup-deploy",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/setup-deploy",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "ship",
+    "slug": "ship",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/ship",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "unfreeze",
+    "slug": "unfreeze",
+    "category": "",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "0.1.0",
+    "path": "skills/cli/gstack/unfreeze",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "ai-call-with-mock-fallback",
     "slug": "ai-call-with-mock-fallback",
     "category": "ai",
     "description": "Wrap unreliable LLM/AI calls with a deterministic mock fallback so the UI always receives a valid shape — annotate the response with a `mock: true` or `error:` field so the client can show a badge.",
-    "tags": [],
-    "triggers": [],
+    "tags": [
+      "llm",
+      "resilience",
+      "fallback",
+      "mock",
+      "ux",
+      "error-handling"
+    ],
+    "triggers": [
+      "AI 생성 실패",
+      "mock data",
+      "ANTHROPIC_API_KEY",
+      "fallback response",
+      "mock: true",
+      "degraded mode"
+    ],
     "version": "0.1.0-draft",
     "path": "skills/ai/ai-call-with-mock-fallback",
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "ai-subagent-scope-narrowing",
     "slug": "ai-subagent-scope-narrowing",
     "category": "ai",
     "description": "Orchestrator-first pattern for multi-agent AI coding — humans triage and curate context per task, subagents execute in isolated worktrees with narrowly-scoped briefs. Trades parallel throughput for reduced hallucination.",
-    "tags": [],
-    "triggers": [],
+    "tags": [
+      "agents",
+      "subagents",
+      "orchestration",
+      "context-isolation",
+      "worktree",
+      "hallucination"
+    ],
+    "triggers": [
+      "subagent",
+      "multiple agents",
+      "parallel agents",
+      "worktree",
+      "agent hallucination",
+      "narrow scope",
+      "orchestrator agent",
+      "context engineering"
+    ],
     "version": "1.0.0",
     "path": "skills/ai/ai-subagent-scope-narrowing",
     "has_content": true
   },
   {
-    "name": "antd-wrapper-component-pattern",
-    "slug": "antd-wrapper-component-pattern",
-    "category": "design",
-    "description": "Wrap Ant Design components with a custom design system layer (Sirius pattern) that extends props, enforces standards, and maintains upgrade compatibility",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/design/antd-wrapper-component-pattern",
-    "has_content": false
-  },
-  {
-    "name": "api-versioning-data-simulation",
-    "slug": "api-versioning-data-simulation",
-    "category": "workflow",
-    "description": "Generate synthetic API version traffic, changelog events, and consumer migration progress for realistic demos",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "api versioning data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/api-versioning-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "api-versioning-visualization-pattern",
-    "slug": "api-versioning-visualization-pattern",
-    "category": "design",
-    "description": "Three-panel visual encoding for API version lifecycle — timeline, traffic flow, and deprecation health",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "api versioning visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/api-versioning-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "async-subagent-resume-on-missing-artifact",
-    "slug": "async-subagent-resume-on-missing-artifact",
-    "category": "workflow",
-    "description": "When an async subagent is reported \"completed\" but its final message hints at unfinished work (e.g., \"Now let me build…\"), verify the expected on-disk artifact before moving on; if missing, use SendMessage to the agent id to finalize rather than re-dispatching a fresh agent.",
-    "tags": [],
-    "triggers": [
-      "\"agent completed but artifact missing\"",
-      "\"subagent incomplete output\""
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/async-subagent-resume-on-missing-artifact",
-    "has_content": false
-  },
-  {
-    "name": "audit-change-data-capture-pattern",
-    "slug": "audit-change-data-capture-pattern",
-    "category": "backend",
-    "description": "Compute before/after diffs for audit logs by comparing two BSON/JSON documents field-by-field — always iterate the BEFORE doc and read from AFTER to avoid prev/after swap bugs",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/audit-change-data-capture-pattern",
-    "has_content": true
-  },
-  {
-    "name": "autoplan",
-    "slug": "autoplan",
-    "category": "workflow",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/workflow/autoplan",
-    "has_content": false
-  },
-  {
-    "name": "availability-ttl-punctuate-processor",
-    "slug": "availability-ttl-punctuate-processor",
-    "category": "backend",
-    "description": "Kafka Streams processor schedules a wall-clock `punctuate` for TTL eviction of the state store, and emits downstream only on value change. Wall-clock (not stream-time) so idle inputs still trigger cleanup.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/availability-ttl-punctuate-processor",
-    "has_content": true
-  },
-  {
-    "name": "avro-event-with-change-flags",
-    "slug": "avro-event-change-flags",
-    "category": "backend",
-    "description": "Design Kafka Avro event schemas that carry an actionType enum plus boolean \"changed\" flags per mutable section so consumers can branch cheaply without diffing payloads.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/avro-event-change-flags",
-    "has_content": true
-  },
-  {
-    "name": "avro-gradle-kafka-schema-pipeline",
-    "slug": "avro-gradle-kafka-schema-pipeline",
-    "category": "backend",
-    "description": "Wire the davidmc24 Avro Gradle plugin so .avsc schemas generate Java sources consumed by Kafka producers/consumers with Confluent Schema Registry",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/avro-gradle-kafka-schema-pipeline",
-    "has_content": true
-  },
-  {
-    "name": "axios-refresh-queue-zustand",
-    "slug": "axios-refresh-queue-zustand",
-    "category": "frontend",
-    "description": "Axios response interceptor that intercepts 401, queues concurrent failed requests, refreshes the token once, and replays queued requests with the new token. Prevents thundering-herd refresh calls.",
-    "tags": [
-      "axios",
-      "jwt",
-      "refresh-token",
-      "interceptor",
-      "zustand",
-      "auth"
-    ],
-    "triggers": [
-      "axios 401 refresh",
-      "token refresh queue",
-      "isRefreshing flag",
-      "axios interceptor zustand",
-      "refresh thundering herd",
-      "retry original request"
-    ],
-    "version": "0.1.0-draft",
-    "path": "skills/frontend/axios-refresh-queue-zustand",
-    "has_content": true
-  },
-  {
-    "name": "axios-token-refresh-queue",
-    "slug": "axios-token-refresh-queue",
-    "category": "backend",
-    "description": "Axios interceptor with window-scoped request queue during JWT token refresh to prevent concurrent refresh races",
-    "tags": [],
-    "triggers": [
-      "token refresh",
-      "axios interceptor",
-      "jwt refresh",
-      "401 retry",
-      "authentication interceptor"
-    ],
-    "version": "1.0.0",
-    "path": "skills/backend/axios-token-refresh-queue",
-    "has_content": true
-  },
-  {
-    "name": "backpressure-data-simulation",
-    "slug": "backpressure-data-simulation",
-    "category": "workflow",
-    "description": "Strategies for generating realistic backpressure scenarios with controllable producer/consumer imbalance, wave propagation, and load-shedding behavior.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "backpressure data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/backpressure-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "backpressure-visualization-pattern",
-    "slug": "backpressure-visualization-pattern",
-    "category": "design",
-    "description": "Reusable visual encoding patterns for rendering backpressure state across pipeline, wave, and dashboard views using Canvas and CSS.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "backpressure visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/backpressure-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "baseline-historical-comparison-threshold",
-    "slug": "baseline-historical-comparison-threshold",
-    "category": "backend",
-    "description": "Evaluate a current metric against a historical baseline (prev hour/day/week/month/year, with MIN/AVG/MAX aggregation) as a dynamic threshold; supports RATE or VALUE change modes and dampening.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/baseline-historical-comparison-threshold",
-    "has_content": true
-  },
-  {
-    "name": "benchmark",
-    "slug": "benchmark",
-    "category": "testing",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/testing/benchmark",
-    "has_content": false
-  },
-  {
-    "name": "bff-pattern-data-simulation",
-    "slug": "bff-pattern-data-simulation",
-    "category": "workflow",
-    "description": "Stochastic latency simulation modeling per-service delays, BFF overhead, and sequential-vs-parallel aggregation to generate realistic request traces.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "bff pattern data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/bff-pattern-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "bff-pattern-visualization-pattern",
-    "slug": "bff-pattern-visualization-pattern",
-    "category": "design",
-    "description": "Three-tier canvas/SVG flow diagram showing client-to-BFF-to-microservice request routing with animated particle traces and glow-on-select feedback.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "bff pattern visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/bff-pattern-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "blue-green-deploy-data-simulation",
-    "slug": "blue-green-deploy-data-simulation",
-    "category": "workflow",
-    "description": "Strategies for generating synthetic blue-green deployment events, traffic metrics, and state transitions for testing and demos.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "blue green deploy data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/blue-green-deploy-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "blue-green-deploy-visualization-pattern",
-    "slug": "blue-green-deploy-visualization-pattern",
-    "category": "design",
-    "description": "Reusable visual encoding patterns for rendering blue-green deployment state, traffic flow, and history on HTML5 Canvas and DOM.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "blue green deploy visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/blue-green-deploy-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "bootrun-jvmargs-jdwp-opens-java21",
-    "slug": "bootrun-jvmargs-jdwp-opens-java21",
-    "category": "backend",
-    "description": "Bake JDWP debug port and required --add-opens flags into Gradle bootRun so every dev gets the same Java 17/21-compatible local runtime",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/bootrun-jvmargs-jdwp-opens-java21",
-    "has_content": true
-  },
-  {
-    "name": "browse",
-    "slug": "browse",
-    "category": "testing",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.1.0",
-    "path": "skills/testing/browse",
-    "has_content": false
-  },
-  {
-    "name": "bucket-parallel-java-annotation-dispatch",
-    "slug": "bucket-parallel-java-annotation-dispatch",
-    "category": "workflow",
-    "description": "For bulk Java annotation work (200+ @Operation methods across many controllers, or 500+ @Schema fields across many DTOs), dispatch N parallel executor subagents with disjoint file buckets. Leader runs a single compile at the end; agents never run gradle themselves.",
-    "tags": [],
-    "triggers": [
-      "\"bulk annotation\"",
-      "\"전수 적용\"",
-      "\"controller 전체 주석\"",
-      "\"DTO @Schema 전수\""
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/bucket-parallel-java-annotation-dispatch",
-    "has_content": false
-  },
-  {
-    "name": "build-error-triage",
-    "slug": "build-error-triage",
-    "category": "debug",
-    "description": "Systematic triage workflow for build/compilation errors — classify by root cause (missing symbol, signature mismatch, instantiation failure), then isolate the first error before chasing cascades.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/debug/build-error-triage",
-    "has_content": true
-  },
-  {
-    "name": "bulkhead-data-simulation",
-    "slug": "bulkhead-data-simulation",
-    "category": "workflow",
-    "description": "Tick-based probabilistic simulation patterns for modeling bulkhead breach flooding, thread pool request load, and partition stress testing.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "bulkhead data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/bulkhead-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "bulkhead-visualization-pattern",
-    "slug": "bulkhead-visualization-pattern",
-    "category": "design",
-    "description": "Reusable visual encoding patterns for rendering bulkhead compartmentalization, breach propagation, and structural integrity in canvas/SVG.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "bulkhead visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/bulkhead-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "byte-aware-sms-truncation-with-ellipsis",
-    "slug": "byte-aware-sms-truncation-with-ellipsis",
-    "category": "backend",
-    "description": "Truncate SMS message body to a byte budget (not char count) per charset, appending '...' without exceeding the budget",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/byte-aware-sms-truncation-with-ellipsis",
-    "has_content": true
-  },
-  {
-    "name": "cache-variance-ttl-jitter",
-    "slug": "cache-variance-ttl-jitter",
-    "category": "backend",
-    "description": "Add ±N% random jitter to cache TTLs so keys written together don't all expire in the same tick, avoiding synchronized recompute storms",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/cache-variance-ttl-jitter",
-    "has_content": true
-  },
-  {
-    "name": "calendar-cron-vs-spring-cron-migration",
-    "slug": "calendar-cron-vs-spring-cron-migration",
-    "category": "backend",
-    "description": "Convert between Spring 6-field cron and Quartz/calendar 7-field cron without DST/leap-year regressions",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/calendar-cron-vs-spring-cron-migration",
-    "has_content": true
-  },
-  {
-    "name": "canary",
-    "slug": "canary",
-    "category": "workflow",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/workflow/canary",
-    "has_content": false
-  },
-  {
-    "name": "canary-release-data-simulation",
-    "slug": "canary-release-data-simulation",
-    "category": "workflow",
-    "description": "Tick-based probabilistic generators for canary traffic ratios, error injection, latency degradation, and phased auto-promotion.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "canary release data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/canary-release-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "canary-release-visualization-pattern",
-    "slug": "canary-release-visualization-pattern",
-    "category": "design",
-    "description": "Canvas particle traffic flow, SVG polyline metric charts, and vertical phase-dot timelines for canary deployment UIs.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "canary release visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/canary-release-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "careful",
-    "slug": "careful",
-    "category": "security",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0",
-    "path": "skills/security/careful",
-    "has_content": false
-  },
-  {
-    "name": "cdc-data-simulation",
-    "slug": "cdc-data-simulation",
-    "category": "workflow",
-    "description": "Synthetic CDC event generation patterns for realistic stream monitoring, table replay, and pipeline flow testing without a live database.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "cdc data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/cdc-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "cdc-visualization-pattern",
-    "slug": "cdc-visualization-pattern",
-    "category": "design",
-    "description": "Reusable visual encoding for Change Data Capture event streams across canvas, table-diff, and SVG pipeline views.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "cdc visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/cdc-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "challenge-response-auth-redis-ttl",
-    "slug": "challenge-response-auth-redis-ttl",
-    "category": "backend",
-    "description": "Replay-resistant two-step login — server issues a short-lived random challenge stored in Redis with TTL, client signs/hashes response, bounded attempts per key",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/challenge-response-auth-redis-ttl",
-    "has_content": true
-  },
-  {
-    "name": "chaos-engineering-data-simulation",
-    "slug": "chaos-engineering-data-simulation",
-    "category": "workflow",
-    "description": "Generate synthetic chaos experiment data including failure propagation, resilience scoring, and gameday event timelines for testing and demos.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "chaos engineering data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/chaos-engineering-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "chaos-engineering-visualization-pattern",
-    "slug": "chaos-engineering-visualization-pattern",
-    "category": "design",
-    "description": "Reusable visual encoding for chaos experiment state across service dependency graphs, resilience matrices, and operational dashboards.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "chaos engineering visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/chaos-engineering-visualization-pattern",
-    "has_content": false
-  },
-  {
+    "kind": "skill",
     "name": "character-sheet-multi-panel-consistency",
     "slug": "character-sheet-multi-panel-consistency",
     "category": "ai",
     "description": "Keep a consistent character across multiple diffusion-model image generations by emitting a reusable \"character sheet\" description string from the LLM and prefixing it into every panel's image prompt.",
-    "tags": [],
-    "triggers": [],
+    "tags": [
+      "stable-diffusion",
+      "prompt-engineering",
+      "character-consistency",
+      "comic",
+      "storyboard",
+      "multi-panel"
+    ],
+    "triggers": [
+      "character sheet",
+      "characterSheet",
+      "consistent character",
+      "multi-panel",
+      "storyboard",
+      "comic",
+      "same character in all panels"
+    ],
     "version": "0.1.0-draft",
     "path": "skills/ai/character-sheet-multi-panel-consistency",
     "has_content": true
   },
   {
-    "name": "checkpoint",
-    "slug": "checkpoint",
-    "category": "workflow",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/workflow/checkpoint",
-    "has_content": false
-  },
-  {
-    "name": "chunked-resource-id-batch-fetch",
-    "slug": "chunked-resource-id-batch-fetch",
-    "category": "backend",
-    "description": "Split large ID lists into ~1000-item chunks before querying DB or Elasticsearch to avoid bind-parameter limits (MSSQL 2100, Oracle 1000) and OOM on bulk responses",
-    "tags": [],
-    "triggers": [
-      "`WHERE id IN (?, ?, …)` with thousands of IDs",
-      "ES `terms` query near 65536-item ceiling",
-      "monitor/report accepts an unbounded target ID list"
-    ],
-    "version": "1.0.0",
-    "path": "skills/backend/chunked-resource-id-batch-fetch",
-    "has_content": true
-  },
-  {
-    "name": "circuit-breaker-data-simulation",
-    "slug": "circuit-breaker-data-simulation",
-    "category": "workflow",
-    "description": "Tick-based probabilistic state machine for generating realistic circuit-breaker open/close/half-open transitions with configurable failure rates and cooldown jitter.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "circuit breaker data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/circuit-breaker-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "circuit-breaker-visualization-pattern",
-    "slug": "circuit-breaker-visualization-pattern",
-    "category": "design",
-    "description": "Three complementary visual metaphors for circuit-breaker state: ring gauge, flow diagram, and time-series timeline.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "circuit breaker visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/circuit-breaker-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "clang-tidy-integration-workflow",
-    "slug": "clang-tidy-integration-workflow",
-    "category": "devops",
-    "description": "Automated static analysis pipeline using clang-tidy with project-specific checks and suppression strategies for large multi-file C++ codebases.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/devops/clang-tidy-integration-workflow",
-    "has_content": false
-  },
-  {
+    "kind": "skill",
     "name": "claude-cli-from-jvm-via-node-wrapper",
     "slug": "claude-cli-from-jvm-via-node-wrapper",
     "category": "ai",
     "description": "Shell out to the `claude` CLI from a JVM / Spring Boot app by going through a tiny Node.js wrapper that supplies the required empty stdin — the CLI hangs when invoked with a directly-inherited TTY-less stdin from ProcessBuilder.",
-    "tags": [],
-    "triggers": [],
+    "tags": [
+      "claude-cli",
+      "subprocess",
+      "spring-boot",
+      "processbuilder",
+      "node-wrapper",
+      "stdin",
+      "hang"
+    ],
+    "triggers": [
+      "claude -p",
+      "ProcessBuilder",
+      "claude CLI",
+      "node claude-runner",
+      "execFileSync",
+      "subprocess hang",
+      "cli stdin"
+    ],
     "version": "0.1.0-draft",
     "path": "skills/ai/claude-cli-from-jvm-via-node-wrapper",
     "has_content": true
   },
   {
-    "name": "claude-code-skill-scaffold",
-    "slug": "claude-code-skill-scaffold",
-    "category": "devops",
-    "description": "[Tooling] Claude Code 스킬 표준 구조(SKILL.md + prompts/ + scripts/ + references/)를 자동 생성하는 스캐폴딩.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/devops/claude-code-skill-scaffold",
-    "has_content": false
-  },
-  {
-    "name": "claude-plugin-catalog-publish",
-    "slug": "claude-plugin-catalog-publish",
-    "category": "devops",
-    "description": "[Tooling] 로컬 스킬을 원격 Git repo에 배포하고 AGENTS.md 카탈로그를 자동 갱신하는 publish 플로우.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/devops/claude-plugin-catalog-publish",
-    "has_content": false
-  },
-  {
+    "kind": "skill",
     "name": "codex",
     "slug": "codex",
     "category": "ai",
@@ -712,238 +5132,264 @@
     "has_content": false
   },
   {
-    "name": "collection-routing-by-period",
-    "slug": "collection-routing-by-period",
-    "category": "backend",
-    "description": "Single resolver maps `(Period.Mode, from, to)` → time-series collection (raw view / 1-min / hour-with-monthly-suffix / day). Callers never hardcode collection names.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/collection-routing-by-period",
+    "kind": "skill",
+    "name": "llm-json-extraction",
+    "slug": "llm-json-extraction",
+    "category": "ai",
+    "description": "Robustly extract a JSON object from free-form LLM text output — strip markdown fences, locate outermost braces, tolerate prelude/postlude prose.",
+    "tags": [
+      "llm",
+      "json",
+      "parsing",
+      "prompt-engineering",
+      "robustness"
+    ],
+    "triggers": [
+      "extract JSON",
+      "parse LLM response",
+      "strip code fence",
+      "ObjectMapper.readValue",
+      "JSON from model",
+      "```json"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/ai/llm-json-extraction",
     "has_content": true
   },
   {
-    "name": "command-query-data-simulation",
-    "slug": "command-query-data-simulation",
-    "category": "workflow",
-    "description": "Prefix-based verb classification and stochastic command/query/event generation for CQRS simulation loops.",
+    "kind": "skill",
+    "name": "mcp-runtime-prompt-refresh",
+    "slug": "mcp-runtime-prompt-refresh",
+    "category": "ai",
+    "description": "Expose a built-in MCP tool that hot-swaps the server's prompt set at runtime, persists it to disk, and emits notifications/prompts/list_changed so clients pick it up without reconnecting.",
     "tags": [
-      "auto-loop"
+      "mcp",
+      "prompts",
+      "hot-reload",
+      "json-rpc",
+      "tool-design"
     ],
     "triggers": [
-      "command query data simulation"
+      "refresh prompts",
+      "update mcp prompts at runtime",
+      "prompts list_changed",
+      "mcp hot reload"
     ],
-    "version": "1.0.0",
-    "path": "skills/workflow/command-query-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "command-query-visualization-pattern",
-    "slug": "command-query-visualization-pattern",
-    "category": "design",
-    "description": "Canvas-based dual-lane particle animation showing command (write) and query (read) paths through a CQRS topology.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "command query visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/command-query-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "compact-binary-wire-protocol-with-variable-length-encoding",
-    "slug": "compact-binary-wire-protocol-with-variable-length-encoding",
-    "category": "backend",
-    "description": "Define a custom binary wire format with variable-length integer encodings (e.g. 3-byte / 5-byte) to minimize UDP packet size for high-volume metric or telemetry streams",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/compact-binary-wire-protocol-with-variable-length-encoding",
-    "has_content": false
-  },
-  {
-    "name": "concurrent-jdbc-pool-datasource-lifecycle",
-    "slug": "concurrent-jdbc-pool-datasource-lifecycle",
-    "category": "backend",
-    "description": "Manage a pool of short-lived JDBC targets for monitoring agents with dual maps (active vs all) and periodic revalidation",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/concurrent-jdbc-pool-datasource-lifecycle",
-    "has_content": false
-  },
-  {
-    "name": "conditional-feature-flag-rollout",
-    "slug": "conditional-feature-flag-rollout",
-    "category": "backend",
-    "description": "@ConditionalOnProperty로 구/신 구현을 공존시키고 런타임 속성 하나로 전환하는 점진적 롤아웃 패턴",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/conditional-feature-flag-rollout",
+    "version": "0.1.0-draft",
+    "path": "skills/ai/mcp-runtime-prompt-refresh",
     "has_content": true
   },
   {
-    "name": "connection-pool-data-simulation",
-    "slug": "connection-pool-data-simulation",
-    "category": "workflow",
-    "description": "Tick-based probabilistic simulation strategies for generating realistic connection-pool demand, state transitions, and lifecycle events.",
+    "kind": "skill",
+    "name": "openapi-to-mcp-tag-grouping",
+    "slug": "openapi-to-mcp-tag-grouping",
+    "category": "ai",
+    "description": "Convert OpenAPI specs into MCP tools by grouping operations under their OpenAPI tag, exposing one tool per tag with an operation selector and per-operation arguments.",
     "tags": [
-      "auto-loop"
+      "mcp",
+      "openapi",
+      "tool-design",
+      "schema",
+      "json-schema"
     ],
     "triggers": [
-      "connection pool data simulation"
+      "openapi to mcp",
+      "swagger to mcp",
+      "generate mcp tools",
+      "tag based tool grouping"
     ],
-    "version": "1.0.0",
-    "path": "skills/workflow/connection-pool-data-simulation",
-    "has_content": false
+    "version": "0.1.0-draft",
+    "path": "skills/ai/openapi-to-mcp-tag-grouping",
+    "has_content": true
   },
   {
-    "name": "connection-pool-visualization-pattern",
-    "slug": "connection-pool-visualization-pattern",
-    "category": "design",
-    "description": "Three complementary visual encodings for connection-pool state — time-series canvas chart, SVG bubble grid, and swimlane lifecycle cards.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "connection pool visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/connection-pool-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "consistent-hashing-data-simulation",
-    "slug": "consistent-hashing-data-simulation",
-    "category": "workflow",
-    "description": "Parameterized simulation of key distribution across physical and virtual nodes with statistical balance metrics.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "consistent hashing data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/consistent-hashing-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "consistent-hashing-visualization-pattern",
-    "slug": "consistent-hashing-visualization-pattern",
-    "category": "design",
-    "description": "Canvas-based visual encoding for consistent hash rings with node-key assignment lines and per-node load counters.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "consistent hashing visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/consistent-hashing-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "cso",
-    "slug": "cso",
-    "category": "security",
+    "kind": "skill",
+    "name": "pair-agent",
+    "slug": "pair-agent",
+    "category": "ai",
     "description": "|",
     "tags": [],
     "triggers": [],
-    "version": "2.0.0",
-    "path": "skills/security/cso",
+    "version": "0.1.0",
+    "path": "skills/ai/pair-agent",
     "has_content": false
   },
   {
-    "name": "custom-actuator-command-whitelist",
-    "slug": "custom-actuator-command-whitelist",
-    "category": "backend",
-    "description": "Expose safe remote OS command execution on a Spring Boot service via a custom Actuator endpoint, restricted by a command whitelist, an argument sanitizer, and an execution timeout.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/custom-actuator-command-whitelist",
+    "kind": "skill",
+    "name": "stable-horde-async-poll",
+    "slug": "stable-horde-async-poll",
+    "category": "ai",
+    "description": "Submit-then-poll integration pattern for Stable Horde image generation — anonymous apikey, model fallback list, negative-prompt separator, bounded poll loop.",
+    "tags": [
+      "stable-horde",
+      "image-generation",
+      "stable-diffusion",
+      "async",
+      "polling",
+      "anonymous-api"
+    ],
+    "triggers": [
+      "stablehorde.net",
+      "generate/async",
+      "generate/status",
+      "apikey 0000000000",
+      "image generation",
+      "Stable Horde",
+      "horde"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/ai/stable-horde-async-poll",
     "has_content": true
   },
   {
-    "name": "data-pipeline-data-simulation",
-    "slug": "data-pipeline-data-simulation",
-    "category": "workflow",
-    "description": "Strategies for generating synthetic pipeline telemetry — record flow, stage latencies, failure injection, and backpressure signals.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "data pipeline data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/data-pipeline-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "data-pipeline-visualization-pattern",
-    "slug": "data-pipeline-visualization-pattern",
-    "category": "design",
-    "description": "Reusable visual encoding patterns for rendering data pipeline stages, DAG topology, and record flow on Canvas/SVG.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "data pipeline visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/data-pipeline-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "database-sharding-data-simulation",
-    "slug": "database-sharding-data-simulation",
-    "category": "workflow",
-    "description": "Stochastic data-generation strategies for simulating shard routing, load skew, hot-shard spikes, and latency degradation.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "database sharding data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/database-sharding-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "database-sharding-visualization-pattern",
-    "slug": "database-sharding-visualization-pattern",
-    "category": "design",
-    "description": "Canvas-based visual encoding patterns for shard topology, load distribution, and health monitoring in database-sharding UIs.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "database sharding visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/database-sharding-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "debug-lockorder-detection-system",
-    "slug": "debug-lockorder-detection-system",
-    "category": "debug",
-    "description": "Runtime lock-order deadlock detection via a DEBUG_LOCKORDER compile flag that tracks lock acquisition order and reports circular dependencies.",
+    "kind": "skill",
+    "name": "vllm-nginx-tls-single-port-routing",
+    "slug": "vllm-nginx-tls-single-port-routing",
+    "category": "ai",
+    "description": "Serve multiple vLLM OpenAI-API backends behind one Nginx TLS proxy on 443 using path-based routing",
     "tags": [],
     "triggers": [],
     "version": "1.0.0",
-    "path": "skills/debug/debug-lockorder-detection-system",
+    "path": "skills/ai/vllm-nginx-tls-single-port-routing",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "click-to-relative-direction-sign",
+    "slug": "click-to-relative-direction-sign",
+    "category": "algorithms",
+    "description": "Derive a normalized movement vector from any clicked grid cell via `Math.sign(target-current)` on each axis — one click handler covers all 8 directions.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "click to relative direction sign"
+    ],
+    "version": "1.0.0",
+    "path": "skills/algorithms/click-to-relative-direction-sign",
     "has_content": false
   },
   {
+    "kind": "skill",
+    "name": "fnv1a-xorshift-text-to-procedural-seed",
+    "slug": "fnv1a-xorshift-text-to-procedural-seed",
+    "category": "algorithms",
+    "description": "Deterministically turn any user text into repeatable procedural layouts using FNV-1a + xorshift32.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "fnv1a xorshift text to procedural seed"
+    ],
+    "version": "1.0.0",
+    "path": "skills/algorithms/fnv1a-xorshift-text-to-procedural-seed",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "eclipse-rcp-rich-client-for-apm-ui",
+    "slug": "eclipse-rcp-rich-client-for-apm-ui",
+    "category": "apm",
+    "description": "Build a desktop-class APM / observability client on Eclipse RCP + ZEST/GEF for high-throughput real-time visualization that HTTP + JSON browsers struggle with",
+    "tags": [
+      "rcp",
+      "eclipse",
+      "desktop",
+      "apm",
+      "visualization"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/apm/eclipse-rcp-rich-client-for-apm-ui",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "opentelemetry-java-bootstrap",
+    "slug": "opentelemetry-java-bootstrap",
+    "category": "apm",
+    "description": "Minimal OpenTelemetry bootstrap for a Java service — OTLP exporter, resource attributes, auto-instrumentation agent, and graceful shutdown. Covers the common setup mistakes that cause spans to silently drop.",
+    "tags": [
+      "opentelemetry",
+      "otel",
+      "java",
+      "tracing",
+      "otlp",
+      "observability"
+    ],
+    "triggers": [
+      "OpenTelemetry",
+      "OTEL",
+      "otel-javaagent",
+      "otlp",
+      "tracing setup",
+      "service.name",
+      "span exporter"
+    ],
+    "version": "1.0.0",
+    "path": "skills/apm/opentelemetry-java-bootstrap",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "transaction-trace-pack-serialization-with-step-hierarchy",
+    "slug": "transaction-trace-pack-serialization-with-step-hierarchy",
+    "category": "apm",
+    "description": "Encode per-request distributed traces as a hierarchical list of typed steps (method, DB, external call, error) in a compressed binary pack, indexed by request end-time",
+    "tags": [
+      "tracing",
+      "apm",
+      "xlog",
+      "serialization",
+      "perf"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/apm/transaction-trace-pack-serialization-with-step-hierarchy",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "adaptive-strategy-hot-swap",
+    "slug": "adaptive-strategy-hot-swap",
+    "category": "arch",
+    "description": "Periodically re-evaluate candidate strategies/policies against recent data, swap the active one only when a weighted composite score beats the incumbent by a hysteresis threshold — prevents flapping while staying adaptive.",
+    "tags": [
+      "strategy",
+      "adaptive",
+      "hot-swap",
+      "hysteresis",
+      "rebalance",
+      "composite-score",
+      "backtest"
+    ],
+    "triggers": [
+      "shouldUpdateStrategy",
+      "reanalyze",
+      "strategy update",
+      "hot swap",
+      "policy rotation",
+      "best strategy",
+      "composite score",
+      "hysteresis threshold"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/arch/adaptive-strategy-hot-swap",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
     "name": "definition-registry-helper-cache",
     "slug": "definition-registry-helper-cache",
     "category": "arch",
     "description": "Static helper class with ConcurrentHashMap caches populated at startup by @PostConstruct providers, enabling zero-allocation hot-path lookups via static getters",
-    "tags": [],
+    "tags": [
+      "spring",
+      "cache",
+      "static",
+      "concurrenthashmap",
+      "performance"
+    ],
     "triggers": [
       "static helper cache",
       "ConcurrentHashMap static cache",
@@ -956,678 +5402,77 @@
     "has_content": false
   },
   {
-    "name": "design-an-interface",
-    "slug": "design-an-interface",
-    "category": "misc",
-    "description": "Generate multiple radically different interface designs for a module using parallel sub-agents. Use when user wants to design an API, explore interface options, compare module shapes, or mentions \"design it twice\".",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/misc/design-an-interface",
-    "has_content": false
-  },
-  {
-    "name": "design-consultation",
-    "slug": "design-consultation",
-    "category": "design",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/design/design-consultation",
-    "has_content": false
-  },
-  {
-    "name": "design-html",
-    "slug": "design-html",
-    "category": "design",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/design/design-html",
-    "has_content": false
-  },
-  {
-    "name": "design-review",
-    "slug": "design-review",
-    "category": "design",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "2.0.0",
-    "path": "skills/design/design-review",
-    "has_content": false
-  },
-  {
-    "name": "design-shotgun",
-    "slug": "design-shotgun",
-    "category": "design",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/design/design-shotgun",
-    "has_content": false
-  },
-  {
-    "name": "deterministic-coverage-verification",
-    "slug": "deterministic-coverage-verification",
-    "category": "testing",
-    "description": "Run LLVM-instrumented tests multiple times and verify identical coverage reports — catches compiler/env non-determinism that can mask real bugs.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/testing/deterministic-coverage-verification",
-    "has_content": false
-  },
-  {
-    "name": "dev-controller-tenant-wrapping-helper",
-    "slug": "dev-controller-tenant-wrapping-helper",
-    "category": "backend",
-    "description": "Dev/로컬 전용 컨트롤러의 테넌트+JWT 반복 래핑을 함수형 인터페이스 + 헬퍼 컴포넌트로 추출",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/dev-controller-tenant-wrapping-helper",
-    "has_content": true
-  },
-  {
-    "name": "devex-review",
-    "slug": "devex-review",
-    "category": "testing",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/testing/devex-review",
-    "has_content": false
-  },
-  {
-    "name": "distributed-lock-mongodb",
-    "slug": "distributed-lock-mongodb",
-    "category": "backend",
-    "description": "MongoDB findAndModify-based distributed lock with TTL expiry, owner tagging, and retry loop for multi-instance Spring Boot services.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/distributed-lock-mongodb",
-    "has_content": true
-  },
-  {
-    "name": "distributed-tracing-data-simulation",
-    "slug": "distributed-tracing-data-simulation",
-    "category": "workflow",
-    "description": "Three strategies for generating synthetic distributed trace data — flat span lists, directed service graphs, and recursive span trees.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "distributed tracing data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/distributed-tracing-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "distributed-tracing-visualization-pattern",
-    "slug": "distributed-tracing-visualization-pattern",
-    "category": "design",
-    "description": "Three complementary visual encodings for rendering distributed traces — waterfall timeline, service topology graph, and span flame chart.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "distributed tracing visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/distributed-tracing-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "divide-by-zero-rate-guard",
-    "slug": "divide-by-zero-rate-guard",
-    "category": "backend",
-    "description": "Guard rate/percentage calculations against zero denominators to prevent NaN from poisoning downstream metrics and serialization.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/divide-by-zero-rate-guard",
-    "has_content": false
-  },
-  {
-    "name": "dnd-kit-tab-reordering",
-    "slug": "dnd-kit-tab-reordering",
-    "category": "design",
-    "description": "Implement horizontal tab drag reordering using @dnd-kit/core + @dnd-kit/sortable with PointerSensor and CSS.Transform",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/design/dnd-kit-tab-reordering",
-    "has_content": false
-  },
-  {
-    "name": "docker-compose-service-inventory-files",
-    "slug": "docker-compose-service-inventory-files",
-    "category": "devops",
-    "description": "Manage large Docker Compose service fleets using flat inventory files with '#' as an EX (exclude) marker",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/devops/docker-compose-service-inventory-files",
-    "has_content": true
-  },
-  {
-    "name": "docker-compose-v1-v2-auto-detect",
-    "slug": "docker-compose-v1-v2-auto-detect",
-    "category": "devops",
-    "description": "Shell helper that prefers `docker compose` (v2) over `docker-compose` (v1) with graceful fallback",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/devops/docker-compose-v1-v2-auto-detect",
-    "has_content": true
-  },
-  {
-    "name": "document-release",
-    "slug": "document-release",
-    "category": "docs",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/docs/document-release",
-    "has_content": false
-  },
-  {
+    "kind": "skill",
     "name": "domain-category-endpoint-registry",
     "slug": "domain-category-endpoint-registry",
     "category": "arch",
     "description": "Organize a large vendor-API client (100s of endpoints) under a three-level `{domain}/{category}/{Action}{Entity}` package convention with a shared base class and a single `initializeEndpoints()` registry — scalable, greppable, and uniformly logged.",
-    "tags": [],
-    "triggers": [],
+    "tags": [
+      "api-client",
+      "registry",
+      "code-organization",
+      "vendor-sdk",
+      "base-class",
+      "sdk-wrapping"
+    ],
+    "triggers": [
+      "BaseApiEndpoint",
+      "initializeEndpoints",
+      "ApiEndpoint",
+      "api registry",
+      "vendor sdk",
+      "many endpoints",
+      "endpoint catalog"
+    ],
     "version": "0.1.0-draft",
     "path": "skills/arch/domain-category-endpoint-registry",
     "has_content": true
   },
   {
-    "name": "domain-driven-data-simulation",
-    "slug": "domain-driven-data-simulation",
-    "category": "workflow",
-    "description": "Structured command-event-state triplets for simulating aggregate lifecycles and context relationships.",
+    "kind": "skill",
+    "name": "event-returning-pure-reducer",
+    "slug": "event-returning-pure-reducer",
+    "category": "arch",
+    "description": "State reducer that returns `{state, events, done}` so UI layer renders new state and appends to a log in one pass without the reducer touching DOM.",
     "tags": [
       "auto-loop"
     ],
     "triggers": [
-      "domain driven data simulation"
+      "event returning pure reducer"
     ],
     "version": "1.0.0",
-    "path": "skills/workflow/domain-driven-data-simulation",
+    "path": "skills/arch/event-returning-pure-reducer",
     "has_content": false
   },
   {
-    "name": "domain-driven-visualization-pattern",
-    "slug": "domain-driven-visualization-pattern",
-    "category": "design",
-    "description": "Canvas and card-based visual encodings for DDD strategic and tactical concepts with interactive exploration.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "domain driven visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/domain-driven-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "dotenv-multi-env-routing",
-    "slug": "dotenv-multi-env-routing",
-    "category": "backend",
-    "description": "Single ENV variable flips an entire stack (REST base URL, WebSocket base, per-operation transaction IDs) between production and sandbox tiers, loaded via dotenv with OS-env precedence.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/backend/dotenv-multi-env-routing",
-    "has_content": true
-  },
-  {
-    "name": "drawer-resizable-composition",
-    "slug": "drawer-resizable-composition",
-    "category": "frontend",
-    "description": "Drawer-as-primary-modal pattern with preset widths, resizable handles, and parent state composition for React apps",
-    "tags": [],
-    "triggers": [
-      "drawer",
-      "modal drawer",
-      "resizable drawer",
-      "side panel"
-    ],
-    "version": "1.0.0",
-    "path": "skills/frontend/drawer-resizable-composition",
-    "has_content": true
-  },
-  {
-    "name": "drawer-resizable-mouse-drag",
-    "slug": "drawer-resizable-mouse-drag",
-    "category": "design",
-    "description": "Make Ant Design Drawer resizable via mouse drag with styled-components handle, min/max width constraints, and transition suppression during drag",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/design/drawer-resizable-mouse-drag",
-    "has_content": false
-  },
-  {
-    "name": "dry-run-confirm-retry-write-flow",
-    "slug": "dry-run-confirm-retry-write-flow",
-    "category": "backend",
-    "description": "[Backend] 트래커/외부 API 쓰기 작업에 적용하는 공통 플로우: 미리보기 → 사용자 확인 → 쓰기 → 재시도.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/dry-run-confirm-retry-write-flow",
-    "has_content": false
-  },
-  {
-    "name": "dual-jre-docker-oz-report",
-    "slug": "dual-jre-docker-oz-report",
-    "category": "devops",
-    "description": "Package a Java 21 Spring Boot app that bundles a legacy JRE 8 + sidecar Tomcat (OZ Report engine) in one Alpine container",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/devops/dual-jre-docker-oz-report",
-    "has_content": true
-  },
-  {
-    "name": "dynamic-gridfs-template-multi-tenant",
-    "slug": "dynamic-gridfs-template-multi-tenant",
-    "category": "backend",
-    "description": "Resolve MongoDB GridFsTemplate per (tenant-db, bucket) pair with lazy caching, for storing large binary assets per tenant",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/dynamic-gridfs-template-multi-tenant",
-    "has_content": true
-  },
-  {
-    "name": "echarts-svg-worker-chart",
-    "slug": "echarts-svg-worker-chart",
-    "category": "design",
-    "description": "High-performance chart component using ECharts with custom SVG overlays (markLine/markArea/markPoint), worker thread data processing, and brush selection interaction",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/design/echarts-svg-worker-chart",
-    "has_content": false
-  },
-  {
-    "name": "eclipse-rcp-rich-client-for-apm-ui",
-    "slug": "eclipse-rcp-rich-client-for-apm-ui",
-    "category": "apm",
-    "description": "Build a desktop-class APM / observability client on Eclipse RCP + ZEST/GEF for high-throughput real-time visualization that HTTP + JSON browsers struggle with",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/apm/eclipse-rcp-rich-client-for-apm-ui",
-    "has_content": false
-  },
-  {
-    "name": "edit-article",
-    "slug": "edit-article",
-    "category": "docs",
-    "description": "Edit and improve articles by restructuring sections, improving clarity, and tightening prose. Use when user wants to edit, revise, or improve an article draft.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/docs/edit-article",
-    "has_content": false
-  },
-  {
-    "name": "elasticsearch-xpack-ssl-transport",
-    "slug": "elasticsearch-xpack-ssl-transport",
-    "category": "backend",
-    "description": "Gate `PreBuiltXPackTransportClient` vs `PreBuiltTransportClient` on auth flag (not SSL flag) and configure keystore/truststore as independent ES X-Pack settings",
-    "tags": [],
-    "triggers": [
-      "connect Java client to X-Pack-secured Elasticsearch cluster",
-      "production ES requires auth and optional transport TLS"
-    ],
-    "version": "1.0.0",
-    "path": "skills/backend/elasticsearch-xpack-ssl-transport",
-    "has_content": true
-  },
-  {
-    "name": "enable-async-tenant-aware",
-    "slug": "enable-async-tenant-aware",
-    "category": "backend",
-    "description": "Place @EnableAsync on a dedicated @Configuration that extends a tenant-aware AsyncConfigurer, so tenant/MDC context propagates across the executor boundary",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/enable-async-tenant-aware",
-    "has_content": true
-  },
-  {
-    "name": "encrypted-pii-decrypt-before-send",
-    "slug": "encrypted-pii-decrypt-before-send",
-    "category": "backend",
-    "description": "Store user email/phone encrypted at rest; decrypt only inside the sender, never in cache/DTO/log boundaries",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/encrypted-pii-decrypt-before-send",
-    "has_content": true
-  },
-  {
-    "name": "etl-data-simulation",
-    "slug": "etl-data-simulation",
-    "category": "workflow",
-    "description": "Generate realistic synthetic ETL pipeline data including job states, row volumes, null distributions, and time-series ingestion metrics for UI prototyping.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "etl data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/etl-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "etl-visualization-pattern",
-    "slug": "etl-visualization-pattern",
-    "category": "design",
-    "description": "Visual encoding patterns for representing ETL pipeline stages, data flow direction, and processing state transitions in dark-themed dashboards.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "etl visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/etl-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "eureka-service-discovery-wait-annotation",
-    "slug": "eureka-service-discovery-wait-annotation",
-    "category": "backend",
-    "description": "Declarative @WaitForServices annotation on @EventListener methods — blocks initialization until named Eureka services are healthy, with optional leader-only execution",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/eureka-service-discovery-wait-annotation",
-    "has_content": true
-  },
-  {
-    "name": "event-driven-kafka-scheduling",
-    "slug": "event-driven-kafka-scheduling",
-    "category": "backend",
-    "description": "Replace Spring @Scheduled with a Kafka-delivered JobExecuteNotice so a central scheduler service fans out tick events — with a skip-if-previous-still-running guard to prevent pile-up.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/event-driven-kafka-scheduling",
-    "has_content": true
-  },
-  {
-    "name": "event-sourcing-data-simulation",
-    "slug": "event-sourcing-data-simulation",
-    "category": "workflow",
-    "description": "Strategies for generating synthetic event streams with domain-typed events, versioned aggregates, and replay-capable stores for event-sourcing demos.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "event sourcing data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/event-sourcing-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "event-sourcing-visualization-pattern",
-    "slug": "event-sourcing-visualization-pattern",
-    "category": "design",
-    "description": "Reusable visual encoding patterns for rendering event streams, aggregate state, and CQRS data flow in browser-based event-sourcing UIs.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "event sourcing visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/event-sourcing-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "excel-download-null-date-range-handling",
-    "slug": "excel-download-null-date-range-handling",
-    "category": "backend",
-    "description": "Defensive pattern for grid/list excel-export endpoints — null-check every filter value and normalize field names before querying",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/excel-download-null-date-range-handling",
-    "has_content": true
-  },
-  {
-    "name": "excel-export-enum-replacer",
-    "slug": "excel-export-enum-replacer",
-    "category": "backend",
-    "description": "Use DataToBeReplace.builder() to map enum/code values to display labels before passing content to ExcelExportManager.objectToExcelAndDownload()",
-    "tags": [],
-    "triggers": [
-      "excel export enum replace",
-      "DataToBeReplace",
-      "ExcelExportManager",
-      "objectToExcelAndDownload",
-      "excel download controller"
-    ],
-    "version": "0.1.0-draft",
-    "path": "skills/backend/excel-export-enum-replacer",
-    "has_content": false
-  },
-  {
-    "name": "feed-envelope-frame",
-    "slug": "feed-envelope-frame",
-    "category": "backend",
-    "description": "Uniform WebSocket payload wrapper with Type (ACK/SNAPSHOT/DELTA/ERROR), PayloadKind, and correlation requestId, including null-safe factory methods",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/feed-envelope-frame",
-    "has_content": true
-  },
-  {
-    "name": "figma-code-connect-react",
-    "slug": "figma-code-connect-react",
-    "category": "frontend",
-    "description": "Map Figma component variants to React props using @figma/code-connect with co-located *.figma.tsx files",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/frontend/figma-code-connect-react",
-    "has_content": true
-  },
-  {
-    "name": "figma-token-scss-style-dictionary-v3",
-    "slug": "figma-token-scss-style-dictionary-v3",
-    "category": "frontend",
-    "description": "Figma Tokens Studio JSON → split files → Style Dictionary v3 → SCSS variables, typography classes, and composition classes",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/frontend/figma-token-scss-style-dictionary-v3",
-    "has_content": true
-  },
-  {
-    "name": "figma-token-to-tailwind-theme",
-    "slug": "figma-token-to-tailwind-theme",
-    "category": "design",
-    "description": "Pipeline from Figma Token Studio JSON exports through Style Dictionary v5 to Tailwind v4 @theme CSS custom properties, with dark/light/contrast mode support and breaking change detection",
-    "tags": [],
-    "triggers": [],
-    "version": "1.1.0",
-    "path": "skills/design/figma-token-to-tailwind-theme",
-    "has_content": true
-  },
-  {
-    "name": "finite-state-machine-data-simulation",
-    "slug": "finite-state-machine-data-simulation",
-    "category": "workflow",
-    "description": "Canonical FSM data models, transition lookup strategies, and step-through simulation loops for accept/reject testing.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "finite state machine data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/finite-state-machine-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "finite-state-machine-visualization-pattern",
-    "slug": "finite-state-machine-visualization-pattern",
-    "category": "design",
-    "description": "Circular-node state graph with directional arrows, active-state glow, and dark-theme FSM rendering on Canvas/SVG.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "finite state machine visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/finite-state-machine-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "folder-coloc-style-types",
-    "slug": "folder-coloc-style-types",
-    "category": "frontend",
-    "description": "Keep component, style, and types files at the same depth; never split into styles/ or types/ subfolders",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/frontend/folder-coloc-style-types",
-    "has_content": true
-  },
-  {
-    "name": "font-cache-alpine-locale-docker",
-    "slug": "font-cache-alpine-locale-docker",
-    "category": "devops",
-    "description": "Make CJK/custom fonts usable inside an Alpine container by copying TTF/OTF and rebuilding the fontconfig cache",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/devops/font-cache-alpine-locale-docker",
-    "has_content": true
-  },
-  {
-    "name": "freemarker-two-phase-expression-subst",
-    "slug": "freemarker-two-phase-expression-subst",
-    "category": "backend",
-    "description": "Render templates by first replacing raw ${var} placeholders via string-replace, then running FreeMarker for expression-object binding, avoiding double-evaluation and escape conflicts",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/freemarker-two-phase-expression-subst",
-    "has_content": true
-  },
-  {
-    "name": "freeze",
-    "slug": "freeze",
-    "category": "workflow",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0",
-    "path": "skills/workflow/freeze",
-    "has_content": false
-  },
-  {
-    "name": "frozen-detection-consecutive-count",
-    "slug": "frozen-detection-consecutive-count",
-    "category": "backend",
-    "description": "Detect a stuck/frozen metric (identical value for N consecutive samples) by CONSECUTIVE-dampening equality check; catches sensor/collector failures that threshold alarms miss.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/frozen-detection-consecutive-count",
-    "has_content": true
-  },
-  {
-    "name": "fuzz-corpus-seed-management",
-    "slug": "fuzz-corpus-seed-management",
-    "category": "testing",
-    "description": "Structured libFuzzer workflow — seed corpora in a separate asset repo, determinism verification, and reproducible crash workflows.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/testing/fuzz-corpus-seed-management",
-    "has_content": false
-  },
-  {
-    "name": "gacha-soft-hard-pity",
-    "slug": "gacha-soft-hard-pity",
-    "category": "game-dev",
-    "description": "Server-authoritative gacha with soft pity (rate ramp after N pulls), hard pity (guaranteed top rarity at M pulls), and 50/50 guarantee carryover. Split rate calculation from result resolution so probability is testable.",
-    "tags": [
-      "gacha",
-      "pity",
-      "probability",
-      "securerandom",
-      "loot",
-      "rng-fairness"
-    ],
-    "triggers": [
-      "gacha pity system",
-      "soft pity hard pity",
-      "50/50 pity",
-      "banner rate up",
-      "rate calculator"
-    ],
-    "version": "0.1.0-draft",
-    "path": "skills/game-dev/gacha-soft-hard-pity",
-    "has_content": true
-  },
-  {
-    "name": "git-guardrails-claude-code",
-    "slug": "git-guardrails-claude-code",
-    "category": "cli",
-    "description": "Set up Claude Code hooks to block dangerous git commands (push, reset --hard, clean, branch -D, etc.) before they execute. Use when user wants to prevent destructive git operations, add git safety hooks, or block git push/reset in Claude Code.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/cli/git-guardrails-claude-code",
-    "has_content": false
-  },
-  {
+    "kind": "skill",
     "name": "git-tag-registry-versioning",
     "slug": "git-tag-registry-versioning",
     "category": "arch",
     "description": "Add semver rollback and pinning to any git-backed asset registry (skills, prompts, commands, snippets) using namespaced annotated tags per item and per-release bundle.",
-    "tags": [],
-    "triggers": [],
+    "tags": [
+      "git",
+      "versioning",
+      "semver",
+      "registry",
+      "rollback",
+      "tags"
+    ],
+    "triggers": [
+      "version pin",
+      "rollback",
+      "git tag",
+      "registry versioning",
+      "skill versioning",
+      "prompt versioning",
+      "install specific version"
+    ],
     "version": "1.0.0",
     "path": "skills/arch/git-tag-registry-versioning",
     "has_content": true
   },
   {
-    "name": "github-triage",
-    "slug": "github-triage",
-    "category": "workflow",
-    "description": "Triage GitHub issues through a label-based state machine with interactive grilling sessions. Use when user wants to triage issues, review incoming bugs or feature requests, prepare issues for an AFK agent, or manage issue workflow.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/workflow/github-triage",
-    "has_content": false
-  },
-  {
+    "kind": "skill",
     "name": "gradle-bootjar-conditional-archive-bundle",
     "slug": "gradle-bootjar-conditional-archive-bundle",
     "category": "arch",
@@ -1639,284 +5484,7 @@
     "has_content": true
   },
   {
-    "name": "gradle-bootrun-local-dev-env",
-    "slug": "gradle-bootrun-local-dev-env",
-    "category": "devops",
-    "description": "Gradle bootRun task recipe that wires local MongoDB/Kafka/Redis/MQTT/Eureka/Quartz via environment variables — no docker-compose needed",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/devops/gradle-bootrun-local-dev-env",
-    "has_content": true
-  },
-  {
-    "name": "gradle-jacoco-exclusion-strategy",
-    "slug": "gradle-jacoco-exclusion-strategy",
-    "category": "devops",
-    "description": "Curated Jacoco/Sonar exclusion patterns for Spring Boot projects — skips config/DAO/entity/generated layers and Querydsl Q-classes",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/devops/gradle-jacoco-exclusion-strategy",
-    "has_content": true
-  },
-  {
-    "name": "gradle-shared-exclusions-jacoco-sonar",
-    "slug": "gradle-shared-exclusions-jacoco-sonar",
-    "category": "devops",
-    "description": "Keep Jacoco report, Jacoco coverage verification, and SonarQube exclusions in sync by defining one `exclusionPatterns` list in Gradle ext",
-    "tags": [],
-    "triggers": [
-      "jacoco and sonarqube exclusion lists drift apart",
-      "adding a new package to coverage exclusions requires editing multiple blocks",
-      "querydsl Q-classes / generated code leaking into coverage reports"
-    ],
-    "version": "1.0.0",
-    "path": "skills/devops/gradle-shared-exclusions-jacoco-sonar",
-    "has_content": true
-  },
-  {
-    "name": "grid-filter-to-criteria-converter",
-    "slug": "grid-filter-to-criteria-converter",
-    "category": "backend",
-    "description": "Convert a UI grid filter DTO (gridFilters + tagFilters + pageable) to MongoDB Criteria using CriteriaMakeHelper, supporting equals/contains/greaterThan/inRange operators",
-    "tags": [],
-    "triggers": [
-      "grid filter to criteria",
-      "FiltersPageableDto",
-      "CriteriaMakeHelper",
-      "mongodb dynamic filter",
-      "UI filter to query"
-    ],
-    "version": "0.1.0-draft",
-    "path": "skills/backend/grid-filter-to-criteria-converter",
-    "has_content": false
-  },
-  {
-    "name": "grill-me",
-    "slug": "grill-me",
-    "category": "workflow",
-    "description": "Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions \"grill me\".",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/workflow/grill-me",
-    "has_content": false
-  },
-  {
-    "name": "gstack",
-    "slug": "gstack",
-    "category": "cli",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.1.0",
-    "path": "skills/cli/gstack",
-    "has_content": false
-  },
-  {
-    "name": "gstack-qa",
-    "slug": "gstack-qa",
-    "category": "testing",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "2.0.0",
-    "path": "skills/testing/gstack-qa",
-    "has_content": false
-  },
-  {
-    "name": "gstack-qa-only",
-    "slug": "gstack-qa-only",
-    "category": "testing",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/testing/gstack-qa-only",
-    "has_content": false
-  },
-  {
-    "name": "gstack-upgrade",
-    "slug": "gstack-upgrade",
-    "category": "cli",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.1.0",
-    "path": "skills/cli/gstack-upgrade",
-    "has_content": false
-  },
-  {
-    "name": "guard",
-    "slug": "guard",
-    "category": "security",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0",
-    "path": "skills/security/guard",
-    "has_content": false
-  },
-  {
-    "name": "health",
-    "slug": "health",
-    "category": "testing",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/testing/health",
-    "has_content": false
-  },
-  {
-    "name": "health-check-data-simulation",
-    "slug": "health-check-data-simulation",
-    "category": "workflow",
-    "description": "Stochastic tick-based simulation of service latency, resource utilization, and uptime status using biased random walks with threshold-triggered state transitions.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "health check data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/health-check-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "health-check-visualization-pattern",
-    "slug": "health-check-visualization-pattern",
-    "category": "design",
-    "description": "Three-tier visual encoding for service health — traffic-light palette, temporal pulse lines, and calendar heatmaps on a dark operations background.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "health check visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/health-check-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "hexagonal-architecture-data-simulation",
-    "slug": "hexagonal-architecture-data-simulation",
-    "category": "workflow",
-    "description": "Structured node-edge-layer data model for simulating request flows, component placement, and dependency graphs in hexagonal architectures.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "hexagonal architecture data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/hexagonal-architecture-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "hexagonal-architecture-visualization-pattern",
-    "slug": "hexagonal-architecture-visualization-pattern",
-    "category": "design",
-    "description": "Three-ring concentric hexagon layout with layer-coded nodes, inward-flow edges, and polar positioning for domain/port/adapter components.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "hexagonal architecture visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/hexagonal-architecture-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "hibernate-multi-dialect-swap",
-    "slug": "hibernate-multi-dialect-swap",
-    "category": "backend",
-    "description": "Ship one WAR that connects to Oracle, PostgreSQL, MSSQL, Tibero, DB2, or MariaDB based on Spring profile — all JDBC drivers bundled, dialect and datasource resolved from externalized config",
-    "tags": [],
-    "triggers": [
-      "one deployable must support multiple RDBMS vendors without rebuild",
-      "hibernate dialect chosen at startup, not compile time",
-      "customer deployments dictate DB vendor"
-    ],
-    "version": "1.0.0",
-    "path": "skills/backend/hibernate-multi-dialect-swap",
-    "has_content": true
-  },
-  {
-    "name": "hierarchical-group-entity-mongo",
-    "slug": "hierarchical-group-entity",
-    "category": "backend",
-    "description": "Model a tree-structured group entity in MongoDB with parentId + path + pathIds + level, plus recursive child-path update on move and cycle detection.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/hierarchical-group-entity",
-    "has_content": true
-  },
-  {
-    "name": "hub-make-parallel-build",
-    "slug": "hub-make-parallel-build",
-    "category": "workflow",
-    "description": "Build multiple zero-dep single-file HTML apps in parallel from installed skills/knowledge data, verify, and publish via PR branch",
-    "tags": [],
-    "triggers": [
-      "hub-make",
-      "build examples",
-      "parallel html build"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/hub-make-parallel-build",
-    "has_content": true
-  },
-  {
-    "name": "idempotency-data-simulation",
-    "slug": "idempotency-data-simulation",
-    "category": "workflow",
-    "description": "Synthetic data generation strategies for simulating idempotency key lookups, repeated function applications, and duplicate state-machine event dispatch.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "idempotency data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/idempotency-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "idempotency-visualization-pattern",
-    "slug": "idempotency-visualization-pattern",
-    "category": "design",
-    "description": "Visual encoding patterns for rendering idempotency key deduplication, function stability, and state machine no-ops in browser-based simulations.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "idempotency visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/idempotency-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "identifier-truncate-with-hash-suffix",
-    "slug": "identifier-truncate-with-hash-suffix",
-    "category": "backend",
-    "description": "Deterministically shrink any identifier to a length cap while preserving uniqueness by appending a short hash of the original.",
-    "tags": [],
-    "triggers": [
-      "\"name too long\"",
-      "\"identifier length limit\"",
-      "\"shorten tool name\"",
-      "\"truncate unique\""
-    ],
-    "version": "0.1.0-draft",
-    "path": "skills/backend/identifier-truncate-with-hash-suffix",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "immutable-action-event-log",
     "slug": "immutable-action-event-log",
     "category": "arch",
@@ -1941,17 +5509,786 @@
     "has_content": true
   },
   {
-    "name": "improve-codebase-architecture",
-    "slug": "improve-codebase-architecture",
-    "category": "refactor",
-    "description": "Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. Use when user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more AI-navigable.",
+    "kind": "skill",
+    "name": "kafka-avro-topic-auto-create-config",
+    "slug": "kafka-avro-topic-auto-create-config",
+    "category": "arch",
+    "description": "Spring Boot Kafka config bean that auto-creates topics on startup via ApplicationRunner, with Avro serde, manual-ack listener, and bounded concurrency",
     "tags": [],
     "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/arch/kafka-avro-topic-auto-create-config",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "kafka-engine-distributed-job-framework",
+    "slug": "kafka-engine-distributed-job-framework",
+    "category": "arch",
+    "description": "Kafka 이벤트 기반 분산 작업 실행 프레임워크 스켈레톤 — Publisher→Topic→Consumer→Queue→Worker + Admission Control + Strategy SPI",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/arch/kafka-engine-distributed-job-framework",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "layered-risk-gates",
+    "slug": "layered-risk-gates",
+    "category": "arch",
+    "description": "Three-layer safety pattern for autonomous action loops — pre-action admission gate, in-flight monitor (stop/target thresholds), and a consecutive-failure circuit breaker — so a single runaway loop can't clear out the account before a human sees it.",
+    "tags": [
+      "risk",
+      "circuit-breaker",
+      "safety",
+      "autonomous",
+      "limits",
+      "guardrails"
+    ],
+    "triggers": [
+      "risk management",
+      "position sizing",
+      "max daily loss",
+      "consecutive losses",
+      "stop loss",
+      "take profit",
+      "kill switch",
+      "circuit breaker"
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/refactor/improve-codebase-architecture",
+    "path": "skills/arch/layered-risk-gates",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "module-federation-expose-wrapper",
+    "slug": "module-federation-expose-wrapper",
+    "category": "arch",
+    "description": "Six-step pattern for exposing a component from one Module Federation remote and consuming it from another via a shared library — implementation → expose wrapper → MF config → MF name constant → RemoteApp wrapper in shared → consumer import. Prevents direct cross-remote imports and webpack alias collisions.",
+    "tags": [
+      "module-federation",
+      "micro-frontend",
+      "webpack",
+      "react",
+      "remote",
+      "expose",
+      "mfa"
+    ],
+    "triggers": [
+      "module federation",
+      "MFA",
+      "cross-remote import",
+      "exposes",
+      "RemoteApp",
+      "webpack alias collision"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/arch/module-federation-expose-wrapper",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "optional-outbound-adapter-no-op-port",
+    "slug": "optional-outbound-adapter-no-op-port",
+    "category": "arch",
+    "description": "Register a No-Op implementation of an optional outbound port with @ConditionalOnMissingBean so services boot when the real adapter (Kafka audit, tracing, notifications) is absent.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/arch/optional-outbound-adapter-no-op-port",
     "has_content": false
   },
   {
+    "kind": "skill",
+    "name": "pluggable-sender-factory-pattern",
+    "slug": "pluggable-sender-factory-pattern",
+    "category": "arch",
+    "description": "Register multiple notification/transport backends (SMS, EMAIL, SMTP, JDBC, REST, SLACK, SOCKET) behind a single FactoryBean that dispatches by enum type",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/arch/pluggable-sender-factory-pattern",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "plugin-resource-provider-architecture",
+    "slug": "plugin-resource-provider-architecture",
+    "category": "arch",
+    "description": "Stable `ResourceProvider` SPI loaded via Spring component scan; each new device/resource type is a separate Gradle-module JAR packaged into the WAR — zero core edits",
+    "tags": [],
+    "triggers": [
+      "extensible monitoring/management platform",
+      "vendor support must be pluggable per deployment"
+    ],
+    "version": "1.0.0",
+    "path": "skills/arch/plugin-resource-provider-architecture",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "resource-provider-registry",
+    "slug": "resource-provider-registry",
+    "category": "arch",
+    "description": "Spring DI plugin registry where @Component implementations of a typed interface are auto-discovered and looked up at runtime by a string type key",
+    "tags": [
+      "spring",
+      "plugin",
+      "registry",
+      "interface",
+      "component"
+    ],
+    "triggers": [
+      "plugin registry",
+      "provider lookup by type",
+      "auto-discovered handlers",
+      "resource provider pattern"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/arch/resource-provider-registry",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "resource-summary-resolve-override-template",
+    "slug": "resource-summary-resolve-override-template",
+    "category": "arch",
+    "description": "리소스 상세 화면의 \"요약\" 탭에서 `OVERRIDE → TEMPLATE → NONE` 순으로 대시보드를 결정하는 서버-클라이언트 패턴. 오버라이드 엔티티, resolve API, 상태별 UI 드롭다운 규칙까지 포함.",
+    "tags": [
+      "resource-detail",
+      "dashboard",
+      "override",
+      "template",
+      "resolve",
+      "widget",
+      "summary"
+    ],
+    "triggers": [
+      "resource summary",
+      "리소스 요약",
+      "resolve override template",
+      "dashboard override",
+      "resourceSummary",
+      "composition override"
+    ],
+    "version": "1.0.0",
+    "path": "skills/arch/resource-summary-resolve-override-template",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "shared-package-only-cross-module",
+    "slug": "shared-package-only-cross-module",
+    "category": "arch",
+    "description": "Enforce a one-way dependency graph in a multi-module repo — sibling modules may only import from a single `shared/` package, never from each other. Prevents webpack alias collisions, keeps module boundaries enforceable, and makes build/deploy units independent.",
+    "tags": [
+      "monorepo",
+      "module-boundaries",
+      "webpack",
+      "alias",
+      "micro-frontend",
+      "dependency-direction"
+    ],
+    "triggers": [
+      "cross-module import",
+      "cannot resolve @/",
+      "alias collision",
+      "webpack root",
+      "monorepo boundaries"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/arch/shared-package-only-cross-module",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "site-per-customer-override-modules",
+    "slug": "site-per-customer-override-modules",
+    "category": "arch",
+    "description": "One Gradle module per customer (`<product>-site-<customer>`) overrides core beans, auth, notification channels, and assets — keeps core customer-agnostic and scales to dozens of deployments",
+    "tags": [],
+    "triggers": [
+      "B2B product delivered to many customers with bespoke requirements",
+      "feature-flag soup is polluting core"
+    ],
+    "version": "1.0.0",
+    "path": "skills/arch/site-per-customer-override-modules",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "tenant-context-holder-propagation",
+    "slug": "tenant-context-holder-propagation",
+    "category": "arch",
+    "description": "Set TenantContextHolder.INSTANCE.setTenantId(orgId) on the current thread so MongoDB tenant-isolated templates route queries correctly, always clearing in a finally block",
+    "tags": [
+      "spring",
+      "multi-tenant",
+      "threadlocal",
+      "mongodb",
+      "isolation"
+    ],
+    "triggers": [
+      "TenantContextHolder",
+      "tenant context propagation",
+      "multi-tenant thread local",
+      "MONGODB_TEMPLATE_ISOLATION",
+      "tenant isolation mongodb"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/arch/tenant-context-holder-propagation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "tiered-rebalance-schedule",
+    "slug": "tiered-rebalance-schedule",
+    "category": "arch",
+    "description": "Run three cadences against the same managed set — fast performance review, mid-frequency policy re-analysis, slow portfolio rebalance — each with its own trigger interval and mutation budget, so urgency scales with cost.",
+    "tags": [
+      "scheduler",
+      "rebalance",
+      "tiers",
+      "cadence",
+      "cron",
+      "portfolio",
+      "lifecycle"
+    ],
+    "triggers": [
+      "scheduleWithFixedDelay",
+      "periodic review",
+      "rebalance",
+      "reanalysis interval",
+      "tiered schedule",
+      "performance review",
+      "portfolio rebalance"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/arch/tiered-rebalance-schedule",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "audit-change-data-capture-pattern",
+    "slug": "audit-change-data-capture-pattern",
+    "category": "backend",
+    "description": "Compute before/after diffs for audit logs by comparing two BSON/JSON documents field-by-field — always iterate the BEFORE doc and read from AFTER to avoid prev/after swap bugs",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/audit-change-data-capture-pattern",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "availability-ttl-punctuate-processor",
+    "slug": "availability-ttl-punctuate-processor",
+    "category": "backend",
+    "description": "Kafka Streams processor schedules a wall-clock `punctuate` for TTL eviction of the state store, and emits downstream only on value change. Wall-clock (not stream-time) so idle inputs still trigger cleanup.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/availability-ttl-punctuate-processor",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "avro-event-with-change-flags",
+    "slug": "avro-event-with-change-flags",
+    "category": "backend",
+    "description": "Design Kafka Avro event schemas that carry an actionType enum plus boolean \"changed\" flags per mutable section so consumers can branch cheaply without diffing payloads.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/avro-event-change-flags",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "avro-gradle-kafka-schema-pipeline",
+    "slug": "avro-gradle-kafka-schema-pipeline",
+    "category": "backend",
+    "description": "Wire the davidmc24 Avro Gradle plugin so .avsc schemas generate Java sources consumed by Kafka producers/consumers with Confluent Schema Registry",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/avro-gradle-kafka-schema-pipeline",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "axios-token-refresh-queue",
+    "slug": "axios-token-refresh-queue",
+    "category": "backend",
+    "description": "Axios interceptor with window-scoped request queue during JWT token refresh to prevent concurrent refresh races",
+    "tags": [],
+    "triggers": [
+      "token refresh",
+      "axios interceptor",
+      "jwt refresh",
+      "401 retry",
+      "authentication interceptor"
+    ],
+    "version": "1.0.0",
+    "path": "skills/backend/axios-token-refresh-queue",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "baseline-historical-comparison-threshold",
+    "slug": "baseline-historical-comparison-threshold",
+    "category": "backend",
+    "description": "Evaluate a current metric against a historical baseline (prev hour/day/week/month/year, with MIN/AVG/MAX aggregation) as a dynamic threshold; supports RATE or VALUE change modes and dampening.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/baseline-historical-comparison-threshold",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "bootrun-jvmargs-jdwp-opens-java21",
+    "slug": "bootrun-jvmargs-jdwp-opens-java21",
+    "category": "backend",
+    "description": "Bake JDWP debug port and required --add-opens flags into Gradle bootRun so every dev gets the same Java 17/21-compatible local runtime",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/bootrun-jvmargs-jdwp-opens-java21",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "byte-aware-sms-truncation-with-ellipsis",
+    "slug": "byte-aware-sms-truncation-with-ellipsis",
+    "category": "backend",
+    "description": "Truncate SMS message body to a byte budget (not char count) per charset, appending '...' without exceeding the budget",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/byte-aware-sms-truncation-with-ellipsis",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "cache-variance-ttl-jitter",
+    "slug": "cache-variance-ttl-jitter",
+    "category": "backend",
+    "description": "Add ±N% random jitter to cache TTLs so keys written together don't all expire in the same tick, avoiding synchronized recompute storms",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/cache-variance-ttl-jitter",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "calendar-cron-vs-spring-cron-migration",
+    "slug": "calendar-cron-vs-spring-cron-migration",
+    "category": "backend",
+    "description": "Convert between Spring 6-field cron and Quartz/calendar 7-field cron without DST/leap-year regressions",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/calendar-cron-vs-spring-cron-migration",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "challenge-response-auth-redis-ttl",
+    "slug": "challenge-response-auth-redis-ttl",
+    "category": "backend",
+    "description": "Replay-resistant two-step login — server issues a short-lived random challenge stored in Redis with TTL, client signs/hashes response, bounded attempts per key",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/challenge-response-auth-redis-ttl",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "chunked-resource-id-batch-fetch",
+    "slug": "chunked-resource-id-batch-fetch",
+    "category": "backend",
+    "description": "Split large ID lists into ~1000-item chunks before querying DB or Elasticsearch to avoid bind-parameter limits (MSSQL 2100, Oracle 1000) and OOM on bulk responses",
+    "tags": [],
+    "triggers": [
+      "`WHERE id IN (?, ?, …)` with thousands of IDs",
+      "ES `terms` query near 65536-item ceiling",
+      "monitor/report accepts an unbounded target ID list"
+    ],
+    "version": "1.0.0",
+    "path": "skills/backend/chunked-resource-id-batch-fetch",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "collection-routing-by-period",
+    "slug": "collection-routing-by-period",
+    "category": "backend",
+    "description": "Single resolver maps `(Period.Mode, from, to)` → time-series collection (raw view / 1-min / hour-with-monthly-suffix / day). Callers never hardcode collection names.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/collection-routing-by-period",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "compact-binary-wire-protocol-with-variable-length-encoding",
+    "slug": "compact-binary-wire-protocol-with-variable-length-encoding",
+    "category": "backend",
+    "description": "Define a custom binary wire format with variable-length integer encodings (e.g. 3-byte / 5-byte) to minimize UDP packet size for high-volume metric or telemetry streams",
+    "tags": [
+      "protocol",
+      "binary",
+      "varint",
+      "udp",
+      "telemetry",
+      "perf"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/compact-binary-wire-protocol-with-variable-length-encoding",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "concurrent-jdbc-pool-datasource-lifecycle",
+    "slug": "concurrent-jdbc-pool-datasource-lifecycle",
+    "category": "backend",
+    "description": "Manage a pool of short-lived JDBC targets for monitoring agents with dual maps (active vs all) and periodic revalidation",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/concurrent-jdbc-pool-datasource-lifecycle",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "conditional-feature-flag-rollout",
+    "slug": "conditional-feature-flag-rollout",
+    "category": "backend",
+    "description": "@ConditionalOnProperty로 구/신 구현을 공존시키고 런타임 속성 하나로 전환하는 점진적 롤아웃 패턴",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/conditional-feature-flag-rollout",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "custom-actuator-command-whitelist",
+    "slug": "custom-actuator-command-whitelist",
+    "category": "backend",
+    "description": "Expose safe remote OS command execution on a Spring Boot service via a custom Actuator endpoint, restricted by a command whitelist, an argument sanitizer, and an execution timeout.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/custom-actuator-command-whitelist",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "dev-controller-tenant-wrapping-helper",
+    "slug": "dev-controller-tenant-wrapping-helper",
+    "category": "backend",
+    "description": "Dev/로컬 전용 컨트롤러의 테넌트+JWT 반복 래핑을 함수형 인터페이스 + 헬퍼 컴포넌트로 추출",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/dev-controller-tenant-wrapping-helper",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "distributed-lock-mongodb",
+    "slug": "distributed-lock-mongodb",
+    "category": "backend",
+    "description": "MongoDB findAndModify-based distributed lock with TTL expiry, owner tagging, and retry loop for multi-instance Spring Boot services.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/distributed-lock-mongodb",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "divide-by-zero-rate-guard",
+    "slug": "divide-by-zero-rate-guard",
+    "category": "backend",
+    "description": "Guard rate/percentage calculations against zero denominators to prevent NaN from poisoning downstream metrics and serialization.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/divide-by-zero-rate-guard",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "dotenv-multi-env-routing",
+    "slug": "dotenv-multi-env-routing",
+    "category": "backend",
+    "description": "Single ENV variable flips an entire stack (REST base URL, WebSocket base, per-operation transaction IDs) between production and sandbox tiers, loaded via dotenv with OS-env precedence.",
+    "tags": [
+      "dotenv",
+      "config",
+      "environments",
+      "sandbox",
+      "production",
+      "routing"
+    ],
+    "triggers": [
+      "KIS_ENV",
+      "prod",
+      "vts",
+      "sandbox",
+      "dotenv",
+      "Dotenv.configure",
+      "multi-environment",
+      "openapi host"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/backend/dotenv-multi-env-routing",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "dry-run-confirm-retry-write-flow",
+    "slug": "dry-run-confirm-retry-write-flow",
+    "category": "backend",
+    "description": "[Backend] 트래커/외부 API 쓰기 작업에 적용하는 공통 플로우: 미리보기 → 사용자 확인 → 쓰기 → 재시도.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/dry-run-confirm-retry-write-flow",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "dynamic-gridfs-template-multi-tenant",
+    "slug": "dynamic-gridfs-template-multi-tenant",
+    "category": "backend",
+    "description": "Resolve MongoDB GridFsTemplate per (tenant-db, bucket) pair with lazy caching, for storing large binary assets per tenant",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/dynamic-gridfs-template-multi-tenant",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "elasticsearch-xpack-ssl-transport",
+    "slug": "elasticsearch-xpack-ssl-transport",
+    "category": "backend",
+    "description": "Gate `PreBuiltXPackTransportClient` vs `PreBuiltTransportClient` on auth flag (not SSL flag) and configure keystore/truststore as independent ES X-Pack settings",
+    "tags": [],
+    "triggers": [
+      "connect Java client to X-Pack-secured Elasticsearch cluster",
+      "production ES requires auth and optional transport TLS"
+    ],
+    "version": "1.0.0",
+    "path": "skills/backend/elasticsearch-xpack-ssl-transport",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "enable-async-tenant-aware",
+    "slug": "enable-async-tenant-aware",
+    "category": "backend",
+    "description": "Place @EnableAsync on a dedicated @Configuration that extends a tenant-aware AsyncConfigurer, so tenant/MDC context propagates across the executor boundary",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/enable-async-tenant-aware",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "encrypted-pii-decrypt-before-send",
+    "slug": "encrypted-pii-decrypt-before-send",
+    "category": "backend",
+    "description": "Store user email/phone encrypted at rest; decrypt only inside the sender, never in cache/DTO/log boundaries",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/encrypted-pii-decrypt-before-send",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "eureka-service-discovery-wait-annotation",
+    "slug": "eureka-service-discovery-wait-annotation",
+    "category": "backend",
+    "description": "Declarative @WaitForServices annotation on @EventListener methods — blocks initialization until named Eureka services are healthy, with optional leader-only execution",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/eureka-service-discovery-wait-annotation",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "event-driven-kafka-scheduling",
+    "slug": "event-driven-kafka-scheduling",
+    "category": "backend",
+    "description": "Replace Spring @Scheduled with a Kafka-delivered JobExecuteNotice so a central scheduler service fans out tick events — with a skip-if-previous-still-running guard to prevent pile-up.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/event-driven-kafka-scheduling",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "excel-download-null-date-range-handling",
+    "slug": "excel-download-null-date-range-handling",
+    "category": "backend",
+    "description": "Defensive pattern for grid/list excel-export endpoints — null-check every filter value and normalize field names before querying",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/excel-download-null-date-range-handling",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "excel-export-enum-replacer",
+    "slug": "excel-export-enum-replacer",
+    "category": "backend",
+    "description": "Use DataToBeReplace.builder() to map enum/code values to display labels before passing content to ExcelExportManager.objectToExcelAndDownload()",
+    "tags": [
+      "spring",
+      "excel",
+      "export",
+      "enum",
+      "controller"
+    ],
+    "triggers": [
+      "excel export enum replace",
+      "DataToBeReplace",
+      "ExcelExportManager",
+      "objectToExcelAndDownload",
+      "excel download controller"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/backend/excel-export-enum-replacer",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "feed-envelope-frame",
+    "slug": "feed-envelope-frame",
+    "category": "backend",
+    "description": "Uniform WebSocket payload wrapper with Type (ACK/SNAPSHOT/DELTA/ERROR), PayloadKind, and correlation requestId, including null-safe factory methods",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/feed-envelope-frame",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "freemarker-two-phase-expression-subst",
+    "slug": "freemarker-two-phase-expression-subst",
+    "category": "backend",
+    "description": "Render templates by first replacing raw ${var} placeholders via string-replace, then running FreeMarker for expression-object binding, avoiding double-evaluation and escape conflicts",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/freemarker-two-phase-expression-subst",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "frozen-detection-consecutive-count",
+    "slug": "frozen-detection-consecutive-count",
+    "category": "backend",
+    "description": "Detect a stuck/frozen metric (identical value for N consecutive samples) by CONSECUTIVE-dampening equality check; catches sensor/collector failures that threshold alarms miss.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/frozen-detection-consecutive-count",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "grid-filter-to-criteria-converter",
+    "slug": "grid-filter-to-criteria-converter",
+    "category": "backend",
+    "description": "Convert a UI grid filter DTO (gridFilters + tagFilters + pageable) to MongoDB Criteria using CriteriaMakeHelper, supporting equals/contains/greaterThan/inRange operators",
+    "tags": [
+      "spring",
+      "mongodb",
+      "filter",
+      "criteria",
+      "pagination",
+      "grid"
+    ],
+    "triggers": [
+      "grid filter to criteria",
+      "FiltersPageableDto",
+      "CriteriaMakeHelper",
+      "mongodb dynamic filter",
+      "UI filter to query"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/backend/grid-filter-to-criteria-converter",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "hibernate-multi-dialect-swap",
+    "slug": "hibernate-multi-dialect-swap",
+    "category": "backend",
+    "description": "Ship one WAR that connects to Oracle, PostgreSQL, MSSQL, Tibero, DB2, or MariaDB based on Spring profile — all JDBC drivers bundled, dialect and datasource resolved from externalized config",
+    "tags": [],
+    "triggers": [
+      "one deployable must support multiple RDBMS vendors without rebuild",
+      "hibernate dialect chosen at startup, not compile time",
+      "customer deployments dictate DB vendor"
+    ],
+    "version": "1.0.0",
+    "path": "skills/backend/hibernate-multi-dialect-swap",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "hierarchical-group-entity-mongo",
+    "slug": "hierarchical-group-entity-mongo",
+    "category": "backend",
+    "description": "Model a tree-structured group entity in MongoDB with parentId + path + pathIds + level, plus recursive child-path update on move and cycle detection.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/hierarchical-group-entity",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "identifier-truncate-with-hash-suffix",
+    "slug": "identifier-truncate-with-hash-suffix",
+    "category": "backend",
+    "description": "Deterministically shrink any identifier to a length cap while preserving uniqueness by appending a short hash of the original.",
+    "tags": [
+      "identifiers",
+      "hashing",
+      "naming",
+      "collision-avoidance"
+    ],
+    "triggers": [
+      "name too long",
+      "identifier length limit",
+      "shorten tool name",
+      "truncate unique"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/backend/identifier-truncate-with-hash-suffix",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
     "name": "init-deadline-guard",
     "slug": "init-deadline-guard",
     "category": "backend",
@@ -1963,17 +6300,7 @@
     "has_content": true
   },
   {
-    "name": "investigate",
-    "slug": "investigate",
-    "category": "debug",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/debug/investigate",
-    "has_content": false
-  },
-  {
+    "kind": "skill",
     "name": "ip-allowlist-cidr-validator",
     "slug": "ip-allowlist-cidr-validator",
     "category": "backend",
@@ -1985,6 +6312,7 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "jacoco-exclude-boilerplate-layers",
     "slug": "jacoco-exclude-boilerplate-layers",
     "category": "backend",
@@ -1996,6 +6324,7 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "jacoco-sonar-shared-exclusion-list",
     "slug": "jacoco-sonar-shared-exclusion-list",
     "category": "backend",
@@ -2007,17 +6336,26 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "java-agent-bytecode-instrumentation-with-asm",
     "slug": "java-agent-bytecode-instrumentation-with-asm",
     "category": "backend",
     "description": "Build a JVM agent using ASM's ClassFileTransformer to inject profiling/monitoring hooks into application classes via pluggable visitor chains",
-    "tags": [],
+    "tags": [
+      "java",
+      "jvm",
+      "apm",
+      "instrumentation",
+      "asm",
+      "bytecode"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/java-agent-bytecode-instrumentation-with-asm",
     "has_content": false
   },
   {
+    "kind": "skill",
     "name": "jdbc-configurable-sql-insert-sender",
     "slug": "jdbc-configurable-sql-insert-sender",
     "category": "backend",
@@ -2029,39 +6367,7 @@
     "has_content": true
   },
   {
-    "name": "jenkins-dual-registry-docker-push",
-    "slug": "jenkins-dual-registry-docker-push",
-    "category": "devops",
-    "description": "Jenkins pipeline that builds one image and tags+pushes it to two registries (SaaS + on-prem) with both build-specific and rolling-latest tags",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/devops/jenkins-dual-registry-docker-push",
-    "has_content": true
-  },
-  {
-    "name": "jest-test-file-naming-test-only",
-    "slug": "jest-test-file-naming-test-only",
-    "category": "frontend",
-    "description": "Use .test.ts naming (not .spec.ts) and explicitly import jest globals; .spec.ts is excluded from the runner",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/frontend/jest-test-file-naming-test-only",
-    "has_content": true
-  },
-  {
-    "name": "jj-jujutsu-day-one-workflow",
-    "slug": "jj-jujutsu-day-one-workflow",
-    "category": "git",
-    "description": "Minimum viable jj (Jujutsu) workflow for a git user — init on top of an existing git repo, the five commands that cover 95% of day-1 usage, and the mental-model shift from git's staging area.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/git/jj-jujutsu-day-one-workflow",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "json-seeded-jpa-loader",
     "slug": "json-seeded-jpa-loader",
     "category": "backend",
@@ -2087,46 +6393,29 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "jwt-extraction-via-base-controller",
     "slug": "jwt-extraction-via-base-controller",
     "category": "backend",
     "description": "Consolidate repeated `JwtTokenService.getXxxFromBearerToken(headerAuthorization)` calls across Spring controllers by moving the service and helper methods onto a shared `BaseController`. Subclass controllers call `getOrganizationId(h)` / `getLoginId(h)` / `getRoleIds(h)` directly.",
-    "tags": [],
+    "tags": [
+      "spring-boot",
+      "jwt",
+      "controller",
+      "refactor",
+      "base-class"
+    ],
     "triggers": [
-      "\"jwt extraction controller duplication\"",
-      "\"base controller jwt\"",
-      "\"getXxxFromBearerToken 중복 제거\""
+      "jwt extraction controller duplication",
+      "base controller jwt",
+      "getXxxFromBearerToken 중복 제거"
     ],
     "version": "1.0.0",
     "path": "skills/backend/jwt-extraction-via-base-controller",
     "has_content": false
   },
   {
-    "name": "jwt-refresh-rotation-spring",
-    "slug": "jwt-refresh-rotation-spring",
-    "category": "security",
-    "description": "Spring Boot 3 JWT with short-lived access token + long-lived refresh token, filter-chain integration, and stateless session config. Avoids common mistakes that silently break refresh flows.",
-    "tags": [
-      "jwt",
-      "spring-boot",
-      "auth",
-      "refresh-token",
-      "jjwt",
-      "security-filter"
-    ],
-    "triggers": [
-      "jwt spring boot",
-      "refresh token rotation",
-      "JwtAuthenticationFilter",
-      "jjwt 0.12",
-      "SessionCreationPolicy.STATELESS",
-      "access token refresh token"
-    ],
-    "version": "0.1.0-draft",
-    "path": "skills/security/jwt-refresh-rotation-spring",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "k8s-health-via-getnodelist",
     "slug": "k8s-health-via-getnodelist",
     "category": "backend",
@@ -2141,28 +6430,25 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "kafka-avro-producer-gzip-30mb",
     "slug": "kafka-avro-producer-gzip-30mb",
     "category": "backend",
     "description": "Spring Kafka producer config for Avro values with gzip compression and a raised 30MB max.request.size for schema-registry payloads",
-    "tags": [],
+    "tags": [
+      "kafka",
+      "avro",
+      "spring-kafka",
+      "schema-registry",
+      "producer"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/kafka-avro-producer-gzip-30mb",
     "has_content": true
   },
   {
-    "name": "kafka-avro-topic-auto-create-config",
-    "slug": "kafka-avro-topic-auto-create-config",
-    "category": "arch",
-    "description": "Spring Boot Kafka config bean that auto-creates topics on startup via ApplicationRunner, with Avro serde, manual-ack listener, and bounded concurrency",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/arch/kafka-avro-topic-auto-create-config",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "kafka-batch-consumer-partition-tuning",
     "slug": "kafka-batch-consumer-partition-tuning",
     "category": "backend",
@@ -2174,6 +6460,7 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "kafka-consumer-config-3-factories",
     "slug": "kafka-consumer-config-3-factories",
     "category": "backend",
@@ -2185,17 +6472,25 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "kafka-consumer-errorhandling-wrapper",
     "slug": "kafka-consumer-errorhandling-wrapper",
     "category": "backend",
     "description": "Wrap key/value deserializers in Spring Kafka's ErrorHandlingDeserializer so a single poison record doesn't halt the consumer",
-    "tags": [],
+    "tags": [
+      "kafka",
+      "spring-kafka",
+      "avro",
+      "poison-pill",
+      "resilience"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/kafka-consumer-errorhandling-wrapper",
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "kafka-consumer-semaphore-chunking",
     "slug": "kafka-consumer-semaphore-chunking",
     "category": "backend",
@@ -2207,6 +6502,7 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "kafka-consumer-tenant-fan-out",
     "slug": "kafka-consumer-tenant-fan-out",
     "category": "backend",
@@ -2218,6 +6514,7 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "kafka-debounce-event-coalescing",
     "slug": "kafka-debounce-event-coalescing",
     "category": "backend",
@@ -2229,22 +6526,18 @@
     "has_content": true
   },
   {
-    "name": "kafka-engine-distributed-job-framework",
-    "slug": "kafka-engine-distributed-job-framework",
-    "category": "arch",
-    "description": "Kafka 이벤트 기반 분산 작업 실행 프레임워크 스켈레톤 — Publisher→Topic→Consumer→Queue→Worker + Admission Control + Strategy SPI",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/arch/kafka-engine-distributed-job-framework",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "kafka-message-header-metadata",
     "slug": "kafka-message-header-metadata",
     "category": "backend",
     "description": "Attach org-id, user-id, and timestamp as RecordHeader[] on a ProducerRecord to enable multi-tenant event routing without polluting the Avro payload",
-    "tags": [],
+    "tags": [
+      "kafka",
+      "avro",
+      "multi-tenant",
+      "headers",
+      "spring"
+    ],
     "triggers": [
       "kafka record headers",
       "ProducerRecord headers",
@@ -2257,6 +6550,7 @@
     "has_content": false
   },
   {
+    "kind": "skill",
     "name": "kafka-producer-async-callback",
     "slug": "kafka-producer-async-callback",
     "category": "backend",
@@ -2268,6 +6562,7 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "kafka-producer-config-avro-schema-registry",
     "slug": "kafka-producer-config-avro-schema-registry",
     "category": "backend",
@@ -2279,194 +6574,29 @@
     "has_content": true
   },
   {
-    "name": "land-and-deploy",
-    "slug": "land-and-deploy",
-    "category": "workflow",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/workflow/land-and-deploy",
-    "has_content": false
-  },
-  {
-    "name": "layered-risk-gates",
-    "slug": "layered-risk-gates",
-    "category": "arch",
-    "description": "Three-layer safety pattern for autonomous action loops — pre-action admission gate, in-flight monitor (stop/target thresholds), and a consecutive-failure circuit breaker — so a single runaway loop can't clear out the account before a human sees it.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/arch/layered-risk-gates",
-    "has_content": true
-  },
-  {
-    "name": "lean-verified-code-threat-boundary",
-    "slug": "lean-verified-code-threat-boundary",
-    "category": "security",
-    "description": "When shipping formally-verified code (Lean 4, Coq, F*), explicitly map what is inside and outside the verification boundary — untrusted parsers, runtime, and TCB assumptions almost always harbor the real bugs.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/security/lean-verified-code-threat-boundary",
-    "has_content": true
-  },
-  {
-    "name": "learn",
-    "slug": "learn",
-    "category": "docs",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/docs/learn",
-    "has_content": false
-  },
-  {
-    "name": "llm-integration-test-failure-diagnosis",
-    "slug": "llm-integration-test-failure-diagnosis",
-    "category": "testing",
-    "description": "Wire an LLM-based diagnosis step into your CI for integration-test failures — summarize noisy logs, identify probable root cause, post findings to the code-review/PR UI. Based on Google's Auto-Diagnose system (90%+ accuracy on 71-case study, adopted across 52k tests).",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/testing/llm-integration-test-failure-diagnosis",
-    "has_content": true
-  },
-  {
-    "name": "llm-json-extraction",
-    "slug": "llm-json-extraction",
-    "category": "ai",
-    "description": "Robustly extract a JSON object from free-form LLM text output — strip markdown fences, locate outermost braces, tolerate prelude/postlude prose.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/ai/llm-json-extraction",
-    "has_content": true
-  },
-  {
-    "name": "load-balancer-data-simulation",
-    "slug": "load-balancer-data-simulation",
-    "category": "workflow",
-    "description": "Strategies for generating realistic synthetic load balancer traffic, server state fluctuations, and algorithm comparison data without real infrastructure.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "load balancer data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/load-balancer-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "load-balancer-visualization-pattern",
-    "slug": "load-balancer-visualization-pattern",
-    "category": "design",
-    "description": "Reusable visual encoding patterns for rendering load balancer topology, server health, and traffic distribution in canvas/DOM UIs.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "load balancer visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/load-balancer-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "log-aggregation-data-simulation",
-    "slug": "log-aggregation-data-simulation",
-    "category": "workflow",
-    "description": "Strategies for generating realistic synthetic log streams, pattern distributions, and pipeline throughput metrics for development and demo environments.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "log aggregation data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/log-aggregation-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "log-aggregation-visualization-pattern",
-    "slug": "log-aggregation-visualization-pattern",
-    "category": "design",
-    "description": "Reusable visual encoding patterns for rendering log volume, severity distribution, and pipeline topology on a dark-themed ops dashboard.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "log aggregation visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/log-aggregation-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "materialized-view-data-simulation",
-    "slug": "materialized-view-data-simulation",
-    "category": "workflow",
-    "description": "Generate realistic MV topology, freshness telemetry, and query-match scoring without a live database.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "materialized view data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/materialized-view-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "materialized-view-visualization-pattern",
-    "slug": "materialized-view-visualization-pattern",
-    "category": "design",
-    "description": "Render MV dependency graphs, freshness dashboards, and query plans using Canvas/SVG with staleness-aware color coding.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "materialized view visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/materialized-view-visualization-pattern",
-    "has_content": false
-  },
-  {
+    "kind": "skill",
     "name": "mcp-capability-negotiated-initialize",
     "slug": "mcp-capability-negotiated-initialize",
     "category": "backend",
     "description": "In MCP `initialize`, advertise optional server capabilities (prompts, resources, sampling) only when the client declared matching support — avoids clients rejecting the handshake or spamming unsupported methods.",
-    "tags": [],
+    "tags": [
+      "mcp",
+      "json-rpc",
+      "capability-negotiation",
+      "handshake"
+    ],
     "triggers": [
-      "\"mcp initialize\"",
-      "\"capability negotiation\"",
-      "\"server capabilities\"",
-      "\"prompts/resources not showing\""
+      "mcp initialize",
+      "capability negotiation",
+      "server capabilities",
+      "prompts/resources not showing"
     ],
     "version": "0.1.0-draft",
     "path": "skills/backend/mcp-capability-negotiated-initialize",
     "has_content": true
   },
   {
-    "name": "mcp-runtime-prompt-refresh",
-    "slug": "mcp-runtime-prompt-refresh",
-    "category": "ai",
-    "description": "Expose a built-in MCP tool that hot-swaps the server's prompt set at runtime, persists it to disk, and emits notifications/prompts/list_changed so clients pick it up without reconnecting.",
-    "tags": [],
-    "triggers": [
-      "\"refresh prompts\"",
-      "\"update mcp prompts at runtime\"",
-      "\"prompts list_changed\"",
-      "\"mcp hot reload\""
-    ],
-    "version": "0.1.0-draft",
-    "path": "skills/ai/mcp-runtime-prompt-refresh",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "measurement-grouping-combiner",
     "slug": "measurement-grouping-combiner",
     "category": "backend",
@@ -2478,28 +6608,7 @@
     "has_content": true
   },
   {
-    "name": "menu-key-config-registry",
-    "slug": "menu-key-config-registry",
-    "category": "frontend",
-    "description": "Centralize sidebar/drawer menu keys as a union type + config object per domain, so menu rendering, drawer view switches, and default-expand state all reference the same source of truth. Eliminates string-key drift across the three places a menu key appears.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/frontend/menu-key-config-registry",
-    "has_content": true
-  },
-  {
-    "name": "mermaid-gitlab-mr-size-rules",
-    "slug": "mermaid-gitlab-mr-size-rules",
-    "category": "workflow",
-    "description": "Keep Mermaid diagrams in GitLab MRs readable — cap nodes, avoid nested subgraphs, quote IDs with special chars, connect all subgraphs",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/workflow/mermaid-gitlab-mr-size-rules",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "message-loader-gated-on-database-ready",
     "slug": "message-loader-gated-on-database-ready",
     "category": "backend",
@@ -2511,72 +6620,19 @@
     "has_content": true
   },
   {
-    "name": "mfa-federated-component-loader",
-    "slug": "mfa-federated-component-loader",
-    "category": "frontend",
-    "description": "Three-layer dynamic component loading for Webpack 5 Module Federation with retry logic, script caching, and error boundaries",
-    "tags": [],
-    "triggers": [
-      "module federation",
-      "federated component",
-      "remote component loading",
-      "dynamic import remote",
-      "RemoteApp"
-    ],
-    "version": "1.0.0",
-    "path": "skills/frontend/mfa-federated-component-loader",
-    "has_content": true
-  },
-  {
-    "name": "mfa-memoryrouter-isolation",
-    "slug": "mfa-memoryrouter-isolation",
-    "category": "frontend",
-    "description": "Wrap Module Federation-exposed React components in `MemoryRouter` so they own a private router context instead of inheriting the host's — avoids cross-origin router errors in dev and keeps the remote's routes from leaking into the host URL bar.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/frontend/mfa-memoryrouter-isolation",
-    "has_content": true
-  },
-  {
-    "name": "mfa-plain-html-dropdown-escape-hatch",
-    "slug": "mfa-plain-html-dropdown-escape-hatch",
-    "category": "frontend",
-    "description": "When a library Dropdown component infinite-loops or cross-origin-fails inside a Module Federation remote, replace it with a plain HTML `<button>` + absolutely-positioned menu `<ul>`. Cheaper than debugging the library's portal/context assumptions.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/frontend/mfa-plain-html-dropdown-escape-hatch",
-    "has_content": true
-  },
-  {
-    "name": "mfa-portal-css-isolation",
-    "slug": "mfa-portal-css-isolation",
-    "category": "design",
-    "description": "Isolate Tailwind CSS in Module Federation portals using lazyStyleTag injection, postcss-prefix-selector with :where() specificity control, scoped root elements, and Headless UI PortalGroup",
-    "tags": [],
-    "triggers": [],
-    "version": "1.1.0",
-    "path": "skills/design/mfa-portal-css-isolation",
-    "has_content": true
-  },
-  {
-    "name": "migrate-to-shoehorn",
-    "slug": "migrate-to-shoehorn",
-    "category": "refactor",
-    "description": "Migrate test files from `as` type assertions to @total-typescript/shoehorn. Use when user mentions shoehorn, wants to replace `as` in tests, or needs partial test data.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/refactor/migrate-to-shoehorn",
-    "has_content": false
-  },
-  {
+    "kind": "skill",
     "name": "migration-processor-pipeline",
     "slug": "migration-processor-pipeline",
     "category": "backend",
     "description": "Abstract migration processor template — validate → load → transform → emit Kafka Avro event with org-id header → audit log, multi-tenant safe",
-    "tags": [],
+    "tags": [
+      "spring",
+      "kafka",
+      "avro",
+      "migration",
+      "multi-tenant",
+      "mongodb"
+    ],
     "triggers": [
       "migration processor",
       "data migration pipeline",
@@ -2588,28 +6644,7 @@
     "has_content": false
   },
   {
-    "name": "module-federation-expose-react-component",
-    "slug": "module-federation-expose-react-component",
-    "category": "frontend",
-    "description": "Expose a React component from one MF remote to be consumed by other remotes via a stable 6-step pipeline (implementation → expose wrapper → config → MF constant → RemoteApp wrapper → consumer import).",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/frontend/module-federation-expose-react-component",
-    "has_content": true
-  },
-  {
-    "name": "module-federation-expose-wrapper",
-    "slug": "module-federation-expose-wrapper",
-    "category": "arch",
-    "description": "Six-step pattern for exposing a component from one Module Federation remote and consuming it from another via a shared library — implementation → expose wrapper → MF config → MF name constant → RemoteApp wrapper in shared → consumer import. Prevents direct cross-remote imports and webpack alias collisions.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/arch/module-federation-expose-wrapper",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "mongo-aggregation-filter-optimization",
     "slug": "mongo-aggregation-filter-optimization",
     "category": "backend",
@@ -2621,6 +6656,7 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "mongo-criteria-maker-elemmatch-and-or",
     "slug": "mongo-criteria-maker-elemmatch-and-or",
     "category": "backend",
@@ -2636,17 +6672,7 @@
     "has_content": true
   },
   {
-    "name": "spring-data-mongo-repository-custom-split",
-    "slug": "mongo-repository-custom-impl-split",
-    "category": "backend",
-    "description": "Standard 3-file split for MongoRepository — the base interface, a *Custom interface for handwritten queries, and a *Impl class that uses MongoTemplate — so complex queries live beside the CRUD without breaking derived-query inference.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/mongo-repository-custom-impl-split",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "mongo-timestamp-densification",
     "slug": "mongo-timestamp-densification",
     "category": "backend",
@@ -2658,6 +6684,7 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "mongo-ttl-with-aggregation-delta",
     "slug": "mongo-ttl-with-aggregation-delta",
     "category": "backend",
@@ -2669,6 +6696,7 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "mongodb-changestream-field-filter",
     "slug": "mongodb-changestream-field-filter",
     "category": "backend",
@@ -2680,6 +6708,7 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "mongodb-compound-index-esr-rule",
     "slug": "mongodb-compound-index-esr-rule",
     "category": "backend",
@@ -2691,28 +6720,24 @@
     "has_content": false
   },
   {
+    "kind": "skill",
     "name": "mongodb-datetrunc-binsize-zero-guard",
     "slug": "mongodb-datetrunc-binsize-zero-guard",
     "category": "backend",
     "description": "Guard MongoDB $dateTrunc binSize against 0 when your interval may be auto/unset; coerce to 1 to avoid runtime error",
-    "tags": [],
+    "tags": [
+      "mongodb",
+      "aggregation",
+      "dateTrunc",
+      "pitfall"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/mongodb-datetrunc-binsize-zero-guard",
     "has_content": true
   },
   {
-    "name": "mongodb-volume-copy-backup",
-    "slug": "mongodb-volume-copy-backup",
-    "category": "devops",
-    "description": "Back up and restore MongoDB Docker volumes via rsync volume-copy instead of mongodump/tar.gz",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/devops/mongodb-volume-copy-backup",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "multi-dbms-resource-provider-pattern",
     "slug": "multi-dbms-resource-provider-pattern",
     "category": "backend",
@@ -2724,6 +6749,7 @@
     "has_content": false
   },
   {
+    "kind": "skill",
     "name": "multi-resource-or-batch-query",
     "slug": "multi-resource-or-batch-query",
     "category": "backend",
@@ -2735,6 +6761,7 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "multi-tenant-kafka-header-organization-context",
     "slug": "multi-tenant-kafka-header-organization-context",
     "category": "backend",
@@ -2746,6 +6773,7 @@
     "has_content": false
   },
   {
+    "kind": "skill",
     "name": "multi-tenant-scheduler-iteration",
     "slug": "multi-tenant-scheduler-iteration",
     "category": "backend",
@@ -2757,23 +6785,7 @@
     "has_content": true
   },
   {
-    "name": "nds-html-mockup-from-tokens",
-    "slug": "nds-html-mockup-from-tokens",
-    "category": "design",
-    "description": "lucida-ui 디자인 토큰을 추출하여 실제 제품과 동일한 스타일의 static HTML 목업 생성",
-    "tags": [],
-    "triggers": [
-      "\"HTML 목업\"",
-      "\"디자인 목업\"",
-      "\"NDS 스타일 HTML\"",
-      "\"lucida 디자인으로 HTML\"",
-      "\"화면 프로토타입\""
-    ],
-    "version": "0.1.0-draft",
-    "path": "skills/design/nds-html-mockup-from-tokens",
-    "has_content": false
-  },
-  {
+    "kind": "skill",
     "name": "netty-tcp-reconnect-backoff",
     "slug": "netty-tcp-reconnect-backoff",
     "category": "backend",
@@ -2788,6 +6800,7 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "non-metric-saveraw-null-rule",
     "slug": "non-metric-saveraw-null-rule",
     "category": "backend",
@@ -2799,159 +6812,7 @@
     "has_content": true
   },
   {
-    "name": "oauth-data-simulation",
-    "slug": "oauth-data-simulation",
-    "category": "workflow",
-    "description": "Client-side simulation strategies for generating realistic OAuth flow steps, JWT claims, and scope-permission matrices without any backend.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "oauth data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/oauth-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "oauth-token-env-persistence",
-    "slug": "oauth-token-env-persistence",
-    "category": "security",
-    "description": "Persist OAuth access tokens to a sidecar env file (token + refresh + issue_time), refresh N minutes before expiry with a thread-safe guard, auto-inject into outgoing API calls — survives process restart without re-login.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/security/oauth-token-env-persistence",
-    "has_content": true
-  },
-  {
-    "name": "oauth-visualization-pattern",
-    "slug": "oauth-visualization-pattern",
-    "category": "design",
-    "description": "Multi-panel SVG/CSS pattern for visualizing OAuth 2.0 flows, token structure, and scope-permission mappings in dark-themed educational UIs.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "oauth visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/oauth-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "object-storage-data-simulation",
-    "slug": "object-storage-data-simulation",
-    "category": "workflow",
-    "description": "Strategies for generating realistic synthetic object-storage data — bucket populations, S3 API latency distributions, and tiered lifecycle transitions.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "object storage data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/object-storage-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "object-storage-visualization-pattern",
-    "slug": "object-storage-visualization-pattern",
-    "category": "design",
-    "description": "Reusable visual encoding patterns for rendering object-storage buckets, objects, and operations on a dark-themed canvas/SVG dashboard.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "object storage visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/object-storage-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "obsidian-vault",
-    "slug": "obsidian-vault",
-    "category": "docs",
-    "description": "Search, create, and manage notes in the Obsidian vault with wikilinks and index notes. Use when user wants to find, create, or organize notes in Obsidian.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/docs/obsidian-vault",
-    "has_content": false
-  },
-  {
-    "name": "office-hours",
-    "slug": "office-hours",
-    "category": "workflow",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "2.0.0",
-    "path": "skills/workflow/office-hours",
-    "has_content": false
-  },
-  {
-    "name": "open-gstack-browser",
-    "slug": "open-gstack-browser",
-    "category": "cli",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "0.2.0",
-    "path": "skills/cli/open-gstack-browser",
-    "has_content": false
-  },
-  {
-    "name": "openapi-to-mcp-tag-grouping",
-    "slug": "openapi-to-mcp-tag-grouping",
-    "category": "ai",
-    "description": "Convert OpenAPI specs into MCP tools by grouping operations under their OpenAPI tag, exposing one tool per tag with an operation selector and per-operation arguments.",
-    "tags": [],
-    "triggers": [
-      "\"openapi to mcp\"",
-      "\"swagger to mcp\"",
-      "\"generate mcp tools\"",
-      "\"tag based tool grouping\""
-    ],
-    "version": "0.1.0-draft",
-    "path": "skills/ai/openapi-to-mcp-tag-grouping",
-    "has_content": true
-  },
-  {
-    "name": "openssl-4-migration-checklist",
-    "slug": "openssl-4-migration-checklist",
-    "category": "security",
-    "description": "Step-by-step migration checklist for upgrading a C/C++ codebase from OpenSSL 3.x to 4.0.0 — const-qualified APIs, removed SSLv3 support, opaque ASN1_STRING, engine removal, cleanup semantics.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/security/openssl-4-migration-checklist",
-    "has_content": true
-  },
-  {
-    "name": "opentelemetry-java-bootstrap",
-    "slug": "opentelemetry-java-bootstrap",
-    "category": "apm",
-    "description": "Minimal OpenTelemetry bootstrap for a Java service — OTLP exporter, resource attributes, auto-instrumentation agent, and graceful shutdown. Covers the common setup mistakes that cause spans to silently drop.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/apm/opentelemetry-java-bootstrap",
-    "has_content": true
-  },
-  {
-    "name": "optional-outbound-adapter-no-op-port",
-    "slug": "optional-outbound-adapter-no-op-port",
-    "category": "arch",
-    "description": "Register a No-Op implementation of an optional outbound port with @ConditionalOnMissingBean so services boot when the real adapter (Kafka audit, tracing, notifications) is absent.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/arch/optional-outbound-adapter-no-op-port",
-    "has_content": false
-  },
-  {
+    "kind": "skill",
     "name": "org-scoped-kafka-topic-bootstrap",
     "slug": "org-scoped-kafka-topic-bootstrap",
     "category": "backend",
@@ -2963,80 +6824,7 @@
     "has_content": true
   },
   {
-    "name": "outbox-pattern-data-simulation",
-    "slug": "outbox-pattern-data-simulation",
-    "category": "workflow",
-    "description": "Tick-based and stream-based strategies for generating realistic outbox event flows with configurable failure rates, batch polling, and retry mechanics.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "outbox pattern data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/outbox-pattern-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "outbox-pattern-visualization-pattern",
-    "slug": "outbox-pattern-visualization-pattern",
-    "category": "design",
-    "description": "Three complementary visual encodings for outbox relay pipelines — lane flow, dashboard metrics, and SVG node graph with animated message lifecycle.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "outbox pattern visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/outbox-pattern-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "pair-agent",
-    "slug": "pair-agent",
-    "category": "ai",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0",
-    "path": "skills/ai/pair-agent",
-    "has_content": false
-  },
-  {
-    "name": "paired-flag-multi-instance-registration",
-    "slug": "paired-flag-multi-instance-registration",
-    "category": "cli",
-    "description": "CLI pattern for registering N instances of a composite config (e.g. spec+baseUrl pairs) using repeated paired flags and a pending-state parser.",
-    "tags": [],
-    "triggers": [
-      "\"multiple config pairs\"",
-      "\"repeated flag\"",
-      "\"paired cli args\"",
-      "\"multi-spec cli\""
-    ],
-    "version": "0.1.0-draft",
-    "path": "skills/cli/paired-flag-multi-instance-registration",
-    "has_content": true
-  },
-  {
-    "name": "parallel-bulk-annotation",
-    "slug": "parallel-bulk-annotation",
-    "category": "workflow",
-    "description": "수십~수백 개 Java 파일에 어노테이션(@Schema, @Operation, @ApiResponse 등)을 대량 추가할 때 병렬 에이전트로 분산 실행하는 패턴",
-    "tags": [],
-    "triggers": [
-      "대량 어노테이션 추가",
-      "@Schema 전수 부여",
-      "operationId 전수 부여",
-      "200개 메서드 어노테이션",
-      "bulk annotation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/parallel-bulk-annotation",
-    "has_content": false
-  },
-  {
+    "kind": "skill",
     "name": "parallel-tasks-generic-extraction",
     "slug": "parallel-tasks-generic-extraction",
     "category": "backend",
@@ -3048,6 +6836,7 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "period-mode-enum-config",
     "slug": "period-mode-enum-config",
     "category": "backend",
@@ -3059,135 +6848,51 @@
     "has_content": true
   },
   {
-    "name": "plan-ceo-review",
-    "slug": "plan-ceo-review",
-    "category": "workflow",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/workflow/plan-ceo-review",
-    "has_content": false
-  },
-  {
-    "name": "plan-design-review",
-    "slug": "plan-design-review",
-    "category": "design",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "2.0.0",
-    "path": "skills/design/plan-design-review",
-    "has_content": false
-  },
-  {
-    "name": "plan-devex-review",
-    "slug": "plan-devex-review",
-    "category": "workflow",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "2.0.0",
-    "path": "skills/workflow/plan-devex-review",
-    "has_content": false
-  },
-  {
-    "name": "plan-eng-review",
-    "slug": "plan-eng-review",
-    "category": "workflow",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/workflow/plan-eng-review",
-    "has_content": false
-  },
-  {
-    "name": "plan-to-screen-spec-conversion",
-    "slug": "plan-to-screen-spec-conversion",
-    "category": "design",
-    "description": "PLAN 작업지시서를 rules/fe/02-screen-spec-template.md 형식의 화면 스펙 문서로 변환",
-    "tags": [],
-    "triggers": [
-      "\"PLAN을 스펙으로\"",
-      "\"작업지시서를 화면 스펙으로\"",
-      "\"screen spec 변환\"",
-      "\"기획서를 스펙 템플릿으로\""
-    ],
-    "version": "0.1.0-draft",
-    "path": "skills/design/plan-to-screen-spec-conversion",
-    "has_content": false
-  },
-  {
+    "kind": "skill",
     "name": "playwright-exception-advice",
     "slug": "playwright-exception-advice",
     "category": "backend",
     "description": "Map PlaywrightException to a structured JSON error in Spring @ControllerAdvice, detecting common cases (cert errors, timeouts) and attaching actionable suggestions",
-    "tags": [],
-    "triggers": [],
+    "tags": [
+      "spring-boot",
+      "exception-handling",
+      "playwright",
+      "controller-advice"
+    ],
+    "triggers": [
+      "ControllerAdvice playwright",
+      "PlaywrightException spring",
+      "ERR_CERT_AUTHORITY_INVALID"
+    ],
     "version": "0.1.0-draft",
     "path": "skills/backend/playwright-exception-advice",
     "has_content": true
   },
   {
-    "name": "playwright-inspector-codegen",
-    "slug": "playwright-inspector-codegen",
-    "category": "debug",
-    "description": "Enable Playwright Inspector / codegen from a running Java app by setting PWDEBUG env vars before Playwright.create() and exposing an mvn codegen invocation for the user",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/debug/playwright-inspector-codegen",
-    "has_content": true
-  },
-  {
-    "name": "playwright-java-dockerfile",
-    "slug": "playwright-java-dockerfile",
-    "category": "devops",
-    "description": "Multi-stage Dockerfile that builds a Java/Maven app in a JDK image and runs it on the official Playwright Java runtime image, avoiding manual browser installation",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/devops/playwright-java-dockerfile",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "playwright-java-spring-lifecycle",
     "slug": "playwright-java-spring-lifecycle",
     "category": "backend",
     "description": "Share one Playwright+Browser instance across a Spring Boot app and create per-request BrowserContext/Page, cleaning up with try-with-resources and @PreDestroy",
-    "tags": [],
-    "triggers": [],
+    "tags": [
+      "playwright",
+      "spring-boot",
+      "java",
+      "lifecycle",
+      "browser"
+    ],
+    "triggers": [
+      "playwright",
+      "BrowserManager",
+      "BrowserContext",
+      "headless browser spring"
+    ],
     "version": "0.1.0-draft",
     "path": "skills/backend/playwright-java-spring-lifecycle",
     "has_content": true
   },
   {
-    "name": "pluggable-sender-factory-pattern",
-    "slug": "pluggable-sender-factory-pattern",
-    "category": "arch",
-    "description": "Register multiple notification/transport backends (SMS, EMAIL, SMTP, JDBC, REST, SLACK, SOCKET) behind a single FactoryBean that dispatches by enum type",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/arch/pluggable-sender-factory-pattern",
-    "has_content": true
-  },
-  {
-    "name": "plugin-resource-provider-architecture",
-    "slug": "plugin-resource-provider-architecture",
-    "category": "arch",
-    "description": "Stable `ResourceProvider` SPI loaded via Spring component scan; each new device/resource type is a separate Gradle-module JAR packaged into the WAR — zero core edits",
-    "tags": [],
-    "triggers": [
-      "extensible monitoring/management platform",
-      "vendor support must be pluggable per deployment"
-    ],
-    "version": "1.0.0",
-    "path": "skills/arch/plugin-resource-provider-architecture",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "policy-target-evaluation-with-groups-tags",
     "slug": "policy-target-evaluation-with-groups-tags",
     "category": "backend",
@@ -3199,132 +6904,30 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "polymorphic-command-entities",
     "slug": "polymorphic-command-entities",
     "category": "backend",
     "description": "Expose a list of typed commands over JSON using Jackson @JsonTypeInfo + @JsonSubTypes so clients can submit executable scripts to a REST endpoint",
-    "tags": [],
-    "triggers": [],
+    "tags": [
+      "jackson",
+      "polymorphism",
+      "command-pattern",
+      "rest",
+      "java"
+    ],
+    "triggers": [
+      "JsonTypeInfo",
+      "JsonSubTypes",
+      "command pattern json",
+      "polymorphic deserialization"
+    ],
     "version": "0.1.0-draft",
     "path": "skills/backend/polymorphic-command-entities",
     "has_content": true
   },
   {
-    "name": "prd-to-issues",
-    "slug": "prd-to-issues",
-    "category": "workflow",
-    "description": "Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. Use when user wants to convert a PRD to issues, create implementation tickets, or break down a PRD into work items.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/workflow/prd-to-issues",
-    "has_content": false
-  },
-  {
-    "name": "prd-to-plan",
-    "slug": "prd-to-plan",
-    "category": "workflow",
-    "description": "Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in ./plans/. Use when user wants to break down a PRD, create an implementation plan, plan phases from a PRD, or mentions \"tracer bullets\".",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/workflow/prd-to-plan",
-    "has_content": false
-  },
-  {
-    "name": "pub-sub-data-simulation",
-    "slug": "pub-sub-data-simulation",
-    "category": "workflow",
-    "description": "Interval-driven mock message generation with domain-typed payloads, random topic selection, and bounded retention for pub-sub demos.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "pub sub data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/pub-sub-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "pub-sub-visualization-pattern",
-    "slug": "pub-sub-visualization-pattern",
-    "category": "design",
-    "description": "Reusable visual encoding for publisher-subscriber message flow using topic-colored particles, node graphs, and fan-out animation.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "pub sub visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/pub-sub-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "qa",
-    "slug": "qa",
-    "category": "testing",
-    "description": "Interactive QA session where user reports bugs or issues conversationally, and the agent files GitHub issues. Explores the codebase in the background for context and domain language. Use when user wants to report bugs, do QA, file issues conversationally, or mentions \"QA session\".",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/testing/qa",
-    "has_content": false
-  },
-  {
-    "name": "querydsl-q-class-exclusion-pattern",
-    "slug": "querydsl-q-class-exclusion-pattern",
-    "category": "devops",
-    "description": "One `exclusionPatterns` list drives Jacoco report + verification + Sonar exclusions; catches generated Querydsl Q-classes via `('A'..'Z').collect { \"**/**/Q${it}*\" }`.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/devops/querydsl-q-class-exclusion-pattern",
-    "has_content": true
-  },
-  {
-    "name": "rate-limiter-data-simulation",
-    "slug": "rate-limiter-data-simulation",
-    "category": "workflow",
-    "description": "Stochastic request generation with multi-speed tick separation and configurable traffic patterns for rate-limiter algorithm demos.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "rate limiter data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/rate-limiter-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "rate-limiter-visualization-pattern",
-    "slug": "rate-limiter-visualization-pattern",
-    "category": "design",
-    "description": "Canvas-based visual metaphor for rate-limiter algorithms with color-coded saturation, particle feedback, and real-time parameter controls.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "rate limiter visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/rate-limiter-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "react-native-android-emulator-localhost",
-    "slug": "react-native-android-emulator-localhost",
-    "category": "mobile",
-    "description": "Use Platform.select to pick the right loopback host when a React Native dev build talks to a backend on the host machine — Android emulator needs 10.0.2.2, iOS simulator uses localhost.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/mobile/react-native-android-emulator-localhost",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "reactive-webclient-ssl-jdk",
     "slug": "reactive-webclient-ssl-jdk",
     "category": "backend",
@@ -3336,6 +6939,7 @@
     "has_content": false
   },
   {
+    "kind": "skill",
     "name": "reactor-subscription-router-backpressure",
     "slug": "reactor-subscription-router-backpressure",
     "category": "backend",
@@ -3347,6 +6951,7 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "realtime-vs-polling-fallback",
     "slug": "realtime-vs-polling-fallback",
     "category": "backend",
@@ -3361,22 +6966,7 @@
     "has_content": true
   },
   {
-    "name": "recoil-domain-atom-store",
-    "slug": "recoil-domain-atom-store",
-    "category": "frontend",
-    "description": "Domain-scoped Recoil atom organization with typed hook wrappers for large-scale React state management",
-    "tags": [],
-    "triggers": [
-      "recoil atom",
-      "state management",
-      "domain store",
-      "global state"
-    ],
-    "version": "1.0.0",
-    "path": "skills/frontend/recoil-domain-atom-store",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "redis-lock-recheck-flag-pattern",
     "slug": "redis-lock-recheck-flag-pattern",
     "category": "backend",
@@ -3388,174 +6978,7 @@
     "has_content": true
   },
   {
-    "name": "request-refactor-plan",
-    "slug": "request-refactor-plan",
-    "category": "refactor",
-    "description": "Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/refactor/request-refactor-plan",
-    "has_content": false
-  },
-  {
-    "name": "resource-provider-registry",
-    "slug": "resource-provider-registry",
-    "category": "arch",
-    "description": "Spring DI plugin registry where @Component implementations of a typed interface are auto-discovered and looked up at runtime by a string type key",
-    "tags": [],
-    "triggers": [
-      "plugin registry",
-      "provider lookup by type",
-      "auto-discovered handlers",
-      "resource provider pattern"
-    ],
-    "version": "0.1.0-draft",
-    "path": "skills/arch/resource-provider-registry",
-    "has_content": false
-  },
-  {
-    "name": "resource-summary-resolve-override-template",
-    "slug": "resource-summary-resolve-override-template",
-    "category": "arch",
-    "description": "리소스 상세 화면의 \"요약\" 탭에서 `OVERRIDE → TEMPLATE → NONE` 순으로 대시보드를 결정하는 서버-클라이언트 패턴. 오버라이드 엔티티, resolve API, 상태별 UI 드롭다운 규칙까지 포함.",
-    "tags": [],
-    "triggers": [
-      "resource summary",
-      "리소스 요약",
-      "resolve override template",
-      "dashboard override",
-      "resourceSummary",
-      "composition override"
-    ],
-    "version": "1.0.0",
-    "path": "skills/arch/resource-summary-resolve-override-template",
-    "has_content": false
-  },
-  {
-    "name": "retro",
-    "slug": "retro",
-    "category": "docs",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "2.0.0",
-    "path": "skills/docs/retro",
-    "has_content": false
-  },
-  {
-    "name": "retry-strategy-data-simulation",
-    "slug": "retry-strategy-data-simulation",
-    "category": "workflow",
-    "description": "Three simulation modes for retry data — real-time probabilistic, shared-sequence deterministic, and pure curve computation with jitter bands.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "retry strategy data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/retry-strategy-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "retry-strategy-visualization-pattern",
-    "slug": "retry-strategy-visualization-pattern",
-    "category": "design",
-    "description": "Three complementary visual encodings for retry delay curves, attempt timelines, and strategy comparison races.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "retry strategy visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/retry-strategy-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "review",
-    "slug": "review",
-    "category": "workflow",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/workflow/review",
-    "has_content": false
-  },
-  {
-    "name": "saga-pattern-data-simulation",
-    "slug": "saga-pattern-data-simulation",
-    "category": "workflow",
-    "description": "Generate synthetic saga execution traces with configurable failure injection, multi-service event sequences, and realistic compensation cascades.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "saga pattern data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/saga-pattern-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "saga-pattern-visualization-pattern",
-    "slug": "saga-pattern-visualization-pattern",
-    "category": "design",
-    "description": "Canvas and DOM rendering patterns for saga orchestration flows, compensation cascades, and multi-service event timelines.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "saga pattern visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/saga-pattern-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "scaffold-exercises",
-    "slug": "scaffold-exercises",
-    "category": "misc",
-    "description": "Create exercise directory structures with sections, problems, solutions, and explainers that pass linting. Use when user wants to scaffold exercises, create exercise stubs, or set up a new course section.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/misc/scaffold-exercises",
-    "has_content": false
-  },
-  {
-    "name": "schema-registry-data-simulation",
-    "slug": "schema-registry-data-simulation",
-    "category": "workflow",
-    "description": "Generate realistic synthetic schema registry data covering multi-format subjects, version histories, and compatibility check results.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "schema registry data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/schema-registry-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "schema-registry-visualization-pattern",
-    "slug": "schema-registry-visualization-pattern",
-    "category": "design",
-    "description": "Three complementary visual encodings for schema registry data — explorer tree, version timeline, and compatibility heatmap.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "schema registry visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/schema-registry-visualization-pattern",
-    "has_content": false
-  },
-  {
+    "kind": "skill",
     "name": "second-aggregation-snapshot-merge",
     "slug": "second-aggregation-snapshot-merge",
     "category": "backend",
@@ -3567,17 +6990,25 @@
     "has_content": false
   },
   {
+    "kind": "skill",
     "name": "server-plugin-scripting-and-builtin-extensibility",
     "slug": "server-plugin-scripting-and-builtin-extensibility",
     "category": "backend",
     "description": "Dual plugin system for a monitoring server — hot-reload script plugins (alert rules, filters) plus compiled JAR plugins for stateful, performance-critical data handlers",
-    "tags": [],
+    "tags": [
+      "plugin",
+      "extensibility",
+      "scripting",
+      "hot-reload",
+      "monitoring"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/server-plugin-scripting-and-builtin-extensibility",
     "has_content": false
   },
   {
+    "kind": "skill",
     "name": "service-discovery-replica-leader-tracking",
     "slug": "service-discovery-replica-leader-tracking",
     "category": "backend",
@@ -3589,6 +7020,7 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "service-readiness-event-listener-pattern",
     "slug": "service-readiness-event-listener-pattern",
     "category": "backend",
@@ -3600,6 +7032,7 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "service-status-provider-actuator",
     "slug": "service-status-provider-actuator",
     "category": "backend",
@@ -3611,6 +7044,7 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "servicejar-embeddable-library-task",
     "slug": "servicejar-embeddable-library-task",
     "category": "backend",
@@ -3622,6 +7056,7 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "session-lock-tree-blocking-chain-modeling",
     "slug": "session-lock-tree-blocking-chain-modeling",
     "category": "backend",
@@ -3633,174 +7068,7 @@
     "has_content": false
   },
   {
-    "name": "setup-browser-cookies",
-    "slug": "setup-browser-cookies",
-    "category": "cli",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/setup-browser-cookies",
-    "has_content": false
-  },
-  {
-    "name": "setup-deploy",
-    "slug": "setup-deploy",
-    "category": "workflow",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/workflow/setup-deploy",
-    "has_content": false
-  },
-  {
-    "name": "setup-pre-commit",
-    "slug": "setup-pre-commit",
-    "category": "cli",
-    "description": "Set up Husky pre-commit hooks with lint-staged (Prettier), type checking, and tests in the current repo. Use when user wants to add pre-commit hooks, set up Husky, configure lint-staged, or add commit-time formatting/typechecking/testing.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/cli/setup-pre-commit",
-    "has_content": false
-  },
-  {
-    "name": "shared-apis-endpoint-service-pattern",
-    "slug": "shared-apis-endpoint-service-pattern",
-    "category": "frontend",
-    "description": "Module Federation 모노레포에서 REST 엔드포인트를 추가할 때 `endpoint 상수 → services 메서드 → commonApiService 호출` 3계층 레이어링으로 도메인 일관성을 유지하는 패턴.",
-    "tags": [],
-    "triggers": [
-      "엔드포인트 추가",
-      "widgetEndPoint",
-      "shared/apis",
-      "commonApiService",
-      "API 레이어 추가",
-      "endpoint constant"
-    ],
-    "version": "1.0.0",
-    "path": "skills/frontend/shared-apis-endpoint-service-pattern",
-    "has_content": false
-  },
-  {
-    "name": "shared-package-only-cross-module",
-    "slug": "shared-package-only-cross-module",
-    "category": "arch",
-    "description": "Enforce a one-way dependency graph in a multi-module repo — sibling modules may only import from a single `shared/` package, never from each other. Prevents webpack alias collisions, keeps module boundaries enforceable, and makes build/deploy units independent.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/arch/shared-package-only-cross-module",
-    "has_content": true
-  },
-  {
-    "name": "ship",
-    "slug": "ship",
-    "category": "workflow",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/workflow/ship",
-    "has_content": false
-  },
-  {
-    "name": "sidecar-proxy-data-simulation",
-    "slug": "sidecar-proxy-data-simulation",
-    "category": "workflow",
-    "description": "Procedural generation of mesh topology, request-pipeline traffic, and time-series proxy metrics with multi-mode fault injection.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "sidecar proxy data simulation"
-    ],
-    "version": "1.0.0",
-    "path": "skills/workflow/sidecar-proxy-data-simulation",
-    "has_content": false
-  },
-  {
-    "name": "sidecar-proxy-visualization-pattern",
-    "slug": "sidecar-proxy-visualization-pattern",
-    "category": "design",
-    "description": "Three complementary canvas/DOM views — mesh topology, request pipeline, and ops dashboard — for sidecar-proxy architectures.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "sidecar proxy visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/sidecar-proxy-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "site-per-customer-override-modules",
-    "slug": "site-per-customer-override-modules",
-    "category": "arch",
-    "description": "One Gradle module per customer (`<product>-site-<customer>`) overrides core beans, auth, notification channels, and assets — keeps core customer-agnostic and scales to dozens of deployments",
-    "tags": [],
-    "triggers": [
-      "B2B product delivered to many customers with bespoke requirements",
-      "feature-flag soup is polluting core"
-    ],
-    "version": "1.0.0",
-    "path": "skills/arch/site-per-customer-override-modules",
-    "has_content": true
-  },
-  {
-    "name": "skill-md-validator",
-    "slug": "skill-md-validator",
-    "category": "devops",
-    "description": "[Tooling] SKILL.md frontmatter + 필수 섹션을 CRITICAL/WARNING 등급으로 검증하는 품질 게이트.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/devops/skill-md-validator",
-    "has_content": false
-  },
-  {
-    "name": "skill-repo-bootstrap-architecture",
-    "slug": "skill-repo-bootstrap-architecture",
-    "category": "workflow",
-    "description": "Lay out a shared skill/knowledge git repo so it is simultaneously a catalog and a self-installer — separate bootstrap (commands + umbrella skill + installers) from skills (category/name/SKILL.md). Covers repo layout, safety gates, registry pinning, and skill deprecation lifecycle.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/workflow/skill-repo-bootstrap-architecture",
-    "has_content": true
-  },
-  {
-    "name": "slack-webhook-notify",
-    "slug": "slack-webhook-notify",
-    "category": "devops",
-    "description": "Slack Incoming Webhook으로 메시지를 전송한다. 빌드/테스트/배포 결과, 작업 완료 알림 등을 Slack 채널에 보낼 때 사용.",
-    "tags": [],
-    "triggers": [
-      "slack",
-      "슬랙",
-      "slack notify",
-      "webhook 알림",
-      "빌드 알림",
-      "작업 완료 알림"
-    ],
-    "version": "1.0.0",
-    "path": "skills/devops/slack-webhook-notify",
-    "has_content": false
-  },
-  {
-    "name": "slash-command-authoring",
-    "slug": "slash-command-authoring",
-    "category": "workflow",
-    "description": "Author Claude Code slash commands that read cleanly, include safety rules, and compose with OMC skills — frontmatter, argument-hint, step ordering, and dry-run patterns.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/workflow/slash-command-authoring",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "spring-actuator-health-collector",
     "slug": "spring-actuator-health-collector",
     "category": "backend",
@@ -3812,21 +7080,31 @@
     "has_content": true
   },
   {
-    "name": "spring-bootrun-local-dev-env-block",
-    "slug": "spring-bootrun-local-dev-env-block",
-    "category": "devops",
-    "description": "Gradle `bootRun` env block that wires local Redis/Mongo/Kafka/Eureka/MQTT for zero-config `./gradlew bootRun` developer experience",
+    "kind": "skill",
+    "name": "spring-applicationrunner-system-seed",
+    "slug": "spring-applicationrunner-system-seed",
+    "category": "backend",
+    "description": "Use ApplicationRunner to seed required system/root records on startup, guarded by an exists-check and marked with a systemFlag so they can't be deleted or moved by users.",
     "tags": [],
-    "triggers": [
-      "new engineer asks \"how do I run this locally?\"",
-      "application-local.yaml is gitignored and no-one knows the defaults",
-      "Spring Cloud service refuses to start locally because Eureka client is enabled"
-    ],
+    "triggers": [],
     "version": "1.0.0",
-    "path": "skills/devops/spring-bootrun-local-dev-env-block",
+    "path": "skills/backend/system-data-initializer-runner",
     "has_content": true
   },
   {
+    "kind": "skill",
+    "name": "spring-data-mongo-repository-custom-split",
+    "slug": "spring-data-mongo-repository-custom-split",
+    "category": "backend",
+    "description": "Standard 3-file split for MongoRepository — the base interface, a *Custom interface for handwritten queries, and a *Impl class that uses MongoTemplate — so complex queries live beside the CRUD without breaking derived-query inference.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/mongo-repository-custom-impl-split",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
     "name": "spring-dual-profile-flyway",
     "slug": "spring-dual-profile-flyway",
     "category": "backend",
@@ -3852,21 +7130,29 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "spring-mongo-lightweight-migration",
     "slug": "spring-mongo-lightweight-migration",
     "category": "backend",
     "description": "Annotation-driven MongoDB migration runner for Spring Boot — `@MongoMigration` methods on `MigrationScript` beans execute in order at startup, with history in `{prefix}_migrations` collection. No Mongock dependency.",
-    "tags": [],
+    "tags": [
+      "spring-boot",
+      "mongodb",
+      "migration",
+      "annotation-driven",
+      "idempotent"
+    ],
     "triggers": [
-      "\"mongo migration spring boot\"",
-      "\"mongock 없이 마이그레이션\"",
-      "\"annotation-based mongo migration\""
+      "mongo migration spring boot",
+      "mongock 없이 마이그레이션",
+      "annotation-based mongo migration"
     ],
     "version": "1.0.0",
     "path": "skills/backend/spring-mongo-lightweight-migration",
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "spring-profile-datasource-activation",
     "slug": "spring-profile-datasource-activation",
     "category": "backend",
@@ -3881,17 +7167,7 @@
     "has_content": true
   },
   {
-    "name": "spring-testcontainers-multitenant-base",
-    "slug": "spring-testcontainers-multitenant-base",
-    "category": "testing",
-    "description": "Base test class that boots Testcontainers (Mongo + Kafka), pre-sets tenant/auth context, and forces JVM halt in AfterAll to avoid leaked containers.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/testing/spring-testcontainers-multitenant-base",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "spring-typed-config-properties",
     "slug": "spring-typed-config-properties",
     "category": "backend",
@@ -3915,21 +7191,2220 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "springdoc-yaml-externalization",
     "slug": "springdoc-yaml-externalization",
     "category": "backend",
     "description": "Move long `@Operation description` and `@RequestBody examples` text out of Spring controllers into per-controller YAML files under `resources/api-docs/`, injected at runtime via a single `OperationCustomizer` bean. Swagger UI output unchanged.",
-    "tags": [],
+    "tags": [
+      "spring-boot",
+      "springdoc",
+      "openapi",
+      "swagger",
+      "yaml",
+      "refactor"
+    ],
     "triggers": [
-      "\"swagger externalize annotations\"",
-      "\"move swagger description to yaml\"",
-      "\"OperationCustomizer\""
+      "swagger externalize annotations",
+      "move swagger description to yaml",
+      "OperationCustomizer"
     ],
     "version": "1.0.0",
     "path": "skills/backend/springdoc-yaml-externalization",
     "has_content": false
   },
   {
+    "kind": "skill",
+    "name": "stack-parse-tag-filter-to-mongo-criteria",
+    "slug": "stack-parse-tag-filter-to-mongo-criteria",
+    "category": "backend",
+    "description": "Parse a tokenized boolean filter expression (key=value, AND, OR, parens) into a MongoDB Criteria tree using a shunting-yard/stack algorithm, with elemMatch for array-of-tag subdocs.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/stack-tag-filter-to-mongo-criteria",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "stomp-cookie-auth-handshake",
+    "slug": "stomp-cookie-auth-handshake",
+    "category": "backend",
+    "description": "Authenticate STOMP WebSocket upgrade using an HttpOnly cookie extracted during the handshake, then bind identity to the STOMP session",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/stomp-cookie-auth-handshake",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "stomp-principal-jwt-channel",
+    "slug": "stomp-principal-jwt-channel",
+    "category": "backend",
+    "description": "STOMP ChannelInterceptor that validates a JWT on CONNECT and binds a multi-tenant Principal (orgId + userId + sessionId) for downstream routing",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/stomp-principal-jwt-channel",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "strategy-spi-list-to-map-autoinject",
+    "slug": "strategy-spi-list-to-map-autoinject",
+    "category": "backend",
+    "description": "Spring이 자동 주입하는 List<T>를 생성자에서 Map<Key,T>로 변환해 Strategy를 enum 키로 O(1) 디스패치하는 패턴",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/strategy-spi-list-to-map-autoinject",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "tenant-context-try-finally-on-worker",
+    "slug": "tenant-context-try-finally-on-worker",
+    "category": "backend",
+    "description": "Kafka/Queue Worker에서 멀티테넌트 ThreadLocal 컨텍스트를 try-finally로 안전하게 세팅/정리하는 패턴",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/tenant-context-try-finally-on-worker",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "tenant-db-initialization-on-startup",
+    "slug": "tenant-db-initialization-on-startup",
+    "category": "backend",
+    "description": "On leader startup, fetch tenant/org list from metadata service and provision per-tenant MongoDB databases — idempotent, leader-only",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/tenant-db-initialization-on-startup",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "tenant-isolated-mongo-collection",
+    "slug": "tenant-isolated-mongo-collection",
+    "category": "backend",
+    "description": "Route each tenant to its own MongoDB collection (or collection-name suffix) via a custom annotation resolved at repository/template layer, so application code stays tenant-agnostic.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/tenant-isolated-mongo-collection",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "tenant-per-database-mongo-routing",
+    "slug": "tenant-per-database-mongo-routing",
+    "category": "backend",
+    "description": "Route Spring Data Mongo operations to per-tenant databases via a ThreadLocal tenant holder and two MongoTemplate beans (isolated vs shared collections).",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/tenant-per-database-mongo-routing",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "testcontainers-mongo-kafka-abstract-base",
+    "slug": "testcontainers-mongo-kafka-abstract-base",
+    "category": "backend",
+    "description": "Abstract test base classes that spin up MongoDB + Kafka via Testcontainers with static start() and reuse=true, exposing mapped ports via System.setProperty",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/testcontainers-mongo-kafka-abstract-base",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "testcontainers-reuse-disabled",
+    "slug": "testcontainers-reuse-disabled",
+    "category": "backend",
+    "description": "Set TESTCONTAINERS_REUSE_ENABLE=false on the Gradle test task so CI and shared dev machines never inherit stale container state across suites",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/testcontainers-reuse-disabled",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "thread-pool-config-tenant-aware",
+    "slug": "thread-pool-config-tenant-aware",
+    "category": "backend",
+    "description": "Property-driven ThreadPoolTaskExecutor + Scheduler config that extends TenantAsyncConfigurerSupport so @Async tasks inherit tenant context",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/thread-pool-config-tenant-aware",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "thread-pool-queue-backpressure",
+    "slug": "thread-pool-queue-backpressure",
+    "category": "backend",
+    "description": "Bounded in-memory queue between Kafka consumer and async thread pool, with hysteretic pause/resume thresholds driving Spring Kafka container pause()/resume() so bursts do not OOM the JVM.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/thread-pool-queue-backpressure",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "tsv-driven-permission-bootstrap",
+    "slug": "tsv-driven-permission-bootstrap",
+    "category": "backend",
+    "description": "Treat a version-controlled TSV file as source of truth for the Function/Permission/Menu catalog; the service reconciles the DB against it on startup",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/tsv-driven-permission-bootstrap",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "udp-with-tcp-fallback-metrics-transport",
+    "slug": "udp-with-tcp-fallback-metrics-transport",
+    "category": "backend",
+    "description": "Transport telemetry via UDP for low-latency fire-and-forget streams, and fall back to TCP for critical request/response and bulk uploads that require delivery guarantees",
+    "tags": [
+      "network",
+      "udp",
+      "tcp",
+      "apm",
+      "telemetry"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/udp-with-tcp-fallback-metrics-transport",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "version-specific-sql-map-selection",
+    "slug": "version-specific-sql-map-selection",
+    "category": "backend",
+    "description": "Select MyBatis-style SQL maps at runtime by DBMS + version with graceful fallback to a default supported version",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/version-specific-sql-map-selection",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "websocket-stomp-channel-pool-config",
+    "slug": "websocket-stomp-channel-pool-config",
+    "category": "backend",
+    "description": "Spring WebSocket STOMP config with separate inbound/outbound task executors and raised transport buffer limits, sized for burst notification fan-out to many role-filtered subscribers.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/websocket-stomp-channel-pool-config",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "yorkie-crdt-sync-pattern",
+    "slug": "yorkie-crdt-sync-pattern",
+    "category": "backend",
+    "description": "Apply a single doc.update callback for local mutations and pullRemoteChangesIntoLocal(WithNodeIds) for remote→local sync in Yorkie-backed apps",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/backend/yorkie-crdt-sync-pattern",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "git-guardrails-claude-code",
+    "slug": "git-guardrails-claude-code",
+    "category": "cli",
+    "description": "Set up Claude Code hooks to block dangerous git commands (push, reset --hard, clean, branch -D, etc.) before they execute. Use when user wants to prevent destructive git operations, add git safety hooks, or block git push/reset in Claude Code.",
+    "tags": [
+      "git",
+      "hooks",
+      "claude-code",
+      "guardrails",
+      "safety"
+    ],
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "skills/cli/git-guardrails-claude-code",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "gstack",
+    "slug": "gstack",
+    "category": "cli",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.1.0",
+    "path": "skills/cli/gstack",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "gstack-upgrade",
+    "slug": "gstack-upgrade",
+    "category": "cli",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.1.0",
+    "path": "skills/cli/gstack-upgrade",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "open-gstack-browser",
+    "slug": "open-gstack-browser",
+    "category": "cli",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "0.2.0",
+    "path": "skills/cli/open-gstack-browser",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "paired-flag-multi-instance-registration",
+    "slug": "paired-flag-multi-instance-registration",
+    "category": "cli",
+    "description": "CLI pattern for registering N instances of a composite config (e.g. spec+baseUrl pairs) using repeated paired flags and a pending-state parser.",
+    "tags": [
+      "argparse",
+      "cli-design",
+      "multi-instance",
+      "config"
+    ],
+    "triggers": [
+      "multiple config pairs",
+      "repeated flag",
+      "paired cli args",
+      "multi-spec cli"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/cli/paired-flag-multi-instance-registration",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "setup-browser-cookies",
+    "slug": "setup-browser-cookies",
+    "category": "cli",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/setup-browser-cookies",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "setup-pre-commit",
+    "slug": "setup-pre-commit",
+    "category": "cli",
+    "description": "Set up Husky pre-commit hooks with lint-staged (Prettier), type checking, and tests in the current repo. Use when user wants to add pre-commit hooks, set up Husky, configure lint-staged, or add commit-time formatting/typechecking/testing.",
+    "tags": [
+      "husky",
+      "lint-staged",
+      "pre-commit",
+      "prettier",
+      "typescript"
+    ],
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "skills/cli/setup-pre-commit",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "build-error-triage",
+    "slug": "build-error-triage",
+    "category": "debug",
+    "description": "Systematic triage workflow for build/compilation errors — classify by root cause (missing symbol, signature mismatch, instantiation failure), then isolate the first error before chasing cascades.",
+    "tags": [
+      "build",
+      "compilation",
+      "java",
+      "javac",
+      "errors",
+      "triage"
+    ],
+    "triggers": [
+      "Unresolved compilation",
+      "Cannot instantiate",
+      "method is undefined",
+      "cannot find symbol",
+      "compilation error"
+    ],
+    "version": "1.0.0",
+    "path": "skills/debug/build-error-triage",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "debug-lockorder-detection-system",
+    "slug": "debug-lockorder-detection-system",
+    "category": "debug",
+    "description": "Runtime lock-order deadlock detection via a DEBUG_LOCKORDER compile flag that tracks lock acquisition order and reports circular dependencies.",
+    "tags": [
+      "cpp",
+      "threading",
+      "deadlock",
+      "debugging",
+      "instrumentation"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/debug/debug-lockorder-detection-system",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "investigate",
+    "slug": "investigate",
+    "category": "debug",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/debug/investigate",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "playwright-inspector-codegen",
+    "slug": "playwright-inspector-codegen",
+    "category": "debug",
+    "description": "Enable Playwright Inspector / codegen from a running Java app by setting PWDEBUG env vars before Playwright.create() and exposing an mvn codegen invocation for the user",
+    "tags": [
+      "playwright",
+      "inspector",
+      "codegen",
+      "debugging",
+      "java"
+    ],
+    "triggers": [
+      "PWDEBUG",
+      "playwright inspector",
+      "playwright codegen",
+      "record selectors"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/debug/playwright-inspector-codegen",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "triage-issue",
+    "slug": "triage-issue",
+    "category": "debug",
+    "description": "Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. Use when user reports a bug, wants to file an issue, mentions \"triage\", or wants to investigate and plan a fix for a problem.",
+    "tags": [
+      "bug",
+      "triage",
+      "root-cause",
+      "investigation"
+    ],
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "skills/debug/triage-issue",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "actor-model-visualization-pattern",
+    "slug": "actor-model-visualization-pattern",
+    "category": "design",
+    "description": "Render actor mailboxes, supervision trees, and message flows as live, inspectable graphs",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "actor model visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/actor-model-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "ag-grid-custom-filter-system",
+    "slug": "ag-grid-custom-filter-system",
+    "category": "design",
+    "description": "ag-grid Enterprise wrapper with GridContext provider, custom filter components (Boolean, Number, DateRange, SelectMulti), and pagination state management",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/design/ag-grid-custom-filter-system",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "antd-wrapper-component-pattern",
+    "slug": "antd-wrapper-component-pattern",
+    "category": "design",
+    "description": "Wrap Ant Design components with a custom design system layer (Sirius pattern) that extends props, enforces standards, and maintains upgrade compatibility",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/design/antd-wrapper-component-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "api-gateway-pattern-visualization-pattern",
+    "slug": "api-gateway-pattern-visualization-pattern",
+    "category": "design",
+    "description": "Single-pane visualization showing client traffic funneling through a gateway layer that fans out to backend services with per-hop status",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "api gateway pattern visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/api-gateway-pattern-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "api-versioning-visualization-pattern",
+    "slug": "api-versioning-visualization-pattern",
+    "category": "design",
+    "description": "Multi-view composition for rendering API version lifecycles, schema diffs, and traffic splits side-by-side",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "api versioning visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/api-versioning-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "backpressure-visualization-pattern",
+    "slug": "backpressure-visualization-pattern",
+    "category": "design",
+    "description": "Visualize producer/consumer rate mismatch with buffer fill gauges, drop counters, and upstream signal arrows",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "backpressure visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/backpressure-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "bff-pattern-visualization-pattern",
+    "slug": "bff-pattern-visualization-pattern",
+    "category": "design",
+    "description": "Visualize BFF fan-out by rendering per-client gateways as distinct swim lanes that aggregate multiple backend service calls into a single client response",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "bff pattern visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/bff-pattern-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "bloom-filter-visualization-pattern",
+    "slug": "bloom-filter-visualization-pattern",
+    "category": "design",
+    "description": "Visualizing bloom filter bit arrays, hash function mappings, and false-positive regions for interactive exploration",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "bloom filter visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/bloom-filter-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "blue-green-deploy-visualization-pattern",
+    "slug": "blue-green-deploy-visualization-pattern",
+    "category": "design",
+    "description": "Dual-environment (Blue/Active vs Green/Idle) side-by-side canvas with traffic-router arrow and version badges for blue-green deployment dashboards",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "blue green deploy visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/blue-green-deploy-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "bulkhead-visualization-pattern",
+    "slug": "bulkhead-visualization-pattern",
+    "category": "design",
+    "description": "Visual layout conventions for rendering isolated resource pools side-by-side with saturation indicators",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "bulkhead visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/bulkhead-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "canary-release-visualization-pattern",
+    "slug": "canary-release-visualization-pattern",
+    "category": "design",
+    "description": "Split-lane visualization showing stable vs canary traffic flow with weighted percentage bands and promotion gates",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "canary release visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/canary-release-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "canvas-chromakey-bg-removal",
+    "slug": "canvas-chromakey-bg-removal",
+    "category": "design",
+    "description": "Browser-side background removal for sprite sheets and JPEG assets using canvas pixel data with white/color key to transparency",
+    "tags": [
+      "canvas",
+      "image-processing",
+      "chroma-key",
+      "transparency"
+    ],
+    "triggers": [
+      "remove white background",
+      "chroma key browser",
+      "sprite sheet transparent",
+      "make image background transparent css"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/canvas-chromakey-bg-removal",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "cdc-visualization-pattern",
+    "slug": "cdc-visualization-pattern",
+    "category": "design",
+    "description": "Visualizing CDC event flow from source database through log capture to downstream consumers with row-level change granularity",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "cdc visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/cdc-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "chaos-engineering-visualization-pattern",
+    "slug": "chaos-engineering-visualization-pattern",
+    "category": "design",
+    "description": "Visualizing blast radius, failure propagation, and steady-state deviation in chaos experiments",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "chaos engineering visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/chaos-engineering-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "circuit-breaker-visualization-pattern",
+    "slug": "circuit-breaker-visualization-pattern",
+    "category": "design",
+    "description": "Three-state circuit breaker visualization using color-coded state machine with real-time metrics dashboard",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "circuit breaker visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/circuit-breaker-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "click-to-inspect-corpus-from-dashboard",
+    "slug": "click-to-inspect-corpus-from-dashboard",
+    "category": "design",
+    "description": "Make every corpus item (skill, doc, reference) clickable in a dashboard and open its source .md content in a modal via a server endpoint",
+    "tags": [
+      "dashboard",
+      "ux",
+      "modal",
+      "sse"
+    ],
+    "triggers": [
+      "skill preview modal",
+      "inspect corpus item",
+      "dashboard item drilldown",
+      "clickable reference list"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/click-to-inspect-corpus-from-dashboard",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "command-query-visualization-pattern",
+    "slug": "command-query-visualization-pattern",
+    "category": "design",
+    "description": "Split-pane UI that visually separates command write paths from query read paths in CQRS systems",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "command query visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/command-query-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "connection-pool-visualization-pattern",
+    "slug": "connection-pool-visualization-pattern",
+    "category": "design",
+    "description": "Visual conventions for rendering connection pool state, connection lifecycles, and waiter queues in real-time dashboards",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "connection pool visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/connection-pool-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "consistent-hashing-visualization-pattern",
+    "slug": "consistent-hashing-visualization-pattern",
+    "category": "design",
+    "description": "Ring-based SVG/Canvas rendering pattern for visualizing consistent hashing node placement and key distribution",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "consistent hashing visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/consistent-hashing-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "cqrs-visualization-pattern",
+    "slug": "cqrs-visualization-pattern",
+    "category": "design",
+    "description": "Split-panel visualization showing command-side writes and query-side reads as distinct, independently-scaling lanes with a projection bridge between them.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "cqrs visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/cqrs-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "crdt-visualization-pattern",
+    "slug": "crdt-visualization-pattern",
+    "category": "design",
+    "description": "Side-by-side replica panels with convergence indicators for visualizing CRDT state synchronization",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "crdt visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/crdt-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "css-sprite-sheet-phase-row-switch",
+    "slug": "css-sprite-sheet-phase-row-switch",
+    "category": "design",
+    "description": "Single CSS sprite sheet animated via steps() on X, with inline-style row switch on Y for phase-specific animations",
+    "tags": [
+      "css",
+      "animation",
+      "sprite-sheet",
+      "pixel-art"
+    ],
+    "triggers": [
+      "css sprite animation",
+      "sprite sheet phase",
+      "pixel art character animation",
+      "game-style sprite"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/css-sprite-sheet-phase-row-switch",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "data-pipeline-visualization-pattern",
+    "slug": "data-pipeline-visualization-pattern",
+    "category": "design",
+    "description": "Visual patterns for rendering multi-stage data pipelines with flow direction, stage health, and throughput indicators",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "data pipeline visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/data-pipeline-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "database-sharding-visualization-pattern",
+    "slug": "database-sharding-visualization-pattern",
+    "category": "design",
+    "description": "Canvas-based rendering pattern for visualizing shard topology, key distribution, and routing decisions in database sharding systems",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "database sharding visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/database-sharding-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "dead-letter-queue-visualization-pattern",
+    "slug": "dead-letter-queue-visualization-pattern",
+    "category": "design",
+    "description": "Visual patterns for surfacing DLQ message flow, failure reasons, and replay decisions in triage UIs",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "dead letter queue visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/dead-letter-queue-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "design-consultation",
+    "slug": "design-consultation",
+    "category": "design",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/design/design-consultation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "design-html",
+    "slug": "design-html",
+    "category": "design",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/design/design-html",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "design-review",
+    "slug": "design-review",
+    "category": "design",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/design/design-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "design-shotgun",
+    "slug": "design-shotgun",
+    "category": "design",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/design/design-shotgun",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "distributed-tracing-visualization-pattern",
+    "slug": "distributed-tracing-visualization-pattern",
+    "category": "design",
+    "description": "Three complementary views (waterfall, service graph, latency heatmap) for reasoning about distributed traces",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "distributed tracing visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/distributed-tracing-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "dnd-kit-tab-reordering",
+    "slug": "dnd-kit-tab-reordering",
+    "category": "design",
+    "description": "Implement horizontal tab drag reordering using @dnd-kit/core + @dnd-kit/sortable with PointerSensor and CSS.Transform",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/design/dnd-kit-tab-reordering",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "domain-driven-visualization-pattern",
+    "slug": "domain-driven-visualization-pattern",
+    "category": "design",
+    "description": "Rendering bounded contexts, aggregates, and ubiquitous language as navigable maps with relationship overlays",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "domain driven visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/domain-driven-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "drawer-resizable-mouse-drag",
+    "slug": "drawer-resizable-mouse-drag",
+    "category": "design",
+    "description": "Make Ant Design Drawer resizable via mouse drag with styled-components handle, min/max width constraints, and transition suppression during drag",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/design/drawer-resizable-mouse-drag",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "echarts-svg-worker-chart",
+    "slug": "echarts-svg-worker-chart",
+    "category": "design",
+    "description": "High-performance chart component using ECharts with custom SVG overlays (markLine/markArea/markPoint), worker thread data processing, and brush selection interaction",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/design/echarts-svg-worker-chart",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "etl-visualization-pattern",
+    "slug": "etl-visualization-pattern",
+    "category": "design",
+    "description": "Canvas-based visual representations for ETL flow, rules, and lineage with node-edge topology",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "etl visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/etl-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "event-sourcing-visualization-pattern",
+    "slug": "event-sourcing-visualization-pattern",
+    "category": "design",
+    "description": "Render append-only event logs alongside derived state projections with replay scrubber controls",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "event sourcing visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/event-sourcing-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "feature-flags-visualization-pattern",
+    "slug": "feature-flags-visualization-pattern",
+    "category": "design",
+    "description": "Visualization pattern for feature-flag rollout, dependency, and A/B experiment dashboards",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "feature flags visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/feature-flags-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "figma-token-to-tailwind-theme",
+    "slug": "figma-token-to-tailwind-theme",
+    "category": "design",
+    "description": "Pipeline from Figma Token Studio JSON exports through Style Dictionary v5 to Tailwind v4 @theme CSS custom properties, with dark/light/contrast mode support and breaking change detection",
+    "tags": [],
+    "triggers": [],
+    "version": "1.1.0",
+    "path": "skills/design/figma-token-to-tailwind-theme",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "finite-state-machine-visualization-pattern",
+    "slug": "finite-state-machine-visualization-pattern",
+    "category": "design",
+    "description": "Render FSM states as a node graph with animated active-state highlighting and transition edge pulses driven by the current state variable.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "finite state machine visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/finite-state-machine-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "graphql-visualization-pattern",
+    "slug": "graphql-visualization-pattern",
+    "category": "design",
+    "description": "Visualizing GraphQL operations (queries, schemas, subscriptions) through interactive node-graph and live-feed UIs",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "graphql visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/graphql-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "health-check-visualization-pattern",
+    "slug": "health-check-visualization-pattern",
+    "category": "design",
+    "description": "Dashboard layout pattern for rendering heterogeneous health-check signals into a single at-a-glance status surface",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "health check visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/health-check-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "hexagonal-architecture-visualization-pattern",
+    "slug": "hexagonal-architecture-visualization-pattern",
+    "category": "design",
+    "description": "Render the hexagon with domain core centered and ports/adapters radiating outward through driving/driven lanes",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "hexagonal architecture visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/hexagonal-architecture-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "hue-rotate-sprite-identity",
+    "slug": "hue-rotate-sprite-identity",
+    "category": "design",
+    "description": "Create distinct named character variants from a single sprite sheet using CSS hue-rotate + data attributes",
+    "tags": [
+      "css",
+      "sprite",
+      "palette-swap",
+      "game-ui"
+    ],
+    "triggers": [
+      "character variants sprite",
+      "palette swap",
+      "hue rotation identity",
+      "npc color variants"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/hue-rotate-sprite-identity",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "idempotency-visualization-pattern",
+    "slug": "idempotency-visualization-pattern",
+    "category": "design",
+    "description": "Visual patterns for demonstrating idempotency guarantees through request replay, key-based deduplication, and state convergence animations.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "idempotency visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/idempotency-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "lantern-visualization-pattern",
+    "slug": "lantern-visualization-pattern",
+    "category": "design",
+    "description": "Canvas-based lantern rendering with flicker, glow halos, and ember particle systems for atmospheric visualization",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "lantern visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/lantern-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "layout-stable-hover-via-inset-shadow",
+    "slug": "layout-stable-hover-via-inset-shadow",
+    "category": "design",
+    "description": "Replace transform-based hover effects (translate, scale) with inset box-shadow to avoid layout shifts and horizontal-scrollbar flicker",
+    "tags": [
+      "css",
+      "hover",
+      "scrollbar",
+      "layout"
+    ],
+    "triggers": [
+      "hover causes scrollbar",
+      "hover layout shift",
+      "translate hover flicker",
+      "scrollbar flashes on hover"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/layout-stable-hover-via-inset-shadow",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "load-balancer-visualization-pattern",
+    "slug": "load-balancer-visualization-pattern",
+    "category": "design",
+    "description": "Canvas/SVG-based real-time visualization for load balancer request distribution across backend pools",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "load balancer visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/load-balancer-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "log-aggregation-visualization-pattern",
+    "slug": "log-aggregation-visualization-pattern",
+    "category": "design",
+    "description": "Visual patterns for rendering streaming logs, heatmap density, and query-filtered timelines in log aggregation UIs",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "log aggregation visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/log-aggregation-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "materialized-view-visualization-pattern",
+    "slug": "materialized-view-visualization-pattern",
+    "category": "design",
+    "description": "Visual layout conventions for rendering materialized view lifecycle (base tables → MV → queries) with staleness indicators",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "materialized view visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/materialized-view-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "message-queue-visualization-pattern",
+    "slug": "message-queue-visualization-pattern",
+    "category": "design",
+    "description": "Canvas-based rendering pattern for animating message flow through producers, queues, and consumers",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "message queue visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/message-queue-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "mfa-portal-css-isolation",
+    "slug": "mfa-portal-css-isolation",
+    "category": "design",
+    "description": "Isolate Tailwind CSS in Module Federation portals using lazyStyleTag injection, postcss-prefix-selector with :where() specificity control, scoped root elements, and Headless UI PortalGroup",
+    "tags": [],
+    "triggers": [],
+    "version": "1.1.0",
+    "path": "skills/design/mfa-portal-css-isolation",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "nds-html-mockup-from-tokens",
+    "slug": "nds-html-mockup-from-tokens",
+    "category": "design",
+    "description": "lucida-ui 디자인 토큰을 추출하여 실제 제품과 동일한 스타일의 static HTML 목업 생성",
+    "tags": [],
+    "triggers": [
+      "HTML 목업",
+      "디자인 목업",
+      "NDS 스타일 HTML",
+      "lucida 디자인으로 HTML",
+      "화면 프로토타입"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/design/nds-html-mockup-from-tokens",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "oauth-visualization-pattern",
+    "slug": "oauth-visualization-pattern",
+    "category": "design",
+    "description": "Visualizing OAuth flows, JWT structure, and scope relationships through staged, interactive diagrams",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "oauth visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/oauth-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "object-storage-visualization-pattern",
+    "slug": "object-storage-visualization-pattern",
+    "category": "design",
+    "description": "Canvas/SVG patterns for visualizing object storage buckets, objects, and replication topologies",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "object storage visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/object-storage-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "outbox-pattern-visualization-pattern",
+    "slug": "outbox-pattern-visualization-pattern",
+    "category": "design",
+    "description": "Three-lane visualization showing business transaction, outbox table, and relay publisher for outbox pattern demos",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "outbox pattern visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/outbox-pattern-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "parallax-sine-silhouette-horizon",
+    "slug": "parallax-sine-silhouette-horizon",
+    "category": "design",
+    "description": "Multi-layer animated horizon backdrop built from 3-N sine-displaced silhouette polygons with decreasing opacity and rising baselines for cheap parallax depth.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "parallax sine silhouette horizon"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/parallax-sine-silhouette-horizon",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "plan-design-review",
+    "slug": "plan-design-review",
+    "category": "design",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/design/plan-design-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "pub-sub-visualization-pattern",
+    "slug": "pub-sub-visualization-pattern",
+    "category": "design",
+    "description": "Canvas-based visualization showing topic channels, publishers fanning out messages to multiple subscribers with animated message particles",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "pub sub visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/pub-sub-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "raft-consensus-visualization-pattern",
+    "slug": "raft-consensus-visualization-pattern",
+    "category": "design",
+    "description": "Multi-panel layout for visualizing Raft consensus state across leader election, log replication, and term progression",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "raft consensus visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/raft-consensus-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "rate-limiter-visualization-pattern",
+    "slug": "rate-limiter-visualization-pattern",
+    "category": "design",
+    "description": "Visual patterns for rendering token buckets, sliding windows, and quota consumption in real-time dashboards",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "rate limiter visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/rate-limiter-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "read-replica-visualization-pattern",
+    "slug": "read-replica-visualization-pattern",
+    "category": "design",
+    "description": "Canvas-based topology visualization for primary-replica clusters with lag indicators and routing flows",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "read replica visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/read-replica-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "retry-strategy-visualization-pattern",
+    "slug": "retry-strategy-visualization-pattern",
+    "category": "design",
+    "description": "Visualize retry attempts as timeline tracks with backoff intervals, jitter bands, and terminal outcome markers",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "retry strategy visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/retry-strategy-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "saga-pattern-visualization-pattern",
+    "slug": "saga-pattern-visualization-pattern",
+    "category": "design",
+    "description": "Visualize saga transaction flows with step states, compensation paths, and forward/backward progress indicators",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "saga pattern visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/saga-pattern-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "schema-registry-visualization-pattern",
+    "slug": "schema-registry-visualization-pattern",
+    "category": "design",
+    "description": "Visualization patterns for schema registry evolution, compatibility, and dependency graphs",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "schema registry visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/schema-registry-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "service-mesh-visualization-pattern",
+    "slug": "service-mesh-visualization-pattern",
+    "category": "design",
+    "description": "Rendering sidecar proxies, control plane, and east-west traffic flows as an interactive topology graph",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "service mesh visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/service-mesh-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "sidecar-proxy-visualization-pattern",
+    "slug": "sidecar-proxy-visualization-pattern",
+    "category": "design",
+    "description": "Visualize sidecar proxy topology as paired app+proxy nodes with intercepted traffic flows and policy overlays.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "sidecar proxy visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/sidecar-proxy-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "strangler-fig-visualization-pattern",
+    "slug": "strangler-fig-visualization-pattern",
+    "category": "design",
+    "description": "Side-by-side legacy/new system visualization with traffic routing overlay for strangler-fig migration apps",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "strangler fig visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/strangler-fig-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "time-series-db-visualization-pattern",
+    "slug": "time-series-db-visualization-pattern",
+    "category": "design",
+    "description": "Render time-series data as a scrolling multi-series canvas chart with downsampled LTTB buckets and a brushable overview band.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "time series db visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/time-series-db-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "websocket-visualization-pattern",
+    "slug": "websocket-visualization-pattern",
+    "category": "design",
+    "description": "Canvas/SVG-based frame-level visualization for WebSocket protocol state, handshake phases, and message flow",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "websocket visualization pattern"
+    ],
+    "version": "1.0.0",
+    "path": "skills/design/websocket-visualization-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "widget-card-composition",
+    "slug": "widget-card-composition",
+    "category": "design",
+    "description": "Dashboard widget composition pattern using a CardWidget chrome wrapper with domain-specific Card* content components, resize tracking, and popover menus",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/design/widget-card-composition",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "zero-dep-dark-html-app",
+    "slug": "zero-dep-dark-html-app",
+    "category": "design",
+    "description": "Scaffold a zero-dependency dark-theme HTML+CSS+JS interactive app with canvas charts, tab navigation, and detail panels",
+    "tags": [
+      "html",
+      "css",
+      "vanilla-js",
+      "canvas",
+      "dark-theme",
+      "zero-dependency"
+    ],
+    "triggers": [
+      "zero-dep html app",
+      "dark theme dashboard",
+      "self-contained html tool",
+      "vanilla js interactive app",
+      "canvas visualization app"
+    ],
+    "version": "1.0.0",
+    "path": "skills/zero-dep-dark-html-app",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "clang-tidy-integration-workflow",
+    "slug": "clang-tidy-integration-workflow",
+    "category": "devops",
+    "description": "Automated static analysis pipeline using clang-tidy with project-specific checks and suppression strategies for large multi-file C++ codebases.",
+    "tags": [
+      "cpp",
+      "static-analysis",
+      "clang-tidy",
+      "ci",
+      "linting"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/clang-tidy-integration-workflow",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "claude-code-skill-scaffold",
+    "slug": "claude-code-skill-scaffold",
+    "category": "devops",
+    "description": "[Tooling] Claude Code 스킬 표준 구조(SKILL.md + prompts/ + scripts/ + references/)를 자동 생성하는 스캐폴딩.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/claude-code-skill-scaffold",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "claude-plugin-catalog-publish",
+    "slug": "claude-plugin-catalog-publish",
+    "category": "devops",
+    "description": "[Tooling] 로컬 스킬을 원격 Git repo에 배포하고 AGENTS.md 카탈로그를 자동 갱신하는 publish 플로우.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/claude-plugin-catalog-publish",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "docker-compose-service-inventory-files",
+    "slug": "docker-compose-service-inventory-files",
+    "category": "devops",
+    "description": "Manage large Docker Compose service fleets using flat inventory files with '#' as an EX (exclude) marker",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/docker-compose-service-inventory-files",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "docker-compose-v1-v2-auto-detect",
+    "slug": "docker-compose-v1-v2-auto-detect",
+    "category": "devops",
+    "description": "Shell helper that prefers `docker compose` (v2) over `docker-compose` (v1) with graceful fallback",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/docker-compose-v1-v2-auto-detect",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "dual-jre-docker-oz-report",
+    "slug": "dual-jre-docker-oz-report",
+    "category": "devops",
+    "description": "Package a Java 21 Spring Boot app that bundles a legacy JRE 8 + sidecar Tomcat (OZ Report engine) in one Alpine container",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/dual-jre-docker-oz-report",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "font-cache-alpine-locale-docker",
+    "slug": "font-cache-alpine-locale-docker",
+    "category": "devops",
+    "description": "Make CJK/custom fonts usable inside an Alpine container by copying TTF/OTF and rebuilding the fontconfig cache",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/font-cache-alpine-locale-docker",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "gradle-bootrun-local-dev-env",
+    "slug": "gradle-bootrun-local-dev-env",
+    "category": "devops",
+    "description": "Gradle bootRun task recipe that wires local MongoDB/Kafka/Redis/MQTT/Eureka/Quartz via environment variables — no docker-compose needed",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/gradle-bootrun-local-dev-env",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "gradle-jacoco-exclusion-strategy",
+    "slug": "gradle-jacoco-exclusion-strategy",
+    "category": "devops",
+    "description": "Curated Jacoco/Sonar exclusion patterns for Spring Boot projects — skips config/DAO/entity/generated layers and Querydsl Q-classes",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/gradle-jacoco-exclusion-strategy",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "gradle-shared-exclusions-jacoco-sonar",
+    "slug": "gradle-shared-exclusions-jacoco-sonar",
+    "category": "devops",
+    "description": "Keep Jacoco report, Jacoco coverage verification, and SonarQube exclusions in sync by defining one `exclusionPatterns` list in Gradle ext",
+    "tags": [],
+    "triggers": [
+      "jacoco and sonarqube exclusion lists drift apart",
+      "adding a new package to coverage exclusions requires editing multiple blocks",
+      "querydsl Q-classes / generated code leaking into coverage reports"
+    ],
+    "version": "1.0.0",
+    "path": "skills/devops/gradle-shared-exclusions-jacoco-sonar",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "jenkins-dual-registry-docker-push",
+    "slug": "jenkins-dual-registry-docker-push",
+    "category": "devops",
+    "description": "Jenkins pipeline that builds one image and tags+pushes it to two registries (SaaS + on-prem) with both build-specific and rolling-latest tags",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/jenkins-dual-registry-docker-push",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "mongodb-volume-copy-backup",
+    "slug": "mongodb-volume-copy-backup",
+    "category": "devops",
+    "description": "Back up and restore MongoDB Docker volumes via rsync volume-copy instead of mongodump/tar.gz",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/mongodb-volume-copy-backup",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "playwright-java-dockerfile",
+    "slug": "playwright-java-dockerfile",
+    "category": "devops",
+    "description": "Multi-stage Dockerfile that builds a Java/Maven app in a JDK image and runs it on the official Playwright Java runtime image, avoiding manual browser installation",
+    "tags": [
+      "docker",
+      "playwright",
+      "java",
+      "maven",
+      "multi-stage"
+    ],
+    "triggers": [
+      "dockerfile playwright java",
+      "mcr.microsoft.com/playwright/java",
+      "playwright container"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/devops/playwright-java-dockerfile",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "querydsl-q-class-exclusion-pattern",
+    "slug": "querydsl-q-class-exclusion-pattern",
+    "category": "devops",
+    "description": "One `exclusionPatterns` list drives Jacoco report + verification + Sonar exclusions; catches generated Querydsl Q-classes via `('A'..'Z').collect { \"**/**/Q${it}*\" }`.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/querydsl-q-class-exclusion-pattern",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "skill-md-validator",
+    "slug": "skill-md-validator",
+    "category": "devops",
+    "description": "[Tooling] SKILL.md frontmatter + 필수 섹션을 CRITICAL/WARNING 등급으로 검증하는 품질 게이트.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/skill-md-validator",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "slack-webhook-notify",
+    "slug": "slack-webhook-notify",
+    "category": "devops",
+    "description": "Slack Incoming Webhook으로 메시지를 전송한다. 빌드/테스트/배포 결과, 작업 완료 알림 등을 Slack 채널에 보낼 때 사용.",
+    "tags": [],
+    "triggers": [
+      "slack",
+      "슬랙",
+      "slack notify",
+      "webhook 알림",
+      "빌드 알림",
+      "작업 완료 알림"
+    ],
+    "version": "1.0.0",
+    "path": "skills/devops/slack-webhook-notify",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "spring-bootrun-local-dev-env-block",
+    "slug": "spring-bootrun-local-dev-env-block",
+    "category": "devops",
+    "description": "Gradle `bootRun` env block that wires local Redis/Mongo/Kafka/Eureka/MQTT for zero-config `./gradlew bootRun` developer experience",
+    "tags": [],
+    "triggers": [
+      "new engineer asks \"how do I run this locally?",
+      "application-local.yaml is gitignored and no-one knows the defaults",
+      "Spring Cloud service refuses to start locally because Eureka client is enabled"
+    ],
+    "version": "1.0.0",
+    "path": "skills/devops/spring-bootrun-local-dev-env-block",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "triple-env-file-split-loader",
+    "slug": "triple-env-file-split-loader",
+    "category": "devops",
+    "description": "Split operator-facing env into three files (.env / .version / .memory) and load them in a fixed order",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/triple-env-file-split-loader",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "document-release",
+    "slug": "document-release",
+    "category": "docs",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/docs/document-release",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "edit-article",
+    "slug": "edit-article",
+    "category": "docs",
+    "description": "Edit and improve articles by restructuring sections, improving clarity, and tightening prose. Use when user wants to edit, revise, or improve an article draft.",
+    "tags": [
+      "writing",
+      "editing",
+      "clarity"
+    ],
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "skills/docs/edit-article",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "learn",
+    "slug": "learn",
+    "category": "docs",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/docs/learn",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "obsidian-vault",
+    "slug": "obsidian-vault",
+    "category": "docs",
+    "description": "Search, create, and manage notes in the Obsidian vault with wikilinks and index notes. Use when user wants to find, create, or organize notes in Obsidian.",
+    "tags": [
+      "obsidian",
+      "notes",
+      "wikilinks",
+      "vault"
+    ],
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "skills/docs/obsidian-vault",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "retro",
+    "slug": "retro",
+    "category": "docs",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/docs/retro",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "ubiquitous-language",
+    "slug": "ubiquitous-language",
+    "category": "docs",
+    "description": "Extract a DDD-style ubiquitous language glossary from the current conversation, flagging ambiguities and proposing canonical terms. Saves to UBIQUITOUS_LANGUAGE.md. Use when user wants to define domain terms, build a glossary, harden terminology, create a ubiquitous language, or mentions \"domain model\" or \"DDD\".",
+    "tags": [
+      "ddd",
+      "glossary",
+      "language",
+      "domain"
+    ],
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "skills/docs/ubiquitous-language",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "ag-grid-cell-renderer-pattern",
+    "slug": "ag-grid-cell-renderer-pattern",
+    "category": "frontend",
+    "description": "Structured AG-Grid custom cell renderer catalog with typed column definitions and category-based organization",
+    "tags": [],
+    "triggers": [
+      "ag-grid",
+      "cell renderer",
+      "grid column",
+      "custom renderer",
+      "grid cell"
+    ],
+    "version": "1.0.0",
+    "path": "skills/frontend/ag-grid-cell-renderer-pattern",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "axios-refresh-queue-zustand",
+    "slug": "axios-refresh-queue-zustand",
+    "category": "frontend",
+    "description": "Axios response interceptor that intercepts 401, queues concurrent failed requests, refreshes the token once, and replays queued requests with the new token. Prevents thundering-herd refresh calls.",
+    "tags": [
+      "axios",
+      "jwt",
+      "refresh-token",
+      "interceptor",
+      "zustand",
+      "auth"
+    ],
+    "triggers": [
+      "axios 401 refresh",
+      "token refresh queue",
+      "isRefreshing flag",
+      "axios interceptor zustand",
+      "refresh thundering herd",
+      "retry original request"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/frontend/axios-refresh-queue-zustand",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "canvas-svg-dual-layer-hit-dispatch",
+    "slug": "canvas-svg-dual-layer-hit-dispatch",
+    "category": "frontend",
+    "description": "Composite scene from an animated `<canvas>` plus an overlaid `<svg>`, routing pointer events to the layer that owns each element class.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "canvas svg dual layer hit dispatch"
+    ],
+    "version": "1.0.0",
+    "path": "skills/frontend/canvas-svg-dual-layer-hit-dispatch",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "drawer-resizable-composition",
+    "slug": "drawer-resizable-composition",
+    "category": "frontend",
+    "description": "Drawer-as-primary-modal pattern with preset widths, resizable handles, and parent state composition for React apps",
+    "tags": [],
+    "triggers": [
+      "drawer",
+      "modal drawer",
+      "resizable drawer",
+      "side panel"
+    ],
+    "version": "1.0.0",
+    "path": "skills/frontend/drawer-resizable-composition",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "figma-code-connect-react",
+    "slug": "figma-code-connect-react",
+    "category": "frontend",
+    "description": "Map Figma component variants to React props using @figma/code-connect with co-located *.figma.tsx files",
+    "tags": [],
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "skills/frontend/figma-code-connect-react",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "figma-token-scss-style-dictionary-v3",
+    "slug": "figma-token-scss-style-dictionary-v3",
+    "category": "frontend",
+    "description": "Figma Tokens Studio JSON → split files → Style Dictionary v3 → SCSS variables, typography classes, and composition classes",
+    "tags": [],
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "skills/frontend/figma-token-scss-style-dictionary-v3",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "folder-coloc-style-types",
+    "slug": "folder-coloc-style-types",
+    "category": "frontend",
+    "description": "Keep component, style, and types files at the same depth; never split into styles/ or types/ subfolders",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/frontend/folder-coloc-style-types",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "incommensurate-sine-organic-flicker",
+    "slug": "incommensurate-sine-organic-flicker",
+    "category": "frontend",
+    "description": "Compose a natural-looking flicker/sway value by summing 2–3 sine waves whose frequencies are non-integer ratios so the pattern never visibly loops.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "incommensurate sine organic flicker"
+    ],
+    "version": "1.0.0",
+    "path": "skills/frontend/incommensurate-sine-organic-flicker",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "jest-test-file-naming-test-only",
+    "slug": "jest-test-file-naming-test-only",
+    "category": "frontend",
+    "description": "Use .test.ts naming (not .spec.ts) and explicitly import jest globals; .spec.ts is excluded from the runner",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/frontend/jest-test-file-naming-test-only",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "menu-key-config-registry",
+    "slug": "menu-key-config-registry",
+    "category": "frontend",
+    "description": "Centralize sidebar/drawer menu keys as a union type + config object per domain, so menu rendering, drawer view switches, and default-expand state all reference the same source of truth. Eliminates string-key drift across the three places a menu key appears.",
+    "tags": [
+      "react",
+      "menu",
+      "drawer",
+      "registry",
+      "typescript",
+      "union-type",
+      "configuration"
+    ],
+    "triggers": [
+      "menu key drift",
+      "Drawer case switch",
+      "selectedSubMenu",
+      "DetailMenuList",
+      "sidebar menu config"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/frontend/menu-key-config-registry",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "mfa-federated-component-loader",
+    "slug": "mfa-federated-component-loader",
+    "category": "frontend",
+    "description": "Three-layer dynamic component loading for Webpack 5 Module Federation with retry logic, script caching, and error boundaries",
+    "tags": [],
+    "triggers": [
+      "module federation",
+      "federated component",
+      "remote component loading",
+      "dynamic import remote",
+      "RemoteApp"
+    ],
+    "version": "1.0.0",
+    "path": "skills/frontend/mfa-federated-component-loader",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "mfa-memoryrouter-isolation",
+    "slug": "mfa-memoryrouter-isolation",
+    "category": "frontend",
+    "description": "Wrap Module Federation-exposed React components in `MemoryRouter` so they own a private router context instead of inheriting the host's — avoids cross-origin router errors in dev and keeps the remote's routes from leaking into the host URL bar.",
+    "tags": [
+      "module-federation",
+      "react-router",
+      "memoryrouter",
+      "micro-frontend",
+      "cross-origin"
+    ],
+    "triggers": [
+      "MemoryRouter",
+      "Router context",
+      "cross-origin",
+      "useNavigate outside Router",
+      "MFA expose router"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/frontend/mfa-memoryrouter-isolation",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "mfa-plain-html-dropdown-escape-hatch",
+    "slug": "mfa-plain-html-dropdown-escape-hatch",
+    "category": "frontend",
+    "description": "When a library Dropdown component infinite-loops or cross-origin-fails inside a Module Federation remote, replace it with a plain HTML `<button>` + absolutely-positioned menu `<ul>`. Cheaper than debugging the library's portal/context assumptions.",
+    "tags": [
+      "module-federation",
+      "dropdown",
+      "antd",
+      "infinite-loop",
+      "cross-origin",
+      "react"
+    ],
+    "triggers": [
+      "Dropdown infinite loop",
+      "options useMemo",
+      "MFA dropdown",
+      "portal cross-origin",
+      "library dropdown broken in remote"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/frontend/mfa-plain-html-dropdown-escape-hatch",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "module-federation-expose-react-component",
+    "slug": "module-federation-expose-react-component",
+    "category": "frontend",
+    "description": "Canonical 6-step pipeline for exposing a React component from one Module Federation remote and consuming it from another — implementation → expose wrapper (MemoryRouter) → MF config → shared MF-name constants → shared RemoteApp wrapper → consumer import. Prevents direct cross-remote imports and webpack `@/` alias collisions.",
+    "tags": [
+      "module-federation",
+      "micro-frontend",
+      "webpack",
+      "react",
+      "remote",
+      "expose",
+      "mfa",
+      "monorepo"
+    ],
+    "triggers": [
+      "expose a component across module federation remotes",
+      "share React component between MFA remotes",
+      "MFA expose pipeline",
+      "cross-remote import forbidden",
+      "RemoteApp wrapper",
+      "webpack alias collision"
+    ],
+    "version": "1.1.0",
+    "path": "skills/frontend/module-federation-expose-react-component",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "phase-window-timing-grade-with-pity",
+    "slug": "phase-window-timing-grade-with-pity",
+    "category": "frontend",
+    "description": "Rhythm-game timing mechanic that grades clicks by distance from a cyclic \"golden window\" center, with pity expansion after consecutive misses.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "phase window timing grade with pity"
+    ],
+    "version": "1.0.0",
+    "path": "skills/frontend/phase-window-timing-grade-with-pity",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "recoil-domain-atom-store",
+    "slug": "recoil-domain-atom-store",
+    "category": "frontend",
+    "description": "Domain-scoped Recoil atom organization with typed hook wrappers for large-scale React state management",
+    "tags": [],
+    "triggers": [
+      "recoil atom",
+      "state management",
+      "domain store",
+      "global state"
+    ],
+    "version": "1.0.0",
+    "path": "skills/frontend/recoil-domain-atom-store",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "shared-apis-endpoint-service-pattern",
+    "slug": "shared-apis-endpoint-service-pattern",
+    "category": "frontend",
+    "description": "Module Federation 모노레포에서 REST 엔드포인트를 추가할 때 `endpoint 상수 → services 메서드 → commonApiService 호출` 3계층 레이어링으로 도메인 일관성을 유지하는 패턴.",
+    "tags": [
+      "api",
+      "services",
+      "endpoint",
+      "module-federation",
+      "monorepo",
+      "layering"
+    ],
+    "triggers": [
+      "엔드포인트 추가",
+      "widgetEndPoint",
+      "shared/apis",
+      "commonApiService",
+      "API 레이어 추가",
+      "endpoint constant"
+    ],
+    "version": "1.0.0",
+    "path": "skills/frontend/shared-apis-endpoint-service-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "sse-fetch-streaming",
     "slug": "sse-fetch-streaming",
     "category": "frontend",
@@ -3947,39 +9422,134 @@
     "has_content": true
   },
   {
-    "name": "stable-horde-async-poll",
-    "slug": "stable-horde-async-poll",
-    "category": "ai",
-    "description": "Submit-then-poll integration pattern for Stable Horde image generation — anonymous apikey, model fallback list, negative-prompt separator, bounded poll loop.",
+    "kind": "skill",
+    "name": "ts-type-prefix-convention",
+    "slug": "ts-type-prefix-convention",
+    "category": "frontend",
+    "description": "Prefix interfaces with I and type aliases with T; use type for unions/literals and interface for inheritable shapes",
     "tags": [],
     "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/frontend/ts-type-prefix-convention",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "webaudio-burst-schedule-melody-with-raf-playhead",
+    "slug": "webaudio-burst-schedule-melody-with-raf-playhead",
+    "category": "frontend",
+    "description": "Play a pre-computed note list by scheduling every oscillator upfront on the AudioContext clock, while JS only drives a requestAnimationFrame playhead.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "webaudio burst schedule melody with raf playhead"
+    ],
+    "version": "1.0.0",
+    "path": "skills/frontend/webaudio-burst-schedule-melody-with-raf-playhead",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "widget-confid-injection-sweep",
+    "slug": "widget-confid-injection-sweep",
+    "category": "frontend",
+    "description": "리소스 상세 대시보드에서 모든 위젯 데이터 요청에 `confId` 를 일관되게 주입하기 위한 위젯 fetch 지점 전수 스윕(sweep) 패턴 — 일부만 주입하면 같은 대시보드 안에서 위젯별 필터 동작이 갈라지는 버그를 방지한다.",
+    "tags": [
+      "widget",
+      "dashboard",
+      "resource-detail",
+      "data-fetch",
+      "scope-injection"
+    ],
+    "triggers": [
+      "confId 주입",
+      "selectCondition confId",
+      "위젯 필터링",
+      "widget scope injection",
+      "resource-scoped widget"
+    ],
+    "version": "1.0.0",
+    "path": "skills/frontend/widget-confid-injection-sweep",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "widget-grid-type-registration-checklist",
+    "slug": "widget-grid-type-registration-checklist",
+    "category": "frontend",
+    "description": "대시보드의 TableGrid/차트 위젯에 새로운 타입을 추가할 때 드리프트 없이 5곳(columns 매핑, fetch hook, 에디터 폼, detectType, 모델 DTO) 모두 반영하게 하는 체크리스트 스킬.",
+    "tags": [
+      "widget",
+      "dashboard",
+      "registry",
+      "grid",
+      "checklist"
+    ],
+    "triggers": [
+      "TableGridType",
+      "위젯 타입 추가",
+      "tableGridType",
+      "widget type registration",
+      "detectType",
+      "columns mapping"
+    ],
+    "version": "1.0.0",
+    "path": "skills/frontend/widget-grid-type-registration-checklist",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "zustand-preset-manager",
+    "slug": "zustand-preset-manager",
+    "category": "frontend",
+    "description": "Zustand + persist middleware pattern for managing N named presets (team comps, saved filters, dashboard layouts) with active-selection, max-count guard, and auto-reselect on delete.",
+    "tags": [
+      "zustand",
+      "localstorage",
+      "preset",
+      "state-management",
+      "persist-middleware"
+    ],
+    "triggers": [
+      "zustand persist",
+      "saved presets",
+      "team presets",
+      "named configurations",
+      "localStorage preset",
+      "multi-preset selector"
+    ],
     "version": "0.1.0-draft",
-    "path": "skills/ai/stable-horde-async-poll",
+    "path": "skills/frontend/zustand-preset-manager",
     "has_content": true
   },
   {
-    "name": "stack-parse-tag-filter-to-mongo-criteria",
-    "slug": "stack-tag-filter-to-mongo-criteria",
-    "category": "backend",
-    "description": "Parse a tokenized boolean filter expression (key=value, AND, OR, parens) into a MongoDB Criteria tree using a shunting-yard/stack algorithm, with elemMatch for array-of-tag subdocs.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/stack-tag-filter-to-mongo-criteria",
+    "kind": "skill",
+    "name": "gacha-soft-hard-pity",
+    "slug": "gacha-soft-hard-pity",
+    "category": "game-dev",
+    "description": "Server-authoritative gacha with soft pity (rate ramp after N pulls), hard pity (guaranteed top rarity at M pulls), and 50/50 guarantee carryover. Split rate calculation from result resolution so probability is testable.",
+    "tags": [
+      "gacha",
+      "pity",
+      "probability",
+      "securerandom",
+      "loot",
+      "rng-fairness"
+    ],
+    "triggers": [
+      "gacha pity system",
+      "soft pity hard pity",
+      "50/50 pity",
+      "banner rate up",
+      "rate calculator"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/game-dev/gacha-soft-hard-pity",
     "has_content": true
   },
   {
-    "name": "stale-persistent-context-detection",
-    "slug": "stale-persistent-context-detection",
-    "category": "workflow",
-    "description": "Detect and remove stale error snapshots that LLM tools inject via persistent-context files (CLAUDE.md, AGENTS.md, system prompts, memory) before chasing a fix. If the current source already compiles, the injected error is a ghost from a previous session, not a real bug.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/workflow/stale-persistent-context-detection",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "stateless-turn-combat-engine",
     "slug": "stateless-turn-combat-engine",
     "category": "game-dev",
@@ -4004,6 +9574,7 @@
     "has_content": true
   },
   {
+    "kind": "skill",
     "name": "status-effect-enum-system",
     "slug": "status-effect-enum-system",
     "category": "game-dev",
@@ -4028,32 +9599,1748 @@
     "has_content": true
   },
   {
-    "name": "stomp-cookie-auth-handshake",
-    "slug": "stomp-cookie-auth-handshake",
-    "category": "backend",
-    "description": "Authenticate STOMP WebSocket upgrade using an HttpOnly cookie extracted during the handshake, then bind identity to the STOMP session",
-    "tags": [],
-    "triggers": [],
+    "kind": "skill",
+    "name": "jj-jujutsu-day-one-workflow",
+    "slug": "jj-jujutsu-day-one-workflow",
+    "category": "git",
+    "description": "Minimum viable jj (Jujutsu) workflow for a git user — init on top of an existing git repo, the five commands that cover 95% of day-1 usage, and the mental-model shift from git's staging area.",
+    "tags": [
+      "jj",
+      "jujutsu",
+      "version-control",
+      "git-compatible",
+      "workflow",
+      "onboarding"
+    ],
+    "triggers": [
+      "jj",
+      "jujutsu",
+      "jj git init",
+      "jj describe",
+      "jj bookmark",
+      "jj st",
+      "jj new",
+      "jj log"
+    ],
     "version": "1.0.0",
-    "path": "skills/backend/stomp-cookie-auth-handshake",
+    "path": "skills/git/jj-jujutsu-day-one-workflow",
     "has_content": true
   },
   {
-    "name": "stomp-principal-jwt-channel",
-    "slug": "stomp-principal-jwt-channel",
-    "category": "backend",
-    "description": "STOMP ChannelInterceptor that validates a JWT on CONNECT and binds a multi-tenant Principal (orgId + userId + sessionId) for downstream routing",
-    "tags": [],
+    "kind": "skill",
+    "name": "design-an-interface",
+    "slug": "design-an-interface",
+    "category": "misc",
+    "description": "Generate multiple radically different interface designs for a module using parallel sub-agents. Use when user wants to design an API, explore interface options, compare module shapes, or mentions \"design it twice\".",
+    "tags": [
+      "design",
+      "api-design",
+      "sub-agents",
+      "design-it-twice"
+    ],
     "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/stomp-principal-jwt-channel",
+    "version": "0.1.0-draft",
+    "path": "skills/misc/design-an-interface",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "scaffold-exercises",
+    "slug": "scaffold-exercises",
+    "category": "misc",
+    "description": "Create exercise directory structures with sections, problems, solutions, and explainers that pass linting. Use when user wants to scaffold exercises, create exercise stubs, or set up a new course section.",
+    "tags": [
+      "scaffolding",
+      "exercises",
+      "template"
+    ],
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "skills/misc/scaffold-exercises",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "write-a-skill",
+    "slug": "write-a-skill",
+    "category": "misc",
+    "description": "Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, or build a new skill.",
+    "tags": [
+      "skills",
+      "meta",
+      "authoring",
+      "progressive-disclosure"
+    ],
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "skills/misc/write-a-skill",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "react-native-android-emulator-localhost",
+    "slug": "react-native-android-emulator-localhost",
+    "category": "mobile",
+    "description": "Use Platform.select to pick the right loopback host when a React Native dev build talks to a backend on the host machine — Android emulator needs 10.0.2.2, iOS simulator uses localhost.",
+    "tags": [
+      "react-native",
+      "android",
+      "emulator",
+      "localhost",
+      "10.0.2.2",
+      "networking",
+      "dev-environment"
+    ],
+    "triggers": [
+      "10.0.2.2",
+      "Platform.select",
+      "localhost:8080",
+      "android emulator network",
+      "React Native API base",
+      "fetch failed",
+      "Network request failed"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/mobile/react-native-android-emulator-localhost",
     "has_content": true
   },
   {
+    "kind": "skill",
+    "name": "improve-codebase-architecture",
+    "slug": "improve-codebase-architecture",
+    "category": "refactor",
+    "description": "Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. Use when user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more AI-navigable.",
+    "tags": [
+      "architecture",
+      "codebase",
+      "exploration"
+    ],
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "skills/refactor/improve-codebase-architecture",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "migrate-to-shoehorn",
+    "slug": "migrate-to-shoehorn",
+    "category": "refactor",
+    "description": "Migrate test files from `as` type assertions to @total-typescript/shoehorn. Use when user mentions shoehorn, wants to replace `as` in tests, or needs partial test data.",
+    "tags": [
+      "typescript",
+      "shoehorn",
+      "type-assertions",
+      "migration"
+    ],
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "skills/refactor/migrate-to-shoehorn",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "request-refactor-plan",
+    "slug": "request-refactor-plan",
+    "category": "refactor",
+    "description": "Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.",
+    "tags": [
+      "planning",
+      "commits",
+      "interview"
+    ],
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "skills/refactor/request-refactor-plan",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "careful",
+    "slug": "careful",
+    "category": "security",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "0.1.0",
+    "path": "skills/security/careful",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "cso",
+    "slug": "cso",
+    "category": "security",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/security/cso",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "guard",
+    "slug": "guard",
+    "category": "security",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "0.1.0",
+    "path": "skills/security/guard",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "jwt-refresh-rotation-spring",
+    "slug": "jwt-refresh-rotation-spring",
+    "category": "security",
+    "description": "Spring Boot 3 JWT with short-lived access token + long-lived refresh token, filter-chain integration, and stateless session config. Avoids common mistakes that silently break refresh flows.",
+    "tags": [
+      "jwt",
+      "spring-boot",
+      "auth",
+      "refresh-token",
+      "jjwt",
+      "security-filter"
+    ],
+    "triggers": [
+      "jwt spring boot",
+      "refresh token rotation",
+      "JwtAuthenticationFilter",
+      "jjwt 0.12",
+      "SessionCreationPolicy.STATELESS",
+      "access token refresh token"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/security/jwt-refresh-rotation-spring",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "lean-verified-code-threat-boundary",
+    "slug": "lean-verified-code-threat-boundary",
+    "category": "security",
+    "description": "When shipping formally-verified code (Lean 4, Coq, F*), explicitly map what is inside and outside the verification boundary — untrusted parsers, runtime, and TCB assumptions almost always harbor the real bugs.",
+    "tags": [
+      "formal-verification",
+      "lean",
+      "coq",
+      "threat-modeling",
+      "fuzzing",
+      "tcb",
+      "security"
+    ],
+    "triggers": [
+      "formally verified",
+      "lean 4",
+      "formal proof",
+      "Coq",
+      "F-star",
+      "lean_alloc_sarray",
+      "trusted computing base",
+      "TCB",
+      "verified library",
+      "CompCert"
+    ],
+    "version": "1.0.0",
+    "path": "skills/security/lean-verified-code-threat-boundary",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "oauth-token-env-persistence",
+    "slug": "oauth-token-env-persistence",
+    "category": "security",
+    "description": "Persist OAuth access tokens to a sidecar env file (token + refresh + issue_time), refresh N minutes before expiry with a thread-safe guard, auto-inject into outgoing API calls — survives process restart without re-login.",
+    "tags": [
+      "oauth",
+      "token",
+      "refresh",
+      "dotenv",
+      "persistence",
+      "auth",
+      "thread-safety"
+    ],
+    "triggers": [
+      "access_token",
+      "refresh_token",
+      "token refresh",
+      "access_token.env",
+      "token issue time",
+      "bearer auto inject",
+      "token expiry"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/security/oauth-token-env-persistence",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "openssl-4-migration-checklist",
+    "slug": "openssl-4-migration-checklist",
+    "category": "security",
+    "description": "Step-by-step migration checklist for upgrading a C/C++ codebase from OpenSSL 3.x to 4.0.0 — const-qualified APIs, removed SSLv3 support, opaque ASN1_STRING, engine removal, cleanup semantics.",
+    "tags": [
+      "openssl",
+      "tls",
+      "cryptography",
+      "migration",
+      "c-api",
+      "breaking-changes",
+      "upgrade"
+    ],
+    "triggers": [
+      "openssl 4",
+      "OpenSSL 4.0.0",
+      "openssl upgrade",
+      "SSLv3_method",
+      "ENGINE_load",
+      "ASN1_STRING opaque",
+      "X509_cmp_time",
+      "openssl deprecated"
+    ],
+    "version": "1.0.0",
+    "path": "skills/security/openssl-4-migration-checklist",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "benchmark",
+    "slug": "benchmark",
+    "category": "testing",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/testing/benchmark",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "browse",
+    "slug": "browse",
+    "category": "testing",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.1.0",
+    "path": "skills/testing/browse",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "deterministic-coverage-verification",
+    "slug": "deterministic-coverage-verification",
+    "category": "testing",
+    "description": "Run LLVM-instrumented tests multiple times and verify identical coverage reports — catches compiler/env non-determinism that can mask real bugs.",
+    "tags": [
+      "coverage",
+      "llvm",
+      "testing",
+      "determinism",
+      "ci"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/testing/deterministic-coverage-verification",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "devex-review",
+    "slug": "devex-review",
+    "category": "testing",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/testing/devex-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "fuzz-corpus-seed-management",
+    "slug": "fuzz-corpus-seed-management",
+    "category": "testing",
+    "description": "Structured libFuzzer workflow — seed corpora in a separate asset repo, determinism verification, and reproducible crash workflows.",
+    "tags": [
+      "fuzzing",
+      "libfuzzer",
+      "llvm",
+      "testing",
+      "corpus"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/testing/fuzz-corpus-seed-management",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "gstack-qa",
+    "slug": "gstack-qa",
+    "category": "testing",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/testing/gstack-qa",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "gstack-qa-only",
+    "slug": "gstack-qa-only",
+    "category": "testing",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/testing/gstack-qa-only",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "health",
+    "slug": "health",
+    "category": "testing",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/testing/health",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "llm-integration-test-failure-diagnosis",
+    "slug": "llm-integration-test-failure-diagnosis",
+    "category": "testing",
+    "description": "Wire an LLM-based diagnosis step into your CI for integration-test failures — summarize noisy logs, identify probable root cause, post findings to the code-review/PR UI. Based on Google's Auto-Diagnose system (90%+ accuracy on 71-case study, adopted across 52k tests).",
+    "tags": [
+      "llm",
+      "ci",
+      "integration-tests",
+      "test-diagnosis",
+      "log-analysis",
+      "root-cause",
+      "auto-diagnose"
+    ],
+    "triggers": [
+      "test failure diagnosis",
+      "integration test flaky",
+      "log summarization",
+      "auto-diagnose",
+      "test failure LLM",
+      "root cause analysis"
+    ],
+    "version": "1.0.0",
+    "path": "skills/testing/llm-integration-test-failure-diagnosis",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "qa",
+    "slug": "qa",
+    "category": "testing",
+    "description": "Interactive QA session where user reports bugs or issues conversationally, and the agent files GitHub issues. Explores the codebase in the background for context and domain language. Use when user wants to report bugs, do QA, file issues conversationally, or mentions \"QA session\".",
+    "tags": [
+      "qa",
+      "interactive",
+      "bug-reports"
+    ],
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "skills/testing/qa",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "spring-testcontainers-multitenant-base",
+    "slug": "spring-testcontainers-multitenant-base",
+    "category": "testing",
+    "description": "Base test class that boots Testcontainers (Mongo + Kafka), pre-sets tenant/auth context, and forces JVM halt in AfterAll to avoid leaked containers.",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/testing/spring-testcontainers-multitenant-base",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "tdd",
+    "slug": "tdd",
+    "category": "testing",
+    "description": "Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions \"red-green-refactor\", wants integration tests, or asks for test-first development.",
+    "tags": [
+      "tdd",
+      "red-green-refactor"
+    ],
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "skills/testing/tdd",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "actor-model-data-simulation",
+    "slug": "actor-model-data-simulation",
+    "category": "workflow",
+    "description": "Generate realistic actor workloads with crashes, backpressure, and supervision restarts for demos",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "actor model data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/actor-model-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "api-gateway-pattern-data-simulation",
+    "slug": "api-gateway-pattern-data-simulation",
+    "category": "workflow",
+    "description": "Generate realistic gateway traffic with burst patterns, policy hits, and backend-selection skew driven by a seeded PRNG",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "api gateway pattern data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/api-gateway-pattern-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "api-versioning-data-simulation",
+    "slug": "api-versioning-data-simulation",
+    "category": "workflow",
+    "description": "Generating realistic fixture data for API version timelines, diffs, and traffic migration curves",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "api versioning data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/api-versioning-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "async-subagent-resume-on-missing-artifact",
+    "slug": "async-subagent-resume-on-missing-artifact",
+    "category": "workflow",
+    "description": "When an async subagent is reported \"completed\" but its final message hints at unfinished work (e.g., \"Now let me build…\"), verify the expected on-disk artifact before moving on; if missing, use SendMessage to the agent id to finalize rather than re-dispatching a fresh agent.",
+    "tags": [
+      "agents",
+      "async",
+      "verification",
+      "send-message"
+    ],
+    "triggers": [
+      "agent completed but artifact missing",
+      "subagent incomplete output"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/async-subagent-resume-on-missing-artifact",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "autoplan",
+    "slug": "autoplan",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/autoplan",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "backpressure-data-simulation",
+    "slug": "backpressure-data-simulation",
+    "category": "workflow",
+    "description": "Token-stepped discrete event loop driving producer/buffer/consumer with per-tick rate budgets",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "backpressure data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/backpressure-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "bff-pattern-data-simulation",
+    "slug": "bff-pattern-data-simulation",
+    "category": "workflow",
+    "description": "Generate realistic BFF traffic by simulating per-client request shapes, parallel backend fan-out with varied latency, and client-specific response trimming",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "bff pattern data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/bff-pattern-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "bloom-filter-data-simulation",
+    "slug": "bloom-filter-data-simulation",
+    "category": "workflow",
+    "description": "Generating realistic workloads (usernames, collisions, concurrent inserts) to exercise bloom filter behavior end-to-end",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "bloom filter data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/bloom-filter-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "blue-green-deploy-data-simulation",
+    "slug": "blue-green-deploy-data-simulation",
+    "category": "workflow",
+    "description": "Deterministic state-machine generator for blue-green cutover phases with realistic traffic drain and health-check dynamics",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "blue green deploy data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/blue-green-deploy-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "bucket-parallel-java-annotation-dispatch",
+    "slug": "bucket-parallel-java-annotation-dispatch",
+    "category": "workflow",
+    "description": "For bulk Java annotation work (200+ @Operation methods across many controllers, or 500+ @Schema fields across many DTOs), dispatch N parallel executor subagents with disjoint file buckets. Leader runs a single compile at the end; agents never run gradle themselves.",
+    "tags": [
+      "parallel-agents",
+      "java",
+      "annotation",
+      "spring",
+      "swagger",
+      "gradle"
+    ],
+    "triggers": [
+      "bulk annotation",
+      "전수 적용",
+      "controller 전체 주석",
+      "DTO @Schema 전수"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/bucket-parallel-java-annotation-dispatch",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "bulkhead-data-simulation",
+    "slug": "bulkhead-data-simulation",
+    "category": "workflow",
+    "description": "Generating realistic traffic patterns that exercise bulkhead isolation and failure containment",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "bulkhead data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/bulkhead-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "canary",
+    "slug": "canary",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/canary",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "canary-release-data-simulation",
+    "slug": "canary-release-data-simulation",
+    "category": "workflow",
+    "description": "Deterministic synthetic generator for canary traffic, SLO metrics, and bake-time gate evaluations",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "canary release data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/canary-release-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "cdc-data-simulation",
+    "slug": "cdc-data-simulation",
+    "category": "workflow",
+    "description": "Generating realistic synthetic CDC event streams with proper transaction grouping, LSN monotonicity, and schema evolution",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "cdc data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/cdc-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "chaos-engineering-data-simulation",
+    "slug": "chaos-engineering-data-simulation",
+    "category": "workflow",
+    "description": "Generating realistic fault-injection scenarios, blast radii, and recovery curves without a real cluster",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "chaos engineering data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/chaos-engineering-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "checkpoint",
+    "slug": "checkpoint",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/checkpoint",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "circuit-breaker-data-simulation",
+    "slug": "circuit-breaker-data-simulation",
+    "category": "workflow",
+    "description": "Deterministic synthetic call stream generator for circuit breaker state machine demonstrations",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "circuit breaker data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/circuit-breaker-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "command-query-data-simulation",
+    "slug": "command-query-data-simulation",
+    "category": "workflow",
+    "description": "Generate realistic command/query/event streams with controllable lag and conflict patterns for CQRS demos",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "command query data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/command-query-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "connection-pool-data-simulation",
+    "slug": "connection-pool-data-simulation",
+    "category": "workflow",
+    "description": "Deterministic simulation model for generating realistic connection pool workloads across acquisition, validation, and eviction events",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "connection pool data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/connection-pool-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "consistent-hashing-data-simulation",
+    "slug": "consistent-hashing-data-simulation",
+    "category": "workflow",
+    "description": "Workflow for generating reproducible node/key datasets and rebalance event streams for consistent-hashing demos",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "consistent hashing data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/consistent-hashing-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "cqrs-data-simulation",
+    "slug": "cqrs-data-simulation",
+    "category": "workflow",
+    "description": "Generate correlated command/event/projection streams with tunable skew so read-model lag and replay behavior are observable.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "cqrs data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/cqrs-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "crdt-data-simulation",
+    "slug": "crdt-data-simulation",
+    "category": "workflow",
+    "description": "Simulating network partitions, concurrent edits, and message reordering to exercise CRDT merge logic",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "crdt data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/crdt-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "data-pipeline-data-simulation",
+    "slug": "data-pipeline-data-simulation",
+    "category": "workflow",
+    "description": "Generating realistic synthetic pipeline telemetry with backpressure, lag, failure modes, and cascading effects",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "data pipeline data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/data-pipeline-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "database-sharding-data-simulation",
+    "slug": "database-sharding-data-simulation",
+    "category": "workflow",
+    "description": "Synthetic workload generator for sharding scenarios using skewed key distributions and configurable hash strategies",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "database sharding data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/database-sharding-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "dead-letter-queue-data-simulation",
+    "slug": "dead-letter-queue-data-simulation",
+    "category": "workflow",
+    "description": "Generating realistic DLQ fixtures with clustered failure signatures, retry metadata, and replay outcomes",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "dead letter queue data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/dead-letter-queue-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "distributed-tracing-data-simulation",
+    "slug": "distributed-tracing-data-simulation",
+    "category": "workflow",
+    "description": "Generating realistic synthetic trace data with parent-child causality, latency distributions, and injected faults",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "distributed tracing data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/distributed-tracing-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "domain-driven-data-simulation",
+    "slug": "domain-driven-data-simulation",
+    "category": "workflow",
+    "description": "Generating synthetic bounded contexts, aggregates, and corpus text for DDD tooling demos",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "domain driven data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/domain-driven-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "etl-data-simulation",
+    "slug": "etl-data-simulation",
+    "category": "workflow",
+    "description": "Deterministic mock ETL data generation with realistic row counts, schemas, and job run histories",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "etl data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/etl-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "event-sourcing-data-simulation",
+    "slug": "event-sourcing-data-simulation",
+    "category": "workflow",
+    "description": "Generate realistic causally-ordered event streams with aggregate lifecycles for replay demos",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "event sourcing data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/event-sourcing-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "feature-flags-data-simulation",
+    "slug": "feature-flags-data-simulation",
+    "category": "workflow",
+    "description": "Synthetic data generation for feature-flag rollouts, dependencies, and experiments",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "feature flags data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/feature-flags-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "finite-state-machine-data-simulation",
+    "slug": "finite-state-machine-data-simulation",
+    "category": "workflow",
+    "description": "Drive FSM demos with a deterministic event queue plus auto-play timer so users can step, reset, and replay transitions reproducibly.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "finite state machine data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/finite-state-machine-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "freeze",
+    "slug": "freeze",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "0.1.0",
+    "path": "skills/workflow/freeze",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "full-inventory-over-sampling-prompt",
+    "slug": "full-inventory-over-sampling-prompt",
+    "category": "workflow",
+    "description": "When a reference corpus fits comfortably in the LLM context window, pass the full inventory and let the model filter — don't sample arbitrarily",
+    "tags": [
+      "llm",
+      "prompt-engineering",
+      "claude-api",
+      "rag"
+    ],
+    "triggers": [
+      "llm prompt design",
+      "rag vs full context",
+      "skill sampling",
+      "reference corpus prompt"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/full-inventory-over-sampling-prompt",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "github-triage",
+    "slug": "github-triage",
+    "category": "workflow",
+    "description": "Triage GitHub issues through a label-based state machine with interactive grilling sessions. Use when user wants to triage issues, review incoming bugs or feature requests, prepare issues for an AFK agent, or manage issue workflow.",
+    "tags": [
+      "github",
+      "triage",
+      "issues",
+      "labels",
+      "state-machine"
+    ],
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "skills/workflow/github-triage",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "graphql-data-simulation",
+    "slug": "graphql-data-simulation",
+    "category": "workflow",
+    "description": "Faking GraphQL responses, schemas, and subscription streams for offline demos without a live server",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "graphql data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/graphql-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "grill-me",
+    "slug": "grill-me",
+    "category": "workflow",
+    "description": "Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions \"grill me\".",
+    "tags": [
+      "interview",
+      "planning",
+      "clarification",
+      "socratic"
+    ],
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "skills/workflow/grill-me",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "health-check-data-simulation",
+    "slug": "health-check-data-simulation",
+    "category": "workflow",
+    "description": "Generate realistic health-check sample streams with correlated failures, flapping, and recovery curves for demos and tests",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "health check data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/health-check-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "heuristic-scan-iterative-tuning",
+    "slug": "heuristic-scan-iterative-tuning",
+    "category": "workflow",
+    "description": "When writing a new heuristic scanner over a corpus (dedup, archive, compress, lint), expect the first run to be wrong in predictable ways. Run → inspect false positives → add one guard → re-run. Tighten the spec and the scan script in lockstep so the shipped version reflects real-world calibration, not guessed thresholds.",
+    "tags": [],
+    "triggers": [
+      "writing a corpus-level heuristic scanner",
+      "false positive triage on a scan",
+      "detector over-fires or under-fires",
+      "calibrating dedup/archive/compression thresholds",
+      "heuristic scan tuning"
+    ],
+    "version": "0.1.0",
+    "path": "skills/workflow/heuristic-scan-iterative-tuning",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "hexagonal-architecture-data-simulation",
+    "slug": "hexagonal-architecture-data-simulation",
+    "category": "workflow",
+    "description": "Seed realistic port traffic with paired driving/driven adapter pairs and domain invariants that make violations visible",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "hexagonal architecture data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/hexagonal-architecture-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "hub-make-parallel-build",
+    "slug": "hub-make-parallel-build",
+    "category": "workflow",
+    "description": "Build multiple zero-dep single-file HTML apps in parallel from installed skills/knowledge data, verify, and publish via PR branch",
+    "tags": [
+      "hub-make",
+      "parallel",
+      "html",
+      "zero-dep",
+      "examples",
+      "publish"
+    ],
+    "triggers": [
+      "hub-make",
+      "build examples",
+      "parallel html build"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/hub-make-parallel-build",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "idempotency-data-simulation",
+    "slug": "idempotency-data-simulation",
+    "category": "workflow",
+    "description": "Generating realistic duplicate-request streams, key-collision scenarios, and retry storms to stress-test idempotency implementations.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "idempotency data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/idempotency-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "land-and-deploy",
+    "slug": "land-and-deploy",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/land-and-deploy",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "lantern-data-simulation",
+    "slug": "lantern-data-simulation",
+    "category": "workflow",
+    "description": "Generating plausible synthetic lantern fleet state (position, fuel, wick health, release events) for demo and test scenarios",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "lantern data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/lantern-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "load-balancer-data-simulation",
+    "slug": "load-balancer-data-simulation",
+    "category": "workflow",
+    "description": "Deterministic seeded traffic generator for exercising load balancer algorithms with reproducible scenarios",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "load balancer data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/load-balancer-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "log-aggregation-data-simulation",
+    "slug": "log-aggregation-data-simulation",
+    "category": "workflow",
+    "description": "Generating realistic synthetic log streams with bursts, level distributions, and source correlation for demo UIs",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "log aggregation data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/log-aggregation-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "materialized-view-data-simulation",
+    "slug": "materialized-view-data-simulation",
+    "category": "workflow",
+    "description": "Generating synthetic base-table writes and refresh cycles to exercise materialized-view behaviors without a real warehouse",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "materialized view data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/materialized-view-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "mermaid-gitlab-mr-size-rules",
+    "slug": "mermaid-gitlab-mr-size-rules",
+    "category": "workflow",
+    "description": "Keep Mermaid diagrams in GitLab MRs readable — cap nodes, avoid nested subgraphs, quote IDs with special chars, connect all subgraphs",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/mermaid-gitlab-mr-size-rules",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "message-queue-data-simulation",
+    "slug": "message-queue-data-simulation",
+    "category": "workflow",
+    "description": "Deterministic producer-consumer event generation for reproducible queue behavior demos",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "message queue data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/message-queue-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "oauth-data-simulation",
+    "slug": "oauth-data-simulation",
+    "category": "workflow",
+    "description": "Generating realistic OAuth tokens, flow states, and scope sets for client-side simulators without a real auth server",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "oauth data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/oauth-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "object-storage-data-simulation",
+    "slug": "object-storage-data-simulation",
+    "category": "workflow",
+    "description": "Generating realistic synthetic object storage datasets with proper size/access distributions",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "object storage data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/object-storage-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "office-hours",
+    "slug": "office-hours",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/workflow/office-hours",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "outbox-pattern-data-simulation",
+    "slug": "outbox-pattern-data-simulation",
+    "category": "workflow",
+    "description": "Generate deterministic outbox event streams with configurable failure and duplicate scenarios for demos",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "outbox pattern data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/outbox-pattern-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "parallel-build-sequential-publish",
+    "slug": "parallel-build-sequential-publish",
+    "category": "workflow",
+    "description": "Build multiple independent projects in parallel via executor agents, then publish to a shared git repo sequentially",
+    "tags": [
+      "parallel",
+      "agents",
+      "git",
+      "publishing",
+      "workflow"
+    ],
+    "triggers": [
+      "build multiple projects",
+      "parallel agent build",
+      "batch publish examples",
+      "hub-make all"
+    ],
+    "version": "1.0.0",
+    "path": "skills/parallel-build-sequential-publish",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "parallel-bulk-annotation",
+    "slug": "parallel-bulk-annotation",
+    "category": "workflow",
+    "description": "수십~수백 개 Java 파일에 어노테이션(@Schema, @Operation, @ApiResponse 등)을 대량 추가할 때 병렬 에이전트로 분산 실행하는 패턴",
+    "tags": [],
+    "triggers": [
+      "대량 어노테이션 추가",
+      "@Schema 전수 부여",
+      "operationId 전수 부여",
+      "200개 메서드 어노테이션",
+      "bulk annotation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/parallel-bulk-annotation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "plan-ceo-review",
+    "slug": "plan-ceo-review",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/plan-ceo-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "plan-devex-review",
+    "slug": "plan-devex-review",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/workflow/plan-devex-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "plan-eng-review",
+    "slug": "plan-eng-review",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/plan-eng-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "plan-to-screen-spec-conversion",
+    "slug": "plan-to-screen-spec-conversion",
+    "category": "workflow",
+    "description": "PLAN 작업지시서를 rules/fe/02-screen-spec-template.md 형식의 화면 스펙 문서로 변환",
+    "tags": [],
+    "triggers": [
+      "PLAN을 스펙으로",
+      "작업지시서를 화면 스펙으로",
+      "screen spec 변환",
+      "기획서를 스펙 템플릿으로"
+    ],
+    "version": "0.1.0-draft",
+    "path": "skills/design/plan-to-screen-spec-conversion",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "prd-to-issues",
+    "slug": "prd-to-issues",
+    "category": "workflow",
+    "description": "Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. Use when user wants to convert a PRD to issues, create implementation tickets, or break down a PRD into work items.",
+    "tags": [
+      "prd",
+      "github",
+      "issues",
+      "tracer-bullet",
+      "planning"
+    ],
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "skills/workflow/prd-to-issues",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "prd-to-plan",
+    "slug": "prd-to-plan",
+    "category": "workflow",
+    "description": "Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in ./plans/. Use when user wants to break down a PRD, create an implementation plan, plan phases from a PRD, or mentions \"tracer bullets\".",
+    "tags": [
+      "prd",
+      "planning",
+      "phased",
+      "tracer-bullet"
+    ],
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "skills/workflow/prd-to-plan",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "pub-sub-data-simulation",
+    "slug": "pub-sub-data-simulation",
+    "category": "workflow",
+    "description": "Generate realistic pub-sub traffic with topic hierarchies, bursty publishers, and heterogeneous subscriber latencies",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "pub sub data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/pub-sub-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "raft-consensus-data-simulation",
+    "slug": "raft-consensus-data-simulation",
+    "category": "workflow",
+    "description": "Deterministic event stream generation for Raft scenarios covering elections, replication, and term changes",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "raft consensus data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/raft-consensus-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "rate-limiter-data-simulation",
+    "slug": "rate-limiter-data-simulation",
+    "category": "workflow",
+    "description": "Generating realistic request arrival patterns to stress-test rate limiter algorithms in demo apps",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "rate limiter data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/rate-limiter-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "read-replica-data-simulation",
+    "slug": "read-replica-data-simulation",
+    "category": "workflow",
+    "description": "Synthetic replication-log generator with configurable lag distributions and consistency violation injection",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "read replica data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/read-replica-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "retry-strategy-data-simulation",
+    "slug": "retry-strategy-data-simulation",
+    "category": "workflow",
+    "description": "Generate synthetic failure streams and retry attempts to stress-test backoff, jitter, and budget policies",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "retry strategy data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/retry-strategy-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "review",
+    "slug": "review",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "saga-pattern-data-simulation",
+    "slug": "saga-pattern-data-simulation",
+    "category": "workflow",
+    "description": "Generate realistic saga transaction data with failure injection, compensation chains, and participant latency",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "saga pattern data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/saga-pattern-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "schema-registry-data-simulation",
+    "slug": "schema-registry-data-simulation",
+    "category": "workflow",
+    "description": "Generating realistic synthetic schema evolution histories for registry demos and tests",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "schema registry data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/schema-registry-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "service-mesh-data-simulation",
+    "slug": "service-mesh-data-simulation",
+    "category": "workflow",
+    "description": "Generating realistic synthetic traffic, policy, and telemetry data for service mesh demos without a live cluster",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "service mesh data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/service-mesh-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "setup-deploy",
+    "slug": "setup-deploy",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/setup-deploy",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "ship",
+    "slug": "ship",
+    "category": "workflow",
+    "description": "|",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/ship",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "sidecar-proxy-data-simulation",
+    "slug": "sidecar-proxy-data-simulation",
+    "category": "workflow",
+    "description": "Generate synthetic sidecar proxy traffic with realistic latency, retry, and mTLS handshake semantics.",
+    "tags": [
+      "auto-loop"
+    ],
+    "triggers": [
+      "sidecar proxy data simulation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/sidecar-proxy-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "skill-repo-bootstrap-architecture",
+    "slug": "skill-repo-bootstrap-architecture",
+    "category": "workflow",
+    "description": "Lay out a shared skill/knowledge git repo so it is simultaneously a catalog and a self-installer — separate bootstrap (commands + umbrella skill + installers) from skills (category/name/SKILL.md). Covers repo layout, safety gates, registry pinning, and skill deprecation lifecycle.",
+    "tags": [
+      "skill-hub",
+      "repo-layout",
+      "bootstrap",
+      "claude-code",
+      "cursor",
+      "git",
+      "architecture",
+      "deprecation"
+    ],
+    "triggers": [
+      "skill repo",
+      "skill hub",
+      "bootstrap install",
+      "category-separated",
+      "skills registry",
+      "skill deprecation",
+      "umbrella skill"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/skill-repo-bootstrap-architecture",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "slash-command-authoring",
+    "slug": "slash-command-authoring",
+    "category": "workflow",
+    "description": "Author Claude Code slash commands that read cleanly, include safety rules, and compose with OMC skills — frontmatter, argument-hint, step ordering, and dry-run patterns.",
+    "tags": [
+      "claude-code",
+      "slash-command",
+      "skill",
+      "authoring",
+      "frontmatter"
+    ],
+    "triggers": [
+      "slash command",
+      "/skills_",
+      "/init_",
+      ".claude/commands",
+      "argument-hint",
+      "command frontmatter"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/slash-command-authoring",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "stale-persistent-context-detection",
+    "slug": "stale-persistent-context-detection",
+    "category": "workflow",
+    "description": "Detect and remove stale error snapshots that LLM tools inject via persistent-context files (CLAUDE.md, AGENTS.md, system prompts, memory) before chasing a fix. If the current source already compiles, the injected error is a ghost from a previous session, not a real bug.",
+    "tags": [
+      "llm",
+      "context",
+      "claude-code",
+      "cursor",
+      "agents-md",
+      "memory",
+      "stale",
+      "debugging",
+      "hygiene"
+    ],
+    "triggers": [
+      "CLAUDE.md",
+      "AGENTS.md",
+      "persistent context",
+      "stale error",
+      "system-reminder",
+      "injected error",
+      "claudeMd context",
+      "system prompt",
+      "agent instructions",
+      "injected context"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/stale-persistent-context-detection",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "stdin-redirect-cli-large-prompts",
+    "slug": "stdin-redirect-cli-large-prompts",
+    "category": "workflow",
+    "description": "Pipe large prompts to CLI tools via temp file + shell redirect to bypass argv length limits and stdin propagation issues",
+    "tags": [
+      "cli",
+      "ipc",
+      "workflow",
+      "shell",
+      "cross-platform"
+    ],
+    "triggers": [
+      "ENAMETOOLONG spawn",
+      "large prompt cli",
+      "claude -p long input",
+      "argv too long",
+      "stdin propagation"
+    ],
+    "version": "1.0.0",
+    "path": "skills/workflow/stdin-redirect-cli-large-prompts",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "strangler-fig-data-simulation",
     "slug": "strangler-fig-data-simulation",
     "category": "workflow",
-    "description": "Incremental module-by-module migration simulation modeling the strangler fig pattern's facade-routing and legacy-decay lifecycle.",
+    "description": "Synthetic endpoint/route inventory with migration-state machine and traffic-split fixtures for strangler-fig demos",
     "tags": [
       "auto-loop"
     ],
@@ -4065,32 +11352,7 @@
     "has_content": false
   },
   {
-    "name": "strangler-fig-visualization-pattern",
-    "slug": "strangler-fig-visualization-pattern",
-    "category": "design",
-    "description": "Canvas-based visual encoding of strangler fig lifecycle stages with host-tree decay and aerial root growth animation.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "strangler fig visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/strangler-fig-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "strategy-spi-list-to-map-autoinject",
-    "slug": "strategy-spi-list-to-map-autoinject",
-    "category": "backend",
-    "description": "Spring이 자동 주입하는 List<T>를 생성자에서 Map<Key,T>로 변환해 Strategy를 enum 키로 O(1) 디스패치하는 패턴",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/strategy-spi-list-to-map-autoinject",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "swagger-ai-optimization",
     "slug": "swagger-ai-optimization",
     "category": "workflow",
@@ -4108,163 +11370,33 @@
     "has_content": false
   },
   {
+    "kind": "skill",
     "name": "swagger-spec-baseline-from-git",
     "slug": "swagger-spec-baseline-from-git",
     "category": "workflow",
     "description": "Re-run spec-based optimization workflow on a clean branch without running the Spring Boot app — restore prior baseline artifacts (swagger-before.json + scripts) via `git show <sha>:<path>` from the commit on another branch that already captured them.",
-    "tags": [],
+    "tags": [
+      "swagger",
+      "openapi",
+      "git",
+      "baseline",
+      "spring-boot"
+    ],
     "triggers": [
-      "\"swagger 전체 재실행\"",
-      "\"rerun swagger optimization\"",
-      "\"baseline 없이 시작\""
+      "swagger 전체 재실행",
+      "rerun swagger optimization",
+      "baseline 없이 시작"
     ],
     "version": "1.0.0",
     "path": "skills/workflow/swagger-spec-baseline-from-git",
     "has_content": false
   },
   {
-    "name": "spring-applicationrunner-system-seed",
-    "slug": "system-data-initializer-runner",
-    "category": "backend",
-    "description": "Use ApplicationRunner to seed required system/root records on startup, guarded by an exists-check and marked with a systemFlag so they can't be deleted or moved by users.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/system-data-initializer-runner",
-    "has_content": true
-  },
-  {
-    "name": "tdd",
-    "slug": "tdd",
-    "category": "testing",
-    "description": "Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions \"red-green-refactor\", wants integration tests, or asks for test-first development.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/testing/tdd",
-    "has_content": false
-  },
-  {
-    "name": "tenant-context-holder-propagation",
-    "slug": "tenant-context-holder-propagation",
-    "category": "arch",
-    "description": "Set TenantContextHolder.INSTANCE.setTenantId(orgId) on the current thread so MongoDB tenant-isolated templates route queries correctly, always clearing in a finally block",
-    "tags": [],
-    "triggers": [
-      "TenantContextHolder",
-      "tenant context propagation",
-      "multi-tenant thread local",
-      "MONGODB_TEMPLATE_ISOLATION",
-      "tenant isolation mongodb"
-    ],
-    "version": "0.1.0-draft",
-    "path": "skills/arch/tenant-context-holder-propagation",
-    "has_content": false
-  },
-  {
-    "name": "tenant-context-try-finally-on-worker",
-    "slug": "tenant-context-try-finally-on-worker",
-    "category": "backend",
-    "description": "Kafka/Queue Worker에서 멀티테넌트 ThreadLocal 컨텍스트를 try-finally로 안전하게 세팅/정리하는 패턴",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/tenant-context-try-finally-on-worker",
-    "has_content": true
-  },
-  {
-    "name": "tenant-db-initialization-on-startup",
-    "slug": "tenant-db-initialization-on-startup",
-    "category": "backend",
-    "description": "On leader startup, fetch tenant/org list from metadata service and provision per-tenant MongoDB databases — idempotent, leader-only",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/tenant-db-initialization-on-startup",
-    "has_content": true
-  },
-  {
-    "name": "tenant-isolated-mongo-collection",
-    "slug": "tenant-isolated-mongo-collection",
-    "category": "backend",
-    "description": "Route each tenant to its own MongoDB collection (or collection-name suffix) via a custom annotation resolved at repository/template layer, so application code stays tenant-agnostic.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/tenant-isolated-mongo-collection",
-    "has_content": true
-  },
-  {
-    "name": "tenant-per-database-mongo-routing",
-    "slug": "tenant-per-database-mongo-routing",
-    "category": "backend",
-    "description": "Route Spring Data Mongo operations to per-tenant databases via a ThreadLocal tenant holder and two MongoTemplate beans (isolated vs shared collections).",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/tenant-per-database-mongo-routing",
-    "has_content": true
-  },
-  {
-    "name": "testcontainers-mongo-kafka-abstract-base",
-    "slug": "testcontainers-mongo-kafka-abstract-base",
-    "category": "backend",
-    "description": "Abstract test base classes that spin up MongoDB + Kafka via Testcontainers with static start() and reuse=true, exposing mapped ports via System.setProperty",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/testcontainers-mongo-kafka-abstract-base",
-    "has_content": true
-  },
-  {
-    "name": "testcontainers-reuse-disabled",
-    "slug": "testcontainers-reuse-disabled",
-    "category": "backend",
-    "description": "Set TESTCONTAINERS_REUSE_ENABLE=false on the Gradle test task so CI and shared dev machines never inherit stale container state across suites",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/testcontainers-reuse-disabled",
-    "has_content": true
-  },
-  {
-    "name": "thread-pool-config-tenant-aware",
-    "slug": "thread-pool-config-tenant-aware",
-    "category": "backend",
-    "description": "Property-driven ThreadPoolTaskExecutor + Scheduler config that extends TenantAsyncConfigurerSupport so @Async tasks inherit tenant context",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/thread-pool-config-tenant-aware",
-    "has_content": true
-  },
-  {
-    "name": "thread-pool-queue-backpressure",
-    "slug": "thread-pool-queue-backpressure",
-    "category": "backend",
-    "description": "Bounded in-memory queue between Kafka consumer and async thread pool, with hysteretic pause/resume thresholds driving Spring Kafka container pause()/resume() so bursts do not OOM the JVM.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/thread-pool-queue-backpressure",
-    "has_content": true
-  },
-  {
-    "name": "tiered-rebalance-schedule",
-    "slug": "tiered-rebalance-schedule",
-    "category": "arch",
-    "description": "Run three cadences against the same managed set — fast performance review, mid-frequency policy re-analysis, slow portfolio rebalance — each with its own trigger interval and mutation budget, so urgency scales with cost.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/arch/tiered-rebalance-schedule",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "time-series-db-data-simulation",
     "slug": "time-series-db-data-simulation",
     "category": "workflow",
-    "description": "Generate realistic TSDB metric streams using sinusoidal base curves with random noise, configurable step intervals, and storage-cost estimation at 16 bytes per point.",
+    "description": "Generate synthetic TSDB workloads using layered signal components (trend + seasonality + noise + anomalies) with back-dated timestamps.",
     "tags": [
       "auto-loop"
     ],
@@ -4276,98 +11408,7 @@
     "has_content": false
   },
   {
-    "name": "time-series-db-visualization-pattern",
-    "slug": "time-series-db-visualization-pattern",
-    "category": "design",
-    "description": "Render TSDB metrics as real-time area charts with gradient fills, stat cards, and DPR-aware canvas/SVG on a dark monitoring theme.",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "time series db visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/time-series-db-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "transaction-trace-pack-serialization-with-step-hierarchy",
-    "slug": "transaction-trace-pack-serialization-with-step-hierarchy",
-    "category": "apm",
-    "description": "Encode per-request distributed traces as a hierarchical list of typed steps (method, DB, external call, error) in a compressed binary pack, indexed by request end-time",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/apm/transaction-trace-pack-serialization-with-step-hierarchy",
-    "has_content": false
-  },
-  {
-    "name": "triage-issue",
-    "slug": "triage-issue",
-    "category": "debug",
-    "description": "Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. Use when user reports a bug, wants to file an issue, mentions \"triage\", or wants to investigate and plan a fix for a problem.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/debug/triage-issue",
-    "has_content": false
-  },
-  {
-    "name": "triple-env-file-split-loader",
-    "slug": "triple-env-file-split-loader",
-    "category": "devops",
-    "description": "Split operator-facing env into three files (.env / .version / .memory) and load them in a fixed order",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/devops/triple-env-file-split-loader",
-    "has_content": true
-  },
-  {
-    "name": "ts-type-prefix-convention",
-    "slug": "ts-type-prefix-convention",
-    "category": "frontend",
-    "description": "Prefix interfaces with I and type aliases with T; use type for unions/literals and interface for inheritable shapes",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/frontend/ts-type-prefix-convention",
-    "has_content": true
-  },
-  {
-    "name": "tsv-driven-permission-bootstrap",
-    "slug": "tsv-driven-permission-bootstrap",
-    "category": "backend",
-    "description": "Treat a version-controlled TSV file as source of truth for the Function/Permission/Menu catalog; the service reconciles the DB against it on startup",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/tsv-driven-permission-bootstrap",
-    "has_content": true
-  },
-  {
-    "name": "ubiquitous-language",
-    "slug": "ubiquitous-language",
-    "category": "docs",
-    "description": "Extract a DDD-style ubiquitous language glossary from the current conversation, flagging ambiguities and proposing canonical terms. Saves to UBIQUITOUS_LANGUAGE.md. Use when user wants to define domain terms, build a glossary, harden terminology, create a ubiquitous language, or mentions \"domain model\" or \"DDD\".",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/docs/ubiquitous-language",
-    "has_content": false
-  },
-  {
-    "name": "udp-with-tcp-fallback-metrics-transport",
-    "slug": "udp-with-tcp-fallback-metrics-transport",
-    "category": "backend",
-    "description": "Transport telemetry via UDP for low-latency fire-and-forget streams, and fall back to TCP for critical request/response and bulk uploads that require delivery guarantees",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/udp-with-tcp-fallback-metrics-transport",
-    "has_content": false
-  },
-  {
+    "kind": "skill",
     "name": "unfreeze",
     "slug": "unfreeze",
     "category": "workflow",
@@ -4379,32 +11420,11 @@
     "has_content": false
   },
   {
-    "name": "version-specific-sql-map-selection",
-    "slug": "version-specific-sql-map-selection",
-    "category": "backend",
-    "description": "Select MyBatis-style SQL maps at runtime by DBMS + version with graceful fallback to a default supported version",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/version-specific-sql-map-selection",
-    "has_content": false
-  },
-  {
-    "name": "vllm-nginx-tls-single-port-routing",
-    "slug": "vllm-nginx-tls-single-port-routing",
-    "category": "ai",
-    "description": "Serve multiple vLLM OpenAI-API backends behind one Nginx TLS proxy on 443 using path-based routing",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/ai/vllm-nginx-tls-single-port-routing",
-    "has_content": true
-  },
-  {
+    "kind": "skill",
     "name": "websocket-data-simulation",
     "slug": "websocket-data-simulation",
     "category": "workflow",
-    "description": "Generate realistic simulated WebSocket traffic (latency curves, typed frames, chat presence) without a live server using timer-driven random generators.",
+    "description": "Deterministic fake WebSocket traffic generator with opcode/frame fidelity for offline demos",
     "tags": [
       "auto-loop"
     ],
@@ -4416,100 +11436,24 @@
     "has_content": false
   },
   {
-    "name": "websocket-stomp-channel-pool-config",
-    "slug": "websocket-stomp-channel-pool-config",
-    "category": "backend",
-    "description": "Spring WebSocket STOMP config with separate inbound/outbound task executors and raised transport buffer limits, sized for burst notification fan-out to many role-filtered subscribers.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/websocket-stomp-channel-pool-config",
-    "has_content": true
-  },
-  {
-    "name": "websocket-visualization-pattern",
-    "slug": "websocket-visualization-pattern",
-    "category": "design",
-    "description": "Render WebSocket traffic, latency, and connection state using three complementary visual encodings (canvas time-series, SVG frame flow, DOM chat stream).",
-    "tags": [
-      "auto-loop"
-    ],
-    "triggers": [
-      "websocket visualization pattern"
-    ],
-    "version": "1.0.0",
-    "path": "skills/design/websocket-visualization-pattern",
-    "has_content": false
-  },
-  {
-    "name": "widget-card-composition",
-    "slug": "widget-card-composition",
-    "category": "design",
-    "description": "Dashboard widget composition pattern using a CardWidget chrome wrapper with domain-specific Card* content components, resize tracking, and popover menus",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/design/widget-card-composition",
-    "has_content": false
-  },
-  {
-    "name": "widget-confid-injection-sweep",
-    "slug": "widget-confid-injection-sweep",
-    "category": "frontend",
-    "description": "리소스 상세 대시보드에서 모든 위젯 데이터 요청에 `confId` 를 일관되게 주입하기 위한 위젯 fetch 지점 전수 스윕(sweep) 패턴 — 일부만 주입하면 같은 대시보드 안에서 위젯별 필터 동작이 갈라지는 버그를 방지한다.",
-    "tags": [],
-    "triggers": [
-      "confId 주입",
-      "selectCondition confId",
-      "위젯 필터링",
-      "widget scope injection",
-      "resource-scoped widget"
-    ],
-    "version": "1.0.0",
-    "path": "skills/frontend/widget-confid-injection-sweep",
-    "has_content": false
-  },
-  {
-    "name": "widget-grid-type-registration-checklist",
-    "slug": "widget-grid-type-registration-checklist",
-    "category": "frontend",
-    "description": "대시보드의 TableGrid/차트 위젯에 새로운 타입을 추가할 때 드리프트 없이 5곳(columns 매핑, fetch hook, 에디터 폼, detectType, 모델 DTO) 모두 반영하게 하는 체크리스트 스킬.",
-    "tags": [],
-    "triggers": [
-      "TableGridType",
-      "위젯 타입 추가",
-      "tableGridType",
-      "widget type registration",
-      "detectType",
-      "columns mapping"
-    ],
-    "version": "1.0.0",
-    "path": "skills/frontend/widget-grid-type-registration-checklist",
-    "has_content": false
-  },
-  {
+    "kind": "skill",
     "name": "write-a-prd",
     "slug": "write-a-prd",
     "category": "workflow",
     "description": "Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. Use when user wants to write a PRD, create a product requirements document, or plan a new feature.",
-    "tags": [],
+    "tags": [
+      "prd",
+      "requirements",
+      "interview",
+      "planning"
+    ],
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "skills/workflow/write-a-prd",
     "has_content": false
   },
   {
-    "name": "write-a-skill",
-    "slug": "write-a-skill",
-    "category": "misc",
-    "description": "Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, or build a new skill.",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0-draft",
-    "path": "skills/misc/write-a-skill",
-    "has_content": false
-  },
-  {
+    "kind": "skill",
     "name": "x-filterable-fields-extraction",
     "slug": "x-filterable-fields-extraction",
     "category": "workflow",
@@ -4526,40 +11470,5 @@
     "version": "1.0.0",
     "path": "skills/workflow/x-filterable-fields-extraction",
     "has_content": false
-  },
-  {
-    "name": "yorkie-crdt-sync-pattern",
-    "slug": "yorkie-crdt-sync-pattern",
-    "category": "backend",
-    "description": "Apply a single doc.update callback for local mutations and pullRemoteChangesIntoLocal(WithNodeIds) for remote→local sync in Yorkie-backed apps",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/yorkie-crdt-sync-pattern",
-    "has_content": true
-  },
-  {
-    "name": "zustand-preset-manager",
-    "slug": "zustand-preset-manager",
-    "category": "frontend",
-    "description": "Zustand + persist middleware pattern for managing N named presets (team comps, saved filters, dashboard layouts) with active-selection, max-count guard, and auto-reselect on delete.",
-    "tags": [
-      "zustand",
-      "localstorage",
-      "preset",
-      "state-management",
-      "persist-middleware"
-    ],
-    "triggers": [
-      "zustand persist",
-      "saved presets",
-      "team presets",
-      "named configurations",
-      "localStorage preset",
-      "multi-preset selector"
-    ],
-    "version": "0.1.0-draft",
-    "path": "skills/frontend/zustand-preset-manager",
-    "has_content": true
   }
 ]


### PR DESCRIPTION
## Summary

- Regenerate `index.json` from filesystem scan.
- Entry count: **354 -> 748** (436 skills + 312 knowledge).
- Sorted by `(kind, category, name)` for stable future diffs.

## Why

`index.json` had drifted significantly behind published content — 393 skills/knowledge entries on disk were missing from the catalog, so `/hub-search-*` and `/hub-list-*` returned incomplete results.

## Scope

Reindex-only. No content changes. Other dry-run findings (265 SKILL.md without content.md, 40 missing-category gstack entries, 2 `algorithms` category violations, 35 duplicate names) are deferred to separate PRs.

## Test plan

- [x] `jq length index.json` returns 748
- [ ] Local `/hub-list-skills` / `/hub-list-knowledge` resolve all entries
- [ ] CI (if any) passes