### PR TITLE
Publish 1 skill + 3 knowledge entries (session 2026-04-18)

### DIFF
--- a/knowledge/decision/single-file-html-for-file-protocol.md
+++ b/knowledge/decision/single-file-html-for-file-protocol.md
@@ -1,0 +1,25 @@
+---
+name: single-file-html-for-file-protocol
+description: Generate single-file HTML apps (inline CSS+JS) to avoid CORS errors when opened via file:// protocol
+category: decision
+source:
+  kind: session
+  ref: "session-20260418-0000"
+confidence: medium
+linked_skills:
+  - zero-dep-dark-html-app
+  - hub-make-parallel-build
+tags:
+  - html
+  - cors
+  - file-protocol
+  - single-file
+---
+
+**Fact:** Browser-based apps generated as multi-file (index.html + app.js + style.css) fail with CORS errors when opened via `file://` protocol. Single-file HTML with inline `<style>` and `<script>` avoids this entirely.
+
+**Why:** `file://` URLs are treated as unique security origins. Loading external `.js` files via `<script src="app.js">` triggers cross-origin blocking. Babel standalone's `<script type="text/babel" src="app.js">` also fetches the file, hitting the same CORS wall.
+
+**How to apply:** When generating browser apps intended for local use (no server): embed ALL CSS in `<style>` tags and ALL JS/JSX in `<script>` tags within the single `index.html`. CDN `<script src="https://...">` imports are fine — only local file references break.
+
+**Evidence:** `38-wal-tombstone-atlas` generated with separate `app.js` containing JSX. CORS error on `file://` open. Fixed by requiring single-file output in the generation prompt.

--- a/knowledge/pitfall/claude-cli-single-response-output-limit.md
+++ b/knowledge/pitfall/claude-cli-single-response-output-limit.md
@@ -1,0 +1,26 @@
+---
+name: claude-cli-single-response-output-limit
+description: Claude CLI practical output limit is ~500-800 lines per code artifact when generating multiple items in one call
+category: pitfall
+source:
+  kind: session
+  ref: "session-20260418-0000"
+confidence: high
+linked_skills:
+  - split-llm-codegen-into-idea-plus-per-item
+  - hub-make-parallel-build
+tags:
+  - claude-cli
+  - code-generation
+  - output-limit
+---
+
+**Fact:** When requesting multiple code artifacts in a single `claude -p` call, each artifact receives roughly equal share of the response capacity. Requesting 3 apps of 10,000 lines each produced 353-505 lines per app instead.
+
+**Why:** LLM response tokens are finite per call. Requesting N large artifacts divides the available output by N. The model also tends to "summarize" later artifacts when running low on capacity.
+
+**How to apply:** Split generation into individual calls per artifact. One idea-generation call (lightweight) followed by N code-generation calls (one per artifact) gives each the full response capacity. Realistic single-call output: ~1,500-2,000 lines for one focused artifact.
+
+**Evidence:** auto-hub-loop cycle with "10,000 lines x 3 apps" prompt produced actual output 353, 424, 505 lines. After splitting to per-app calls, output capacity per app increased to full response window.
+
+**Counter / Caveats:** Single small artifacts (under 500 lines) work fine in multi-item calls. The limit applies to large code generation, not to structured data or short answers.

--- a/knowledge/pitfall/merged-pr-branch-orphan-commits.md
+++ b/knowledge/pitfall/merged-pr-branch-orphan-commits.md
@@ -1,0 +1,25 @@
+---
+name: merged-pr-branch-orphan-commits
+description: Commits pushed to a PR branch after merge do NOT reach main — they become orphaned
+category: pitfall
+source:
+  kind: session
+  ref: "session-20260418-0000"
+confidence: medium
+linked_skills:
+  - hub-commands-publish
+  - hub-publish-example
+tags:
+  - git
+  - pull-request
+  - merge
+  - orphan-commits
+---
+
+**Fact:** After a PR is merged, additional commits pushed to the same branch do NOT automatically appear on `main`. The PR is closed; the branch is effectively orphaned. A new PR must be created for subsequent changes.
+
+**Why:** GitHub merge creates a merge commit (or squash) on the target branch. The source branch is no longer tracked after merge. Pushing to it updates the branch ref but has no effect on `main`.
+
+**How to apply:** Before pushing changes, check if the PR for the current branch is already merged (`gh pr view <number> --json state`). If merged, create a new branch from latest `main` and a new PR. Never assume an existing branch will "carry" new commits to main after merge.
+
+**Evidence:** PR #971 (auto-hub-loop-react-vue-d3) was merged. Three subsequent commits (single-file HTML, IT nouns, 30min timeout) were pushed to the same branch but did not reach main. A new PR #1002 was needed.

--- a/skills/workflow/split-llm-codegen-into-idea-plus-per-item/SKILL.md
+++ b/skills/workflow/split-llm-codegen-into-idea-plus-per-item/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: split-llm-codegen-into-idea-plus-per-item
+description: Split large LLM code generation into lightweight idea call + per-item full code calls to maximize output per artifact
+category: workflow
+tags:
+  - llm
+  - code-generation
+  - output-limit
+  - multi-call
+triggers:
+  - generate multiple apps
+  - large code generation
+  - output limit
+---
+
+# Split LLM Code Generation: Idea + Per-Item Calls
+
+When generating multiple large code artifacts via LLM CLI, a single call requesting N items produces N small results. Splitting into (1 + N) calls — one lightweight idea call plus N individual code calls — gives each artifact the full response capacity.
+
+## When to use
+
+- Generating 3+ substantial code artifacts (apps, components, modules) in one workflow
+- Each artifact needs 500+ lines
+- Single-call approach produces undersized results
+
+## Pattern
+
+```
+Call 1 (lightweight, 2min timeout):
+  "Generate N ideas with names, descriptions, features"
+  → Parse N idea blocks
+
+Call 2..N+1 (heavy, 30min timeout each):
+  "Build ONE complete app for idea[i] with full spec"
+  → Each gets full response capacity
+```
+
+## Key decisions
+
+- Idea call is cheap (short response) — use tight timeout (60-120s)
+- Code calls are heavy — use generous timeout (15-30min)
+- Pass idea metadata (name, features) into each code call for consistency
+- Concatenate results after all calls complete
+
+## Anti-patterns
+
+- Requesting all artifacts in one call ("generate 3 complete 2000-line apps") — each gets ~1/3 capacity
+- Not parsing idea output before code calls — fails silently if ideas malformed
+- Equal timeouts for idea vs code calls — wastes time or causes premature timeout


### PR DESCRIPTION
## Skills
- **workflow/split-llm-codegen-into-idea-plus-per-item** — Split large LLM code gen into lightweight idea call + per-item full code calls

## Knowledge
- **pitfall/claude-cli-single-response-output-limit** (high) — ~500-800 lines per artifact in multi-item calls
- **decision/single-file-html-for-file-protocol** (medium) — Inline CSS+JS avoids file:// CORS errors
- **pitfall/merged-pr-branch-orphan-commits** (medium) — Post-merge pushes to PR branch are orphaned

## Cross-links
- `split-llm-codegen-into-idea-plus-per-item` ↔ `claude-cli-single-response-output-limit`

## Source
Session 2026-04-17/18: auto-hub-loop improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)