### PR TITLE
example(hub-tools/auto-hub-loop-v3): add v3 with drop-in module layer

### DIFF
--- a/example/hub-tools/auto-hub-loop-v3/README.md
+++ b/example/hub-tools/auto-hub-loop-v3/README.md
@@ -1,0 +1,89 @@
+# Hub Auto-Loop Dashboard (v3)
+
+> **Why.** v3 introduces a drop-in `hub-loop-v3/` module layer that replaces the force-quota extraction flow — compressed-index prompts, frontmatter-derived purposes, and a fuzzy dedup gate that catches paraphrased duplicates the old name-equality check missed.
+
+## What's new in v3
+
+- **`hub-loop-v3/hub-inventory.js`** — scans skills-hub once per cycle, derives `purpose` from YAML frontmatter `description:` (falls back to first prose sentence), and produces a compressed one-line index instead of dumping full SKILL.md bodies into every prompt.
+- **`hub-loop-v3/dedup-gate.js`** — zero-dep fuzzy duplicate detector using trigram + token + slug Jaccard similarity. Replaces "tell Claude to avoid duplicates in prompt" with a code gate. Rejects templated suffixes (`-visualization-pattern`, `-data-simulation`, etc.) and paraphrases against the full hub.
+- **`hub-loop-v3/theme-strategies.js`** — optional weighted theme picker (gap-driven / combinatorial / exploratory). Available but not wired by default — keeps the existing `pickKeyword` NOUNS-ONLY IT-terminology behavior.
+- **`hub-loop-v3/prompts/extraction.md`** — novelty-first v3 extraction prompt with explicit "zero is a valid answer" framing.
+
+## Features (from v2, preserved)
+
+- **7-phase pipeline** — generate → build → publish → merge → extract → publish-sk → install → loop
+- **Evocative 5–15 word NOUN-ONLY IT-terminology themes** via `pickKeyword` (Claude-generated)
+- **Live Recipe panel** — real-time display of skills/knowledge cited each cycle
+- **Status strip** — current phase (n/7), live elapsed time, theme phrase
+- **Run Once / Start Loop** — single-cycle or continuous mode
+- **Real-time SSE log stream** with color-coded levels
+- **Apps built / Skills acquired panels** with PR links
+
+## File structure
+
+```
+auto-hub-loop-v3/
+  server.js                    HTTP server + SSE + 7-phase orchestration (~1300 lines)
+  index.html                   Dashboard UI (~900 lines)
+  manifest.json                Hub metadata
+  hub-loop-v3/                 v3 drop-in modules
+    hub-inventory.js           Compressed-index scanner (frontmatter-aware)
+    dedup-gate.js              Fuzzy dedup filter (trigram/token/slug Jaccard)
+    theme-strategies.js        Optional weighted theme picker (not wired)
+    prompts/
+      extraction.md            v3 novelty-first extraction prompt
+  files/                       Drop-in originals (INTEGRATION.md + sources)
+    INTEGRATION.md             Wiring guide
+    hub-inventory.js           Original v3 module (pre-adapted)
+    dedup-gate.js              Original v3 module
+    theme-strategies.js        Original v3 module
+    extraction.md              Original v3 prompt
+```
+
+## Usage
+
+```bash
+node server.js
+# open http://localhost:8917
+# click "Start Loop" or "Run Once"
+```
+
+### Pipeline phases (v3 wiring)
+
+1. **Cycle start** — `refreshInventory()` scans skills-hub (zero Claude calls, cache-friendly)
+2. **Generate Ideas** — theme from `pickKeyword`, prompt uses v3 compressed index
+3. **Build Apps** — parse `===APP===` blocks → write `NN-slug/` directories
+4. **Publish PRs** — git branch + commit + push + `gh pr create` for each app
+5. **Auto-Merge** — `gh pr merge --merge` per PR
+6. **Extract Skills** — Claude emits `===SKILL===` / `===KNOWLEDGE===` blocks
+7. **Dedup gate** — `dedupGate.filter()` against full inventory; broadcasts `dedup-review` + `dedup-rejected` SSE events; only `accepted` items proceed
+8. **Publish S/K** — single PR with extracted items, auto-merged
+9. **Install All** — copy new items into `~/.claude/skills/` and `.claude/knowledge/`
+
+## Stack
+
+`node` · `html` · `css` · `vanilla-js` — zero external dependencies
+
+## Skills applied
+
+| Skill | Used for |
+|---|---|
+| `stdin-redirect-cli-large-prompts` | >30KB prompt delivery via temp file + shell redirect |
+| `full-inventory-over-sampling-prompt` | Passing all 400+ hub items (compressed) to Claude |
+| `parallel-build-sequential-publish` | Build locally in batch, publish to git one at a time |
+| `zero-dep-dark-html-app` | Dashboard scaffold |
+
+## Knowledge respected
+
+| Knowledge | Why |
+|---|---|
+| `dashboard-decoration-vs-evidence` | Recipe panel shows actual cited skills, not animated decoration |
+| `single-keyword-formulaic-llm-output` | Themes are multi-word phrases, not single words |
+| `batch-pr-conflict-recovery` | Per-PR flow avoids catalog README edits |
+| `flat-vs-categorized-folder-structure` | Publishes to `example/<category>/<slug>/` not flat |
+
+## Provenance
+
+- v3 built on 2026-04-18 by wiring drop-in modules from `files/` into an adapted `hub-loop-v3/` layer.
+- Source working copy: `F:/workspace/tool/auto-hub-loop`
+- Predecessor: `example/hub-tools/auto-hub-loop` (v2, PR #111 and subsequent rewrite)

--- a/example/hub-tools/auto-hub-loop-v3/files/INTEGRATION.md
+++ b/example/hub-tools/auto-hub-loop-v3/files/INTEGRATION.md
@@ -1,0 +1,257 @@
+# INTEGRATION.md — wiring v3 modules into `server.js`
+
+> These four files are drop-in modules. Nothing here tries to rewrite
+> your orchestration engine — they replace specific, isolated pieces
+> of it. Hook them in one at a time; each one gives a standalone win.
+
+## Files
+
+The layout below is what these modules expect — but every path in the
+example code uses `__dirname`-relative joins, so the `files/` vs
+`prompts/` vs other naming is up to you. What matters is that all
+five are reachable from `server.js`.
+
+```
+auto-hub-loop/                 ← your project root
+  server.js
+  hub-loop-v3/
+    hub-inventory.js           session-level scan → compressed index + gaps
+    theme-strategies.js        per-cycle theme: gap-driven / combinatorial / exploratory
+    dedup-gate.js              fuzzy duplicate filter for extracted candidates
+    INTEGRATION.md             (this file)
+  files/
+    extraction.md              novelty-first extraction prompt (allows zero)
+```
+
+> If you've already placed `extraction.md` somewhere else, just update
+> `EXTRACTION_PROMPT_PATH` in section 4 below.
+
+## Expected impact
+
+| Change                               | Addresses                 | Token/time win (rough) |
+|---|---|---|
+| Compressed index vs full SKILL.md    | "토큰 많이 듬"            | **10–20× smaller** context per cycle |
+| Session-cached gap list              | "새로운 거 얻기 어려움"   | 1 call/session vs 0 calls (new) — cheap |
+| Gap-driven + combinatorial themes    | "새로운 거 얻기 어려움"   | ~same cost, **much higher novelty hit rate** |
+| Novelty-first extraction prompt      | "억지로 채우는 중복"      | smaller prompt, allows 0-result cycles |
+| Code-side dedup gate                 | "중복 프롬프트로 막기"    | removes ~1KB from every prompt, more reliable |
+
+## Where each hooks in
+
+### 1. Session start (once)
+
+Before your loop begins:
+
+```js
+const hub   = require('./hub-loop-v3/hub-inventory');
+const themes = require('./hub-loop-v3/theme-strategies');
+const gate  = require('./hub-loop-v3/dedup-gate');
+
+// HUB_ROOT: wherever you've cloned skills-hub (the directory
+// that contains `example/<cat>/<slug>/SKILL.md` etc.)
+const HUB_ROOT = process.env.HUB_ROOT || path.resolve('..', 'skills-hub');
+
+const inventory = await hub.load({
+  hubRoot: HUB_ROOT,
+  claudeBin: 'claude',
+});
+
+log.info(`hub: ${inventory.skills.length} skills, ${inventory.knowledge.length} knowledge`);
+log.info(`gaps identified: ${inventory.gaps.map(g => g.area).join(', ')}`);
+```
+
+If the hub grows during a session and you want to refresh:
+
+```js
+hub.invalidate();              // clear cache
+const inv2 = await hub.load({...}); // rescan + re-gap
+```
+
+### 2. Phase 1 (Generate Ideas) — replace your theme line
+
+Before:
+```js
+const theme = RANDOM_THEMES[Math.floor(Math.random() * RANDOM_THEMES.length)];
+```
+
+After:
+```js
+const picked = await themes.pick({
+  inventory,
+  claudeBin: 'claude',
+  weights: { gap: 0.6, combo: 0.3, random: 0.1 },
+});
+const theme = picked.theme;
+log.info(`theme (${picked.mode}): ${theme}`);
+// keep picked.seeds around — send them to the dashboard Recipe panel
+// so users see "this cycle combined X + Y + Z" or "targeting gap: foo"
+```
+
+### 3. Generate-Ideas prompt — swap full inventory for compressed index
+
+Before:
+```js
+const prompt = `...${FULL_HUB_DUMP}... require 100+ citations ...`;
+```
+
+After:
+```js
+const prompt = `...
+## Current hub (compressed)
+${inventory.indexText}
+
+## Theme
+${theme}
+
+Produce 3 apps. Cite 5–15 existing hub items per app where they
+genuinely apply — do NOT pad citations. If an item doesn't truly
+fit, skip it.
+...`;
+```
+
+Dropping the "100+ citations" KPI is the single biggest quality
+lever. Forced quotas pull Claude away from real novelty.
+
+### 4. Phase 5 (Extract Skills) — use the v3 prompt
+
+```js
+// Adjust this path to wherever you dropped extraction.md in your tree.
+// In your current layout it's  auto-hub-loop/files/extraction.md , so:
+const EXTRACTION_PROMPT_PATH = path.join(__dirname, 'files', 'extraction.md');
+
+const template = fs.readFileSync(EXTRACTION_PROMPT_PATH, 'utf8')
+                   .match(/```\n([\s\S]+?)\n```/)[1];
+
+const extractionPrompt = template
+  .replace('{{COMPRESSED_INDEX}}', inventory.indexText)
+  .replace('{{APPS}}',             appsDigest);  // your existing digest
+
+const raw = await runClaudeWithStdinRedirect(extractionPrompt); // your helper
+const parsed = parseExtraction(raw);
+// ...use parsed.skills / parsed.knowledge
+
+// Defense-in-depth parser: even with the prompt fixed, Claude occasionally
+// strays (returns [], wraps output in ```json fences, prefixes prose, etc.).
+// A zero-result cycle MUST NOT crash the pipeline — that defeats the whole
+// "quiet skip" design. Treat any unparseable response as "nothing extracted".
+function parseExtraction(raw) {
+  const empty = { skills: [], knowledge: [] };
+  if (!raw || typeof raw !== 'string') return empty;
+
+  // Strip ```json ... ``` fences if present
+  const fenced = raw.match(/```(?:json)?\s*([\s\S]+?)\s*```/);
+  const body = fenced ? fenced[1] : raw;
+
+  // Try to pick the OUTERMOST JSON value — whichever of `{` or `[` comes
+  // first in the response. Default-to-object would misgrab the inner {...}
+  // from a bare array like  [{...}, {...}]  and fail to parse.
+  const objIdx = body.indexOf('{');
+  const arrIdx = body.indexOf('[');
+  const firstIdx = [objIdx, arrIdx].filter(i => i >= 0).sort((a, b) => a - b)[0];
+  if (firstIdx == null) {
+    console.warn('[extract] no JSON found in response, treating as empty cycle');
+    return empty;
+  }
+  const preferObject = firstIdx === objIdx;
+  const objMatch = body.match(/\{[\s\S]*\}/);
+  const arrMatch = body.match(/\[[\s\S]*\]/);
+  const candidate = preferObject
+    ? (objMatch ? objMatch[0] : (arrMatch ? arrMatch[0] : null))
+    : (arrMatch ? arrMatch[0] : (objMatch ? objMatch[0] : null));
+  if (!candidate) {
+    console.warn('[extract] no JSON found in response, treating as empty cycle');
+    return empty;
+  }
+
+  let json;
+  try { json = JSON.parse(candidate); }
+  catch (e) {
+    console.warn('[extract] JSON parse failed, treating as empty cycle:', e.message);
+    return empty;
+  }
+
+  // Normalize both shapes into { skills, knowledge }
+  if (Array.isArray(json)) {
+    // Bare array fallback — split by "kind" field if present, else assume skills
+    const skills    = json.filter(x => !x.kind || x.kind === 'skill');
+    const knowledge = json.filter(x => x.kind === 'knowledge');
+    return { skills, knowledge };
+  }
+  return {
+    skills:    Array.isArray(json.skills)    ? json.skills    : [],
+    knowledge: Array.isArray(json.knowledge) ? json.knowledge : [],
+  };
+}
+```
+
+### 5. After extraction — run the dedup gate
+
+```js
+const existing = [...inventory.skills, ...inventory.knowledge];
+const skillResult     = gate.filter(parsed.skills     || [], existing);
+const knowledgeResult = gate.filter(parsed.knowledge  || [], existing);
+
+log.info(`skills:    ${skillResult.accepted.length} accepted, ${skillResult.review.length} review, ${skillResult.rejected.length} rejected`);
+log.info(`knowledge: ${knowledgeResult.accepted.length} accepted, ${knowledgeResult.review.length} review, ${knowledgeResult.rejected.length} rejected`);
+
+// Phase 6 (Publish S/K) — only publish accepted
+const toPublish = {
+  skills:    skillResult.accepted,
+  knowledge: knowledgeResult.accepted,
+};
+
+// Broadcast review + rejected to the dashboard for human inspection
+sseBroadcast('extraction:review',   skillResult.review.concat(knowledgeResult.review));
+sseBroadcast('extraction:rejected', skillResult.rejected.concat(knowledgeResult.rejected));
+
+// If nothing is accepted, skip Phase 6/7 gracefully:
+if (!toPublish.skills.length && !toPublish.knowledge.length) {
+  log.info('no novel patterns this cycle — skipping publish/install');
+  return;  // cycle ends clean, no wasted PR churn
+}
+```
+
+This last bit is important: **a cycle that produces zero new skills
+should be cheap and quiet, not an error.** Right now your pipeline
+presumably always publishes something — that's the force-function
+pulling in noise. Removing it is where you'll feel the token/time
+savings the most.
+
+## Optional — dashboard surface
+
+To make the new behavior visible on `index.html`, add three small things:
+
+1. **Theme mode badge** — next to the theme phrase, show `gap-driven`
+   / `combo` / `random` with different colors. Users immediately see
+   whether this cycle is exploring or exploiting.
+2. **Seeds display** — when `mode=combo`, show the 3 seed skills as
+   small chips. When `mode=gap-driven`, show the gap area.
+3. **Dedup panel** — beside "Skills acquired", add "Skipped as dup"
+   with the similar existing slug. Makes it obvious when the loop
+   correctly rejected noise. This is also the `dashboard-decoration-
+   vs-evidence` knowledge applied to the new flow.
+
+## Rollout order (recommended)
+
+Wire them in this order — each is useful alone:
+
+1. **`hub-inventory.js` + compressed index** in the generate prompt.
+   Immediate token savings with zero behavior change beyond that.
+2. **`dedup-gate.js`** after whatever extraction you currently do.
+   Immediately see how many "new" skills were actually duplicates.
+   The answer will probably explain why novelty felt flat.
+3. **v3 extraction prompt** + allow zero-result cycles.
+   Stop publishing quota-filler.
+4. **`theme-strategies.js`**.
+   Now that the pipeline is honest about novelty, bias it toward
+   gaps and combinations to actually find it.
+
+## What's NOT in this patch
+
+- Hybrid "harvest from real Claude Code sessions" channel.
+  That's a bigger architectural change and should be a separate
+  module, not a server.js edit. Happy to design that next if the
+  above four changes do less than expected.
+- Full-inventory embedding similarity (instead of trigram+token).
+  Trigram+token is good enough for a few hundred items and keeps
+  the zero-dep promise. If the hub grows past ~2000 items, revisit.

--- a/example/hub-tools/auto-hub-loop-v3/files/dedup-gate.js
+++ b/example/hub-tools/auto-hub-loop-v3/files/dedup-gate.js
@@ -1,0 +1,174 @@
+// dedup-gate.js
+// -------------------------------------------------------------
+// Zero-dep fuzzy duplicate detector for extracted skill/knowledge
+// candidates. Replaces "tell Claude to avoid duplicates in prompt"
+// with a code gate — more reliable, no token cost, auditable.
+//
+// Strategy: three-signal Jaccard similarity — char-trigrams (typo/
+// suffix robust) + content-word tokens (paraphrase catch) + slug-
+// only tokens (distinctive shared slug words). Take the MAX.
+// Simple, language-agnostic, zero deps, good enough for "is this
+// the same pattern with a different name" detection up to ~2000
+// hub items. Beyond that, revisit with embeddings.
+//
+//   filter(candidates, existing, { accept = 0.30, review = 0.55 })
+//     returns { accepted, review, rejected }
+//
+//   - similarity < accept           -> accepted (genuinely new)
+//   - accept ≤ similarity < review  -> review (possibly same)
+//   - similarity ≥ review           -> rejected (duplicate)
+//
+// Thresholds tuned so that clear paraphrases ("pr-batch-conflict-
+// resolution" vs "batch-pr-conflict-recovery") land in review or
+// rejected, not accepted. Tweak per your tolerance for false
+// positives vs leakage.
+//
+// candidate / existing items: { slug, purpose, category? }
+// -------------------------------------------------------------
+
+const STOPWORDS = new Set([
+  'the','a','an','and','or','of','to','for','in','on','with','by','is','are',
+  'be','that','this','it','as','at','from','via','into','when','during','using',
+]);
+
+function normTokens(str) {
+  return String(str || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9가-힣\s]/g, ' ')
+    .split(/\s+/)
+    .filter(t => t && !STOPWORDS.has(t) && t.length > 1);
+}
+
+function trigrams(str) {
+  const s = '  ' + String(str || '').toLowerCase().replace(/[^a-z0-9가-힣\s]/g, ' ').replace(/\s+/g, ' ') + '  ';
+  const set = new Set();
+  for (let i = 0; i < s.length - 2; i++) set.add(s.slice(i, i + 3));
+  return set;
+}
+
+function jaccard(a, b) {
+  if (!a.size || !b.size) return 0;
+  let inter = 0;
+  for (const t of a) if (b.has(t)) inter++;
+  return inter / (a.size + b.size - inter);
+}
+
+function fingerprint(item) {
+  // Three-signal fingerprint:
+  //   tri  — char trigrams (typo/suffix/variant robust)
+  //   tok  — content-word tokens across slug+purpose (paraphrase catch)
+  //   slug — slug-only tokens (distinctive shared words = near-certain dup)
+  const slugPart = (item.slug || '').replace(/-/g, ' ');
+  const purposePart = item.purpose || '';
+  const text = slugPart + ' ' + slugPart + ' ' + purposePart;
+  return {
+    tri:  trigrams(text),
+    tok:  new Set(normTokens(slugPart + ' ' + slugPart + ' ' + purposePart)),
+    slug: new Set(normTokens(slugPart)),
+  };
+}
+
+function compare(a, b) {
+  return Math.max(
+    jaccard(a.tri, b.tri),
+    jaccard(a.tok, b.tok),
+    jaccard(a.slug, b.slug),
+  );
+}
+
+// Heuristic for "templated" slug patterns that tend to masquerade as
+// new skills but are really variants of the same idea.
+const TEMPLATE_SUFFIXES = [
+  '-visualization-pattern',
+  '-simulation-pattern',
+  '-tool-pattern',
+  '-app-pattern',
+  '-dashboard-pattern',
+];
+
+function looksTemplated(slug) {
+  const s = String(slug || '').toLowerCase();
+  return TEMPLATE_SUFFIXES.some(suf => s.endsWith(suf));
+}
+
+function scoreAgainst(candidate, existingFingerprints) {
+  const f = fingerprint(candidate);
+  let best = { score: 0, slug: null };
+  for (const [slug, fp] of existingFingerprints) {
+    const s = compare(f, fp);
+    if (s > best.score) best = { score: s, slug };
+  }
+  return best;
+}
+
+function filter(candidates, existing, opts = {}) {
+  const accept = opts.accept ?? 0.30;  // below: genuinely new
+  const review = opts.review ?? 0.55;  // above: duplicate
+
+  const existingFp = new Map();
+  for (const it of existing) existingFp.set(it.slug, fingerprint(it));
+
+  const accepted = [];
+  const forReview = [];
+  const rejected = [];
+
+  // also dedupe within the candidate batch itself
+  const seenInBatch = new Map();
+
+  for (const cand of candidates) {
+    if (looksTemplated(cand.slug)) {
+      rejected.push({ ...cand, reason: 'templated-suffix' });
+      continue;
+    }
+
+    // against existing
+    const vsExisting = scoreAgainst(cand, existingFp);
+    // against this batch
+    const vsBatch = scoreAgainst(cand, seenInBatch);
+
+    const worst = vsExisting.score >= vsBatch.score ? vsExisting : vsBatch;
+    const label = worst === vsExisting ? 'existing' : 'batch';
+
+    if (worst.score >= review) {
+      rejected.push({
+        ...cand,
+        reason: `dup-${label}`,
+        nearest: worst.slug,
+        similarity: +worst.score.toFixed(3),
+      });
+    } else if (worst.score >= accept) {
+      forReview.push({
+        ...cand,
+        reason: `similar-${label}`,
+        nearest: worst.slug,
+        similarity: +worst.score.toFixed(3),
+      });
+      // add to seen so a later even-closer twin gets flagged
+      seenInBatch.set(cand.slug, fingerprint(cand));
+    } else {
+      accepted.push(cand);
+      seenInBatch.set(cand.slug, fingerprint(cand));
+    }
+  }
+
+  return { accepted, review: forReview, rejected };
+}
+
+module.exports = { filter, trigrams, jaccard, fingerprint, compare, looksTemplated };
+
+// ---------- self-test (run `node dedup-gate.js` to verify) ----------
+if (require.main === module) {
+  const existing = [
+    { slug: 'batch-pr-conflict-recovery', purpose: 'Recover from merge conflicts during batch PR publishing' },
+    { slug: 'zero-dep-dark-html-app',     purpose: 'Dashboard scaffold using only vanilla HTML CSS JS' },
+    { slug: 'flat-vs-categorized-folder-structure', purpose: 'Choose between flat and categorized folder layouts' },
+  ];
+  const candidates = [
+    { slug: 'pr-batch-conflict-resolution', purpose: 'Resolving merge conflicts when publishing many PRs' },    // dup
+    { slug: 'physics-spring-simulator',     purpose: 'Simulate spring-mass dynamics with verlet integration' }, // novel
+    { slug: 'thermal-gradient-visualization-pattern', purpose: 'Visualize heat flow' }, // templated
+    { slug: 'dark-vanilla-dashboard',       purpose: 'Dashboard built with plain HTML CSS JS no deps' },        // similar
+  ];
+  const result = filter(candidates, existing);
+  console.log(JSON.stringify(result, null, 2));
+}

--- a/example/hub-tools/auto-hub-loop-v3/files/extraction.md
+++ b/example/hub-tools/auto-hub-loop-v3/files/extraction.md
@@ -1,0 +1,113 @@
+# Extraction Prompt (v3)
+
+> Drop this into your Phase 5 (Extract Skills) call. Replaces the
+> previous "produce N skills per cycle" prompt with a novelty-first
+> one that explicitly allows — and rewards — "nothing new this time".
+
+---
+
+## Template
+
+Use with placeholders: `{{APPS}}`, `{{COMPRESSED_INDEX}}`.
+`{{APPS}}` = the diffs / file contents of the 3 apps just built.
+`{{COMPRESSED_INDEX}}` = output of `hub-inventory.js` → `indexText`
+(one line per existing skill/knowledge, never the full SKILL.md bodies).
+
+```
+You are auditing 3 small apps that were just built for reusable
+patterns worth adding to a hub of skills and knowledge.
+
+# What's already in the hub
+
+{{COMPRESSED_INDEX}}
+
+# The apps
+
+{{APPS}}
+
+# Your task
+
+Find patterns in the apps that:
+  1. would genuinely help a FUTURE unrelated project, AND
+  2. are NOT already represented in the hub index above
+     (paraphrased versions count as already-represented), AND
+  3. are CONCRETE — a specific technique with a named failure
+     mode it fixes, not a vague principle.
+
+Most cycles will yield 0–2 such patterns. That is the expected
+outcome, not a failure. If nothing meets the bar, return the empty
+object form shown in "# Output" below — NOT a bare array.
+
+# Hard rules
+
+- Do NOT produce slugs ending in `-visualization-pattern`,
+  `-simulation-pattern`, `-tool-pattern`, `-app-pattern`, or
+  `-dashboard-pattern`. These are templated placeholders, not
+  patterns.
+- Do NOT rename an existing hub item. If your candidate is
+  "basically the same idea as X already in the hub", drop it.
+- Do NOT invent a pattern to fill quota. Zero is a valid answer.
+- A candidate must be describable in ONE sentence with a concrete
+  technique AND a concrete problem it solves. If you can't do that,
+  it's not ready.
+
+# Output
+
+Return ONLY valid JSON (no prose, no code fences) of shape:
+
+{
+  "skills": [
+    {
+      "slug": "kebab-case-slug",
+      "kind": "skill",
+      "category": "one-of-existing-categories-or-new-one",
+      "purpose": "one sentence, ≤20 words, technique + problem",
+      "evidence": "file:lines in the apps where this appears",
+      "why_novel": "why the hub index above doesn't already cover it"
+    }
+  ],
+  "knowledge": [
+    {
+      "slug": "kebab-case-slug",
+      "kind": "knowledge",
+      "category": "...",
+      "purpose": "the insight in one sentence, ≤20 words",
+      "evidence": "where in the apps this insight was applied",
+      "why_novel": "..."
+    }
+  ]
+}
+
+If nothing qualifies:  {"skills": [], "knowledge": []}
+```
+
+---
+
+## Why this prompt is different
+
+| Old prompt                                  | v3                                           |
+|---|---|
+| "Extract ~5–10 skills per cycle"            | "0 is a valid and expected answer"           |
+| Full SKILL.md bodies dumped as context      | One-line compressed index only               |
+| Implicit: must produce something            | Explicit: must justify `why_novel`           |
+| Dedup enforced via "try to avoid" language  | Dedup enforced downstream by `dedup-gate.js` |
+| No fail-fast for vague outputs              | Rejects patterns without concrete technique  |
+
+## Loading and calling
+
+```js
+const fs   = require('fs');
+const path = require('path');
+
+// Adjust this to wherever you actually dropped extraction.md.
+const EXTRACTION_PROMPT_PATH = path.join(__dirname, '..', 'files', 'extraction.md');
+
+const template = fs.readFileSync(EXTRACTION_PROMPT_PATH, 'utf8')
+                   .match(/```\n([\s\S]+?)\n```/)[1];
+
+const prompt = template
+  .replace('{{COMPRESSED_INDEX}}', inventory.indexText)
+  .replace('{{APPS}}', appsDigest);
+
+// then pipe to `claude -p` via your existing stdin-redirect helper
+```

--- a/example/hub-tools/auto-hub-loop-v3/files/hub-inventory.js
+++ b/example/hub-tools/auto-hub-loop-v3/files/hub-inventory.js
@@ -1,0 +1,252 @@
+// hub-inventory.js
+// -------------------------------------------------------------
+// Session-level hub scan. Produces a COMPRESSED one-line index
+// (slug + category + ≤15-word purpose) instead of dumping full
+// SKILL.md bodies into every cycle prompt. Also caches the
+// session's "gap list" — domains Claude itself judged under-
+// developed — so theme generation can target real holes.
+//
+// Typical usage from server.js:
+//
+//   const hub = require('./hub-inventory');
+//   const inv = await hub.load({ hubRoot, claudeBin });
+//   // inv.indexText  -> compressed index (pass to prompts)
+//   // inv.gaps       -> [{ area, reason }]
+//   // inv.skills     -> [{ slug, category, purpose, path }]
+//   // inv.knowledge  -> [{ slug, category, purpose, path }]
+//
+// load() reuses a cached snapshot if the hub mtime hasn't moved,
+// so you call it freely — it only does real work when the hub
+// actually changes.
+// -------------------------------------------------------------
+
+const fs    = require('fs');
+const fsp   = require('fs/promises');
+const path  = require('path');
+const os    = require('os');
+const { spawn } = require('child_process');
+
+const CACHE_DIR  = path.join(os.homedir(), '.cache', 'hub-loop-v3');
+const CACHE_FILE = path.join(CACHE_DIR, 'inventory.json');
+
+// ---------- tiny utilities ----------
+
+async function ensureDir(p) { await fsp.mkdir(p, { recursive: true }); }
+
+// FNV-1a 32-bit — deterministic, zero-dep, collision-fine for signatures
+function hashString(s) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = (h * 0x01000193) >>> 0;
+  }
+  return h.toString(16);
+}
+
+async function walk(dir, depth = 3) {
+  const out = [];
+  async function rec(d, left) {
+    if (left < 0) return;
+    let entries;
+    try { entries = await fsp.readdir(d, { withFileTypes: true }); }
+    catch { return; }
+    for (const e of entries) {
+      const full = path.join(d, e.name);
+      if (e.isDirectory()) await rec(full, left - 1);
+      else if (e.isFile()) out.push(full);
+    }
+  }
+  await rec(dir, depth);
+  return out;
+}
+
+function parseFrontmatter(md) {
+  // SKILL.md convention: leading `---` block with `name:`, `description:`, etc.
+  // The description is ALWAYS a better purpose-line than anything we'd
+  // scrape from the body — so extract it properly instead of nuking the
+  // whole frontmatter.
+  const m = md.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return null;
+  const out = {};
+  for (const line of m[1].split(/\r?\n/)) {
+    const kv = line.match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
+    if (!kv) continue;
+    let v = kv[2].trim();
+    // Strip surrounding quotes (single or double), then unescape \" / \'
+    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+      v = v.slice(1, -1).replace(/\\(["'])/g, '$1');
+    }
+    out[kv[1]] = v;
+  }
+  return out;
+}
+
+function firstSentence(md, maxWords = 20) {
+  // 1) Prefer frontmatter description — canonical summary.
+  const fm = parseFrontmatter(md);
+  let source = fm && fm.description;
+
+  // 2) Fallback: scrape body (strip frontmatter, headers, code blocks)
+  if (!source) {
+    source = md
+      .replace(/^---[\s\S]*?---/, '')
+      .replace(/^#.*$/gm, '')
+      .replace(/```[\s\S]*?```/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+  if (!source) return '';
+
+  // Take first sentence-ish chunk, then cap at maxWords.
+  const sent = source.split(/(?<=[.!?。])\s/)[0] || source;
+  const words = sent.split(/\s+/).slice(0, maxWords);
+  return words.join(' ').replace(/[.,;:]$/, '');
+}
+
+function categoryOf(filePath, hubRoot) {
+  // Expects hubRoot/<kind>/<category>/<slug>/FILE.md
+  const rel = path.relative(hubRoot, filePath).split(path.sep);
+  return rel.length >= 3 ? rel[1] : 'uncategorized';
+}
+
+function slugOf(filePath) {
+  return path.basename(path.dirname(filePath));
+}
+
+// ---------- hub scan ----------
+
+async function scanKind(root, kind, markerFile) {
+  const kindRoot = path.join(root, kind);
+  if (!fs.existsSync(kindRoot)) return [];
+  const files = await walk(kindRoot, 4);
+  const marker = markerFile.toLowerCase();
+  const items = [];
+  for (const f of files) {
+    if (path.basename(f).toLowerCase() !== marker) continue;
+    let body = '';
+    let stat;
+    try {
+      body = await fsp.readFile(f, 'utf8');
+      stat = await fsp.stat(f);
+    } catch { continue; }
+    items.push({
+      slug: slugOf(f),
+      category: categoryOf(f, root),
+      purpose: firstSentence(body),
+      path: f,
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+    });
+  }
+  // stable order
+  items.sort((a, b) => a.category.localeCompare(b.category) || a.slug.localeCompare(b.slug));
+  return items;
+}
+
+function buildIndexText(skills, knowledge) {
+  const lines = [];
+  lines.push(`## Skills (${skills.length})`);
+  for (const s of skills) {
+    lines.push(`- \`${s.slug}\` [${s.category}] — ${s.purpose}`);
+  }
+  lines.push('');
+  lines.push(`## Knowledge (${knowledge.length})`);
+  for (const k of knowledge) {
+    lines.push(`- \`${k.slug}\` [${k.category}] — ${k.purpose}`);
+  }
+  return lines.join('\n');
+}
+
+// ---------- gap analysis (one Claude call, cached) ----------
+
+async function askClaudeForGaps({ indexText, claudeBin }) {
+  const prompt = `Below is the current hub inventory (compressed).
+
+${indexText}
+
+Task: identify 8–12 DOMAINS or CAPABILITY AREAS that are clearly
+underdeveloped or completely absent. Ignore anything already well-
+covered. Do NOT invent areas that overlap existing items.
+
+Return ONLY valid JSON (no prose, no fences) of shape:
+[{"area": "short name", "reason": "≤20 words why it's a gap"}]
+`;
+  return new Promise((resolve, reject) => {
+    const proc = spawn(claudeBin, ['-p'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      // Windows: claude is typically installed as claude.cmd/claude.bat,
+      // and Node's spawn without shell:true can't resolve .cmd/.bat extensions,
+      // producing ENOENT. shell:true is safe here because our argv is a
+      // fixed literal (['-p']) and the prompt goes through stdin.
+      shell: process.platform === 'win32',
+      env: {
+        ...process.env,
+        DISABLE_OMC: '1',
+        OMC_SKIP_HOOKS: '*',
+        CLAUDE_DISABLE_SESSION_HOOKS: '1',
+      },
+    });
+    let out = '', err = '';
+    proc.stdout.on('data', d => out += d);
+    proc.stderr.on('data', d => err += d);
+    proc.on('close', code => {
+      if (code !== 0) return reject(new Error(`claude exit ${code}: ${err}`));
+      try {
+        const match = out.match(/\[[\s\S]*\]/);
+        resolve(JSON.parse(match ? match[0] : out));
+      } catch (e) {
+        reject(new Error('gap JSON parse failed: ' + e.message + '\n' + out.slice(0, 500)));
+      }
+    });
+    proc.stdin.end(prompt);
+  });
+}
+
+// ---------- public API ----------
+
+async function load({ hubRoot, claudeBin = 'claude', forceRefresh = false } = {}) {
+  if (!hubRoot) throw new Error('hubRoot required');
+  await ensureDir(CACHE_DIR);
+
+  // cache validity: hub mtime (deepest) + cache file
+  const skills    = await scanKind(hubRoot, 'example', 'SKILL.md');  // path shape per your repo
+  const knowledge = await scanKind(hubRoot, 'knowledge', 'README.md'); // adjust if your marker differs
+
+  // Signature combines four things so any real change invalidates:
+  //   - counts (add/remove items)
+  //   - max mtime across all marker files (content edits)
+  //   - sum of sizes (touched-but-not-mtime-bumped edge cases)
+  //   - sorted slug list (renames without size change)
+  const all = [...skills, ...knowledge];
+  const maxMtime = all.reduce((m, x) => x.mtimeMs > m ? x.mtimeMs : m, 0);
+  const totalSize = all.reduce((s, x) => s + x.size, 0);
+  const slugList = all.map(x => x.slug).sort().join('|');
+  const signature = `${skills.length}:${knowledge.length}:${maxMtime}:${totalSize}:${hashString(slugList)}`;
+
+  let cached = null;
+  if (!forceRefresh && fs.existsSync(CACHE_FILE)) {
+    try { cached = JSON.parse(await fsp.readFile(CACHE_FILE, 'utf8')); } catch {}
+  }
+
+  const indexText = buildIndexText(skills, knowledge);
+
+  if (cached && cached.signature === signature && Array.isArray(cached.gaps) && cached.gaps.length) {
+    return { skills, knowledge, indexText, gaps: cached.gaps, cached: true };
+  }
+
+  let gaps = [];
+  try {
+    gaps = await askClaudeForGaps({ indexText, claudeBin });
+  } catch (e) {
+    console.error('[hub-inventory] gap analysis failed, continuing with empty gaps:', e.message);
+  }
+
+  await fsp.writeFile(CACHE_FILE, JSON.stringify({ signature, gaps, ts: Date.now() }, null, 2));
+  return { skills, knowledge, indexText, gaps, cached: false };
+}
+
+function invalidate() {
+  try { fs.unlinkSync(CACHE_FILE); } catch {}
+}
+
+module.exports = { load, invalidate, buildIndexText };

--- a/example/hub-tools/auto-hub-loop-v3/files/theme-strategies.js
+++ b/example/hub-tools/auto-hub-loop-v3/files/theme-strategies.js
@@ -1,0 +1,177 @@
+// theme-strategies.js
+// -------------------------------------------------------------
+// Replaces pure random theme generation with THREE strategies,
+// weighted so most cycles target real gaps or explore unusual
+// combinations instead of drifting randomly.
+//
+//   gap-driven    (default 60%) — theme built around a hub gap
+//   combinatorial (default 30%) — theme combining 2–3 existing
+//                                  skills from different categories
+//   exploratory   (default 10%) — your original random-theme mode,
+//                                  kept as a drift channel
+//
+// Each strategy calls Claude ONCE with a tiny prompt (no full
+// inventory — just the specific seeds), so per-cycle token cost
+// is a fraction of the current approach.
+//
+// Usage:
+//   const themes = require('./theme-strategies');
+//   const { theme, mode, seeds } = await themes.pick({
+//     inventory, claudeBin, weights: { gap: 0.6, combo: 0.3, random: 0.1 }
+//   });
+// -------------------------------------------------------------
+
+const { spawn } = require('child_process');
+
+function callClaude(prompt, { claudeBin = 'claude', timeoutMs = 60_000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(claudeBin, ['-p'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      // See hub-inventory.js for why shell:true on win32.
+      shell: process.platform === 'win32',
+      env: {
+        ...process.env,
+        DISABLE_OMC: '1',
+        OMC_SKIP_HOOKS: '*',
+        CLAUDE_DISABLE_SESSION_HOOKS: '1',
+      },
+    });
+    const kill = setTimeout(() => proc.kill('SIGKILL'), timeoutMs);
+    let out = '', err = '';
+    proc.stdout.on('data', d => out += d);
+    proc.stderr.on('data', d => err += d);
+    proc.on('close', code => {
+      clearTimeout(kill);
+      if (code !== 0) return reject(new Error(`claude exit ${code}: ${err.slice(0, 300)}`));
+      resolve(out.trim());
+    });
+    proc.stdin.end(prompt);
+  });
+}
+
+function weightedPick(weights) {
+  const entries = Object.entries(weights);
+  const total = entries.reduce((a, [, v]) => a + v, 0);
+  let r = Math.random() * total;
+  for (const [k, v] of entries) {
+    r -= v;
+    if (r <= 0) return k;
+  }
+  return entries[entries.length - 1][0];
+}
+
+function sampleDistinctCategories(items, n) {
+  const byCat = new Map();
+  for (const it of items) {
+    if (!byCat.has(it.category)) byCat.set(it.category, []);
+    byCat.get(it.category).push(it);
+  }
+  const cats = [...byCat.keys()];
+  if (cats.length < n) return null;
+  // shuffle cats
+  for (let i = cats.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [cats[i], cats[j]] = [cats[j], cats[i]];
+  }
+  const chosen = cats.slice(0, n);
+  return chosen.map(c => {
+    const bucket = byCat.get(c);
+    return bucket[Math.floor(Math.random() * bucket.length)];
+  });
+}
+
+// ---------- strategies ----------
+
+async function gapDriven({ inventory, claudeBin }) {
+  const gaps = inventory.gaps || [];
+  if (!gaps.length) throw new Error('no gaps available');
+  const gap = gaps[Math.floor(Math.random() * gaps.length)];
+  const prompt = `Write ONE theme phrase (10–20 words) for a small app
+that would naturally explore this underdeveloped area of the hub:
+
+AREA: ${gap.area}
+WHY IT'S A GAP: ${gap.reason}
+
+The theme should be evocative and specific — not a category name.
+It should hint at 1–2 concrete mechanisms or metaphors. Return ONLY
+the phrase, no quotes, no preface.`;
+  const theme = await callClaude(prompt, { claudeBin });
+  return { theme: theme.split('\n')[0].trim(), mode: 'gap-driven', seeds: [gap] };
+}
+
+async function combinatorial({ inventory, claudeBin }) {
+  const pool = [...(inventory.skills || []), ...(inventory.knowledge || [])];
+  if (pool.length === 0) {
+    throw new Error('combinatorial: hub pool empty');
+  }
+
+  // Try for diversity: 3 different categories → 2 → 1. If even 1 fails
+  // (because there's literally one item or all items share one cat AND
+  // one item), fall back to two random items same-category.
+  let seeds = sampleDistinctCategories(pool, 3)
+           || sampleDistinctCategories(pool, 2)
+           || sampleDistinctCategories(pool, 1);
+  let mode = 'combinatorial';
+
+  if (!seeds || seeds.length < 2) {
+    // Single-item "extend this pattern" variant — still useful signal
+    if (pool.length === 1) {
+      seeds = [pool[0]];
+      mode = 'combinatorial-extend';
+    } else {
+      // Pool has ≥2 items but they all share one category — mix two of them
+      const a = pool[Math.floor(Math.random() * pool.length)];
+      let b;
+      do { b = pool[Math.floor(Math.random() * pool.length)]; }
+      while (b === a);
+      seeds = [a, b];
+      mode = 'combinatorial-same-cat';
+    }
+  }
+
+  const seedLines = seeds.map(s => `- \`${s.slug}\` [${s.category}] — ${s.purpose}`).join('\n');
+  const intro = seeds.length === 1
+    ? 'This is an existing hub item:'
+    : `These are existing hub items${mode === 'combinatorial' ? ' from DIFFERENT categories' : ''}:`;
+  const task = seeds.length === 1
+    ? `Write ONE theme phrase (10–20 words) for a small app that takes
+this pattern and applies it in an unfamiliar domain — somewhere the
+original author probably didn't consider. Return ONLY the phrase.`
+    : `Write ONE theme phrase (10–20 words) for a small app whose core
+concept meaningfully combines ideas from ALL of the above in a
+non-obvious way. The combination should feel surprising but
+coherent. Return ONLY the phrase.`;
+
+  const prompt = `${intro}\n\n${seedLines}\n\n${task}`;
+  const theme = await callClaude(prompt, { claudeBin });
+  return { theme: theme.split('\n')[0].trim(), mode, seeds };
+}
+
+async function exploratory({ claudeBin }) {
+  const prompt = `Write ONE evocative theme phrase (10–20 words) for a
+small creative app. It can be literary, scientific, whimsical, or
+mechanical — but specific. Return ONLY the phrase.`;
+  const theme = await callClaude(prompt, { claudeBin });
+  return { theme: theme.split('\n')[0].trim(), mode: 'exploratory', seeds: [] };
+}
+
+// ---------- public ----------
+
+async function pick({ inventory, claudeBin = 'claude', weights } = {}) {
+  const w = weights || { gap: 0.6, combo: 0.3, random: 0.1 };
+  const tries = ['gap', 'combo', 'random'];
+  let chosen = weightedPick(w);
+  // put chosen first, then fall back to the others if it fails
+  const order = [chosen, ...tries.filter(t => t !== chosen)];
+  let lastErr;
+  for (const mode of order) {
+    try {
+      if (mode === 'gap')    return await gapDriven({ inventory, claudeBin });
+      if (mode === 'combo')  return await combinatorial({ inventory, claudeBin });
+      if (mode === 'random') return await exploratory({ claudeBin });
+    } catch (e) { lastErr = e; }
+  }
+  throw lastErr || new Error('all theme strategies failed');
+}
+
+module.exports = { pick, gapDriven, combinatorial, exploratory };

--- a/example/hub-tools/auto-hub-loop-v3/hub-loop-v3/dedup-gate.js
+++ b/example/hub-tools/auto-hub-loop-v3/hub-loop-v3/dedup-gate.js
@@ -1,0 +1,145 @@
+// dedup-gate.js
+// -------------------------------------------------------------
+// Zero-dep fuzzy duplicate detector for extracted skill/knowledge
+// candidates. Replaces "tell Claude to avoid duplicates in prompt"
+// with a code gate — more reliable, no token cost, auditable.
+//
+// Strategy: three-signal similarity over slug+purpose.
+//   - tri : char-trigram Jaccard (typo/suffix robust)
+//   - tok : content-word tokens (paraphrase catch)
+//   - slug: slug-only tokens (distinctive shared words → near-cert dup)
+// Final score = max of the three, so either channel can catch a dup.
+//
+//   filter(candidates, existing, { accept = 0.30, review = 0.55 })
+//     returns { accepted, review, rejected }
+//
+//   - similarity < accept           -> accepted (genuinely new)
+//   - accept ≤ similarity < review  -> review (possibly same)
+//   - similarity ≥ review           -> rejected (duplicate)
+//
+// candidate / existing items: { slug, purpose, category? }
+// -------------------------------------------------------------
+
+const STOPWORDS = new Set([
+  'the','a','an','and','or','of','to','for','in','on','with','by','is','are',
+  'be','that','this','it','as','at','from','via','into','when','during','using',
+]);
+
+function normTokens(str) {
+  return String(str || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9가-힣\s]/g, ' ')
+    .split(/\s+/)
+    .filter(t => t && !STOPWORDS.has(t) && t.length > 1);
+}
+
+function trigrams(str) {
+  const s = '  ' + String(str || '').toLowerCase().replace(/[^a-z0-9가-힣\s]/g, ' ').replace(/\s+/g, ' ') + '  ';
+  const set = new Set();
+  for (let i = 0; i < s.length - 2; i++) set.add(s.slice(i, i + 3));
+  return set;
+}
+
+function jaccard(a, b) {
+  if (!a.size || !b.size) return 0;
+  let inter = 0;
+  for (const t of a) if (b.has(t)) inter++;
+  return inter / (a.size + b.size - inter);
+}
+
+function fingerprint(item) {
+  const slugPart = (item.slug || '').replace(/-/g, ' ');
+  const purposePart = item.purpose || item.description || '';
+  const text = slugPart + ' ' + slugPart + ' ' + purposePart;
+  return {
+    tri:  trigrams(text),
+    tok:  new Set(normTokens(slugPart + ' ' + slugPart + ' ' + purposePart)),
+    slug: new Set(normTokens(slugPart)),
+  };
+}
+
+function compare(a, b) {
+  return Math.max(
+    jaccard(a.tri, b.tri),
+    jaccard(a.tok, b.tok),
+    jaccard(a.slug, b.slug),
+  );
+}
+
+const TEMPLATE_SUFFIXES = [
+  '-visualization-pattern',
+  '-simulation-pattern',
+  '-tool-pattern',
+  '-app-pattern',
+  '-dashboard-pattern',
+  '-data-simulation',
+  '-implementation-pitfall',
+];
+
+function looksTemplated(slug) {
+  const s = String(slug || '').toLowerCase();
+  return TEMPLATE_SUFFIXES.some(suf => s.endsWith(suf));
+}
+
+function scoreAgainst(candidate, existingFingerprints) {
+  const f = fingerprint(candidate);
+  let best = { score: 0, slug: null };
+  for (const [slug, fp] of existingFingerprints) {
+    const s = compare(f, fp);
+    if (s > best.score) best = { score: s, slug };
+  }
+  return best;
+}
+
+function filter(candidates, existing, opts = {}) {
+  const accept = opts.accept ?? 0.30;  // below: genuinely new
+  const review = opts.review ?? 0.55;  // above: duplicate
+
+  const existingFp = new Map();
+  for (const it of existing) existingFp.set(it.slug, fingerprint(it));
+
+  const accepted = [];
+  const forReview = [];
+  const rejected = [];
+  const seenInBatch = new Map();
+
+  for (const cand of candidates) {
+    if (looksTemplated(cand.slug)) {
+      rejected.push({ ...cand, reason: 'templated-suffix' });
+      continue;
+    }
+    const vsExisting = scoreAgainst(cand, existingFp);
+    const vsBatch    = scoreAgainst(cand, seenInBatch);
+    const worst = vsExisting.score >= vsBatch.score ? vsExisting : vsBatch;
+    const label = worst === vsExisting ? 'existing' : 'batch';
+
+    if (worst.score >= review) {
+      rejected.push({ ...cand, reason: `dup-${label}`, nearest: worst.slug, similarity: +worst.score.toFixed(3) });
+    } else if (worst.score >= accept) {
+      forReview.push({ ...cand, reason: `similar-${label}`, nearest: worst.slug, similarity: +worst.score.toFixed(3) });
+      seenInBatch.set(cand.slug, fingerprint(cand));
+    } else {
+      accepted.push(cand);
+      seenInBatch.set(cand.slug, fingerprint(cand));
+    }
+  }
+
+  return { accepted, review: forReview, rejected };
+}
+
+module.exports = { filter, trigrams, jaccard, fingerprint, compare, looksTemplated };
+
+if (require.main === module) {
+  const existing = [
+    { slug: 'batch-pr-conflict-recovery', purpose: 'Recover from merge conflicts during batch PR publishing' },
+    { slug: 'zero-dep-dark-html-app',     purpose: 'Dashboard scaffold using only vanilla HTML CSS JS' },
+    { slug: 'flat-vs-categorized-folder-structure', purpose: 'Choose between flat and categorized folder layouts' },
+  ];
+  const candidates = [
+    { slug: 'pr-batch-conflict-resolution', purpose: 'Resolving merge conflicts when publishing many PRs' },
+    { slug: 'physics-spring-simulator',     purpose: 'Simulate spring-mass dynamics with verlet integration' },
+    { slug: 'thermal-gradient-visualization-pattern', purpose: 'Visualize heat flow' },
+    { slug: 'dark-vanilla-dashboard',       purpose: 'Dashboard built with plain HTML CSS JS no deps' },
+  ];
+  console.log(JSON.stringify(filter(candidates, existing), null, 2));
+}

--- a/example/hub-tools/auto-hub-loop-v3/hub-loop-v3/hub-inventory.js
+++ b/example/hub-tools/auto-hub-loop-v3/hub-loop-v3/hub-inventory.js
@@ -1,0 +1,206 @@
+// hub-inventory.js (adapted for auto-hub-loop)
+// -------------------------------------------------------------
+// Scans the skills-hub remote and produces a COMPRESSED one-line
+// index (slug + category + ≤20-word purpose) plus raw item arrays.
+//
+// Hub layout in this project:
+//   <hubRoot>/skills/<category>/<slug>/SKILL.md
+//   <hubRoot>/knowledge/<category>/<slug>.md        (flat per-category)
+//
+// Purpose derivation order:
+//   1. YAML frontmatter `description:` field (primary — already curated)
+//   2. First prose sentence after stripping headers/fences
+//
+// Usage:
+//   const hub = require('./hub-loop-v3/hub-inventory');
+//   const inv = await hub.load({ hubRoot });
+//   // inv.indexText  — compressed one-line-per-item index for prompts
+//   // inv.skills     — [{ slug, category, purpose, description, path }]
+//   // inv.knowledge  — [{ slug, category, purpose, description, path }]
+//   // inv.gaps       — [{ area, reason }] (only when withGaps:true)
+// -------------------------------------------------------------
+
+const fs   = require('fs');
+const fsp  = require('fs/promises');
+const path = require('path');
+const os   = require('os');
+const { spawn } = require('child_process');
+
+const CACHE_DIR  = path.join(os.homedir(), '.cache', 'hub-loop-v3');
+const CACHE_FILE = path.join(CACHE_DIR, 'inventory.json');
+
+async function ensureDir(p) { await fsp.mkdir(p, { recursive: true }); }
+
+function frontmatterField(md, field) {
+  const fm = md.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fm) return '';
+  const re = new RegExp(`^${field}:\\s*(.+)$`, 'm');
+  const m = fm[1].match(re);
+  return (m?.[1] || '').trim().replace(/^["']|["']$/g, '');
+}
+
+function firstProse(md, maxWords = 20) {
+  const stripped = md
+    .replace(/^---[\s\S]*?---/, '')
+    .replace(/^#.*$/gm, '')
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const sent = stripped.split(/(?<=[.!?。])\s/)[0] || stripped;
+  return sent.split(/\s+/).slice(0, maxWords).join(' ').replace(/[.,;:]$/, '');
+}
+
+function derivePurpose(md, maxWords = 20) {
+  const desc = frontmatterField(md, 'description');
+  if (desc) {
+    const words = desc.split(/\s+/).slice(0, maxWords);
+    return words.join(' ').replace(/[.,;:]$/, '');
+  }
+  return firstProse(md, maxWords);
+}
+
+async function safeReaddir(dir) {
+  try { return await fsp.readdir(dir, { withFileTypes: true }); }
+  catch { return []; }
+}
+
+async function scanSkills(hubRoot) {
+  const root = path.join(hubRoot, 'skills');
+  if (!fs.existsSync(root)) return [];
+  const items = [];
+  for (const catEnt of await safeReaddir(root)) {
+    if (!catEnt.isDirectory()) continue;
+    const catPath = path.join(root, catEnt.name);
+    for (const slugEnt of await safeReaddir(catPath)) {
+      if (!slugEnt.isDirectory()) continue;
+      const skillFile = path.join(catPath, slugEnt.name, 'SKILL.md');
+      if (!fs.existsSync(skillFile)) continue;
+      let body = '';
+      try { body = await fsp.readFile(skillFile, 'utf8'); } catch { continue; }
+      items.push({
+        slug: slugEnt.name,
+        category: catEnt.name,
+        description: frontmatterField(body, 'description'),
+        purpose: derivePurpose(body),
+        path: skillFile,
+      });
+    }
+  }
+  items.sort((a, b) => a.category.localeCompare(b.category) || a.slug.localeCompare(b.slug));
+  return items;
+}
+
+async function scanKnowledge(hubRoot) {
+  const root = path.join(hubRoot, 'knowledge');
+  if (!fs.existsSync(root)) return [];
+  const items = [];
+  for (const catEnt of await safeReaddir(root)) {
+    if (!catEnt.isDirectory()) continue;
+    const catPath = path.join(root, catEnt.name);
+    for (const fEnt of await safeReaddir(catPath)) {
+      if (!fEnt.isFile() || !fEnt.name.endsWith('.md')) continue;
+      const full = path.join(catPath, fEnt.name);
+      let body = '';
+      try { body = await fsp.readFile(full, 'utf8'); } catch { continue; }
+      items.push({
+        slug: fEnt.name.replace(/\.md$/, ''),
+        category: catEnt.name,
+        description: frontmatterField(body, 'description'),
+        purpose: derivePurpose(body),
+        path: full,
+      });
+    }
+  }
+  items.sort((a, b) => a.category.localeCompare(b.category) || a.slug.localeCompare(b.slug));
+  return items;
+}
+
+function buildIndexText(skills, knowledge) {
+  const lines = [];
+  lines.push(`## Skills (${skills.length})`);
+  for (const s of skills) lines.push(`- \`${s.slug}\` [${s.category}] — ${s.purpose}`);
+  lines.push('');
+  lines.push(`## Knowledge (${knowledge.length})`);
+  for (const k of knowledge) lines.push(`- \`${k.slug}\` [${k.category}] — ${k.purpose}`);
+  return lines.join('\n');
+}
+
+// Optional gap-analysis Claude call. Skipped unless caller asks.
+async function askClaudeForGaps({ indexText, claudeBin }) {
+  const prompt = `Below is the current hub inventory (compressed).
+
+${indexText}
+
+Task: identify 8–12 DOMAINS or CAPABILITY AREAS that are clearly
+underdeveloped or completely absent. Ignore anything already well-
+covered. Do NOT invent areas that overlap existing items.
+
+Return ONLY valid JSON (no prose, no fences) of shape:
+[{"area": "short name", "reason": "≤20 words why it's a gap"}]
+`;
+  return new Promise((resolve, reject) => {
+    const proc = spawn(claudeBin, ['-p'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      shell: process.platform === 'win32',
+      env: {
+        ...process.env,
+        DISABLE_OMC: '1',
+        OMC_SKIP_HOOKS: '*',
+        CLAUDE_DISABLE_SESSION_HOOKS: '1',
+      },
+    });
+    let out = '', err = '';
+    proc.stdout.on('data', d => out += d);
+    proc.stderr.on('data', d => err += d);
+    proc.on('close', code => {
+      if (code !== 0) return reject(new Error(`claude exit ${code}: ${err.slice(0, 300)}`));
+      try {
+        const m = out.match(/\[[\s\S]*\]/);
+        resolve(JSON.parse(m ? m[0] : out));
+      } catch (e) {
+        reject(new Error('gap JSON parse failed: ' + e.message));
+      }
+    });
+    proc.stdin.end(prompt);
+  });
+}
+
+async function load({ hubRoot, claudeBin = 'claude', forceRefresh = false, withGaps = false } = {}) {
+  if (!hubRoot) throw new Error('hubRoot required');
+  await ensureDir(CACHE_DIR);
+
+  const skills    = await scanSkills(hubRoot);
+  const knowledge = await scanKnowledge(hubRoot);
+  const indexText = buildIndexText(skills, knowledge);
+
+  if (!withGaps) {
+    return { skills, knowledge, indexText, gaps: [], cached: false };
+  }
+
+  const signature = `${skills.length}:${knowledge.length}:${
+    [...skills, ...knowledge].map(x => `${x.category}/${x.slug}`).sort().join('|')
+  }`;
+
+  let cached = null;
+  if (!forceRefresh && fs.existsSync(CACHE_FILE)) {
+    try { cached = JSON.parse(await fsp.readFile(CACHE_FILE, 'utf8')); } catch {}
+  }
+  if (cached && cached.signature === signature && Array.isArray(cached.gaps) && cached.gaps.length) {
+    return { skills, knowledge, indexText, gaps: cached.gaps, cached: true };
+  }
+
+  let gaps = [];
+  try {
+    gaps = await askClaudeForGaps({ indexText, claudeBin });
+  } catch (e) {
+    console.error('[hub-inventory] gap analysis failed:', e.message);
+  }
+  await fsp.writeFile(CACHE_FILE, JSON.stringify({ signature, gaps, ts: Date.now() }, null, 2));
+  return { skills, knowledge, indexText, gaps, cached: false };
+}
+
+function invalidate() {
+  try { fs.unlinkSync(CACHE_FILE); } catch {}
+}
+
+module.exports = { load, invalidate, buildIndexText, derivePurpose, frontmatterField };

--- a/example/hub-tools/auto-hub-loop-v3/hub-loop-v3/prompts/extraction.md
+++ b/example/hub-tools/auto-hub-loop-v3/hub-loop-v3/prompts/extraction.md
@@ -1,0 +1,82 @@
+# Extraction Prompt (v3)
+
+> Drop this into your Phase 5 (Extract Skills) call. Replaces the
+> previous "produce N skills per cycle" prompt with a novelty-first
+> one that explicitly allows — and rewards — "nothing new this time".
+
+---
+
+## Template
+
+Use with placeholders: `{{APPS}}`, `{{COMPRESSED_INDEX}}`.
+`{{APPS}}` = the diffs / file contents of the 3 apps just built.
+`{{COMPRESSED_INDEX}}` = output of `hub-inventory.js` → `indexText`
+(one line per existing skill/knowledge, never the full SKILL.md bodies).
+
+```
+You are auditing 3 small apps that were just built for reusable
+patterns worth adding to a hub of skills and knowledge.
+
+# What's already in the hub
+
+{{COMPRESSED_INDEX}}
+
+# The apps
+
+{{APPS}}
+
+# Your task
+
+Find patterns in the apps that:
+  1. would genuinely help a FUTURE unrelated project, AND
+  2. are NOT already represented in the hub index above
+     (paraphrased versions count as already-represented), AND
+  3. are CONCRETE — a specific technique with a named failure
+     mode it fixes, not a vague principle.
+
+Most cycles will yield 0–2 such patterns. That is the expected
+outcome, not a failure. If nothing meets the bar, return the
+empty-object form below.
+
+# Hard rules
+
+- Do NOT produce slugs ending in `-visualization-pattern`,
+  `-simulation-pattern`, `-tool-pattern`, `-app-pattern`, or
+  `-dashboard-pattern`. These are templated placeholders, not
+  patterns.
+- Do NOT rename an existing hub item. If your candidate is
+  "basically the same idea as X already in the hub", drop it.
+- Do NOT invent a pattern to fill quota. Zero is a valid answer.
+- A candidate must be describable in ONE sentence with a concrete
+  technique AND a concrete problem it solves. If you can't do that,
+  it's not ready.
+
+# Output
+
+Return ONLY valid JSON (no prose, no code fences) of shape:
+
+{
+  "skills": [
+    {
+      "slug": "kebab-case-slug",
+      "kind": "skill",
+      "category": "one-of-existing-categories-or-new-one",
+      "purpose": "one sentence, ≤20 words, technique + problem",
+      "evidence": "file:lines in the apps where this appears",
+      "why_novel": "why the hub index above doesn't already cover it"
+    }
+  ],
+  "knowledge": [
+    {
+      "slug": "kebab-case-slug",
+      "kind": "knowledge",
+      "category": "...",
+      "purpose": "the insight in one sentence, ≤20 words",
+      "evidence": "where in the apps this insight was applied",
+      "why_novel": "..."
+    }
+  ]
+}
+
+If nothing qualifies, return exactly: {"skills": [], "knowledge": []}
+```

--- a/example/hub-tools/auto-hub-loop-v3/hub-loop-v3/theme-strategies.js
+++ b/example/hub-tools/auto-hub-loop-v3/hub-loop-v3/theme-strategies.js
@@ -1,0 +1,130 @@
+// theme-strategies.js
+// -------------------------------------------------------------
+// Optional replacement for pure-random theme generation. Provides
+// three weighted strategies so most cycles target hub gaps or
+// unusual combinations instead of drifting.
+//
+//   gap-driven    (default 60%) — theme built around a known gap
+//   combinatorial (default 30%) — 2–3 seeds from distinct categories
+//   exploratory   (default 10%) — original random drift channel
+//
+// NOT wired into server.js by default — available for opt-in.
+// Requires `inventory.gaps` (from hub-inventory with withGaps:true)
+// for gap-driven mode.
+// -------------------------------------------------------------
+
+const { spawn } = require('child_process');
+
+function callClaude(prompt, { claudeBin = 'claude', timeoutMs = 60_000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(claudeBin, ['-p'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      shell: process.platform === 'win32',
+      env: {
+        ...process.env,
+        DISABLE_OMC: '1',
+        OMC_SKIP_HOOKS: '*',
+        CLAUDE_DISABLE_SESSION_HOOKS: '1',
+      },
+    });
+    const kill = setTimeout(() => proc.kill('SIGKILL'), timeoutMs);
+    let out = '', err = '';
+    proc.stdout.on('data', d => out += d);
+    proc.stderr.on('data', d => err += d);
+    proc.on('close', code => {
+      clearTimeout(kill);
+      if (code !== 0) return reject(new Error(`claude exit ${code}: ${err.slice(0, 300)}`));
+      resolve(out.trim());
+    });
+    proc.stdin.end(prompt);
+  });
+}
+
+function weightedPick(weights) {
+  const entries = Object.entries(weights);
+  const total = entries.reduce((a, [, v]) => a + v, 0);
+  let r = Math.random() * total;
+  for (const [k, v] of entries) {
+    r -= v;
+    if (r <= 0) return k;
+  }
+  return entries[entries.length - 1][0];
+}
+
+function sampleDistinctCategories(items, n) {
+  const byCat = new Map();
+  for (const it of items) {
+    if (!byCat.has(it.category)) byCat.set(it.category, []);
+    byCat.get(it.category).push(it);
+  }
+  const cats = [...byCat.keys()];
+  if (cats.length < n) return null;
+  for (let i = cats.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [cats[i], cats[j]] = [cats[j], cats[i]];
+  }
+  return cats.slice(0, n).map(c => {
+    const bucket = byCat.get(c);
+    return bucket[Math.floor(Math.random() * bucket.length)];
+  });
+}
+
+async function gapDriven({ inventory, claudeBin }) {
+  const gaps = inventory.gaps || [];
+  if (!gaps.length) throw new Error('no gaps available');
+  const gap = gaps[Math.floor(Math.random() * gaps.length)];
+  const prompt = `Write ONE theme phrase (10–20 words) for a small app
+that would naturally explore this underdeveloped area of the hub:
+
+AREA: ${gap.area}
+WHY IT'S A GAP: ${gap.reason}
+
+The theme should be evocative and specific — not a category name.
+It should hint at 1–2 concrete mechanisms or metaphors. Return ONLY
+the phrase, no quotes, no preface.`;
+  const theme = await callClaude(prompt, { claudeBin });
+  return { theme: theme.split('\n')[0].trim(), mode: 'gap-driven', seeds: [gap] };
+}
+
+async function combinatorial({ inventory, claudeBin }) {
+  const pool = [...(inventory.skills || []), ...(inventory.knowledge || [])];
+  const seeds = sampleDistinctCategories(pool, 3) || sampleDistinctCategories(pool, 2);
+  if (!seeds) throw new Error('not enough category diversity');
+  const seedLines = seeds.map(s => `- \`${s.slug}\` [${s.category}] — ${s.purpose}`).join('\n');
+  const prompt = `These are existing hub items from DIFFERENT categories:
+
+${seedLines}
+
+Write ONE theme phrase (10–20 words) for a small app whose core
+concept meaningfully combines ideas from ALL of the above in a
+non-obvious way. The combination should feel surprising but
+coherent. Return ONLY the phrase.`;
+  const theme = await callClaude(prompt, { claudeBin });
+  return { theme: theme.split('\n')[0].trim(), mode: 'combinatorial', seeds };
+}
+
+async function exploratory({ claudeBin }) {
+  const prompt = `Write ONE evocative theme phrase (10–20 words) for a
+small creative app. It can be literary, scientific, whimsical, or
+mechanical — but specific. Return ONLY the phrase.`;
+  const theme = await callClaude(prompt, { claudeBin });
+  return { theme: theme.split('\n')[0].trim(), mode: 'exploratory', seeds: [] };
+}
+
+async function pick({ inventory, claudeBin = 'claude', weights } = {}) {
+  const w = weights || { gap: 0.6, combo: 0.3, random: 0.1 };
+  const tries = ['gap', 'combo', 'random'];
+  const chosen = weightedPick(w);
+  const order = [chosen, ...tries.filter(t => t !== chosen)];
+  let lastErr;
+  for (const mode of order) {
+    try {
+      if (mode === 'gap')    return await gapDriven({ inventory, claudeBin });
+      if (mode === 'combo')  return await combinatorial({ inventory, claudeBin });
+      if (mode === 'random') return await exploratory({ claudeBin });
+    } catch (e) { lastErr = e; }
+  }
+  throw lastErr || new Error('all theme strategies failed');
+}
+
+module.exports = { pick, gapDriven, combinatorial, exploratory };

--- a/example/hub-tools/auto-hub-loop-v3/index.html
+++ b/example/hub-tools/auto-hub-loop-v3/index.html
@@ -1,0 +1,1088 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hub Auto-Loop Dashboard</title>
+<style>
+:root {
+  --bg:#0f1117;--surface:#1a1d27;--surface2:#232733;--border:#2e3344;
+  --text:#e2e8f0;--dim:#8892a8;--accent:#6ee7b7;--accent2:#818cf8;
+  --warn:#fbbf24;--danger:#f87171;--info:#38bdf8;
+}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:'Segoe UI',-apple-system,sans-serif;background:var(--bg);color:var(--text);height:100vh;overflow:hidden;display:flex;flex-direction:column}
+header{display:flex;align-items:center;gap:16px;padding:0 20px;height:48px;background:var(--surface);border-bottom:1px solid var(--border)}
+header .logo{display:flex;align-items:center;gap:8px;font-weight:700;font-size:15px;color:var(--accent)}
+header .logo svg{flex-shrink:0}
+header .controls{margin-left:auto;display:flex;gap:8px;align-items:center}
+.btn{padding:5px 14px;border-radius:6px;font-size:12px;font-weight:600;cursor:pointer;border:1px solid transparent;transition:all .15s}
+.btn-go{background:var(--accent);color:#0f1117}.btn-go:hover{filter:brightness(1.1)}
+.btn-go:disabled{opacity:.4;cursor:not-allowed}
+.btn-stop{background:var(--danger);color:#fff}.btn-stop:hover{filter:brightness(1.1)}
+.btn-once{background:var(--accent2);color:#fff}.btn-once:hover{filter:brightness(1.1)}
+.btn-once:disabled{opacity:.4;cursor:not-allowed}
+.btn-stop:disabled{opacity:.4;cursor:not-allowed}
+.status-pill{font-size:11px;padding:3px 10px;border-radius:99px;font-weight:600;text-transform:uppercase}
+.status-idle{background:#2e3344;color:var(--dim)}
+.status-running{background:#065f4620;color:var(--accent);animation:pulse 2s infinite}
+.status-error{background:#7f1d1d40;color:var(--danger)}
+.usage-chip{display:inline-flex;align-items:center;gap:8px;padding:4px 10px;border-radius:99px;background:var(--surface2);border:1px solid var(--border);font-size:11px;font-weight:600;font-variant-numeric:tabular-nums;color:var(--dim)}
+.usage-chip .u-label{color:var(--dim);font-size:10px;text-transform:uppercase;letter-spacing:.6px}
+.usage-chip .u-seg{display:inline-flex;align-items:center;gap:3px}
+.usage-chip .u-val{font-size:12px;color:var(--text)}
+@keyframes pulse{0%,100%{opacity:1}50%{opacity:.6}}
+
+/* Heartbeat dot */
+.heartbeat{width:8px;height:8px;border-radius:50%;background:var(--accent);display:none;flex-shrink:0}
+.heartbeat.active{display:block;animation:heartbeat 1.2s ease-in-out infinite}
+@keyframes heartbeat{0%,100%{transform:scale(1);opacity:.6}30%{transform:scale(1.4);opacity:1}60%{transform:scale(1);opacity:.6}70%{transform:scale(1.2);opacity:.9}}
+
+main{flex:1;display:grid;grid-template-columns:1fr 1fr;grid-template-rows:auto 48px 1fr 1fr;gap:1px;background:var(--border);overflow:hidden}
+
+.panel{background:var(--surface);padding:12px 16px;overflow-y:auto;display:flex;flex-direction:column}
+.panel-header{display:flex;align-items:center;gap:8px;margin-bottom:8px;font-size:13px;font-weight:700;color:var(--accent);flex-shrink:0}
+.panel-header .count{background:var(--surface2);color:var(--dim);padding:1px 8px;border-radius:99px;font-size:11px;font-weight:600}
+
+/* Pipeline */
+.pipeline{grid-column:1/3;display:flex;align-items:center;gap:0;padding:12px 20px;background:var(--surface)}
+.phase{display:flex;align-items:center;gap:6px;padding:6px 14px;border-radius:6px;font-size:11px;font-weight:600;color:var(--dim);background:var(--surface2);position:relative;transition:all .3s}
+.phase.active{color:var(--bg);background:var(--accent);animation:phaseGlow 1.5s infinite;overflow:hidden}
+.phase.active::after{content:'';position:absolute;top:0;left:-100%;width:60%;height:100%;background:linear-gradient(90deg,transparent,rgba(255,255,255,.25),transparent);animation:shimmer 2s ease-in-out infinite}
+@keyframes shimmer{0%{left:-100%}100%{left:200%}}
+.phase .phase-elapsed{font-size:9px;opacity:.7;margin-left:2px;font-variant-numeric:tabular-nums}
+.phase.done{color:var(--accent);background:#065f4630}
+.phase.error{color:var(--danger);background:#7f1d1d30}
+@keyframes phaseGlow{0%,100%{box-shadow:0 0 0 0 #6ee7b740}50%{box-shadow:0 0 12px 2px #6ee7b740}}
+.phase-arrow{color:var(--border);font-size:16px;margin:0 4px;transition:color .3s}
+.phase-arrow.flowing{color:var(--accent);animation:arrowFlow 1.5s ease-in-out infinite}
+@keyframes arrowFlow{0%,100%{opacity:.4;transform:translateX(0)}50%{opacity:1;transform:translateX(3px)}}
+.cycle-badge{font-size:20px;font-weight:700;color:var(--accent);font-variant-numeric:tabular-nums}
+.keyword-chip{margin-left:auto;display:inline-flex;align-items:center;gap:6px;padding:5px 14px;border-radius:99px;background:linear-gradient(90deg,#818cf840,#f472b640);border:1.5px solid var(--accent2);font-size:13px;font-weight:700;color:#fff;text-transform:lowercase;animation:keywordPulse 2s ease-in-out infinite;box-shadow:0 0 12px rgba(129,140,248,.3)}
+.keyword-chip.hidden{display:none}
+.keyword-chip .keyword-icon{font-size:12px}
+.keyword-chip #keywordText{color:var(--text);font-family:'Cascadia Code','Fira Code',monospace;letter-spacing:.5px}
+@keyframes keywordPulse{0%,100%{box-shadow:0 0 0 0 #818cf830}50%{box-shadow:0 0 10px 2px #818cf840}}
+.cycle-label{font-size:11px;color:var(--dim);margin-right:4px}
+
+/* Activity canvas */
+.activity-strip{grid-column:1/3;height:48px;background:linear-gradient(90deg,var(--surface),var(--surface2),var(--surface));display:flex;align-items:center;padding:0 24px;gap:20px;border-top:1px solid var(--border);border-bottom:1px solid var(--border)}
+.status-slot{display:flex;flex-direction:column;justify-content:center;gap:2px;min-width:0}
+.status-elapsed{flex:0 0 auto}
+.status-phase{flex:0 0 auto}
+.status-theme{flex:1;min-width:0;overflow:hidden}
+.status-label{font-size:9px;font-weight:700;letter-spacing:1.2px;color:var(--dim);text-transform:uppercase;display:flex;align-items:center;gap:4px}
+.status-label #phaseIndex{color:var(--accent);font-variant-numeric:tabular-nums}
+.status-value{font-family:'Cascadia Code','Fira Code',monospace;font-size:13px;font-weight:700;color:var(--text);line-height:1.2;font-variant-numeric:tabular-nums;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.status-elapsed .status-value{color:var(--accent)}
+.status-phase .status-value{color:var(--accent2);text-transform:uppercase;letter-spacing:.5px}
+.status-theme .status-value{color:transparent;background:linear-gradient(90deg,var(--accent) 0%,var(--accent2) 50%,#f472b6 100%);-webkit-background-clip:text;background-clip:text;font-size:12px;font-weight:600;letter-spacing:.3px;animation:kwGlow 3s ease-in-out infinite;white-space:normal;line-height:1.25;max-height:2.5em;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical}
+.status-divider{width:1px;height:32px;background:linear-gradient(180deg,transparent,var(--border),transparent);flex-shrink:0}
+.status-value.swap{animation:kwGlow 3s ease-in-out infinite,valueSwap .4s ease-out}
+@keyframes valueSwap{0%{opacity:0;transform:translateY(4px)}100%{opacity:1;transform:translateY(0)}}
+.activity-keyword{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;gap:16px;pointer-events:none;z-index:2}
+.activity-keyword .kw-prefix{font-family:'Cascadia Code','Fira Code',monospace;font-size:10px;color:var(--dim);letter-spacing:2px;text-transform:uppercase}
+.activity-keyword .kw-word{font-family:'Cascadia Code','Fira Code',monospace;font-size:14px;font-weight:700;letter-spacing:.5px;background:linear-gradient(90deg,var(--accent) 0%,var(--accent2) 50%,#f472b6 100%);-webkit-background-clip:text;background-clip:text;color:transparent;animation:kwGlow 2.5s ease-in-out infinite;position:relative;max-width:80%;text-align:center;line-height:1.3;text-transform:none}
+/* pseudo-element dashes removed — phrase is long */
+@keyframes kwGlow{0%,100%{text-shadow:0 0 10px rgba(129,140,248,.4)}50%{text-shadow:0 0 30px rgba(244,114,182,.7),0 0 15px rgba(110,231,183,.5)}}
+.activity-keyword.swap .kw-word{animation:kwSwap .4s ease-out,kwGlow 2.5s ease-in-out infinite .4s}
+@keyframes kwSwap{0%{opacity:0;transform:translateY(10px) scale(.8)}60%{opacity:1;transform:translateY(-2px) scale(1.1)}100%{transform:translateY(0) scale(1)}}
+
+/* Apps list */
+.app-row{display:flex;align-items:center;gap:8px;padding:6px 8px;border-radius:4px;font-size:12px;border-bottom:1px solid var(--border)}
+.app-row:hover{background:var(--surface2)}
+.app-cycle{width:24px;height:24px;border-radius:50%;background:var(--surface2);display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;color:var(--accent);flex-shrink:0}
+.app-name{font-weight:600;flex:1}
+.app-lines{font-size:10px;color:var(--dim)}
+.app-status{font-size:10px;padding:2px 6px;border-radius:3px;font-weight:600}
+.app-status.built{background:#065f4630;color:var(--accent)}
+.app-status.published{background:#312e8140;color:var(--accent2)}
+.app-status.merged{background:#fbbf2420;color:var(--warn)}
+
+/* Skills/Knowledge */
+.skill-row{display:flex;align-items:center;gap:8px;padding:4px 8px;font-size:12px;border-bottom:1px solid var(--border);cursor:pointer;transition:background .12s}
+.skill-row:hover{background:var(--surface2)}
+.skill-badge{font-size:9px;padding:2px 6px;border-radius:3px;font-weight:700;flex-shrink:0}
+.skill-badge.skill{background:#818cf830;color:var(--accent2)}
+.skill-badge.knowledge{background:#38bdf830;color:var(--info)}
+.skill-name{flex:1;font-weight:500}
+.skill-cat{font-size:10px;color:var(--dim)}
+
+/* Log */
+.log-panel{font-family:'Cascadia Code','Fira Code',monospace;position:relative}
+
+/* Visualization panel */
+.viz-panel{background:linear-gradient(180deg,#151824 0%,var(--surface) 70%);position:relative;overflow:hidden;display:flex;flex-direction:column;padding:14px 16px;gap:10px}
+/* Recipe panel */
+.recipe-header{flex-shrink:0;padding:8px 12px;background:linear-gradient(90deg,#818cf815,#f472b615);border:1px solid var(--border);border-radius:6px}
+.recipe-theme{font-family:'Cascadia Code','Fira Code',monospace;font-size:11px;color:var(--accent2);line-height:1.5;font-style:italic;text-align:center}
+.recipe-body{flex:1;display:flex;flex-direction:column;gap:10px;overflow:hidden}
+.recipe-section{background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:10px 12px;flex:1;display:flex;flex-direction:column;min-height:0}
+.recipe-section-title{display:flex;align-items:center;gap:6px;font-size:11px;font-weight:700;color:var(--accent);text-transform:uppercase;letter-spacing:.5px;margin-bottom:8px;flex-shrink:0}
+.recipe-icon{font-size:13px}
+.recipe-count{margin-left:auto;background:var(--surface2);color:var(--dim);padding:1px 8px;border-radius:99px;font-size:10px;text-transform:none;letter-spacing:0}
+.recipe-list{flex:1;overflow-y:auto;overflow-x:hidden;display:flex;flex-direction:column;gap:3px;min-height:0}
+.recipe-empty{color:var(--dim);font-size:11px;font-style:italic;text-align:center;padding:12px}
+.recipe-item{display:flex;align-items:center;gap:8px;padding:4px 8px;background:var(--surface2);border-radius:4px;font-size:11px;animation:recipeItemIn .3s ease-out;transition:background .2s,box-shadow .2s;cursor:pointer;min-width:0}
+.recipe-item:hover{background:var(--border);box-shadow:inset 2px 0 0 var(--accent2)}
+.recipe-item:active{background:var(--surface2);transform:scale(.98)}
+.recipe-item-name{min-width:0;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+/* Hub Item Modal */
+.hub-item-modal{position:fixed;inset:0;background:rgba(0,0,0,.7);display:none;align-items:center;justify-content:center;z-index:1000;backdrop-filter:blur(4px)}
+.hub-item-modal.visible{display:flex;animation:modalFadeIn .2s ease-out}
+@keyframes modalFadeIn{from{opacity:0}to{opacity:1}}
+.hub-item-content{background:var(--surface);border:1px solid var(--border);border-radius:10px;width:min(800px,90vw);max-height:85vh;display:flex;flex-direction:column;overflow:hidden;box-shadow:0 20px 60px rgba(0,0,0,.5)}
+.hub-item-header{display:flex;align-items:center;gap:12px;padding:14px 18px;background:var(--surface2);border-bottom:1px solid var(--border);flex-shrink:0}
+.hub-item-kind{font-size:10px;font-weight:700;letter-spacing:1px;padding:3px 10px;border-radius:4px;text-transform:uppercase}
+.hub-item-kind.skill{background:#818cf830;color:var(--accent2)}
+.hub-item-kind.knowledge{background:#38bdf830;color:var(--info)}
+.hub-item-title-name{flex:1;font-family:'Cascadia Code','Fira Code',monospace;font-size:14px;font-weight:600;color:var(--text)}
+.hub-item-close{background:none;border:none;color:var(--dim);font-size:24px;cursor:pointer;padding:0 8px;line-height:1;transition:color .15s}
+.hub-item-close:hover{color:var(--danger)}
+.hub-item-path{padding:6px 18px;font-family:'Cascadia Code','Fira Code',monospace;font-size:10px;color:var(--dim);background:var(--bg);border-bottom:1px solid var(--border);flex-shrink:0}
+.hub-item-body{margin:0;padding:18px;font-family:'Cascadia Code','Fira Code',monospace;font-size:12px;line-height:1.6;color:var(--text);overflow-y:auto;flex:1;white-space:pre-wrap;word-break:break-word;background:var(--bg)}
+@keyframes recipeItemIn{from{opacity:0;transform:translateX(-8px)}to{opacity:1;transform:translateX(0)}}
+.recipe-item-bullet{width:5px;height:5px;border-radius:50%;background:var(--accent);flex-shrink:0}
+.recipe-item-bullet.knowledge{background:var(--info)}
+.recipe-item-name{font-family:'Cascadia Code','Fira Code',monospace;color:var(--text);font-weight:500}
+.recipe-item-cat{margin-left:auto;font-size:9px;color:var(--dim);background:var(--bg);padding:1px 6px;border-radius:3px;text-transform:uppercase;letter-spacing:.5px}
+.recipe-footer{flex-shrink:0;padding:6px 12px;font-size:10px;color:var(--dim);text-align:center;border-top:1px dashed var(--border)}
+.recipe-pool-stat b{color:var(--accent);font-variant-numeric:tabular-nums}
+.hidden{display:none !important}
+/* Pixel scene backdrop */
+.pixel-scene{position:absolute;inset:0;z-index:1}
+.pixel-sky{position:absolute;top:0;left:0;right:0;height:65%;background:linear-gradient(180deg,#1e1b4b 0%,#312e81 50%,#4c1d95 100%);image-rendering:pixelated}
+.pixel-sky::before{content:'';position:absolute;inset:0;background-image:
+  radial-gradient(circle 2px at 12% 20%, #fef3c7 100%, transparent 100%),
+  radial-gradient(circle 2px at 28% 40%, #fef3c7 100%, transparent 100%),
+  radial-gradient(circle 2px at 45% 15%, #fef3c7 100%, transparent 100%),
+  radial-gradient(circle 2px at 62% 35%, #a5b4fc 100%, transparent 100%),
+  radial-gradient(circle 2px at 78% 22%, #fef3c7 100%, transparent 100%),
+  radial-gradient(circle 2px at 88% 50%, #fbcfe8 100%, transparent 100%),
+  radial-gradient(circle 2px at 15% 55%, #c7d2fe 100%, transparent 100%),
+  radial-gradient(circle 2px at 35% 60%, #fef3c7 100%, transparent 100%);
+  animation:twinkle 3s steps(2) infinite;image-rendering:pixelated}
+@keyframes twinkle{0%,100%{opacity:.9}50%{opacity:.3}}
+.pixel-window{position:absolute;top:12%;right:10%;width:28%;height:36%;background:
+  linear-gradient(180deg,#60a5fa 0%,#3b82f6 60%,#1e40af 100%);
+  border:4px solid #1f2937;box-shadow:inset 0 0 0 2px #374151, inset 0 0 0 4px #111827;image-rendering:pixelated}
+.pixel-window::before{content:'';position:absolute;top:0;left:50%;width:2px;height:100%;background:#1f2937;transform:translateX(-1px)}
+.pixel-window::after{content:'';position:absolute;top:50%;left:0;width:100%;height:2px;background:#1f2937;transform:translateY(-1px)}
+.pixel-floor{position:absolute;bottom:0;left:0;right:0;height:35%;background:
+  repeating-linear-gradient(90deg, #1f2937 0, #1f2937 32px, #111827 32px, #111827 34px),
+  linear-gradient(180deg, #374151 0%, #1f2937 20px, #111827 100%);
+  background-blend-mode:multiply;image-rendering:pixelated;border-top:3px solid #6ee7b7;box-shadow:0 -4px 0 rgba(110,231,183,.2)}
+.pixel-floor::before{content:'';position:absolute;top:0;left:0;right:0;height:30px;background:repeating-linear-gradient(0deg,transparent 0,transparent 6px,rgba(110,231,183,.08) 6px,rgba(110,231,183,.08) 8px)}
+.pixel-wall-grid{position:absolute;inset:0;pointer-events:none;background-image:
+  linear-gradient(rgba(110,231,183,.04) 1px, transparent 1px),
+  linear-gradient(90deg, rgba(110,231,183,.04) 1px, transparent 1px);
+  background-size:16px 16px;image-rendering:pixelated}
+.agent-label{position:absolute;top:10px;left:12px;font-size:10px;color:var(--dim);font-weight:600;text-transform:uppercase;letter-spacing:.5px;display:flex;align-items:center;gap:6px}
+.agent-label::before{content:'';width:6px;height:6px;border-radius:50%;background:var(--accent);animation:pulse 1.5s infinite}
+.speech-bubble{position:absolute;top:14%;left:50%;transform:translateX(-50%);background:var(--surface2);border:1px solid var(--border);color:var(--text);padding:6px 12px;border-radius:12px;font-size:11px;font-weight:500;white-space:nowrap;opacity:0;transition:opacity .3s;max-width:90%;text-align:center}
+.speech-bubble::after{content:'';position:absolute;bottom:-6px;left:50%;transform:translateX(-50%);width:0;height:0;border-left:6px solid transparent;border-right:6px solid transparent;border-top:6px solid var(--surface2)}
+.speech-bubble.visible{opacity:1}
+.speech-bubble .emoji{margin-right:4px}
+.agent-idle-status{position:absolute;bottom:12px;right:14px;font-size:10px;color:var(--dim);font-variant-numeric:tabular-nums}
+/* Pixel-art Agent Character */
+.agent-img-wrap{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:60%;max-width:360px;aspect-ratio:1;display:flex;align-items:center;justify-content:center;pointer-events:none;z-index:5;transition:width .5s ease}
+.agent-img-wrap.trio{width:95%;max-width:560px;gap:2%}
+.agent-img-wrap.trio .agent-character{width:30%;height:auto}
+.agent-img-wrap.trio .agent-character.extra{animation-name:idleWalk}
+.agent-character{
+  width:48px;height:48px;
+  background-image:url('move.jpg');
+  background-repeat:no-repeat;
+  background-position:0 0;
+  image-rendering:pixelated;
+  image-rendering:crisp-edges;
+  transform:scale(4.5);
+  transform-origin:center center;
+  animation:spriteWalk 1.1s steps(12) infinite;
+  filter:drop-shadow(1px 2px 0 rgba(0,0,0,.4));
+}
+.agent-img-wrap.trio .agent-character{transform:scale(3)}
+@keyframes spriteWalk{
+  from{background-position-x:0}
+  to{background-position-x:-576px}
+}
+/* Phase-specific sprite rows (background-position-y) and speeds */
+.agent .agent-character{background-position-y:0}
+.agent.thinking .agent-character{background-position-y:-48px;animation-duration:1.6s}
+.agent.working  .agent-character{background-position-y:-96px;animation-duration:.55s}
+.agent.sending  .agent-character{background-position-y:-144px;animation-duration:.7s}
+.agent.reading  .agent-character{background-position-y:-192px;animation-duration:1.4s}
+.agent.installing .agent-character{background-position-y:-240px;animation-duration:.8s}
+.agent.celebrating .agent-character{background-position-y:-288px;animation-duration:.5s}
+/* Character color variants per agent identity */
+.agent-character[data-hue="0"]{filter:drop-shadow(1px 2px 0 rgba(0,0,0,.4))}
+.agent-character[data-hue="30"]{filter:hue-rotate(30deg) saturate(1.15) drop-shadow(1px 2px 0 rgba(0,0,0,.4))}
+.agent-character[data-hue="70"]{filter:hue-rotate(70deg) saturate(1.1) drop-shadow(1px 2px 0 rgba(0,0,0,.4))}
+.agent-character[data-hue="140"]{filter:hue-rotate(140deg) saturate(1.2) drop-shadow(1px 2px 0 rgba(0,0,0,.4))}
+.agent-character[data-hue="180"]{filter:hue-rotate(180deg) saturate(1.1) drop-shadow(1px 2px 0 rgba(0,0,0,.4))}
+.agent-character[data-hue="220"]{filter:hue-rotate(220deg) saturate(1.15) drop-shadow(1px 2px 0 rgba(0,0,0,.4))}
+.agent-character[data-hue="280"]{filter:hue-rotate(280deg) saturate(1.1) drop-shadow(1px 2px 0 rgba(0,0,0,.4))}
+/* Name tag under each agent */
+.agent-character{position:relative}
+.agent-name-tag{position:absolute;bottom:-16px;left:50%;transform:translateX(-50%);font-size:9px;font-weight:700;letter-spacing:.5px;color:var(--text);background:var(--surface);padding:2px 6px;border-radius:3px;border:1px solid var(--border);white-space:nowrap;z-index:6;pointer-events:none}
+.agent-img-wrap.trio .agent-name-tag{bottom:-12px;font-size:8px}
+/* Extra motion layered on top via wrapper */
+.agent-img-wrap{animation:charBob 1.1s steps(4) infinite}
+@keyframes charBob{0%,100%{margin-top:0}50%{margin-top:-6px}}
+.agent.working .agent-img-wrap,.agent.working + .agent-img-wrap{animation-duration:.55s}
+.agent.celebrating .agent-img-wrap{animation:charJump .8s ease-out}
+@keyframes charJump{0%{transform:translate(-50%,-50%)}30%{transform:translate(-50%,calc(-50% - 40px))}60%{transform:translate(-50%,calc(-50% - 10px))}100%{transform:translate(-50%,-50%)}}
+/* Swap flash */
+.agent-character.swap{animation:spriteWalk 1.1s steps(12) infinite, flashIn .4s ease-out}
+@keyframes flashIn{0%{filter:brightness(2) drop-shadow(1px 2px 0 rgba(0,0,0,.4))}100%{filter:drop-shadow(1px 2px 0 rgba(0,0,0,.4))}}
+/* Ground shadow */
+.agent-img-wrap::after{
+  content:'';position:absolute;bottom:6%;left:50%;transform:translateX(-50%);
+  width:40%;height:10px;background:radial-gradient(ellipse,rgba(0,0,0,.5) 0%,transparent 70%);
+  animation:shadowBob 1.1s steps(4) infinite;z-index:-1;pointer-events:none;
+}
+.agent-img-wrap.trio::after{display:none}
+@keyframes shadowBob{0%,50%,100%{width:40%;opacity:.6}25%,75%{width:32%;opacity:.3}}
+/* Tool badge */
+.agent-tool-badge{position:absolute;top:-8%;right:-4%;width:56px;height:56px;display:flex;align-items:center;justify-content:center;font-size:32px;background:var(--surface);border:2px solid var(--accent);border-radius:50%;opacity:0;transform:scale(0);transition:all .3s cubic-bezier(.34,1.56,.64,1);box-shadow:0 4px 12px rgba(110,231,183,.4);animation:toolFloat 2s ease-in-out infinite}
+.agent-tool-badge.visible{opacity:1;transform:scale(1)}
+@keyframes toolFloat{0%,100%{transform:scale(1) translateY(0)}50%{transform:scale(1) translateY(-4px)}}
+/* Sparkle */
+.agent-sparkle{position:absolute;top:-4%;left:-4%;font-size:22px;opacity:0;transition:opacity .3s;pointer-events:none;animation:sparkleBlink 1.5s ease-in-out infinite}
+.agent-sparkle.visible{opacity:1}
+@keyframes sparkleBlink{0%,100%{transform:scale(1) rotate(0);opacity:.6}50%{transform:scale(1.2) rotate(20deg);opacity:1}}
+/* Antenna light (unused but kept harmless) */
+.agent-antenna-light{animation:antennaBlink 1.5s ease-in-out infinite}
+@keyframes antennaBlink{0%,100%{opacity:.4}50%{opacity:1}}
+/* Screen glow */
+.screen-content line{animation:codeScroll 4s linear infinite}
+@keyframes codeScroll{0%{opacity:0;transform:translateX(-2px)}10%{opacity:1}90%{opacity:1}100%{opacity:0;transform:translateX(2px)}}
+.screen-glow{animation:screenGlow 2s ease-in-out infinite}
+@keyframes screenGlow{0%,100%{opacity:.3}50%{opacity:.6}}
+/* Particles flying around */
+.agent-particle{opacity:0;transform-origin:center}
+.agent-particle.active{animation:particleFly 1.2s ease-out forwards}
+@keyframes particleFly{0%{opacity:1;transform:translate(0,0) scale(.5)}100%{opacity:0;transform:translate(var(--dx),var(--dy)) scale(1.2)}}
+.log-cursor{display:none;font-size:11px;padding:1px 0;line-height:1.5;color:var(--accent);animation:blink 1s step-end infinite}
+.log-cursor.active{display:block}
+@keyframes blink{0%,100%{opacity:1}50%{opacity:0}}
+.log-line{font-size:11px;padding:1px 0;line-height:1.5;white-space:pre-wrap;word-break:break-all;animation:fadeIn .3s ease-out}
+@keyframes fadeIn{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:translateY(0)}}
+.log-line.info{color:var(--dim)}
+.log-line.success{color:var(--accent)}
+.log-line.warn{color:var(--warn)}
+.log-line.error{color:var(--danger)}
+.log-line.phase{color:var(--accent2);font-weight:700}
+
+/* Stats bar */
+.stats-bar{grid-column:1/3;display:flex;align-items:center;gap:20px;padding:6px 20px;background:var(--surface);font-size:11px;color:var(--dim);border-top:1px solid var(--border)}
+.stat{display:flex;align-items:center;gap:4px}
+.stat b{color:var(--text);font-variant-numeric:tabular-nums}
+
+::-webkit-scrollbar{width:5px}::-webkit-scrollbar-track{background:var(--bg)}::-webkit-scrollbar-thumb{background:var(--border);border-radius:3px}
+</style>
+</head>
+<body>
+<header>
+  <div class="logo">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="#6ee7b7" stroke-width="2"/><path d="M8 12l2 2 4-4" stroke="#6ee7b7" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+    <span>Hub Auto-Loop</span>
+  </div>
+  <div class="heartbeat" id="heartbeat"></div>
+  <span class="status-pill status-idle" id="statusPill">IDLE</span>
+  <div class="usage-chip" id="usageChip" title="Auto-hub-loop token usage (accumulated from claude -p JSON output)">
+    <span class="u-label">LOOP USED</span>
+    <span class="u-seg"><span class="u-label">in</span><span class="u-val" id="uTokIn">0</span></span>
+    <span class="u-seg"><span class="u-label">out</span><span class="u-val" id="uTokOut">0</span></span>
+    <span class="u-seg"><span class="u-label">$</span><span class="u-val" id="uCost">0.00</span></span>
+    <span class="u-seg"><span class="u-label">calls</span><span class="u-val" id="uCalls">0</span></span>
+    <span class="u-seg" title="Estimated % of your 5-hour plan limit consumed by this loop (runtime-calibrated)"><span class="u-label">5h</span><span class="u-val" id="uPct5h">—</span></span>
+  </div>
+  <div class="controls">
+    <button class="btn btn-go" id="btnStart" onclick="start()">Start Loop</button>
+    <button class="btn btn-once" id="btnOnce" onclick="runOnce()">Run Once</button>
+    <button class="btn btn-stop" id="btnStop" onclick="stop()" disabled>Stop</button>
+  </div>
+</header>
+
+<main>
+  <!-- Pipeline phases -->
+  <div class="pipeline" id="pipeline">
+    <div class="phase" data-phase="generate" id="ph-generate">Generate Ideas</div>
+    <span class="phase-arrow">→</span>
+    <div class="phase" data-phase="build">Build Apps</div>
+    <span class="phase-arrow">→</span>
+    <div class="phase" data-phase="publish">Publish PRs</div>
+    <span class="phase-arrow">→</span>
+    <div class="phase" data-phase="merge">Auto-Merge</div>
+    <span class="phase-arrow">→</span>
+    <div class="phase" data-phase="extract">Extract Skills</div>
+    <span class="phase-arrow">→</span>
+    <div class="phase" data-phase="publish-sk">Publish S/K</div>
+    <span class="phase-arrow">→</span>
+    <div class="phase" data-phase="install">Install All</div>
+    <span class="phase-arrow">→</span>
+    <div class="phase" data-phase="loop">Loop ↺</div>
+    <span class="cycle-label" style="margin-left:auto">CYCLE</span>
+    <span class="cycle-badge" id="cycleNum">0</span>
+  </div>
+
+  <!-- Status strip: elapsed / phase / theme -->
+  <div class="activity-strip" id="activityStrip">
+    <div class="status-slot status-elapsed">
+      <span class="status-label">ELAPSED</span>
+      <span class="status-value" id="phaseElapsed">00:00</span>
+    </div>
+    <div class="status-divider"></div>
+    <div class="status-slot status-phase">
+      <span class="status-label">PHASE <span id="phaseIndex">—/7</span></span>
+      <span class="status-value" id="phaseName">IDLE</span>
+    </div>
+    <div class="status-divider"></div>
+    <div class="status-slot status-theme">
+      <span class="status-label">✨ THEME</span>
+      <span class="status-value" id="kwWord">—</span>
+    </div>
+    <!-- Legacy wrap for compat (not used visually anymore) -->
+    <div class="activity-keyword" id="activityKeyword" style="display:none"></div>
+  </div>
+
+  <!-- Apps built -->
+  <div class="panel" id="appsPanel">
+    <div class="panel-header">Apps Built <span class="count" id="appCount">0</span></div>
+    <div id="appsList" style="flex:1;overflow-y:auto"></div>
+  </div>
+
+  <!-- Skills & Knowledge acquired -->
+  <div class="panel" id="skillsPanel">
+    <div class="panel-header">Skills & Knowledge <span class="count" id="skCount">0</span></div>
+    <div id="skList" style="flex:1;overflow-y:auto"></div>
+  </div>
+
+  <!-- Log stream -->
+  <div class="panel log-panel">
+    <div class="panel-header">Log <span class="count" id="logCount">0</span>
+      <button class="btn" style="margin-left:auto;padding:2px 8px;font-size:10px;background:var(--surface2);color:var(--dim);border:1px solid var(--border)" onclick="copyLog()" id="btnCopyLog">Copy Log</button>
+    </div>
+    <div id="logContainer" style="flex:1;overflow-y:auto"></div>
+    <div class="log-cursor" id="logCursor">_</div>
+  </div>
+
+  <!-- Cycle Recipe panel -->
+  <div class="viz-panel">
+    <span class="agent-label">Cycle Recipe</span>
+    <div class="recipe-header">
+      <div class="recipe-theme" id="recipeTheme">Waiting for cycle start...</div>
+    </div>
+    <div class="recipe-body">
+      <div class="recipe-section">
+        <div class="recipe-section-title"><span class="recipe-icon">🎯</span> Applied Skills <span class="recipe-count" id="recipeAppliedCount">0</span></div>
+        <div class="recipe-list" id="recipeApplied"><div class="recipe-empty">— awaiting apps —</div></div>
+      </div>
+      <div class="recipe-section">
+        <div class="recipe-section-title"><span class="recipe-icon">⚠️</span> Respecting Knowledge <span class="recipe-count" id="recipeKnowledgeCount">0</span></div>
+        <div class="recipe-list" id="recipeKnowledge"><div class="recipe-empty">— awaiting apps —</div></div>
+      </div>
+      <div class="recipe-footer">
+        <span class="recipe-pool-stat">Pool scanned: <b id="recipePoolSkills">0</b> skills · <b id="recipePoolKnowledge">0</b> knowledge</span>
+      </div>
+    </div>
+    <!-- Legacy: hidden but kept for JS compatibility -->
+    <div class="speech-bubble hidden" id="speechBubble"><span class="emoji">💤</span>—</div>
+    <!-- Legacy hidden stubs (kept so old JS hooks don't throw) -->
+    <div class="agent-img-wrap hidden" id="agent" style="display:none">
+      <div class="agent-character" id="agentImg"></div>
+      <div class="agent-tool-badge" id="agentToolBadge"></div>
+      <div class="agent-sparkle" id="agentSparkle"></div>
+    </div>
+    <div class="agent-idle-status hidden" id="agentIdleStatus" style="display:none">Standby</div>
+  </div>
+</main>
+
+<div class="stats-bar">
+  <div class="stat">Uptime: <b id="statUptime">00:00:00</b></div>
+  <div class="stat">Total Apps: <b id="statApps">0</b></div>
+  <div class="stat">Total Skills: <b id="statSkills">0</b></div>
+  <div class="stat">Total Knowledge: <b id="statKnowledge">0</b></div>
+  <div class="stat">PRs Created: <b id="statPrs">0</b></div>
+  <div class="stat">Lines Generated: <b id="statLines">0</b></div>
+</div>
+
+<!-- Hub Item Preview Modal -->
+<div class="hub-item-modal" id="hubItemModal" onclick="if(event.target===this)closeHubItem()">
+  <div class="hub-item-content">
+    <div class="hub-item-header">
+      <span class="hub-item-kind skill" id="hubItemKind">SKILL</span>
+      <span class="hub-item-title-name" id="hubItemTitle">—</span>
+      <button class="hub-item-close" onclick="closeHubItem()">×</button>
+    </div>
+    <div class="hub-item-path" id="hubItemPath">—</div>
+    <pre class="hub-item-body" id="hubItemBody">...</pre>
+  </div>
+</div>
+
+<script>
+const API = '';
+let evtSource = null;
+let startTime = null;
+let phaseStartTime = null;
+let isRunning = false;
+
+function start() {
+  fetch(API + '/api/start', { method: 'POST' });
+  document.getElementById('btnStart').disabled = true;
+  document.getElementById('btnOnce').disabled = true;
+  document.getElementById('btnStop').disabled = false;
+  startTime = Date.now();
+  connectSSE();
+}
+
+function runOnce() {
+  fetch(API + '/api/run-once', { method: 'POST' });
+  document.getElementById('btnStart').disabled = true;
+  document.getElementById('btnOnce').disabled = true;
+  document.getElementById('btnStop').disabled = false;
+  startTime = Date.now();
+  connectSSE();
+}
+
+function stop() {
+  fetch(API + '/api/stop', { method: 'POST' });
+  document.getElementById('btnStart').disabled = false;
+  document.getElementById('btnOnce').disabled = false;
+  document.getElementById('btnStop').disabled = true;
+}
+
+function connectSSE() {
+  if (evtSource) evtSource.close();
+  evtSource = new EventSource(API + '/events');
+  evtSource.onmessage = (e) => {
+    const data = JSON.parse(e.data);
+    handleEvent(data);
+  };
+  evtSource.onerror = () => {
+    setTimeout(connectSSE, 3000);
+  };
+}
+
+function handleEvent(data) {
+  switch(data.type) {
+    case 'state': updateFullState(data); break;
+    case 'log': addLog(data.level, data.message); break;
+    case 'phase': setPhase(data.phase, data.status); break;
+    case 'cycle': setCycle(data.cycle, data.keyword); break;
+    case 'recipe': renderRecipe(data); break;
+    case 'app': addApp(data.app); break;
+    case 'skill': addSkill(data.skill); break;
+    case 'stats': updateStats(data.stats); break;
+    case 'status': setStatus(data.status); break;
+  }
+}
+
+function setStatus(status) {
+  const pill = document.getElementById('statusPill');
+  pill.textContent = status.toUpperCase();
+  pill.className = 'status-pill status-' + status;
+  isRunning = status === 'running';
+  document.getElementById('heartbeat').className = 'heartbeat' + (isRunning ? ' active' : '');
+  document.getElementById('logCursor').className = 'log-cursor' + (isRunning ? ' active' : '');
+  // Toggle flowing arrows
+  document.querySelectorAll('.phase-arrow').forEach(el => {
+    el.className = 'phase-arrow' + (isRunning ? ' flowing' : '');
+  });
+  if (status === 'idle') {
+    document.getElementById('btnStart').disabled = false;
+    document.getElementById('btnOnce').disabled = false;
+    document.getElementById('btnStop').disabled = true;
+    phaseStartTime = null;
+  }
+}
+
+function setCycle(n, keyword) {
+  document.getElementById('cycleNum').textContent = n;
+  const kwWord = document.getElementById('kwWord');
+  if (kwWord && keyword) {
+    if (kwWord.textContent.trim() !== keyword) {
+      kwWord.textContent = keyword;
+      kwWord.classList.remove('swap');
+      void kwWord.offsetWidth;
+      kwWord.classList.add('swap');
+    }
+  } else if (kwWord && n === 0) {
+    kwWord.textContent = '—';
+  }
+  // Update recipe theme line
+  const theme = document.getElementById('recipeTheme');
+  if (theme && keyword) theme.textContent = `"${keyword}"`;
+}
+
+function renderRecipe(data) {
+  const theme = document.getElementById('recipeTheme');
+  if (theme && data.keyword) theme.textContent = `"${data.keyword}"`;
+  const applied = data.applied || [];
+  const knowledge = data.respecting || [];
+  const poolS = data.poolSkills || 0;
+  const poolK = data.poolKnowledge || 0;
+
+  const appliedEl = document.getElementById('recipeApplied');
+  const knowledgeEl = document.getElementById('recipeKnowledge');
+  document.getElementById('recipeAppliedCount').textContent = applied.length;
+  document.getElementById('recipeKnowledgeCount').textContent = knowledge.length;
+  document.getElementById('recipePoolSkills').textContent = poolS;
+  document.getElementById('recipePoolKnowledge').textContent = poolK;
+
+  if (applied.length === 0) {
+    appliedEl.innerHTML = '<div class="recipe-empty">— none cited —</div>';
+  } else {
+    appliedEl.innerHTML = applied.map(s => `
+      <div class="recipe-item" data-kind="skill" data-name="${s.name || s}" onclick="openHubItem('skill', '${s.name || s}')">
+        <span class="recipe-item-bullet"></span>
+        <span class="recipe-item-name">${s.name || s}</span>
+        ${s.category ? `<span class="recipe-item-cat">${s.category}</span>` : ''}
+      </div>`).join('');
+  }
+
+  if (knowledge.length === 0) {
+    knowledgeEl.innerHTML = '<div class="recipe-empty">— none cited —</div>';
+  } else {
+    knowledgeEl.innerHTML = knowledge.map(k => `
+      <div class="recipe-item" data-kind="knowledge" data-name="${k.name || k}" onclick="openHubItem('knowledge', '${k.name || k}')">
+        <span class="recipe-item-bullet knowledge"></span>
+        <span class="recipe-item-name">${k.name || k}</span>
+        ${k.category ? `<span class="recipe-item-cat">${k.category}</span>` : ''}
+      </div>`).join('');
+  }
+}
+
+async function openHubItem(kind, name) {
+  const modal = document.getElementById('hubItemModal');
+  const titleEl = document.getElementById('hubItemTitle');
+  const kindEl = document.getElementById('hubItemKind');
+  const pathEl = document.getElementById('hubItemPath');
+  const bodyEl = document.getElementById('hubItemBody');
+  titleEl.textContent = name;
+  kindEl.textContent = kind.toUpperCase();
+  kindEl.className = 'hub-item-kind ' + kind;
+  pathEl.textContent = 'loading...';
+  bodyEl.textContent = '...';
+  modal.classList.add('visible');
+  try {
+    const r = await fetch(`/api/hub-item?kind=${encodeURIComponent(kind)}&name=${encodeURIComponent(name)}`);
+    if (!r.ok) throw new Error('not found');
+    const data = await r.json();
+    pathEl.textContent = data.path;
+    bodyEl.textContent = data.content;
+  } catch (err) {
+    pathEl.textContent = '(error)';
+    bodyEl.textContent = `Failed to load: ${err.message}`;
+  }
+}
+function closeHubItem() {
+  document.getElementById('hubItemModal').classList.remove('visible');
+}
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') closeHubItem();
+});
+
+function setPhase(phase, status) {
+  document.querySelectorAll('.phase').forEach(el => {
+    // Remove any existing elapsed timer
+    const oldTimer = el.querySelector('.phase-elapsed');
+    if (oldTimer) oldTimer.remove();
+    if (el.dataset.phase === phase) {
+      el.className = 'phase ' + (status || 'active');
+      if (status === 'active' || !status) {
+        phaseStartTime = Date.now();
+        const timer = document.createElement('span');
+        timer.className = 'phase-elapsed';
+        timer.id = 'phaseTimer';
+        timer.textContent = '0s';
+        el.appendChild(timer);
+      }
+    }
+  });
+}
+
+function resetPhases() {
+  document.querySelectorAll('.phase').forEach(el => el.className = 'phase');
+}
+
+function addApp(app) {
+  const list = document.getElementById('appsList');
+  const row = document.createElement('div');
+  row.className = 'app-row';
+  row.innerHTML = `
+    <span class="app-cycle">${app.cycle}</span>
+    <span class="app-name">${app.name}</span>
+    <span class="app-lines">${app.lines || '?'} lines</span>
+    <span class="app-status ${app.status}">${app.status}</span>
+  `;
+  list.insertBefore(row, list.firstChild);
+  document.getElementById('appCount').textContent = list.children.length;
+}
+
+function addSkill(sk) {
+  const list = document.getElementById('skList');
+  const row = document.createElement('div');
+  row.className = 'skill-row';
+  row.title = `Click to view ${sk.type === 'skill' ? 'SKILL.md' : sk.name + '.md'}`;
+  row.onclick = () => openHubItem(sk.type, sk.name);
+  row.innerHTML = `
+    <span class="skill-badge ${sk.type}">${sk.type === 'skill' ? 'SKILL' : 'KNOW'}</span>
+    <span class="skill-name">${sk.name}</span>
+    <span class="skill-cat">${sk.category}</span>
+  `;
+  list.insertBefore(row, list.firstChild);
+  document.getElementById('skCount').textContent = list.children.length;
+}
+
+function addLog(level, msg) {
+  const container = document.getElementById('logContainer');
+  const line = document.createElement('div');
+  line.className = 'log-line ' + (level || 'info');
+  const ts = new Date().toLocaleTimeString('en-GB', {hour12:false});
+  line.textContent = `[${ts}] ${msg}`;
+  container.appendChild(line);
+  // Move cursor after last log line
+  const cursor = document.getElementById('logCursor');
+  if (cursor) container.parentNode.insertBefore(cursor, container.nextSibling);
+  container.scrollTop = container.scrollHeight;
+  const count = container.children.length;
+  document.getElementById('logCount').textContent = count;
+  while (container.children.length > 150) container.removeChild(container.firstChild);
+}
+
+function updateStats(s) {
+  document.getElementById('statApps').textContent = s.apps || 0;
+  document.getElementById('statSkills').textContent = s.skills || 0;
+  document.getElementById('statKnowledge').textContent = s.knowledge || 0;
+  document.getElementById('statPrs').textContent = s.prs || 0;
+  document.getElementById('statLines').textContent = (s.lines || 0).toLocaleString();
+}
+
+function updateFullState(data) {
+  setStatus(data.status);
+  setCycle(data.cycle || 0, data.keyword);
+  if (data.apps) data.apps.forEach(a => addApp(a));
+  if (data.skills) data.skills.forEach(s => addSkill(s));
+  if (data.stats) updateStats(data.stats);
+  if (data.status === 'running') {
+    document.getElementById('btnStart').disabled = true;
+    document.getElementById('btnStop').disabled = false;
+    startTime = Date.now() - (data.uptime || 0);
+  }
+}
+
+function copyLog() {
+  const lines = Array.from(document.getElementById('logContainer').children).map(el => el.textContent);
+  const text = lines.join('\n');
+  navigator.clipboard.writeText(text).then(() => {
+    const btn = document.getElementById('btnCopyLog');
+    btn.textContent = 'Copied!';
+    btn.style.color = 'var(--accent)';
+    setTimeout(() => { btn.textContent = 'Copy Log'; btn.style.color = ''; }, 2000);
+  });
+}
+
+// Uptime + phase elapsed ticker
+setInterval(() => {
+  if (!startTime) return;
+  const s = Math.floor((Date.now() - startTime) / 1000);
+  const h = String(Math.floor(s/3600)).padStart(2,'0');
+  const m = String(Math.floor((s%3600)/60)).padStart(2,'0');
+  const sec = String(s%60).padStart(2,'0');
+  document.getElementById('statUptime').textContent = `${h}:${m}:${sec}`;
+  // Phase elapsed timer
+  const timer = document.getElementById('phaseTimer');
+  if (timer && phaseStartTime) {
+    const ps = Math.floor((Date.now() - phaseStartTime) / 1000);
+    if (ps < 60) timer.textContent = ps + 's';
+    else timer.textContent = Math.floor(ps/60) + 'm' + String(ps%60).padStart(2,'0') + 's';
+  }
+}, 1000);
+
+// === Status strip: phase name, phase elapsed, phase index ===
+const PHASE_ORDER = ['generate','build','publish','merge','extract','publish-sk','install','loop'];
+const PHASE_LABELS = {
+  'generate':'Generate Ideas','build':'Build Apps','publish':'Publish PRs',
+  'merge':'Auto-Merge','extract':'Extract Skills','publish-sk':'Publish S/K',
+  'install':'Install All','loop':'Complete',
+};
+let currentPhaseKey = null;
+// phaseStartTime already declared above (line 414) — reuse it
+
+function updatePhaseElapsed() {
+  const el = document.getElementById('phaseElapsed');
+  if (!el) return;
+  if (!phaseStartTime) { el.textContent = '00:00'; return; }
+  const s = Math.floor((Date.now() - phaseStartTime) / 1000);
+  const m = String(Math.floor(s / 60)).padStart(2, '0');
+  const sec = String(s % 60).padStart(2, '0');
+  el.textContent = m + ':' + sec;
+}
+setInterval(updatePhaseElapsed, 500);
+
+// Hook into setPhase to update the strip
+const _origSetPhaseStrip = setPhase;
+setPhase = function(phase, status) {
+  _origSetPhaseStrip.call(this, phase, status);
+  const idx = PHASE_ORDER.indexOf(phase);
+  const phaseIdxEl = document.getElementById('phaseIndex');
+  const phaseNameEl = document.getElementById('phaseName');
+  if (idx >= 0) {
+    if (phaseIdxEl) phaseIdxEl.textContent = (idx + 1) + '/' + PHASE_ORDER.length;
+    if (phaseNameEl) {
+      phaseNameEl.textContent = PHASE_LABELS[phase] || phase.toUpperCase();
+      phaseNameEl.classList.remove('swap'); void phaseNameEl.offsetWidth; phaseNameEl.classList.add('swap');
+    }
+    if (phase !== currentPhaseKey) {
+      currentPhaseKey = phase;
+      phaseStartTime = Date.now();
+    }
+  }
+};
+
+const _origSetStatusStrip = setStatus;
+setStatus = function(status) {
+  _origSetStatusStrip.call(this, status);
+  if (status === 'idle') {
+    currentPhaseKey = null;
+    phaseStartTime = null;
+    const phaseNameEl = document.getElementById('phaseName');
+    const phaseIdxEl = document.getElementById('phaseIndex');
+    if (phaseNameEl) phaseNameEl.textContent = 'IDLE';
+    if (phaseIdxEl) phaseIdxEl.textContent = '—/7';
+  }
+};
+
+// === Agent Character Controller ===
+const agent = document.getElementById('agent');
+const speechBubble = document.getElementById('speechBubble');
+const idleStatus = document.getElementById('agentIdleStatus');
+const agentMouth = document.getElementById('agentMouth');
+const agentParticles = document.getElementById('agentParticles');
+
+// Single CSS sprite sheet (move.jpg) — rows are phase-specific animations.
+// Load sheet, chroma-key white pixels to transparent, inject as CSS background.
+(function preprocessSpriteSheet() {
+  const im = new Image();
+  im.onload = () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = im.naturalWidth;
+    canvas.height = im.naturalHeight;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(im, 0, 0);
+    const data = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    const d = data.data;
+    for (let i = 0; i < d.length; i += 4) {
+      // Make near-white pixels transparent
+      if (d[i] > 230 && d[i+1] > 230 && d[i+2] > 230) {
+        d[i+3] = 0;
+      }
+    }
+    ctx.putImageData(data, 0, 0);
+    const url = canvas.toDataURL('image/png');
+    // Apply to all agent-character elements (current + future)
+    const style = document.createElement('style');
+    style.textContent = `.agent-character{background-image:url(${url}) !important}`;
+    document.head.appendChild(style);
+  };
+  im.onerror = () => console.warn('move.jpg failed to load');
+  im.src = 'move.jpg';
+})();
+
+// Named agents — each has a distinct color (hue) and role
+const AGENTS = {
+  IDEA:     { name: 'Aria',   hue: 280, role: 'Idea Forger' },      // Purple — creative
+  BUILDER:  { name: 'Blaze',  hue: 30,  role: 'Builder' },           // Orange — construction
+  PUBLISHER:{ name: 'Cielo',  hue: 220, role: 'Publisher' },         // Blue — shipping
+  MERGER:   { name: 'Mira',   hue: 140, role: 'Merger' },            // Green — merging
+  EXTRACTOR:{ name: 'Echo',   hue: 180, role: 'Analyst' },           // Cyan — analysis
+  ARCHIVIST:{ name: 'Sage',   hue: 70,  role: 'Archivist' },         // Lime — knowledge
+  INSTALLER:{ name: 'Pixel',  hue: 0,   role: 'Installer' },         // Default — systems
+};
+
+const PHASE_PROFILES = {
+  'generate':   { class: 'thinking',    badge: '💡', text: '💡 Generating ideas...',     agents: [AGENTS.IDEA],                                      trio: false },
+  'build':      { class: 'working',     badge: '🔨', text: '🔨 Building apps...',        agents: [AGENTS.BUILDER, AGENTS.IDEA, AGENTS.EXTRACTOR],    trio: true  },
+  'publish':    { class: 'sending',     badge: '📤', text: '📤 Publishing PRs...',       agents: [AGENTS.PUBLISHER, AGENTS.BUILDER, AGENTS.MERGER],  trio: true  },
+  'merge':      { class: 'working',     badge: '🔀', text: '🔀 Merging branches...',     agents: [AGENTS.MERGER, AGENTS.PUBLISHER, AGENTS.BUILDER],  trio: true  },
+  'extract':    { class: 'reading',     badge: '🔍', text: '🔍 Extracting patterns...',  agents: [AGENTS.EXTRACTOR],                                 trio: false },
+  'publish-sk': { class: 'sending',     badge: '📚', text: '📚 Publishing skills...',    agents: [AGENTS.ARCHIVIST],                                 trio: false },
+  'install':    { class: 'installing',  badge: '📥', text: '📥 Installing skills...',    agents: [AGENTS.INSTALLER],                                 trio: false },
+  'loop':       { class: 'celebrating', badge: '✨', text: '✨ Cycle complete!',         agents: [AGENTS.IDEA],                                      trio: false },
+};
+
+const IDLE_PHRASES = [
+  '💤 Standing by...',
+  '☕ Sipping coffee...',
+  '📖 Reading docs...',
+  '🎵 Humming a tune...',
+  '🧘 Meditating on code...',
+];
+
+const agentWrap = document.getElementById('agent');
+const agentImg = document.getElementById('agentImg');
+const toolBadge = document.getElementById('agentToolBadge');
+const sparkle = document.getElementById('agentSparkle');
+
+let currentImg = 'agent-a.jpg';
+let speechTimeout = null;
+let idleInterval = null;
+
+function clearAgentClasses() {
+  agentWrap.classList.remove('thinking','working','sending','reading','installing','celebrating','trio');
+}
+
+function showSpeech(text) {
+  if (!speechBubble) return;
+  speechBubble.innerHTML = text.replace(/^(\S+)\s/, '<span class="emoji">$1</span>');
+  speechBubble.classList.add('visible');
+  clearTimeout(speechTimeout);
+}
+
+// Legacy flood-fill helper kept only in case of reuse; not called for sprite sheet.
+const processedCache = new Map();
+
+function removeBackground(srcUrl) {
+  if (processedCache.has(srcUrl)) return Promise.resolve(processedCache.get(srcUrl));
+  return new Promise((resolve) => {
+    const im = new Image();
+    im.crossOrigin = 'anonymous';
+    im.onload = () => {
+      const canvas = document.createElement('canvas');
+      const w = canvas.width = im.naturalWidth;
+      const h = canvas.height = im.naturalHeight;
+      const ctx = canvas.getContext('2d');
+      ctx.drawImage(im, 0, 0);
+      const imgData = ctx.getImageData(0, 0, w, h);
+      const d = imgData.data;
+
+      // Flood fill from 4 corners
+      const TOL = 42;        // color distance tolerance
+      const FEATHER = 14;    // alpha ramp distance for edges
+      const visited = new Uint8Array(w * h);
+      const stack = [];
+      const seedPoints = [[0,0],[w-1,0],[0,h-1],[w-1,h-1],[Math.floor(w/2),0],[Math.floor(w/2),h-1],[0,Math.floor(h/2)],[w-1,Math.floor(h/2)]];
+      const seedColors = seedPoints.map(([x,y]) => {
+        const i = (y*w + x)*4;
+        return [d[i], d[i+1], d[i+2]];
+      });
+
+      for (const [sx, sy] of seedPoints) stack.push(sx, sy);
+
+      while (stack.length) {
+        const y = stack.pop();
+        const x = stack.pop();
+        if (x < 0 || y < 0 || x >= w || y >= h) continue;
+        const idx = y*w + x;
+        if (visited[idx]) continue;
+        const pi = idx * 4;
+        const r = d[pi], g = d[pi+1], b = d[pi+2];
+        // Check if any seed color is close enough
+        let isBg = false;
+        for (const [sr, sg, sb] of seedColors) {
+          const dist = Math.abs(r-sr) + Math.abs(g-sg) + Math.abs(b-sb);
+          if (dist < TOL * 3) { isBg = true; break; }
+        }
+        if (!isBg) continue;
+        visited[idx] = 1;
+        d[pi+3] = 0;  // transparent
+        stack.push(x+1, y, x-1, y, x, y+1, x, y-1);
+      }
+
+      // Feather edges: semi-transparent for pixels near transparent ones
+      const out = new Uint8ClampedArray(d);
+      for (let y = 1; y < h-1; y++) {
+        for (let x = 1; x < w-1; x++) {
+          const idx = y*w + x;
+          if (visited[idx]) continue;
+          const pi = idx*4;
+          if (d[pi+3] === 0) continue;
+          let nearBg = 0;
+          for (let dy = -1; dy <= 1; dy++) for (let dx = -1; dx <= 1; dx++) {
+            if (dx === 0 && dy === 0) continue;
+            if (visited[(y+dy)*w + (x+dx)]) nearBg++;
+          }
+          if (nearBg > 0) out[pi+3] = Math.max(0, 255 - nearBg * 80);
+        }
+      }
+      imgData.data.set(out);
+      ctx.putImageData(imgData, 0, 0);
+
+      const url = canvas.toDataURL('image/png');
+      processedCache.set(srcUrl, url);
+      resolve(url);
+    };
+    im.onerror = () => resolve(srcUrl); // fallback to original
+    im.src = srcUrl;
+  });
+}
+
+function setImage() {
+  // Sprite sheet driven by CSS; trigger swap flash animation only
+  agentImg.classList.remove('swap');
+  void agentImg.offsetWidth;
+  agentImg.classList.add('swap');
+}
+
+function renderTrio(on, agentList) {
+  document.querySelectorAll('.agent-character.extra').forEach(el => el.remove());
+  document.querySelectorAll('.agent-name-tag[data-extra-for]').forEach(el => el.remove());
+  if (on) {
+    agentWrap.classList.add('trio');
+    // Primary already rendered on agentImg — add 2 more for agents[1] and agents[2]
+    for (let i = 1; i < Math.min(3, agentList.length); i++) {
+      const div = document.createElement('div');
+      div.className = 'agent-character extra';
+      div.style.animationDelay = (0.15 * i) + 's';
+      div.setAttribute('data-hue', String(agentList[i].hue));
+      div.dataset.tagId = 'extra-' + i;
+      agentWrap.appendChild(div);
+      // Name tag for this extra
+      const tag = document.createElement('div');
+      tag.className = 'agent-name-tag';
+      tag.dataset.extraFor = 'extra-' + i;
+      tag.textContent = agentList[i].name;
+      agentWrap.appendChild(tag);
+    }
+  } else {
+    agentWrap.classList.remove('trio');
+  }
+}
+
+function applyAgentIdentity(el, agent) {
+  if (!agent) return;
+  el.setAttribute('data-hue', String(agent.hue));
+  // Ensure name tag exists
+  let tag = el.parentElement && el.parentElement.querySelector('.agent-name-tag.main-' + (el.classList.contains('extra') ? el.dataset.tagId : 'primary'));
+  if (!tag) {
+    tag = document.createElement('div');
+    tag.className = 'agent-name-tag';
+    if (el.classList.contains('extra')) {
+      tag.dataset.extraFor = el.dataset.tagId || '';
+      el.parentElement.appendChild(tag);
+    } else {
+      agentWrap.appendChild(tag);
+    }
+  }
+  tag.textContent = agent.name;
+}
+
+function clearNameTags() {
+  document.querySelectorAll('.agent-name-tag').forEach(el => el.remove());
+}
+
+function setAgentPhase(phase) {
+  const profile = PHASE_PROFILES[phase];
+  if (!profile) return;
+  clearInterval(idleInterval); idleInterval = null;
+
+  clearAgentClasses();
+  clearNameTags();
+  if (profile.class) agentWrap.classList.add(profile.class);
+
+  // Primary agent (first in list)
+  const primary = profile.agents[0];
+  applyAgentIdentity(agentImg, primary);
+
+  // Flash swap on the sprite
+  setImage();
+
+  // Trio mode for build/publish/merge — use the 3 agents from profile
+  renderTrio(!!profile.trio, profile.agents);
+
+  // Tool badge emoji
+  if (toolBadge) {
+    toolBadge.textContent = profile.badge;
+    toolBadge.classList.add('visible');
+  }
+  // Sparkle for celebrate
+  if (sparkle) {
+    sparkle.textContent = phase === 'loop' ? '🎉' : '✨';
+    sparkle.classList.toggle('visible', phase === 'loop' || phase === 'generate');
+  }
+
+  showSpeech(profile.text);
+
+  if (idleStatus) idleStatus.textContent = phase.toUpperCase().replace('-',' ');
+}
+
+function goIdle() {
+  clearAgentClasses();
+  clearNameTags();
+  document.querySelectorAll('.agent-character.extra').forEach(el => el.remove());
+  if (toolBadge) toolBadge.classList.remove('visible');
+  if (sparkle) sparkle.classList.remove('visible');
+  if (idleStatus) idleStatus.textContent = 'Standby';
+  applyAgentIdentity(agentImg, AGENTS.IDEA); // default agent
+  setImage();
+
+  let idx = 0;
+  showSpeech(IDLE_PHRASES[0]);
+  idleInterval = setInterval(() => {
+    idx = (idx + 1) % IDLE_PHRASES.length;
+    showSpeech(IDLE_PHRASES[idx]);
+  }, 5000);
+}
+
+// Hook into setPhase
+const _origSetPhaseAgent = setPhase;
+setPhase = function(phase, status) {
+  _origSetPhaseAgent.call(this, phase, status);
+  setAgentPhase(phase);
+};
+
+// Hook into status changes for idle
+const _origSetStatusAgent = setStatus;
+setStatus = function(status) {
+  _origSetStatusAgent.call(this, status);
+  if (status === 'idle') goIdle();
+};
+
+// Start in idle mode
+goIdle();
+
+// Auto-connect on load
+fetch(API + '/api/state').then(r => r.json()).then(handleEvent).catch(() => {});
+connectSSE();
+
+function fmtNum(n) {
+  if (n == null) return '0';
+  if (n >= 1e6) return (n/1e6).toFixed(2) + 'M';
+  if (n >= 1e3) return (n/1e3).toFixed(1) + 'k';
+  return String(n);
+}
+function applyUsage(u, cal) {
+  if (!u) return;
+  const set = (id, v) => { const e = document.getElementById(id); if (e) e.textContent = v; };
+  set('uTokIn',  fmtNum((u.input || 0) + (u.cacheRead || 0) + (u.cacheCreation || 0)));
+  set('uTokOut', fmtNum(u.output || 0));
+  set('uCost',   (u.costUsd || 0).toFixed(4));
+  set('uCalls',  String(u.calls || 0));
+  const c = cal || u.calibration;
+  if (c && c.loop5hPercent != null) {
+    const p = c.loop5hPercent;
+    set('uPct5h', p.toFixed(2) + '%');
+    const el = document.getElementById('uPct5h');
+    if (el) el.title = `Estimated: ${c.samples} calibration samples, ~${Math.round((c.estimatedLimit||0)/1000)}k tokens per 1% of 5h limit`;
+  } else {
+    set('uPct5h', '— (calibrating)');
+  }
+}
+async function refreshUsage() {
+  try {
+    const r = await fetch(API + '/api/usage');
+    if (r.ok) applyUsage(await r.json());
+  } catch {}
+}
+refreshUsage();
+setInterval(refreshUsage, 15000);
+const _origHandle = handleEvent;
+handleEvent = function(data) {
+  if (data && data.type === 'usage') { applyUsage(data.usage, data.calibration); return; }
+  return _origHandle(data);
+};
+</script>
+</body>
+</html>

--- a/example/hub-tools/auto-hub-loop-v3/manifest.json
+++ b/example/hub-tools/auto-hub-loop-v3/manifest.json
@@ -1,0 +1,8 @@
+{
+  "slug": "auto-hub-loop-v3",
+  "title": "Hub Auto-Loop Dashboard (v3)",
+  "stack": ["node", "html", "css", "vanilla-js"],
+  "created_at": "2026-04-18T00:00:00Z",
+  "source_project": "auto-hub-loop",
+  "author": "kjuhwa@nkia.co.kr"
+}

--- a/example/hub-tools/auto-hub-loop-v3/server.js
+++ b/example/hub-tools/auto-hub-loop-v3/server.js
@@ -1,0 +1,1353 @@
+// ─── Hub Auto-Loop Server ───
+// Automated pipeline: generate → build → publish → merge → extract → publish-sk → install → loop
+// Zero external dependencies — Node.js built-in modules only
+
+const http = require('http');
+const { exec, execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const hubInventory = require('./hub-loop-v3/hub-inventory');
+const dedupGate = require('./hub-loop-v3/dedup-gate');
+
+const PORT = 8917;
+const toSlash = p => p.replace(/\\/g, '/');  // Windows paths → bash-safe
+const WORK_DIR = toSlash(path.resolve(__dirname, '..'));
+const SKILLS_HUB = toSlash(path.join(process.env.HOME || process.env.USERPROFILE, '.claude', 'skills-hub', 'remote'));
+const SKILLS_DEST = toSlash(path.join(process.env.HOME || process.env.USERPROFILE, '.claude', 'skills'));
+const REGISTRY_PATH = toSlash(path.join(process.env.HOME || process.env.USERPROFILE, '.claude', 'skills-hub', 'registry.json'));
+
+// ── State ──
+const state = {
+  status: 'idle',    // idle | running | stopping | error
+  cycle: 0,
+  currentKeyword: null,
+  phase: null,
+  apps: [],
+  skills: [],
+  knowledge: [],
+  stats: { apps: 0, skills: 0, knowledge: 0, prs: 0, lines: 0 },
+  startTime: null,
+  stopRequested: false,
+  runOnce: false,    // single-cycle mode
+};
+
+// ── Token Usage (accumulated from `claude -p --output-format json`) ──
+const tokenUsage = { input: 0, output: 0, cacheRead: 0, cacheCreation: 0, costUsd: 0, calls: 0, lastUpdated: null };
+function totalLoopTokens() {
+  return tokenUsage.input + tokenUsage.output + tokenUsage.cacheRead + tokenUsage.cacheCreation;
+}
+function addUsage(u, costUsd) {
+  if (!u) return;
+  tokenUsage.input += u.input_tokens || 0;
+  tokenUsage.output += u.output_tokens || 0;
+  tokenUsage.cacheRead += u.cache_read_input_tokens || 0;
+  tokenUsage.cacheCreation += u.cache_creation_input_tokens || 0;
+  tokenUsage.costUsd += costUsd || 0;
+  tokenUsage.calls += 1;
+  tokenUsage.lastUpdated = Date.now();
+  broadcast({ type: 'usage', usage: tokenUsage, calibration: calibrationSnapshot() });
+}
+
+// ── 5h Limit Calibration (runtime estimation from account % delta) ──
+function readUsageCache() {
+  const home = process.env.HOME || process.env.USERPROFILE;
+  const dir = path.join(home, '.claude', 'plugins', 'oh-my-claudecode');
+  // Try both filenames — varies by OMC plugin version
+  for (const name of ['.usage-cache.json', '.usage-cache-anthropic.json']) {
+    const p = path.join(dir, name);
+    if (fs.existsSync(p)) {
+      try { return JSON.parse(fs.readFileSync(p, 'utf8')).data || null; } catch { /* try next */ }
+    }
+  }
+  return null;
+}
+const calibration = { tokensPerPct: null, samples: [], lastPct: null, lastLoopTokens: null };
+function calibrationSnapshot() {
+  const total = totalLoopTokens();
+  const loop5hPercent = calibration.tokensPerPct ? total / calibration.tokensPerPct : null;
+  return { tokensPerPct: calibration.tokensPerPct, estimatedLimit: calibration.tokensPerPct ? calibration.tokensPerPct * 100 : null, loop5hPercent, samples: calibration.samples.length };
+}
+function calibrate() {
+  const data = readUsageCache();
+  if (!data || typeof data.fiveHourPercent !== 'number') return;
+  const pct = data.fiveHourPercent;
+  const total = totalLoopTokens();
+  if (calibration.lastPct != null) {
+    const dPct = pct - calibration.lastPct;
+    const dTokens = total - calibration.lastLoopTokens;
+    if (dPct < -2) calibration.samples = [];  // 5h window rollover — reset estimate
+    else if (dPct > 0.5 && dTokens > 0) {
+      calibration.samples.push({ dTokens, dPct });
+      if (calibration.samples.length > 10) calibration.samples.shift();
+      const sumT = calibration.samples.reduce((s, x) => s + x.dTokens, 0);
+      const sumP = calibration.samples.reduce((s, x) => s + x.dPct, 0);
+      calibration.tokensPerPct = sumT / sumP;
+    }
+  }
+  calibration.lastPct = pct;
+  calibration.lastLoopTokens = total;
+  broadcast({ type: 'usage', usage: tokenUsage, calibration: calibrationSnapshot() });
+}
+setImmediate(calibrate);  // defer until module init finishes (clients/logBuffer are declared below)
+setInterval(calibrate, 60000);
+
+// ── SSE Clients ──
+const clients = [];
+const logBuffer = [];    // Keep last 200 log entries for new SSE connections
+function broadcast(data) {
+  const msg = `data: ${JSON.stringify(data)}\n\n`;
+  clients.forEach(res => { try { res.write(msg); } catch {} });
+}
+function log(level, message) {
+  const entry = { type: 'log', level, message };
+  logBuffer.push(entry);
+  if (logBuffer.length > 200) logBuffer.shift();
+  broadcast(entry);
+  const prefix = { info: '  ', success: '✓', warn: '⚠', error: '✗', phase: '►' }[level] || ' ';
+  console.log(`[${new Date().toLocaleTimeString()}] ${prefix} ${message}`);
+}
+
+// ── Random Keywords ──
+// Fallback pool (10-20 word evocative themes)
+const KEYWORD_FALLBACK = [
+  'A cozy lighthouse keeper decodes midnight signals drifting across the stormy ocean horizon',
+  'Tiny garden gnomes orchestrate a symphony while moonflowers bloom and fireflies weave patterns',
+  'Ancient librarians sort whispered secrets into glowing tomes within a floating crystal archive',
+  'Travelers trade constellations at a bustling skybound market above the clouds at dawn',
+  'Forest spirits knit paths of moss while cartographers chart their shifting territories by lantern',
+  'Dreamers assemble mechanical butterflies and launch them through windows into a neon alley',
+  'A patient cartographer redraws coastlines as tides whisper forgotten names beneath silver moonlight',
+  'Cooks braid ribbons of steam into recipes recorded by a curious mouse wearing spectacles',
+  'Wanderers stitch patchwork quilts from discarded dreams beside a bonfire near an obsidian lake',
+];
+const KEYWORD_TO_CATEGORY = {
+  // Nouns → thematic categories
+  'garden': 'interactive', 'ocean': 'interactive', 'forest': 'interactive',
+  'city': 'interactive', 'galaxy': 'interactive',
+  'library': 'hub-tools', 'museum': 'hub-tools',
+  'kitchen': 'interactive', 'factory': 'interactive', 'workshop': 'interactive',
+  // Verbs → action categories
+  'explore': 'interactive', 'discover': 'interactive', 'navigate': 'interactive',
+  'create': 'interactive', 'compose': 'interactive',
+  'simulate': 'algorithms', 'visualize': 'interactive',
+  'analyze': 'algorithms', 'transform': 'algorithms',
+  'connect': 'messaging',
+};
+
+function categoryForKeyword(kw) {
+  if (!kw) return 'misc';
+  if (KEYWORD_TO_CATEGORY[kw]) return KEYWORD_TO_CATEGORY[kw];
+  // Substring match — scan phrase for known keyword
+  const lower = kw.toLowerCase();
+  for (const [k, cat] of Object.entries(KEYWORD_TO_CATEGORY)) {
+    if (lower.includes(k)) return cat;
+  }
+  // Fallback keyword → category hints based on phrase content
+  const hints = [
+    [['garden','forest','ocean','galaxy','moon','sky','lighthouse','cave','river','mountain'], 'interactive'],
+    [['library','archive','tome','book','map','cartograph'], 'hub-tools'],
+    [['trade','market','orchestrate','assemble','weave','knit','stitch'], 'interactive'],
+    [['analyze','decode','pattern','signal','chart'], 'algorithms'],
+    [['whisper','connect','message','send','transmit'], 'messaging'],
+  ];
+  for (const [words, cat] of hints) {
+    for (const w of words) {
+      if (lower.includes(w)) return cat;
+    }
+  }
+  return 'misc';
+}
+
+const usedKeywords = new Set();
+
+// ── Hub inventory (v3: compressed index, cached between cycles) ──
+let currentInventory = null;
+async function refreshInventory() {
+  try {
+    currentInventory = await hubInventory.load({ hubRoot: SKILLS_HUB });
+    log('info', `Hub inventory: ${currentInventory.skills.length} skills + ${currentInventory.knowledge.length} knowledge (v3 compressed index)`);
+  } catch (e) {
+    log('warn', `Hub inventory load failed: ${e.message.split('\n')[0]} — falling back to legacy sampler`);
+    currentInventory = null;
+  }
+  return currentInventory;
+}
+
+async function pickKeyword() {
+  const recent = [...usedKeywords].slice(-5).join(' | ') || '(none)';
+  const prompt = `Generate ONE random evocative theme phrase (5 to 15 English words) suitable as a creative theme for a set of 3 interactive HTML visualization apps.
+
+Constraints:
+- Must be 5-15 words total (count carefully)
+- NOUNS ONLY — no verbs, no adjectives, no adverbs. Every word must be a noun.
+- IT / computer science / distributed systems terminology ONLY
+- Combine multiple IT concepts into a creative compound phrase
+- Must NOT repeat these recent themes: ${recent}
+- Examples of good themes:
+  - "consensus raft quorum leader election heartbeat timeout partition"
+  - "cache eviction shard replica failover circuit breaker backpressure"
+  - "merkle tree bloom filter consistent hashing ring topology gossip protocol"
+  - "container orchestration pod namespace service mesh sidecar proxy"
+  - "event sourcing saga outbox CDC snapshot aggregate projection"
+
+Output ONLY the phrase, no quotes, no explanation, nothing else.`;
+
+  try {
+    const raw = await askClaude(prompt, 60000);
+    const phrase = raw.trim().replace(/^["']|["']$/g, '');
+    const wordCount = phrase.split(/\s+/).filter(Boolean).length;
+    if (phrase && wordCount >= 8 && wordCount <= 25 && !usedKeywords.has(phrase)) {
+      usedKeywords.add(phrase);
+      return phrase;
+    }
+  } catch {}
+
+  // Fallback: pick from the local pool
+  const available = KEYWORD_FALLBACK.filter(k => !usedKeywords.has(k));
+  const pool = available.length > 0 ? available : KEYWORD_FALLBACK;
+  const kw = pool[Math.floor(Math.random() * pool.length)];
+  usedKeywords.add(kw);
+  return kw;
+}
+
+// ── Shell Helper ──
+function shell(cmd, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const options = { maxBuffer: 10 * 1024 * 1024, timeout: opts.timeout || 600000, cwd: opts.cwd };
+    exec(cmd, options, (err, stdout, stderr) => {
+      if (err && !opts.ignoreError) reject(new Error(`${err.message}\n${stderr}`));
+      else resolve((stdout || '').trim());
+    });
+  });
+}
+
+function shellSync(cmd, opts = {}) {
+  try {
+    return execSync(cmd, { maxBuffer: 10 * 1024 * 1024, cwd: opts.cwd, encoding: 'utf8' }).trim();
+  } catch (e) {
+    if (!opts.ignoreError) throw e;
+    return '';
+  }
+}
+
+// ── Claude CLI Helper ──
+async function askClaude(prompt, timeout = 1800000) {
+  const { spawn } = require('child_process');
+  // Write prompt to a temp file and pipe via shell redirect — avoids argv length limits AND stdin propagation issues
+  const tmpFile = path.join(require('os').tmpdir(), `claude-prompt-${Date.now()}-${Math.random().toString(36).slice(2,8)}.txt`);
+  fs.writeFileSync(tmpFile, prompt, 'utf8');
+
+  return new Promise((resolve, reject) => {
+    // Use shell redirect `< file` so claude's stdin comes from the file
+    const cmd = process.platform === 'win32'
+      ? `claude -p --output-format json < "${tmpFile.replace(/\\/g, '/')}"`
+      : `claude -p --output-format json < "${tmpFile}"`;
+    const child = spawn(cmd, [], {
+      shell: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, DISABLE_OMC: '1', OMC_SKIP_HOOKS: '*', CLAUDE_DISABLE_SESSION_HOOKS: '1' },
+    });
+    let stdout = ''; let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill();
+      try { fs.unlinkSync(tmpFile); } catch {}
+      reject(new Error('askClaude timeout'));
+    }, timeout);
+    child.stdout.on('data', (d) => { stdout += d.toString(); });
+    child.stderr.on('data', (d) => { stderr += d.toString(); });
+    child.on('error', (err) => { clearTimeout(timer); try { fs.unlinkSync(tmpFile); } catch {}; reject(err); });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      try { fs.unlinkSync(tmpFile); } catch {}
+      if (code !== 0) { reject(new Error(`claude exited ${code}: ${stderr.split('\n')[0]}`)); return; }
+      try {
+        const parsed = JSON.parse(stdout.trim());
+        addUsage(parsed.usage, parsed.total_cost_usd);
+        resolve((parsed.result || '').trim());
+      } catch { resolve(stdout.trim()); }
+    });
+  });
+}
+
+// ── File Writer from Claude Output ──
+function parseAndWriteFiles(output, targetDir) {
+  const files = [];
+  const fileRegex = /===FILE:(.+?)===\n([\s\S]*?)===END===/g;
+  let match;
+  while ((match = fileRegex.exec(output)) !== null) {
+    const filePath = match[1].trim();
+    const content = match[2].trim();
+    const fullPath = path.join(targetDir, filePath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, content, 'utf8');
+    files.push({ path: filePath, lines: content.split('\n').length });
+  }
+  return files;
+}
+
+// ── Next project number ──
+function getNextProjectNum() {
+  const dirs = fs.readdirSync(WORK_DIR).filter(d => /^\d{2}-/.test(d)).sort();
+  if (dirs.length === 0) return 17;
+  const last = parseInt(dirs[dirs.length - 1].split('-')[0], 10);
+  return last + 1;
+}
+
+// Remote sampling helpers
+function listExistingSkillNames() {
+  try {
+    const skillsDir = path.join(SKILLS_HUB, 'skills');
+    if (!fs.existsSync(skillsDir)) return [];
+    const names = [];
+    for (const cat of fs.readdirSync(skillsDir)) {
+      const catPath = path.join(skillsDir, cat);
+      if (!fs.statSync(catPath).isDirectory()) continue;
+      for (const name of fs.readdirSync(catPath)) {
+        if (fs.existsSync(path.join(catPath, name, 'SKILL.md'))) names.push(name);
+      }
+    }
+    return names;
+  } catch { return []; }
+}
+
+function listExistingKnowledgeNames() {
+  try {
+    const kDir = path.join(SKILLS_HUB, 'knowledge');
+    if (!fs.existsSync(kDir)) return [];
+    const names = [];
+    for (const cat of fs.readdirSync(kDir)) {
+      const catPath = path.join(kDir, cat);
+      if (!fs.statSync(catPath).isDirectory()) continue;
+      for (const f of fs.readdirSync(catPath)) {
+        if (f.endsWith('.md')) names.push(f.replace(/\.md$/, ''));
+      }
+    }
+    return names;
+  } catch { return []; }
+}
+
+function sampleRandom(arr, n) {
+  const pool = [...arr]; const out = [];
+  while (out.length < n && pool.length > 0) {
+    const idx = Math.floor(Math.random() * pool.length);
+    out.push(pool[idx]); pool.splice(idx, 1);
+  }
+  return out;
+}
+
+function sampleSkillsWithMeta(n) {
+  const skillsDir = path.join(SKILLS_HUB, 'skills');
+  if (!fs.existsSync(skillsDir)) return [];
+  const all = [];
+  try {
+    for (const cat of fs.readdirSync(skillsDir)) {
+      const catPath = path.join(skillsDir, cat);
+      if (!fs.statSync(catPath).isDirectory()) continue;
+      for (const name of fs.readdirSync(catPath)) {
+        const f = path.join(catPath, name, 'SKILL.md');
+        if (!fs.existsSync(f)) continue;
+        try {
+          const txt = fs.readFileSync(f, 'utf8');
+          const desc = (txt.match(/^description:\s*(.+)$/m)?.[1] || '').trim();
+          all.push({ name, category: cat, description: desc });
+        } catch {}
+      }
+    }
+  } catch {}
+  return sampleRandom(all, n);
+}
+
+function sampleKnowledgeWithMeta(n) {
+  const kDir = path.join(SKILLS_HUB, 'knowledge');
+  if (!fs.existsSync(kDir)) return [];
+  const all = [];
+  try {
+    for (const cat of fs.readdirSync(kDir)) {
+      const catPath = path.join(kDir, cat);
+      if (!fs.statSync(catPath).isDirectory()) continue;
+      for (const f of fs.readdirSync(catPath).filter(x => x.endsWith('.md'))) {
+        try {
+          const txt = fs.readFileSync(path.join(catPath, f), 'utf8');
+          const desc = (txt.match(/^description:\s*(.+)$/m)?.[1] || '').trim();
+          all.push({ name: f.replace(/\.md$/, ''), category: cat, description: desc });
+        } catch {}
+      }
+    }
+  } catch {}
+  return sampleRandom(all, n);
+}
+
+// ╔══════════════════════════════════════════════════════════════╗
+// ║  PIPELINE PHASES                                             ║
+// ╚══════════════════════════════════════════════════════════════╝
+
+async function phaseGenerate(keyword) {
+  setPhase('generate');
+  log('phase', `Phase 1: Generate 3 distinct app ideas for "${keyword}"`);
+
+  // Hub inventory (v3 compressed index) — falls back to legacy sampler if v3 unavailable
+  const inv = currentInventory || await refreshInventory();
+  let skillsBlock;
+  if (inv && inv.skills.length > 0) {
+    skillsBlock = inv.skills
+      .map(s => `  - \`${s.slug}\` (${s.category}): ${s.description || s.purpose || ''}`)
+      .join('\n');
+    log('info', `Inventory (v3): ${inv.skills.length} skills + ${inv.knowledge.length} knowledge`);
+  } else {
+    const allSkills = sampleSkillsWithMeta(1000);
+    skillsBlock = allSkills.length > 0
+      ? allSkills.map(s => `  - \`${s.name}\` (${s.category}): ${s.description || ''}`).join('\n')
+      : '  (no skills available)';
+    log('info', `Inventory (legacy): ${allSkills.length} skills`);
+  }
+
+  // ── Phase 1a: Generate 3 app IDEAS (lightweight — names, descriptions, tech assignments) ──
+  const appSpecs = [
+    { role: 'VISUALIZATION/EXPLORER', framework: 'React 18+ (CDN: react, react-dom, babel-standalone)', palette: 'deep ocean (--bg #0a0e1a, --surface #111a2e, --accent #00d4ff)', tech: 'Canvas 2D, hooks, functional components' },
+    { role: 'SIMULATION/GAME', framework: 'Vue 3 (CDN: vue@3 global build)', palette: 'warm amber/copper (--bg #1a1410, --surface #2a2018, --accent #f0a050)', tech: 'SVG, Composition API, directives' },
+    { role: 'TOOL/CALCULATOR', framework: 'D3.js v7 (CDN: d3@7)', palette: 'terminal green (--bg #0a0a0a, --surface #1a1a1a, --accent #33ff33)', tech: 'D3 data joins, scales, force simulations' },
+  ];
+
+  const ideaPrompt = `Generate 3 app ideas for the theme "${keyword}". Each from a DIFFERENT angle:
+
+1. ${appSpecs[0].role} (${appSpecs[0].framework})
+2. ${appSpecs[1].role} (${appSpecs[1].framework})
+3. ${appSpecs[2].role} (${appSpecs[2].framework})
+
+For each, output EXACTLY:
+===IDEA===
+name: <kebab-case, 2-4 words, evocative>
+title: <Human Readable Title>
+why: <one sentence, 10-20 words>
+features:
+- <feature 1>
+- <feature 2>
+- <feature 3>
+- <feature 4>
+- <feature 5>
+===END-IDEA===
+
+Output ONLY the 3 IDEA blocks, nothing else.`;
+
+  log('info', 'Phase 1a: Generating 3 app ideas...');
+  const ideasRaw = await askClaude(ideaPrompt, 120000);
+  const ideaRegex = /===IDEA===\n([\s\S]*?)===END-IDEA===/g;
+  const ideas = [];
+  let im;
+  while ((im = ideaRegex.exec(ideasRaw)) !== null) {
+    const block = im[1];
+    ideas.push({
+      name: (block.match(/^\s*name:\s*(.+)$/m)?.[1] || '').trim(),
+      title: (block.match(/^\s*title:\s*(.+)$/m)?.[1] || '').trim(),
+      why: (block.match(/^\s*why:\s*(.+)$/m)?.[1] || '').trim(),
+      features: (block.match(/features:\n([\s\S]*?)$/)?.[1] || '').trim(),
+    });
+  }
+
+  if (ideas.length < 3) {
+    log('warn', `Only ${ideas.length} ideas parsed, expected 3`);
+    return ideasRaw; // fallback to legacy single-pass
+  }
+
+  log('info', `Ideas: ${ideas.map(i => i.name).join(', ')}`);
+
+  // ── Phase 1b: Generate code for EACH app individually ──
+  const allResponses = [];
+  for (let i = 0; i < 3; i++) {
+    const spec = appSpecs[i];
+    const idea = ideas[i];
+    log('info', `Phase 1b-${i+1}: Generating code for "${idea.name}" (${spec.framework})...`);
+
+    const codePrompt = `You are building a single web app. Theme: "${keyword}". App concept: "${idea.title}" — ${idea.why}
+
+Features to implement:
+${idea.features}
+
+Available skills inventory (use relevant ones):
+${skillsBlock.slice(0, 8000)}
+
+Technical spec:
+- Role: ${spec.role}
+- Framework: ${spec.framework} — use it properly with idiomatic patterns
+- Color palette: ${spec.palette}
+- Rendering: ${spec.tech}
+- CDN imports ONLY (unpkg.com or cdnjs.cloudflare.com)
+- MINIMUM 1,500 lines (aim for 2,000+) — this is ONE app, use the FULL response for it
+- Include 5+ distinct interactive sections/panels/tabs with independent state
+- Immediately interactive on load with meaningful mock data
+- Modern UX: hover states, transitions, keyboard shortcuts
+
+Output EXACTLY this format:
+
+===APP===
+name: ${idea.name}
+title: ${idea.title}
+why: ${idea.why}
+features:
+${idea.features}
+stack: ${spec.framework.split(' ')[0].toLowerCase()}
+===FILE:index.html===
+<SINGLE SELF-CONTAINED HTML FILE — ALL CSS in <style>, ALL JS in <script>. NO external .js/.css files. Must work via file:// protocol.>
+===END===
+===END-APP===
+
+CRITICAL: Output ONLY the APP block. No commentary, no code fences, no explanation.`;
+
+    const response = await askClaude(codePrompt, 1800000);
+    allResponses.push(response);
+    log('info', `App ${i+1} "${idea.name}" generated (${response.length} chars)`);
+  }
+
+  return allResponses.join('\n\n');
+}
+
+async function phaseBuild(claudeOutput, keyword, cycleNum) {
+  setPhase('build');
+  log('phase', 'Phase 2: Build apps from generated code');
+
+  const builtApps = [];
+  const num = getNextProjectNum();
+
+  // Parse structured ===APP=== blocks with metadata + nested ===FILE=== blocks
+  const appBlockRegex = /===APP===\n([\s\S]*?)===END-APP===/g;
+  const parsedApps = [];
+  let m;
+  while ((m = appBlockRegex.exec(claudeOutput)) !== null) {
+    const block = m[1];
+    // Extract metadata (before first ===FILE===)
+    const metaEnd = block.indexOf('===FILE:');
+    const meta = metaEnd >= 0 ? block.slice(0, metaEnd) : block;
+    const name = (meta.match(/^\s*name:\s*(.+)$/m)?.[1] || '').trim();
+    const title = (meta.match(/^\s*title:\s*(.+)$/m)?.[1] || '').trim();
+    const why = (meta.match(/^\s*why:\s*(.+)$/m)?.[1] || '').trim();
+    const stack = (meta.match(/^\s*stack:\s*(.+)$/m)?.[1] || 'html, css, vanilla-js').trim();
+    const featuresBlock = meta.match(/features:\s*\n([\s\S]*?)(?=\n(?:stack|===|$))/i);
+    const features = featuresBlock ? featuresBlock[1].split('\n').map(l => l.replace(/^\s*-\s*/, '').trim()).filter(Boolean) : [];
+
+    // Extract files
+    const fileRegex = /===FILE:(.+?)===\n([\s\S]*?)===END===/g;
+    const files = [];
+    let fm;
+    while ((fm = fileRegex.exec(block)) !== null) {
+      files.push({ path: fm[1].trim(), content: fm[2].trim() });
+    }
+
+    if (name && files.length > 0) {
+      parsedApps.push({ name, title, why, stack, features, files });
+    }
+  }
+
+  // Fallback: legacy ===FILE:app-name/...=== format
+  if (parsedApps.length === 0) {
+    log('warn', 'No ===APP=== blocks found, trying legacy parser');
+    const legacyRegex = /===FILE:(.+?)===\n([\s\S]*?)===END===/g;
+    const byApp = {};
+    let lm;
+    while ((lm = legacyRegex.exec(claudeOutput)) !== null) {
+      const p = lm[1].trim();
+      const content = lm[2].trim();
+      const appName = p.includes('/') ? p.split('/')[0] : null;
+      if (!appName) continue;
+      if (!byApp[appName]) byApp[appName] = [];
+      byApp[appName].push({ path: p.replace(`${appName}/`, ''), content });
+    }
+    for (const [name, files] of Object.entries(byApp)) {
+      parsedApps.push({ name, title: '', why: '', stack: 'html, css, vanilla-js', features: [], files });
+    }
+  }
+
+  if (parsedApps.length === 0) {
+    log('error', 'Parsed 0 apps from Claude output');
+    // Dump response to a log file for inspection
+    try {
+      const dumpFile = path.join(__dirname, `.debug-claude-cycle${cycleNum}.txt`);
+      fs.writeFileSync(dumpFile, claudeOutput || '(empty response)', 'utf8');
+      log('info', `Response dumped to ${dumpFile} (${(claudeOutput||'').length} chars)`);
+      // Log first 300 chars so we can see format
+      const preview = (claudeOutput || '').slice(0, 300).replace(/\n/g, ' | ');
+      log('info', `Preview: ${preview}`);
+    } catch {}
+    return builtApps;
+  }
+
+  let appIdx = 0;
+  for (const app of parsedApps.slice(0, 3)) {
+    const projNum = String(num + appIdx).padStart(2, '0');
+    const projDir = path.join(WORK_DIR, `${projNum}-${app.name}`);
+    fs.mkdirSync(projDir, { recursive: true });
+
+    let totalLines = 0;
+    for (const file of app.files) {
+      const fullPath = path.join(projDir, file.path);
+      fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+      fs.writeFileSync(fullPath, file.content, 'utf8');
+      totalLines += file.content.split('\n').length;
+    }
+
+    // Validate JS — check app.js if it exists (legacy), otherwise skip (single-file HTML apps embed JS inline)
+    let valid = true;
+    const jsFile = path.join(projDir, 'app.js');
+    if (fs.existsSync(jsFile)) {
+      // Skip syntax check for JSX files (contain < tokens that node --check rejects)
+      const content = fs.readFileSync(jsFile, 'utf8');
+      const isJSX = /React|jsx|createElement|<\w+[\s/>]/.test(content);
+      if (!isJSX) {
+        try { shellSync(`node --check "${jsFile}"`); }
+        catch { log('warn', `${app.name}: JS syntax error`); valid = false; }
+      }
+    }
+
+    const title = app.title || app.name.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+    const built = {
+      name: app.name,
+      dir: `${projNum}-${app.name}`,
+      cycle: cycleNum,
+      lines: totalLines,
+      status: 'built',
+      keyword,
+      valid,
+      title,
+      why: app.why || `Interactive ${keyword} experience.`,
+      features: app.features || [],
+      stack: app.stack,
+    };
+    builtApps.push(built);
+    state.apps.push(built);
+    state.stats.apps++;
+    state.stats.lines += totalLines;
+    broadcast({ type: 'app', app: built });
+    broadcast({ type: 'stats', stats: state.stats });
+    log('success', `Built: ${built.dir} (${totalLines} lines) — ${title}`);
+    appIdx++;
+  }
+
+  // Extract cited skills/knowledge from Claude output for the Recipe panel
+  try {
+    const allSkillNames = listExistingSkillNames();
+    const allKnowNames = listExistingKnowledgeNames();
+    // Build {name:category} lookup once
+    const skillCat = {};
+    for (const s of sampleSkillsWithMeta(9999)) skillCat[s.name] = s.category;
+    const knowCat = {};
+    for (const k of sampleKnowledgeWithMeta(9999)) knowCat[k.name] = k.category;
+
+    const bigText = (claudeOutput || '') + ' ' + builtApps.map(a => (a.features || []).join(' ') + ' ' + (a.why || '')).join(' ');
+    const appliedSet = new Set();
+    const respectingSet = new Set();
+
+    for (const name of allSkillNames) {
+      // Look for backtick or whole-word match
+      const re = new RegExp('`' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '`|\\b' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b', 'i');
+      if (re.test(bigText)) appliedSet.add(name);
+    }
+    for (const name of allKnowNames) {
+      const re = new RegExp('`' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '`|\\b' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b', 'i');
+      if (re.test(bigText)) respectingSet.add(name);
+    }
+
+    const applied = [...appliedSet].slice(0, 200).map(n => ({ name: n, category: skillCat[n] || 'misc' }));
+    const respecting = [...respectingSet].slice(0, 100).map(n => ({ name: n, category: knowCat[n] || 'misc' }));
+
+    broadcast({
+      type: 'recipe',
+      keyword,
+      applied,
+      respecting,
+      poolSkills: allSkillNames.length,
+      poolKnowledge: allKnowNames.length,
+    });
+    log('info', `Recipe: cited ${applied.length} skills + ${respecting.length} knowledge (pool: ${allSkillNames.length}/${allKnowNames.length})`);
+  } catch (err) {
+    log('warn', `Recipe extract failed: ${err.message.split('\n')[0]}`);
+  }
+
+  return builtApps;
+}
+
+async function phasePublish(apps, cycleNum) {
+  setPhase('publish');
+  log('phase', 'Phase 3: Publish apps to skills-hub');
+
+  const prUrls = [];
+  for (const app of apps) {
+    if (state.stopRequested) break;
+    try {
+      const slug = app.name;
+      const srcDir = toSlash(path.join(WORK_DIR, app.dir));
+      log('info', `Publishing ${slug} from ${srcDir}...`);
+
+      // Reset to main
+      await shell(`git -C "${SKILLS_HUB}" fetch origin main --prune`);
+      await shell(`git -C "${SKILLS_HUB}" checkout main`);
+      await shell(`git -C "${SKILLS_HUB}" reset --hard origin/main`);
+
+      // Determine category for this keyword
+      const category = categoryForKeyword(app.keyword);
+
+      // Check if slug exists (in category dir)
+      const exCheck = toSlash(path.join(SKILLS_HUB, 'example', category, slug));
+      if (fs.existsSync(exCheck)) {
+        log('warn', `example/${category}/${slug} already exists, skipping`);
+        continue;
+      }
+
+      // Create branch (clean up any leftover from previous runs)
+      const branch = `example/${slug}`;
+      await shell(`git -C "${SKILLS_HUB}" branch -D "${branch}"`, { ignoreError: true });
+      await shell(`git -C "${SKILLS_HUB}" push origin --delete "${branch}"`, { ignoreError: true });
+      await shell(`git -C "${SKILLS_HUB}" checkout -b "${branch}"`);
+
+      // Copy files (use native paths for fs operations)
+      const exDirNative = path.resolve(SKILLS_HUB, 'example', category, slug);
+      const srcDirNative = path.resolve(srcDir);
+      fs.mkdirSync(exDirNative, { recursive: true });
+      const files = fs.readdirSync(srcDirNative).filter(f => !f.startsWith('.'));
+      for (const f of files) {
+        fs.copyFileSync(path.join(srcDirNative, f), path.join(exDirNative, f));
+      }
+      const exDir = exDirNative; // for manifest/readme writes below
+
+      // Write manifest
+      const title = app.title || slug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+      const stackArr = (app.stack || 'html, css, vanilla-js').split(',').map(s => s.trim()).filter(Boolean);
+      const manifest = {
+        slug,
+        title,
+        stack: stackArr,
+        created_at: new Date().toISOString(),
+        source_project: app.dir,
+        author: 'kjuhwa@nkia.co.kr',
+        keyword: app.keyword,
+        cycle: cycleNum,
+      };
+      fs.writeFileSync(path.join(exDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+
+      // Rich README matching /hub-make output style
+      const why = app.why || `Interactive ${app.keyword} experience.`;
+      const features = (app.features && app.features.length > 0) ? app.features : [
+        `Themed around "${app.keyword}"`,
+        'Dark-theme UI with keyboard and pointer interactions',
+        'Self-contained, no build step',
+      ];
+      const readme = [
+        `# ${title}`,
+        '',
+        `> **Why.** ${why}`,
+        '',
+        '## Features',
+        '',
+        ...features.map(f => `- ${f}`),
+        '',
+        '## File structure',
+        '',
+        '```',
+        `${slug}/`,
+        '  index.html    — self-contained single-file app (HTML + CSS + JS inline)',
+        '  manifest.json — hub metadata',
+        '```',
+        '',
+        '## Usage',
+        '',
+        '```bash',
+        '# any static file server works',
+        'python -m http.server 8080',
+        '# or open index.html directly in a browser',
+        '```',
+        '',
+        '## Stack',
+        '',
+        `${stackArr.map(s => '`' + s + '`').join(' · ')} — zero dependencies, ${app.lines} lines`,
+        '',
+        '## Provenance',
+        '',
+        `- Generated by auto-hub-loop cycle ${cycleNum} on ${new Date().toISOString().split('T')[0]}`,
+        `- Theme keyword: \`${app.keyword}\``,
+        `- Source working copy: \`${app.dir}\``,
+        '',
+      ].join('\n');
+      fs.writeFileSync(path.join(exDir, 'README.md'), readme);
+
+      // Commit + push (skip README catalog update to avoid merge conflicts)
+      await shell(`git -C "${SKILLS_HUB}" add "example/${category}/${slug}/"`);
+      await shell(`git -C "${SKILLS_HUB}" commit -m "example(${slug}): add ${manifest.title}
+
+Auto-generated by hub-auto-loop cycle ${cycleNum}.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"`);
+      await shell(`git -C "${SKILLS_HUB}" push -u origin "${branch}"`);
+
+      // Create PR
+      const prTitle = `example(${slug}): add ${manifest.title}`;
+      const prBody = `Auto-generated by hub-auto-loop cycle ${cycleNum}. Keyword: ${app.keyword}.`;
+      const prUrl = await shell(`gh pr create --title "${prTitle}" --body "${prBody}"`, { ignoreError: true, cwd: SKILLS_HUB });
+      log('info', `PR result for ${slug}: ${prUrl || '(empty)'}`);
+
+      if (prUrl && prUrl.includes('github.com')) {
+        prUrls.push(prUrl);
+        app.status = 'published';
+        app.prUrl = prUrl;
+        state.stats.prs++;
+        broadcast({ type: 'app', app });
+        broadcast({ type: 'stats', stats: state.stats });
+        log('success', `PR created: ${prUrl}`);
+      } else {
+        log('warn', `PR creation returned no URL for ${slug}`);
+      }
+    } catch (err) {
+      log('error', `Publish ${app.name} failed: ${err.message.split('\n')[0]}`);
+    }
+  }
+  return prUrls;
+}
+
+async function phaseMerge(prUrls) {
+  setPhase('merge');
+  log('phase', 'Phase 4: Auto-merge PRs');
+
+  for (const url of prUrls) {
+    if (state.stopRequested) break;
+    try {
+      const prNum = url.split('/').pop();
+      await shell(`gh pr merge ${prNum} --merge --auto`, { ignoreError: true, cwd: SKILLS_HUB });
+      await new Promise(r => setTimeout(r, 5000));
+      await shell(`gh pr merge ${prNum} --merge`, { ignoreError: true, cwd: SKILLS_HUB });
+      log('success', `Merged: PR #${prNum}`);
+    } catch (err) {
+      log('warn', `Merge PR failed: ${err.message.split('\n')[0]}`);
+    }
+  }
+}
+
+async function phaseExtract(apps, cycleNum) {
+  setPhase('extract');
+  log('phase', 'Phase 5: Extract skills & knowledge');
+
+  const extracted = { skills: [], knowledge: [] };
+
+  // Analyze built apps for patterns
+  const appNames = apps.map(a => a.name).join(', ');
+  const keyword = apps[0]?.keyword || 'general';
+
+  // Sample existing skill/knowledge names to avoid template duplicates
+  const existingSkills = listExistingSkillNames().slice(0, 200);
+  const existingKnowledge = listExistingKnowledgeNames().slice(0, 100);
+
+  // Full inventory for fuzzy dedup — falls back to name-only if v3 unavailable
+  const inv = currentInventory || { skills: [], knowledge: [] };
+  const existingSkillItems    = inv.skills.length    ? inv.skills    : listExistingSkillNames().map(n => ({ slug: n, purpose: '' }));
+  const existingKnowItems     = inv.knowledge.length ? inv.knowledge : listExistingKnowledgeNames().map(n => ({ slug: n, purpose: '' }));
+
+  const prompt = `You built 3 apps this cycle about "${keyword}" (names: ${appNames}).
+
+Your task: identify genuinely NEW, REUSABLE patterns that emerged during the build — NOT the obvious "${keyword}-visualization-pattern" template. Quality over quantity.
+
+Rules:
+1. Emit ZERO to THREE skills/knowledge entries — only what truly generalizes beyond this cycle.
+2. DO NOT use names already in the repo (these exist): ${existingSkills.slice(0, 60).join(', ')}, ...
+3. Avoid naming patterns like "${keyword}-visualization-pattern", "${keyword}-data-simulation", "${keyword}-implementation-pitfall" — too templated.
+4. Name each entry descriptively based on the SPECIFIC pattern (e.g. "canvas-spatial-grid-renderer", "simulation-tick-event-queue", "react-less-pixel-sprite-swap"). The name should be evocative + specific.
+5. Categories available: design, workflow, arch, ai, backend, frontend, algorithms, misc (pick best fit, not default).
+6. Knowledge types: pitfall, decision, workflow, reference.
+7. If the cycle didn't produce anything interesting beyond generic patterns, output just "===NONE===" and skip entries.
+
+Output format — emit entries as needed (in any mix, any count):
+
+===SKILL===
+name: <descriptive-kebab-case>
+category: <one of above>
+description: (one line summary)
+content: (2-3 paragraphs explaining the reusable pattern, with code-like examples)
+===END===
+
+===KNOWLEDGE===
+name: <descriptive-kebab-case>
+category: <pitfall|decision|workflow|reference>
+description: (one line)
+content: (2-3 paragraphs explaining the specific lesson)
+===END===
+
+Output ONLY blocks that describe real patterns. Empty output is valid. No preamble.`;
+
+  try {
+    const response = await askClaude(prompt, 300000);
+
+    // Short-circuit: NONE means Claude decided nothing is worth extracting
+    if (/===NONE===/i.test(response)) {
+      log('info', 'No new patterns this cycle (Claude returned NONE)');
+    }
+
+    const existingSkillSet = new Set(existingSkills);
+    const existingKnowSet = new Set(existingKnowledge);
+
+    // Collect raw candidates (parse-only — no filter here)
+    const parseBlocks = (regex) => {
+      const out = [];
+      let m;
+      while ((m = regex.exec(response)) !== null) {
+        const block = m[1];
+        const name = (block.match(/name:\s*(.+)/)?.[1] || '').trim();
+        const category = (block.match(/category:\s*(.+)/)?.[1] || '').trim();
+        const description = (block.match(/description:\s*(.+)/)?.[1] || '').trim();
+        const content = (block.match(/content:\s*([\s\S]*?)$/)?.[1] || '').trim();
+        if (!name) continue;
+        out.push({ name, category, description, content });
+      }
+      return out;
+    };
+    const skillCandidates = parseBlocks(/===SKILL===\n([\s\S]*?)===END===/g);
+    const knowCandidates  = parseBlocks(/===KNOWLEDGE===\n([\s\S]*?)===END===/g);
+
+    // Pre-filter: drop exact name matches (cheapest check, keeps gate output cleaner)
+    const skillsAfterNameDedup = skillCandidates.filter(c => {
+      if (existingSkillSet.has(c.name)) { log('warn', `Skipped exact-dup skill: ${c.name}`); return false; }
+      return true;
+    });
+    const knowAfterNameDedup = knowCandidates.filter(c => {
+      if (existingKnowSet.has(c.name)) { log('warn', `Skipped exact-dup knowledge: ${c.name}`); return false; }
+      return true;
+    });
+
+    // Fuzzy dedup-gate: catches paraphrases & templated suffixes against full inventory
+    const toGate = arr => arr.map(c => ({ slug: c.name, purpose: c.description, category: c.category, __orig: c }));
+    const skillGate = dedupGate.filter(toGate(skillsAfterNameDedup), existingSkillItems);
+    const knowGate  = dedupGate.filter(toGate(knowAfterNameDedup),  existingKnowItems);
+
+    for (const rej of [...skillGate.rejected, ...knowGate.rejected]) {
+      log('warn', `dedup-gate rejected "${rej.slug}": ${rej.reason}${rej.nearest ? ` (nearest: ${rej.nearest} @ ${rej.similarity})` : ''}`);
+    }
+    for (const rev of [...skillGate.review, ...knowGate.review]) {
+      log('warn', `dedup-gate review "${rev.slug}": similar to ${rev.nearest} @ ${rev.similarity}`);
+    }
+    broadcast({ type: 'dedup-review',   items: [...skillGate.review,   ...knowGate.review]   });
+    broadcast({ type: 'dedup-rejected', items: [...skillGate.rejected, ...knowGate.rejected] });
+
+    // Finalize accepted skills
+    for (const acc of skillGate.accepted) {
+      const { name, category, description, content } = acc.__orig;
+      extracted.skills.push({ name, category: category || 'misc', description, content });
+      state.skills.push({ name, category: category || 'misc', type: 'skill', cycle: cycleNum });
+      state.stats.skills++;
+      broadcast({ type: 'skill', skill: { name, category: category || 'misc', type: 'skill' } });
+      log('success', `Extracted skill: ${name} (${category || 'misc'})`);
+    }
+    // Finalize accepted knowledge
+    for (const acc of knowGate.accepted) {
+      const { name, category, description, content } = acc.__orig;
+      extracted.knowledge.push({ name, category: category || 'pitfall', description, content });
+      state.knowledge.push({ name, category: category || 'pitfall', type: 'knowledge', cycle: cycleNum });
+      state.stats.knowledge++;
+      broadcast({ type: 'skill', skill: { name, category: category || 'pitfall', type: 'knowledge' } });
+      log('success', `Extracted knowledge: ${name} (${category || 'pitfall'})`);
+    }
+
+    if (extracted.skills.length === 0 && extracted.knowledge.length === 0) {
+      log('info', 'Extraction yielded nothing new — quality over quantity');
+    }
+  } catch (err) {
+    log('error', `Extract failed: ${err.message.split('\n')[0]}`);
+  }
+
+  broadcast({ type: 'stats', stats: state.stats });
+  return extracted;
+}
+
+async function phasePublishSK(extracted, cycleNum) {
+  setPhase('publish-sk');
+  log('phase', 'Phase 6: Publish skills & knowledge');
+
+  if (extracted.skills.length === 0 && extracted.knowledge.length === 0) {
+    log('warn', 'Nothing to publish');
+    return;
+  }
+
+  try {
+    await shell(`git -C "${SKILLS_HUB}" fetch origin main --prune`);
+    await shell(`git -C "${SKILLS_HUB}" checkout main`);
+    await shell(`git -C "${SKILLS_HUB}" reset --hard origin/main`);
+
+    const branch = `release/auto-loop-cycle-${cycleNum}`;
+    await shell(`git -C "${SKILLS_HUB}" branch -D "${branch}"`, { ignoreError: true });
+    await shell(`git -C "${SKILLS_HUB}" push origin --delete "${branch}"`, { ignoreError: true });
+    await shell(`git -C "${SKILLS_HUB}" checkout -b "${branch}"`);
+
+    // Write knowledge
+    for (const k of extracted.knowledge) {
+      const dir = path.join(SKILLS_HUB, 'knowledge', k.category);
+      fs.mkdirSync(dir, { recursive: true });
+      const md = `---\nname: ${k.name}\ndescription: ${k.description}\ncategory: ${k.category}\ntags:\n  - ${extracted.skills[0]?.name?.split('-')[0] || 'auto'}\n  - auto-loop\n---\n\n# ${k.name}\n\n${k.content}\n`;
+      fs.writeFileSync(path.join(dir, `${k.name}.md`), md);
+    }
+
+    if (extracted.knowledge.length > 0) {
+      await shell(`git -C "${SKILLS_HUB}" add knowledge/`);
+      await shell(`git -C "${SKILLS_HUB}" commit -m "knowledge: add ${extracted.knowledge.map(k=>k.name).join(', ')} (auto-loop cycle ${cycleNum})"`, { ignoreError: true });
+    }
+
+    // Write skills
+    for (const s of extracted.skills) {
+      const dir = path.join(SKILLS_HUB, 'skills', s.category, s.name);
+      fs.mkdirSync(dir, { recursive: true });
+      const md = `---\nname: ${s.name}\ndescription: ${s.description}\ncategory: ${s.category}\ntriggers:\n  - ${s.name.replace(/-/g, ' ')}\ntags:\n  - auto-loop\nversion: 1.0.0\n---\n\n# ${s.name}\n\n${s.content}\n`;
+      fs.writeFileSync(path.join(dir, 'SKILL.md'), md);
+    }
+
+    if (extracted.skills.length > 0) {
+      await shell(`git -C "${SKILLS_HUB}" add skills/`);
+      await shell(`git -C "${SKILLS_HUB}" commit -m "skills: add ${extracted.skills.map(s=>s.name).join(', ')} (auto-loop cycle ${cycleNum})"`, { ignoreError: true });
+    }
+
+    // Push + PR
+    await shell(`git -C "${SKILLS_HUB}" push -u origin "${branch}"`);
+    const prTitle = `auto-loop cycle ${cycleNum}: ${extracted.skills.length} skills + ${extracted.knowledge.length} knowledge`;
+    const prUrl = await shell(`gh pr create --title "${prTitle}" --body "Auto-generated by hub-auto-loop cycle ${cycleNum}."`, { ignoreError: true, cwd: SKILLS_HUB });
+
+    if (prUrl && prUrl.includes('github.com')) {
+      state.stats.prs++;
+      broadcast({ type: 'stats', stats: state.stats });
+      log('success', `S/K PR: ${prUrl}`);
+
+      // Auto-merge
+      const prNum = prUrl.split('/').pop();
+      await new Promise(r => setTimeout(r, 3000));
+      await shell(`gh pr merge ${prNum} --merge`, { ignoreError: true, cwd: SKILLS_HUB });
+      log('success', `Merged S/K PR #${prNum}`);
+    }
+  } catch (err) {
+    log('error', `Publish S/K failed: ${err.message.split('\n')[0]}`);
+  }
+}
+
+async function phaseInstall() {
+  setPhase('install');
+  log('phase', 'Phase 7: Install all skills & knowledge');
+
+  try {
+    await shell(`git -C "${SKILLS_HUB}" checkout main`);
+    await shell(`git -C "${SKILLS_HUB}" fetch origin main --prune`);
+    await shell(`git -C "${SKILLS_HUB}" reset --hard origin/main`);
+
+    // Install new skills
+    const skillDirs = shellSync(`find "${SKILLS_HUB}/skills" -mindepth 2 -name "SKILL.md"`, { ignoreError: true });
+    let installed = 0;
+    if (skillDirs) {
+      for (const f of skillDirs.split('\n').filter(Boolean)) {
+        const skillDir = path.dirname(f);
+        const name = path.basename(skillDir);
+        const dest = path.join(SKILLS_DEST, name);
+        if (!fs.existsSync(dest)) {
+          fs.cpSync(skillDir, dest, { recursive: true });
+          installed++;
+        }
+      }
+    }
+
+    // Install new knowledge
+    const knowledgeSrc = path.join(SKILLS_HUB, 'knowledge');
+    const knowledgeDest = path.join(WORK_DIR, '.claude', 'knowledge');
+    let kInstalled = 0;
+    if (fs.existsSync(knowledgeSrc)) {
+      for (const cat of fs.readdirSync(knowledgeSrc)) {
+        const catDir = path.join(knowledgeSrc, cat);
+        if (!fs.statSync(catDir).isDirectory()) continue;
+        const destCat = path.join(knowledgeDest, cat);
+        fs.mkdirSync(destCat, { recursive: true });
+        for (const f of fs.readdirSync(catDir).filter(x => x.endsWith('.md'))) {
+          const destFile = path.join(destCat, f);
+          if (!fs.existsSync(destFile)) {
+            fs.copyFileSync(path.join(catDir, f), destFile);
+            kInstalled++;
+          }
+        }
+      }
+    }
+
+    log('success', `Installed: ${installed} new skills, ${kInstalled} new knowledge`);
+
+    // Update registry
+    if (installed > 0 && fs.existsSync(REGISTRY_PATH)) {
+      try {
+        const reg = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8'));
+        const commit = shellSync(`git -C "${SKILLS_HUB}" rev-parse HEAD`, { ignoreError: true });
+        const now = new Date().toISOString();
+        const files = shellSync(`find "${SKILLS_HUB}/skills" -mindepth 2 -name "SKILL.md"`, { ignoreError: true });
+        for (const f of (files || '').split('\n').filter(Boolean)) {
+          const name = path.basename(path.dirname(f));
+          const cat = path.basename(path.dirname(path.dirname(f)));
+          if (!reg.skills[name]) {
+            reg.skills[name] = { name, category: cat, scope: 'project', installed_at: now, version: '1.0.0', source_commit: commit, pinned: false, linked_knowledge: [] };
+          }
+        }
+        fs.writeFileSync(REGISTRY_PATH, JSON.stringify(reg, null, 2));
+      } catch {}
+    }
+  } catch (err) {
+    log('error', `Install failed: ${err.message.split('\n')[0]}`);
+  }
+}
+
+// ── Phase Helper ──
+function setPhase(phase) {
+  state.phase = phase;
+  broadcast({ type: 'phase', phase, status: 'active' });
+  // Mark previous phases as done
+  const phases = ['generate', 'build', 'publish', 'merge', 'extract', 'publish-sk', 'install', 'loop'];
+  const idx = phases.indexOf(phase);
+  for (let i = 0; i < idx; i++) {
+    broadcast({ type: 'phase', phase: phases[i], status: 'done' });
+  }
+}
+
+// ╔══════════════════════════════════════════════════════════════╗
+// ║  MAIN LOOP                                                   ║
+// ╚══════════════════════════════════════════════════════════════╝
+
+async function runCycle() {
+  state.cycle++;
+  const cycleNum = state.cycle;
+  log('phase', `═══ CYCLE ${cycleNum} START ═══`);
+
+  // Refresh hub inventory at cycle start (cheap — scan only, no Claude call)
+  await refreshInventory();
+
+  const keyword = await pickKeyword();
+  state.currentKeyword = keyword;
+  broadcast({ type: 'cycle', cycle: cycleNum, keyword });
+  log('info', `Keyword: "${keyword}"`);
+
+  try {
+    // Phase 1: Generate
+    const claudeOutput = await phaseGenerate(keyword);
+
+    if (state.stopRequested) return;
+
+    // Phase 2: Build
+    const apps = await phaseBuild(claudeOutput, keyword, cycleNum);
+
+    if (apps.length === 0) {
+      log('warn', 'No apps built this cycle, retrying with different keyword');
+      return;
+    }
+
+    if (state.stopRequested) return;
+
+    // Phase 3: Publish PRs
+    const prUrls = await phasePublish(apps, cycleNum);
+
+    if (state.stopRequested) return;
+
+    // Phase 4: Auto-Merge
+    if (prUrls.length > 0) {
+      await phaseMerge(prUrls);
+    }
+
+    if (state.stopRequested) return;
+
+    // Phase 5: Extract skills/knowledge
+    const extracted = await phaseExtract(apps, cycleNum);
+
+    if (state.stopRequested) return;
+
+    // Phase 6: Publish skills/knowledge
+    await phasePublishSK(extracted, cycleNum);
+
+    if (state.stopRequested) return;
+
+    // Phase 7: Install
+    await phaseInstall();
+
+    setPhase('loop');
+    log('phase', `═══ CYCLE ${cycleNum} COMPLETE ═══`);
+    log('info', `Stats: ${state.stats.apps} apps, ${state.stats.skills} skills, ${state.stats.knowledge} knowledge, ${state.stats.prs} PRs, ${state.stats.lines.toLocaleString()} lines`);
+
+  } catch (err) {
+    log('error', `Cycle ${cycleNum} error: ${err.message.split('\n')[0]}`);
+  }
+}
+
+async function mainLoop() {
+  state.status = 'running';
+  state.startTime = Date.now();
+  state.stopRequested = false;
+  broadcast({ type: 'status', status: 'running' });
+
+  while (!state.stopRequested) {
+    try {
+      await runCycle();
+    } catch (err) {
+      log('error', `Loop error: ${err.message}`);
+    }
+
+    if (state.stopRequested) break;
+
+    // Single-cycle mode: exit after first cycle
+    if (state.runOnce) {
+      log('phase', '═══ Single run complete — stopping ═══');
+      break;
+    }
+
+    // Brief pause between cycles
+    log('info', 'Next cycle in 10 seconds...');
+    await new Promise(r => setTimeout(r, 10000));
+  }
+
+  state.status = 'idle';
+  state.phase = null;
+  broadcast({ type: 'status', status: 'idle' });
+  log('info', 'Loop stopped.');
+}
+
+// ╔══════════════════════════════════════════════════════════════╗
+// ║  HTTP SERVER                                                 ║
+// ╚══════════════════════════════════════════════════════════════╝
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+
+  // CORS
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST');
+
+  // Dashboard
+  if (url.pathname === '/' || url.pathname === '/index.html') {
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8'));
+    return;
+  }
+
+  // Static image/asset serving
+  if (/\.(jpg|jpeg|png|gif|webp|svg)$/i.test(url.pathname)) {
+    const fp = path.join(__dirname, decodeURIComponent(url.pathname.replace(/^\//, '')));
+    if (fp.startsWith(__dirname) && fs.existsSync(fp)) {
+      const ext = path.extname(fp).slice(1).toLowerCase();
+      const mime = { jpg:'image/jpeg', jpeg:'image/jpeg', png:'image/png', gif:'image/gif', webp:'image/webp', svg:'image/svg+xml' }[ext] || 'application/octet-stream';
+      res.writeHead(200, { 'Content-Type': mime, 'Cache-Control': 'public, max-age=3600' });
+      res.end(fs.readFileSync(fp));
+      return;
+    }
+  }
+
+  // SSE
+  if (url.pathname === '/events') {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    });
+    res.write('\n');
+    clients.push(res);
+    req.on('close', () => {
+      const idx = clients.indexOf(res);
+      if (idx >= 0) clients.splice(idx, 1);
+    });
+    // Send current state
+    res.write(`data: ${JSON.stringify({
+      type: 'state',
+      status: state.status,
+      cycle: state.cycle,
+      keyword: state.currentKeyword,
+      apps: state.apps.slice(-20),
+      skills: [...state.skills, ...state.knowledge].slice(-20),
+      stats: state.stats,
+      uptime: state.startTime ? Date.now() - state.startTime : 0,
+    })}\n\n`);
+    // Send buffered logs so new connections see history
+    for (const entry of logBuffer) {
+      res.write(`data: ${JSON.stringify(entry)}\n\n`);
+    }
+    return;
+  }
+
+  // API: auto-hub-loop exact token usage + 5h-limit calibration estimate
+  if (url.pathname === '/api/usage') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ...tokenUsage, calibration: calibrationSnapshot() }));
+    return;
+  }
+
+  // API: state
+  // Serve hub item content (skill or knowledge) for click-to-preview
+  if (url.pathname === '/api/hub-item') {
+    const kind = url.searchParams.get('kind'); // 'skill' or 'knowledge'
+    const name = url.searchParams.get('name');
+    if (!kind || !name || !/^[a-z0-9-]+$/.test(name)) {
+      res.writeHead(400, { 'Content-Type': 'application/json' }); res.end('{"error":"bad request"}'); return;
+    }
+    let content = null, foundPath = null;
+    try {
+      if (kind === 'skill') {
+        const root = path.join(SKILLS_HUB, 'skills');
+        for (const cat of fs.readdirSync(root)) {
+          const f = path.join(root, cat, name, 'SKILL.md');
+          if (fs.existsSync(f)) { content = fs.readFileSync(f, 'utf8'); foundPath = `skills/${cat}/${name}/SKILL.md`; break; }
+        }
+      } else if (kind === 'knowledge') {
+        const root = path.join(SKILLS_HUB, 'knowledge');
+        for (const cat of fs.readdirSync(root)) {
+          const f = path.join(root, cat, `${name}.md`);
+          if (fs.existsSync(f)) { content = fs.readFileSync(f, 'utf8'); foundPath = `knowledge/${cat}/${name}.md`; break; }
+        }
+      }
+    } catch {}
+    if (!content) { res.writeHead(404, { 'Content-Type': 'application/json' }); res.end('{"error":"not found"}'); return; }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ name, kind, path: foundPath, content }));
+    return;
+  }
+
+  if (url.pathname === '/api/state') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      type: 'state',
+      status: state.status,
+      cycle: state.cycle,
+      keyword: state.currentKeyword,
+      apps: state.apps.slice(-50),
+      skills: [...state.skills, ...state.knowledge].slice(-50),
+      stats: state.stats,
+      uptime: state.startTime ? Date.now() - state.startTime : 0,
+    }));
+    return;
+  }
+
+  // API: start
+  if (url.pathname === '/api/start' && req.method === 'POST') {
+    if (state.status !== 'running') {
+      state.runOnce = false;
+      mainLoop().catch(err => log('error', err.message));
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  // Run single cycle then stop
+  if (url.pathname === '/api/run-once' && req.method === 'POST') {
+    if (state.status !== 'running') {
+      state.runOnce = true;
+      mainLoop().catch(err => log('error', err.message));
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, mode: 'run-once' }));
+    return;
+  }
+
+  // API: stop
+  if (url.pathname === '/api/stop' && req.method === 'POST') {
+    state.stopRequested = true;
+    state.status = 'stopping';
+    broadcast({ type: 'status', status: 'stopping' });
+    log('warn', 'Stop requested — finishing current phase...');
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  // 404
+  res.writeHead(404);
+  res.end('Not found');
+});
+
+server.listen(PORT, () => {
+  console.log(`\n  Hub Auto-Loop Dashboard: http://localhost:${PORT}\n`);
+  console.log('  Press Start in the dashboard to begin the automation loop.\n');
+});


### PR DESCRIPTION
## Summary

v3 of `auto-hub-loop` introduces a drop-in `hub-loop-v3/` module layer that replaces the force-quota extraction flow.

- **`hub-inventory.js`** — scans skills-hub once per cycle, derives purpose from YAML frontmatter `description:` field (falls back to first prose sentence), produces a compressed one-line index instead of dumping full SKILL.md bodies.
- **`dedup-gate.js`** — zero-dep fuzzy duplicate detector using trigram + token + slug Jaccard similarity. Catches paraphrased dupes the old name-equality check missed. Rejects templated suffixes (`-visualization-pattern`, `-data-simulation`, etc.).
- **`theme-strategies.js`** — optional weighted theme picker (gap-driven / combinatorial / exploratory). Available but not wired by default.
- **`prompts/extraction.md`** — novelty-first v3 extraction prompt with explicit "zero is a valid answer" framing.

Wired into `server.js`:
- `refreshInventory()` at each cycle start (zero Claude calls, scan-only)
- Phase 1 uses v3 compressed index (with legacy sampler fallback)
- Phase 5 runs `dedupGate.filter()` after exact-name dedup; broadcasts `dedup-review` + `dedup-rejected` SSE events; only accepted items published

## Preview

https://github.com/kjuhwa/skills-hub/tree/example/hub-tools/auto-hub-loop-v3/example/hub-tools/auto-hub-loop-v3

🤖 Generated with [Claude Code](https://claude.com/claude-code)