### PR TITLE
Add 2 pitfall knowledge entries (session 2026-04-17)

### DIFF
--- a/knowledge/pitfall/feature-branch-install-stale-content.md
+++ b/knowledge/pitfall/feature-branch-install-stale-content.md
@@ -1,0 +1,28 @@
+---
+name: feature-branch-install-stale-content
+description: Installing from example/* or skill/* feature branches delivers outdated content — always use main
+category: pitfall
+source:
+  kind: session
+  ref: "session-20260417-1945"
+confidence: high
+linked_skills:
+  - hub-install-example
+  - hub-install
+  - hub-install-all
+tags:
+  - skills-hub
+  - installation
+  - feature-branch
+  - main-branch
+---
+
+**Fact:** Using `example/*` or `skill/*` feature branches as installation sources delivers outdated or unmerged content. Always install from `main` HEAD.
+
+**Why:** Feature branches may contain older versions of files that have since been updated on `main`, include work-in-progress content not yet reviewed, or have `main` merged in but with example files lagging behind canonical versions.
+
+**How to apply:** All `/hub-install*` commands must source exclusively from `main` HEAD. This rule was codified in `bootstrap/v2.4.2` across hub-install-example.md, hub-install.md, and hub-install-all.md.
+
+**Evidence:** Installing `auto-hub-loop` from `origin/example/auto-hub-loop` branch produced files significantly smaller (13KB index.html, 29KB server.js) than the canonical `main` versions (56KB index.html, 52KB server.js).
+
+**Counter / Caveats:** Version-pinned installs use tags that point to commits on `main`, so they are safe. The restriction applies only to feature branches, not tags.

--- a/knowledge/pitfall/windows-crlf-git-show-extraction.md
+++ b/knowledge/pitfall/windows-crlf-git-show-extraction.md
@@ -1,0 +1,27 @@
+---
+name: windows-crlf-git-show-extraction
+description: git show on Windows outputs LF while working tree has CRLF, causing false diffs on all extracted files
+category: pitfall
+source:
+  kind: session
+  ref: "session-20260417-1945"
+confidence: medium
+linked_skills:
+  - hub-commands-update
+  - hub-commands-publish
+tags:
+  - windows
+  - line-endings
+  - crlf
+  - git-show
+---
+
+**Fact:** When extracting files via `git show <ref>:<path> > file` on Windows with Git Bash, output uses LF while the working tree uses CRLF, causing `diff` to report every line as changed.
+
+**Why:** Git's `core.autocrlf` converts LF to CRLF in the working tree, but `git show` outputs raw blob content (LF). Comparing working-tree files (CRLF) against `git show` output (LF) produces false positives.
+
+**How to apply:** When publishing or comparing, normalize line endings: `cat "$file" | sed 's/\r$//' > "$dest"`, or use `diff --strip-trailing-cr` during the diff preview step.
+
+**Evidence:** After `/hub-commands-update` installed 31 command files via `git show`, all appeared modified when running `/hub-commands-publish`. Only 3 had intentional changes; the other 28 were line-ending artifacts.
+
+**Counter / Caveats:** This only affects Windows environments with `core.autocrlf=true`. Unix/macOS systems are unaffected.


### PR DESCRIPTION
## Summary
- **feature-branch-install-stale-content** (high) — Installing from `example/*` or `skill/*` feature branches delivers outdated content; always use `main`
- **windows-crlf-git-show-extraction** (medium) — `git show` on Windows outputs LF while working tree has CRLF, causing false diffs on all extracted files

## Source
Session 2026-04-17: auto-hub-loop example installation + bootstrap v2.4.2 publish workflow

## Linked skills
- hub-install, hub-install-all, hub-install-example
- hub-commands-update, hub-commands-publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)