### PR TITLE
bootstrap: wire /hub-sync to reindex, cross-link /hub-search-* to /hub-find

### DIFF
--- a/bootstrap/commands/hub-search-knowledge.md
+++ b/bootstrap/commands/hub-search-knowledge.md
@@ -7,6 +7,8 @@ argument-hint: <keyword> [--inject] [--top <N>] [--category <cat>] [--tag <tag>]
 
 Locate relevant knowledge entries before acting. Optionally inject the top matches into the current conversation so the next step benefits from prior lessons.
 
+> **Tip:** For a ranked cross-corpus search (skills + knowledge) with Korean synonym expansion, `/hub-find --kind knowledge` is often faster than this command's grep flow.
+
 ## Steps
 
 1. **Gather index**: enumerate all `~/.claude/skills-hub/knowledge/<cat>/*.md` (+ project `.claude/knowledge/` if present).

--- a/bootstrap/commands/hub-search-skills.md
+++ b/bootstrap/commands/hub-search-skills.md
@@ -7,6 +7,8 @@ argument-hint: <keyword> [--category=<name>]
 
 Read-only search of the remote skill repository.
 
+> **Tip:** For keyword-based, ranked search with 180+ Korean↔English synonyms (e.g. "스프링 카프카"), prefer `/hub-find` — it scores `name`/`description`/`tags`/`triggers` and returns top-N.
+
 ## Steps
 
 1. Ensure `~/.claude/skills-hub/remote/` exists and is fresh (see `/hub-install` step 1).

--- a/bootstrap/commands/hub-sync.md
+++ b/bootstrap/commands/hub-sync.md
@@ -43,6 +43,11 @@ Bring local installs to latest — or pin/rollback a specific skill to an exact 
 6. **Local-modified detection**
    - If local SKILL.md/content.md differs from stored commit content, warn user — updating will lose local edits. Offer to save a `.bak` copy.
 
+7. **Refresh indexes**
+   - `git reset --hard` bypasses git hooks, so the L1/L2 index (`~/.claude/skills-hub/indexes/`) won't auto-regenerate after step 1.
+   - Run `hub-precheck --skip-lint` (or `py ~/.claude/skills-hub/tools/precheck.py --skip-lint`) to refresh `00_MASTER_INDEX*.md` and `category_indexes/`.
+   - Skip this step if `--dry-run` (nothing actually applied).
+
 ## Rules
 
 - Never `reset --hard` if the cache has uncommitted changes (shouldn't happen, but guard).


### PR DESCRIPTION
## Summary
Upstream the three local command patches so `/hub-commands-update` installs them for everyone:

1. **`/hub-sync`** — new step 7 calls `hub-precheck --skip-lint` after the `git reset --hard`. Closes a hook-coverage gap: `reset --hard` doesn't fire post-merge / post-commit / post-checkout hooks, so the L1/L2 indexes at `~/.claude/skills-hub/indexes/` would otherwise go stale.
2. **`/hub-search-skills`** — Tip block pointing to `/hub-find` for ranked search with 180+ Korean↔English synonyms.
3. **`/hub-search-knowledge`** — same Tip, with `--kind knowledge`.

## Context
- Index infrastructure was introduced locally: `~/.claude/skills-hub/tools/` (scripts) + `~/.claude/skills-hub/indexes/` (L1/L2 output) + `~/.claude/skills-hub/bin/` (wrappers) + git hooks via `tools/install-hooks.sh`.
- Slash commands `/hub-find`, `/hub-precheck`, `/hub-index-diff` live outside bootstrap (user-managed) and are recommended alongside existing tooling.
- This PR only patches **three** existing bootstrap commands — the new commands are not added here to keep scope small.

## Test plan
- [x] Local edits applied and verified in live `~/.claude/commands/`
- [x] `/hub-sync` dry-run honoured (no precheck call in dry-run)
- [x] `/hub-search-skills` / `/hub-search-knowledge` still return correct results; Tip appears at top
- [ ] Reviewer confirms the Tip lines render correctly in their client

## Rollback
If this causes surprises, revert the single commit (`925e21c`). The change is additive; removing it restores the prior behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)