### PR TITLE
Bootstrap v2.4.2: enforce main-branch-only installation

### DIFF
--- a/bootstrap/commands/hub-install-all.md
+++ b/bootstrap/commands/hub-install-all.md
@@ -74,6 +74,7 @@ For targeted installs (keyword / version pinning), use `/hub-install` instead.
 
 ## Rules
 
+- **Always install from `main` branch HEAD.** Never use feature branches (`example/*`, `skill/*`, etc.) — they may contain outdated or unmerged content. All sources must come from the `main` checkout.
 - Never modify the remote clone cache's working tree (read-only usage).
 - Bulk mode always installs from `main` HEAD — use `/hub-install` for version-pinned installs.
 - Collisions are silently **skipped**, not overwritten — this is a bulk-install convenience, not a sync. For overwrites use `/hub-sync` or targeted `/hub-install <name>`.

--- a/bootstrap/commands/hub-install-example.md
+++ b/bootstrap/commands/hub-install-example.md
@@ -15,7 +15,8 @@ Install example projects from the central repository into the current working di
    - If present and older than 1h: `git -C ~/.claude/skills-hub/remote fetch --tags --prune origin && git -C ~/.claude/skills-hub/remote reset --hard origin/main`.
 
 2. **Scan available examples**
-   - Read all `example/*/manifest.json` files from the remote cache.
+   - **MUST use `main` branch (HEAD) only.** Never install from `example/*` feature branches — they may contain outdated or unmerged versions. Always read from the `main` checkout of the remote cache.
+   - Scan `example/**/manifest.json` files from the remote cache at `main` HEAD (recursive — examples may be nested under category subdirectories like `example/hub-tools/auto-hub-loop/`).
    - Build a list: `slug`, `title`, `stack[]`, `created_at`.
    - If no `manifest.json` exists for an example dir, infer slug from directory name and mark stack as `unknown`.
 
@@ -68,6 +69,7 @@ Install example projects from the central repository into the current working di
 
 ## Rules
 
+- **Always install from `main` branch HEAD.** Never use `example/*` feature branches — they may contain outdated or unmerged content. All installation sources must come from the `main` checkout.
 - **Read-only on remote cache.** Copy files out; never modify the cache.
 - Never install without explicit user confirmation unless only 1 exact-slug match.
 - If the example contains a `package.json`, remind the user to run `npm install` after installation.

--- a/bootstrap/commands/hub-install.md
+++ b/bootstrap/commands/hub-install.md
@@ -56,6 +56,7 @@ Install skills from the central repository matching the keyword.
 
 ## Rules
 
+- **Always install from `main` branch.** All skill/knowledge sources must come from the `main` branch of the remote cache. Never use feature branches (`example/*`, `skill/*`, etc.) — they may contain outdated or unmerged content. Version-pinned installs use tags that point to commits on `main`.
 - Never install without explicit user selection unless `--yes` flag.
 - Never modify the remote clone cache's working tree (read-only usage).
 - If `$ARGUMENTS` is empty, list top-level categories from `CATEGORIES.md` and prompt.


### PR DESCRIPTION
## Summary
- Add explicit **main-branch-only** rule to `hub-install`, `hub-install-all`, and `hub-install-example` commands
- Feature branches (`example/*`, `skill/*`) may contain outdated or unmerged content and must never be used as installation sources
- Prevents accidental installation of stale versions from non-main branches

## Changed files
- `bootstrap/commands/hub-install-example.md` — Steps 2 + Rules section
- `bootstrap/commands/hub-install.md` — Rules section
- `bootstrap/commands/hub-install-all.md` — Rules section

## Tag
`bootstrap/v2.4.2` — immediately usable via `/hub-commands-update --version=2.4.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)