### PR TITLE
Publish 0 skills + 2 knowledge entries (session-extract)

### DIFF
--- a/knowledge/workflow/dropin-module-reality-check-before-wire.md
+++ b/knowledge/workflow/dropin-module-reality-check-before-wire.md
@@ -1,0 +1,58 @@
+---
+name: dropin-module-reality-check-before-wire
+description: Before wiring a drop-in module into a target project, map every path/marker/regex in the module to what the target actually stores on disk — the module's README describes its author's assumed layout, not yours.
+category: workflow
+type: pitfall
+tags:
+  - integration
+  - drop-in-modules
+  - assumptions
+---
+
+# Reality-check drop-in modules against the target project before wiring
+
+## The pitfall
+
+Drop-in modules come with an INTEGRATION.md or README that describes paths, markers, and regexes the module author assumed for their own codebase. Those assumptions leak into the module's defaults — and they almost never match the target project's actual layout exactly.
+
+If you skip the reality-check and wire in the module as-is, the failures are silent: empty scan results, missed files, or zero-hit regexes. The module appears to load fine. You only notice when downstream behavior is anemic.
+
+## Concrete examples
+
+A v3 drop-in bundle advertised paths like:
+
+```
+<hubRoot>/example/<category>/<slug>/SKILL.md
+<hubRoot>/knowledge/<category>/<slug>/README.md
+```
+
+The actual target hub stored:
+
+```
+<hubRoot>/skills/<category>/<slug>/SKILL.md       ← "skills" not "example"
+<hubRoot>/knowledge/<category>/<slug>.md          ← flat .md, no nested dir
+```
+
+Wiring the module without adapting would have scanned an empty `example/` directory and missed every knowledge file. The tests would still pass (the module's own self-test works with mocks), and the prompt would silently degrade to an empty compressed index.
+
+Similar traps to watch for in any drop-in:
+- **Marker filenames** (`SKILL.md` vs `README.md` vs `index.md`)
+- **Directory depth** (nested `<slug>/README.md` vs flat `<slug>.md`)
+- **Kind/root names** (`example/` vs `skills/` vs `recipes/`)
+- **Frontmatter field names** (`description:` vs `summary:` vs `purpose:`)
+- **Spawn / CLI assumptions** (`claude` direct vs `.cmd` wrapper on Windows)
+- **Default thresholds in comments** that drifted from the code's real defaults
+
+## The check
+
+Before wiring, for every path/marker/regex in the module:
+1. Open the target project's actual directory tree and confirm the path exists.
+2. Read an actual file the module would match; confirm the marker name and frontmatter field names line up.
+3. If the module spawns subprocesses, check how the target project already spawns the same binary — adopt its pattern (e.g. `shell: true` on Windows).
+4. If there's a doc/default mismatch in the module itself (e.g. comment header says `threshold = 0.6` but signature is `= 0.3`), trust the code — but note the drift and fix the doc before publishing.
+
+## How to apply
+
+- Adapt the module to match the target first; wire second. Don't leave "TODO: fix paths later" adapters.
+- If the module is a one-person drop-in you don't own, fork it into a project-local `hub-loop-v3/` (or similar) and keep the original `files/` as an untouched archive for diffing.
+- Run the module's own self-test AND a target-integration smoke test (e.g. `node -e "const m=require('./x');m.load({hubRoot: REAL_HUB}).then(r=>console.log(r.count))"`) before writing any server-side wiring.

--- a/knowledge/workflow/repeated-look-again-means-retract-not-escalate.md
+++ b/knowledge/workflow/repeated-look-again-means-retract-not-escalate.md
@@ -1,0 +1,40 @@
+---
+name: repeated-look-again-means-retract-not-escalate
+description: Repeated "look again" from the user after multiple findings is a signal to retract over-reaching claims, not to propose more findings.
+category: workflow
+type: pitfall
+tags:
+  - collaboration
+  - feedback-interpretation
+  - self-correction
+---
+
+# Repeated "look again" means retract, not escalate
+
+## The pitfall
+
+When the user says "look again" / "다시 봐봐" a second or third time after you've already offered a list of findings, the instinct is to search HARDER — add another bullet, find one more defect, raise a new concern. That's usually wrong.
+
+Multiple vague "look again" responses almost always mean: **"your analysis is off — narrow it down, don't expand it."** Escalating by producing MORE candidates compounds the original mistake (over-confident noise), because each new item was generated under the same faulty discrimination that produced the first set.
+
+## What happened
+
+Observed pattern in a real session:
+1. User asks for a file review. Assistant offers 4 items of varying severity.
+2. User: "다시 봐봐" (look again). Assistant proposes 2 more findings (one confessed retraction, one new "crash-inducing" bug based on a prompt-text contradiction).
+3. User: "다시 봐봐" again. Assistant, now anxious, invents a fresh angle.
+4. User: "다시 봐봐" again. Only then does the assistant retract everything except the ONE indisputable finding — a comment-vs-default mismatch — which had been the only real hit all along.
+
+All the intermediate "findings" were speculative: ambiguous prose read as a JSON crash, environment-dependent bugs stated as definite, design preferences framed as bugs.
+
+## What to do instead
+
+- After the **second** "look again," stop proposing and start evaluating: which of your prior claims are **indisputable** (documented mismatch, a failing test, a provable crash), which are **inferential** (probable bug contingent on some env detail), and which are **preference** (a design improvement)?
+- Respond by explicitly re-classifying your earlier claims into those three buckets. Retract the inferential and preference items unless the user asks for them specifically.
+- Ask the user to point at the angle you're missing, rather than guessing at a new one.
+
+## How to tell "look again" apart from "look deeper"
+
+- "Look again" after vague or open-ended assistant output → usually "you're overreaching."
+- "Look again at the error" / "look again at line 42" → localized "you missed something specific."
+- If unsure, ask: "Are my current findings too broad, or am I missing something specific?"


### PR DESCRIPTION
## Knowledge

Two workflow pitfalls extracted from a live auto-hub-loop v3 wiring session.

- `workflow/repeated-look-again-means-retract-not-escalate` — treat repeated vague "look again" feedback as a signal to retract over-reaching claims, not as a cue to propose more findings. Derived from observed 3x escalation → final retraction pattern.
- `workflow/dropin-module-reality-check-before-wire` — before wiring a drop-in module into a target project, map every path / marker / regex in the module to what the target actually stores on disk. Drop-in READMEs describe the author's assumed layout, not yours. Derived from adapting a drop-in that assumed `example/<cat>/<slug>/SKILL.md` + nested README.md knowledge against a target using `skills/<cat>/<slug>/SKILL.md` + flat knowledge `.md`.

## Cross-links

None.

## Source

Session extraction on 2026-04-18, parent project: `example/hub-tools/auto-hub-loop-v3` (PR #1007).

🤖 Generated with [Claude Code](https://claude.com/claude-code)