### PR TITLE
Bootstrap v2.5.0: ship tools/bin/hooks and 3 new commands

### DIFF
--- a/bootstrap/bin/hub-index-diff
+++ b/bootstrap/bin/hub-index-diff
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# _index_diff.py 래퍼. 커밋 간 인덱스 변경 리포트.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${SCRIPT_DIR%/bin}/tools/_index_diff.py"
+if [[ ! -f "$SCRIPT" ]]; then
+    echo "hub-index-diff: cannot find $SCRIPT" >&2
+    exit 1
+fi
+PYTHONIOENCODING=utf-8 py -3 "$SCRIPT" "$@"

--- a/bootstrap/bin/hub-precheck
+++ b/bootstrap/bin/hub-precheck
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# precheck.py 래퍼. lint + master/lite/category 재생성.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${SCRIPT_DIR%/bin}/tools/precheck.py"
+if [[ ! -f "$SCRIPT" ]]; then
+    echo "hub-precheck: cannot find $SCRIPT" >&2
+    exit 1
+fi
+PYTHONIOENCODING=utf-8 py -3 "$SCRIPT" "$@"

--- a/bootstrap/bin/hub-search
+++ b/bootstrap/bin/hub-search
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# hub_search.py 래퍼. 스크립트는 이 파일의 상위 tools/ 에 위치한다.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${SCRIPT_DIR%/bin}/tools/hub_search.py"
+if [[ ! -f "$SCRIPT" ]]; then
+    echo "hub-search: cannot find $SCRIPT" >&2
+    exit 1
+fi
+PYTHONIOENCODING=utf-8 py -3 "$SCRIPT" "$@"

--- a/bootstrap/commands/hub-find.md
+++ b/bootstrap/commands/hub-find.md
@@ -1,0 +1,34 @@
+---
+description: 스킬 허브 전체 코퍼스에서 키워드 기반 top-N 검색 (한/영 동의어 포함)
+argument-hint: <query> [-n N] [--kind skill|knowledge] [--category CAT] [--html --out FILE]
+---
+
+# /hub-find $ARGUMENTS
+
+`~/.claude/skills-hub/remote/index.json` 을 대상으로 키워드 점수화 검색을 수행한다. 한글 쿼리도 180+ 동의어 맵을 거쳐 확장된다 (예: "스프링" → spring, spring-boot).
+
+## 실행
+
+```bash
+hub-search $ARGUMENTS
+```
+
+PATH 에 없으면 직접 호출:
+
+```bash
+PYTHONIOENCODING=utf-8 py -3 ~/.claude/skills-hub/tools/hub_search.py $ARGUMENTS
+```
+
+## 예시
+
+- `/hub-find 카프카 이벤트`
+- `/hub-find websocket -n 20 --kind skill`
+- `/hub-find rate-limit --category decision`
+- `/hub-find 보안 --json`
+- `/hub-find 인증 --html --out /tmp/auth.html`
+
+## 응답 작성 가이드
+
+1. CLI 출력에서 상위 3~5개 항목의 `name` 과 `path` 를 요약.
+2. 직접 관련된 항목은 `~/.claude/skills-hub/remote/<path>` 실제 MD 를 읽어 구체 인용.
+3. 동의어 확장이 의도와 달랐다면 `--synonyms` 로 검증.

--- a/bootstrap/commands/hub-index-diff.md
+++ b/bootstrap/commands/hub-index-diff.md
@@ -1,0 +1,32 @@
+---
+description: 지정 커밋 대비 인덱스 변경 리포트 (추가/수정/제거)
+argument-hint: [base-ref] [--json]
+---
+
+# /hub-index-diff $ARGUMENTS
+
+`~/.claude/skills-hub/remote/` 의 `<base-ref>` 커밋(기본 `HEAD~1`) 과 현재 HEAD 를 비교해 인덱스 항목의 추가·수정·제거를 보고한다.
+
+## 실행
+
+```bash
+hub-index-diff $ARGUMENTS
+```
+
+또는 직접:
+
+```bash
+PYTHONIOENCODING=utf-8 py -3 ~/.claude/skills-hub/tools/_index_diff.py $ARGUMENTS
+```
+
+## 예시
+
+- `/hub-index-diff` — 직전 커밋(HEAD~1) 대비
+- `/hub-index-diff ae3e15d` — 특정 커밋 대비
+- `/hub-index-diff main --json`
+
+## 응답 작성 가이드
+
+1. `추가/수정/제거` 건수를 먼저 한 줄 요약.
+2. 건수가 많으면 카테고리 집계(`knowledge/pitfall +12` 식)를 덧붙인다.
+3. 구체 이름 나열은 10개까지, 나머지는 "...외 N건".

--- a/bootstrap/commands/hub-precheck.md
+++ b/bootstrap/commands/hub-precheck.md
@@ -1,0 +1,30 @@
+---
+description: 스킬 허브 사전 검증 (lint + master/lite/category 인덱스 재생성)
+argument-hint: [--strict] [--skip-lint]
+---
+
+# /hub-precheck $ARGUMENTS
+
+스킬/지식 코퍼스의 프런트매터 스키마를 검증하고 모든 인덱스(L1 전체·L1 경량·L2 카테고리별)를 재생성한다.
+
+## 실행
+
+```bash
+hub-precheck $ARGUMENTS
+```
+
+PATH 에 없으면 직접 호출:
+
+```bash
+PYTHONIOENCODING=utf-8 py -3 ~/.claude/skills-hub/tools/precheck.py $ARGUMENTS
+```
+
+## 출력 해석
+
+- `[ALL PASS]` — 모든 파일이 스키마 충족, 인덱스 3종 (`~/.claude/skills-hub/indexes/`) 갱신 완료.
+- `[ABORT] lint` — 누락 필드가 있는 파일이 있음. 리포트를 보고 자동 보정(`py ~/.claude/skills-hub/tools/_fix_frontmatter.py`)이나 수동 편집을 안내.
+- 비정상 종료 코드는 사용자에게 그대로 전달한다.
+
+## 주의
+
+- 원격 clone (`~/.claude/skills-hub/remote/`) 안의 파일은 PR을 통해서만 수정한다.

--- a/bootstrap/install.sh
+++ b/bootstrap/install.sh
@@ -5,8 +5,10 @@ set -euo pipefail
 
 CLAUDE_DIR="${CLAUDE_DIR:-$HOME/.claude}"
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+HUB_DIR="$CLAUDE_DIR/skills-hub"
 
-mkdir -p "$CLAUDE_DIR/commands" "$CLAUDE_DIR/skills/skills-hub" "$CLAUDE_DIR/skills-hub"
+mkdir -p "$CLAUDE_DIR/commands" "$CLAUDE_DIR/skills/skills-hub" \
+         "$HUB_DIR" "$HUB_DIR/tools" "$HUB_DIR/bin" "$HUB_DIR/indexes"
 
 echo "Installing slash commands → $CLAUDE_DIR/commands/"
 cp "$REPO_DIR/bootstrap/commands/"*.md "$CLAUDE_DIR/commands/"
@@ -14,19 +16,46 @@ cp "$REPO_DIR/bootstrap/commands/"*.md "$CLAUDE_DIR/commands/"
 echo "Installing skills-hub skill → $CLAUDE_DIR/skills/skills-hub/"
 cp "$REPO_DIR/bootstrap/skills/skills-hub/SKILL.md" "$CLAUDE_DIR/skills/skills-hub/SKILL.md"
 
+# --- NEW in v2.5.0: ship the local index/tools/bin layer ---
+if [ -d "$REPO_DIR/bootstrap/tools" ]; then
+  echo "Installing tools → $HUB_DIR/tools/"
+  cp "$REPO_DIR/bootstrap/tools/"*.py "$HUB_DIR/tools/"
+  if [ -f "$REPO_DIR/bootstrap/tools/install-hooks.sh" ]; then
+    cp "$REPO_DIR/bootstrap/tools/install-hooks.sh" "$HUB_DIR/tools/install-hooks.sh"
+    chmod +x "$HUB_DIR/tools/install-hooks.sh"
+  fi
+fi
+
+if [ -d "$REPO_DIR/bootstrap/bin" ]; then
+  echo "Installing CLI wrappers → $HUB_DIR/bin/"
+  cp "$REPO_DIR/bootstrap/bin/"hub-* "$HUB_DIR/bin/" 2>/dev/null || true
+  chmod +x "$HUB_DIR/bin/"hub-* 2>/dev/null || true
+fi
+
 # Ensure the remote cache symlink / copy exists for the runtime commands
-if [ ! -d "$CLAUDE_DIR/skills-hub/remote/.git" ]; then
-  echo "Note: runtime remote cache not present at $CLAUDE_DIR/skills-hub/remote/"
+if [ ! -d "$HUB_DIR/remote/.git" ]; then
+  echo "Note: runtime remote cache not present at $HUB_DIR/remote/"
   echo "      Either clone the repo there, or a /skills_* command will clone on first run."
 fi
 
 # Initialize empty registry if missing
-if [ ! -f "$CLAUDE_DIR/skills-hub/registry.json" ]; then
-  echo "{}" > "$CLAUDE_DIR/skills-hub/registry.json"
+if [ ! -f "$HUB_DIR/registry.json" ]; then
+  echo "{}" > "$HUB_DIR/registry.json"
 fi
+
+# Install git hooks if remote is ready
+if [ -d "$HUB_DIR/remote/.git" ] && [ -f "$HUB_DIR/tools/install-hooks.sh" ]; then
+  echo "Installing git hooks (auto re-index on merge / commit / checkout)"
+  bash "$HUB_DIR/tools/install-hooks.sh" || echo "  warn: hook install failed; run manually later"
+fi
+
+# PATH hint
+echo ""
+echo "To use 'hub-search', 'hub-precheck', 'hub-index-diff' from any shell, add to ~/.bashrc:"
+echo "  export PATH=\"\$HOME/.claude/skills-hub/bin:\$PATH\""
 
 echo ""
 echo "Done. Installed commands:"
-ls "$CLAUDE_DIR/commands/" | grep -E "^(init_skills|skills_)" | sed 's/^/  /'
+ls "$CLAUDE_DIR/commands/" | grep -E "^(init_skills|skills_|hub-)" | sed 's/^/  /'
 echo ""
 echo "Restart Claude Code to pick up the new slash commands."

--- a/bootstrap/tools/_build_category_indexes.py
+++ b/bootstrap/tools/_build_category_indexes.py
@@ -1,0 +1,103 @@
+"""L2 카테고리 인덱스 생성기.
+
+각 (kind, category) 버킷별로 INDEX.md를 생성한다.
+출력 경로: F:/workspace/blank/category_indexes/<kind>/<category>/INDEX.md
+
+설계 가이드 §2 L2 레벨을 채운다 — AI가 큰 카테고리 하나를 열어서
+그 안의 모든 스킬/지식 목록을 바로 볼 수 있도록 한다.
+
+사용법:  py _build_category_indexes.py
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import shutil
+from collections import defaultdict
+from pathlib import Path
+
+HUB_INDEX = Path.home() / ".claude" / "skills-hub" / "remote" / "index.json"
+OUT_ROOT = Path(__file__).resolve().parent.parent / "indexes" / "category_indexes"
+
+
+def clip(text: str, limit: int = 200) -> str:
+    text = (text or "").replace("\n", " ").replace("|", "\\|").strip()
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def tag_str(tags) -> str:
+    return ", ".join(f"`{t}`" for t in tags) if tags else ""
+
+
+def resolve_category(entry: dict) -> str:
+    cat = entry.get("category") or ""
+    if cat:
+        return cat
+    parts = (entry.get("path") or "").split("/")
+    if len(parts) >= 2 and parts[0] in {"skills", "knowledge"}:
+        return parts[1]
+    return "misc"
+
+
+def main() -> None:
+    entries = json.loads(HUB_INDEX.read_text(encoding="utf-8"))
+    groups: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    for e in entries:
+        cat = resolve_category(e)
+        e["category"] = cat
+        groups[(e.get("kind", "unknown"), cat)].append(e)
+
+    if OUT_ROOT.exists():
+        shutil.rmtree(OUT_ROOT)
+    OUT_ROOT.mkdir(parents=True)
+
+    now = dt.datetime.now().isoformat(timespec="seconds")
+    written = 0
+    for (kind, cat), items in sorted(groups.items()):
+        items.sort(key=lambda e: e.get("name", ""))
+        out_dir = OUT_ROOT / kind / cat
+        out_dir.mkdir(parents=True, exist_ok=True)
+        lines: list[str] = []
+        lines.append(f"# {kind}/{cat} 카테고리 인덱스 (L2)")
+        lines.append("")
+        lines.append(f"- **항목 수:** {len(items)}")
+        lines.append(f"- **생성 시각:** {now}")
+        lines.append(
+            f"- **상위 인덱스:** [../../../00_MASTER_INDEX.md](../../../00_MASTER_INDEX.md)"
+        )
+        lines.append("")
+        lines.append("## 목록")
+        lines.append("")
+        lines.append("| # | 이름 | 설명 | 태그 | 경로 |")
+        lines.append("|---:|---|---|---|---|")
+        for i, e in enumerate(items, 1):
+            lines.append(
+                f"| {i} | `{e.get('name','')}` | {clip(e.get('description',''))}"
+                f" | {tag_str(e.get('tags', []))} | `{e.get('path','')}` |"
+            )
+        lines.append("")
+        (out_dir / "INDEX.md").write_text("\n".join(lines), encoding="utf-8")
+        written += 1
+
+    # Top-level README for category_indexes/.
+    readme = OUT_ROOT / "README.md"
+    lines = [
+        "# 카테고리 인덱스 (L2)",
+        "",
+        f"- 생성 시각: {now}",
+        f"- 총 카테고리: {len(groups)}",
+        "",
+        "| Kind | Category | 항목 수 | 인덱스 |",
+        "|---|---|---:|---|",
+    ]
+    for (kind, cat), items in sorted(groups.items()):
+        rel = f"{kind}/{cat}/INDEX.md"
+        lines.append(f"| {kind} | {cat} | {len(items)} | [{rel}]({rel}) |")
+    lines.append("")
+    readme.write_text("\n".join(lines), encoding="utf-8")
+
+    print(f"wrote {written} category INDEX.md files under {OUT_ROOT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bootstrap/tools/_build_master_index.py
+++ b/bootstrap/tools/_build_master_index.py
@@ -1,0 +1,141 @@
+"""Generate 00_MASTER_INDEX.md from the skills-hub index.json.
+
+Implements the L1 index layer defined in 00_DESIGN_GUIDE.md:
+  L1 Master Index  <-  this script's output
+  L2 Category dirs <-  ~/.claude/skills-hub/remote/{skills,knowledge}/<cat>/
+  L3 Skill node    <-  individual .md files with YAML frontmatter
+
+Re-run whenever the hub's index.json changes:
+    py _build_master_index.py
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+
+HUB_ROOT = Path.home() / ".claude" / "skills-hub"
+INDEX_JSON = HUB_ROOT / "remote" / "index.json"
+OUT_PATH = Path(__file__).resolve().parent.parent / "indexes" / "00_MASTER_INDEX.md"
+
+
+def hub_git_info() -> tuple[str, str]:
+    """Return (short commit, committer date) of the remote cache."""
+    remote = HUB_ROOT / "remote"
+    try:
+        sha = subprocess.check_output(
+            ["git", "-C", str(remote), "rev-parse", "--short", "HEAD"],
+            text=True,
+        ).strip()
+        date = subprocess.check_output(
+            ["git", "-C", str(remote), "log", "-1", "--format=%cI"],
+            text=True,
+        ).strip()
+    except Exception:
+        sha, date = "unknown", "unknown"
+    return sha, date
+
+
+def clip(text: str, limit: int = 180) -> str:
+    text = (text or "").replace("\n", " ").replace("|", "\\|").strip()
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def tag_str(tags) -> str:
+    if not tags:
+        return ""
+    return ", ".join(f"`{t}`" for t in tags)
+
+
+def main() -> None:
+    entries = json.loads(INDEX_JSON.read_text(encoding="utf-8"))
+    groups: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    for e in entries:
+        cat = e.get("category") or ""
+        if not cat:
+            # Fall back to first path segment after skills/ or knowledge/.
+            parts = (e.get("path") or "").split("/")
+            if len(parts) >= 2 and parts[0] in {"skills", "knowledge"}:
+                cat = parts[1]
+            else:
+                cat = "misc"
+            e["category"] = cat
+        key = (e.get("kind", "unknown"), cat)
+        groups[key].append(e)
+
+    skills_total = sum(1 for e in entries if e.get("kind") == "skill")
+    knowledge_total = sum(1 for e in entries if e.get("kind") == "knowledge")
+    commit, date = hub_git_info()
+    now = dt.datetime.now().isoformat(timespec="seconds")
+
+    lines: list[str] = []
+    lines.append("# Skills Hub Master Index (L1)")
+    lines.append("")
+    lines.append(
+        "> Auto-generated. Regenerate with `py _build_master_index.py` "
+        "after `/hub-sync` pulls new entries."
+    )
+    lines.append("")
+    lines.append("## Overview")
+    lines.append("")
+    lines.append(f"- **Total entries:** {len(entries)}")
+    lines.append(f"- **Skills:** {skills_total}")
+    lines.append(f"- **Knowledge:** {knowledge_total}")
+    lines.append(f"- **Source commit:** `{commit}` ({date})")
+    lines.append(f"- **Generated at:** {now}")
+    lines.append("")
+    lines.append(
+        "AI usage: search this file first by keyword. "
+        "Each row links to the source MD under `~/.claude/skills-hub/remote/`."
+    )
+    lines.append("")
+
+    lines.append("## Category Map")
+    lines.append("")
+    lines.append("| Kind | Category | Count | Section |")
+    lines.append("|---|---|---:|---|")
+    for (kind, cat) in sorted(groups.keys()):
+        anchor = f"{kind}-{cat}".lower().replace("/", "-")
+        lines.append(
+            f"| {kind} | {cat} | {len(groups[(kind, cat)])} | [#{anchor}](#{anchor}) |"
+        )
+    lines.append("")
+
+    lines.append("## Entries by Category")
+    lines.append("")
+    for (kind, cat) in sorted(groups.keys()):
+        anchor = f"{kind}-{cat}".lower().replace("/", "-")
+        items = sorted(groups[(kind, cat)], key=lambda e: e.get("name", ""))
+        lines.append(f"### {kind}/{cat}  <a id=\"{anchor}\"></a>")
+        lines.append("")
+        lines.append(f"_{len(items)} entries_")
+        lines.append("")
+        lines.append("| Name | Description | Tags | Path |")
+        lines.append("|---|---|---|---|")
+        for e in items:
+            name = e.get("name", "")
+            desc = clip(e.get("description", ""))
+            tags = tag_str(e.get("tags", []))
+            path = e.get("path", "")
+            lines.append(f"| `{name}` | {desc} | {tags} | `{path}` |")
+        lines.append("")
+
+    lines.append("## Flat Name Index (Ctrl+F friendly)")
+    lines.append("")
+    for e in sorted(entries, key=lambda e: (e.get("kind", ""), e.get("name", ""))):
+        kind = e.get("kind", "?")
+        name = e.get("name", "")
+        cat = e.get("category", "")
+        desc = clip(e.get("description", ""), 120)
+        lines.append(f"- **[{kind}/{cat}]** `{name}` — {desc}")
+    lines.append("")
+
+    OUT_PATH.write_text("\n".join(lines), encoding="utf-8")
+    print(f"wrote {OUT_PATH} ({len(entries)} entries, {OUT_PATH.stat().st_size} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/bootstrap/tools/_build_master_index_lite.py
+++ b/bootstrap/tools/_build_master_index_lite.py
@@ -1,0 +1,124 @@
+"""경량 마스터 인덱스 생성기.
+
+전체 748 항목을 다 실은 `00_MASTER_INDEX.md`(310KB)는 토큰 비용이 크다.
+이 스크립트는 **카테고리 맵 + 카테고리별 대표 N개**만 담은
+`00_MASTER_INDEX_LITE.md`를 생성한다. 평소 AI 세션에는 Lite를 먼저 읽히고,
+세부 조회가 필요하면 전체본이나 `hub_search.py`를 호출한다.
+
+품질 점수:
+  - description/summary 존재 : +3
+  - tags 존재 (>=1)          : +2 (개수 상한 5)
+  - version 존재             : +1
+  - description 길이 80~220  : +1
+  - 이름 토큰 수 3~8         : +1
+
+사용법:
+    py _build_master_index_lite.py          # 카테고리당 5개
+    py _build_master_index_lite.py --top 10 # 카테고리당 10개
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+from collections import defaultdict
+from pathlib import Path
+
+HUB_INDEX = Path.home() / ".claude" / "skills-hub" / "remote" / "index.json"
+OUT_PATH = Path(__file__).resolve().parent.parent / "indexes" / "00_MASTER_INDEX_LITE.md"
+
+
+def resolve_category(entry: dict) -> str:
+    cat = entry.get("category") or ""
+    if cat:
+        return cat
+    parts = (entry.get("path") or "").split("/")
+    if len(parts) >= 2 and parts[0] in {"skills", "knowledge"}:
+        return parts[1]
+    return "misc"
+
+
+def quality_score(entry: dict) -> int:
+    desc = entry.get("description") or ""
+    tags = entry.get("tags") or []
+    score = 0
+    if desc:
+        score += 3
+    if tags:
+        score += min(len(tags), 5) + 2
+    if entry.get("version"):
+        score += 1
+    if 80 <= len(desc) <= 220:
+        score += 1
+    name_tokens = [t for t in re.split(r"[-_]", entry.get("name") or "") if t]
+    if 3 <= len(name_tokens) <= 8:
+        score += 1
+    return score
+
+
+def clip(text: str, limit: int = 120) -> str:
+    text = (text or "").replace("\n", " ").replace("|", "\\|").strip()
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--top", type=int, default=5, help="카테고리당 상위 N개")
+    args = ap.parse_args()
+
+    entries = json.loads(HUB_INDEX.read_text(encoding="utf-8"))
+    for e in entries:
+        e["category"] = resolve_category(e)
+
+    groups: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    for e in entries:
+        groups[(e.get("kind", "unknown"), e["category"])].append(e)
+
+    now = dt.datetime.now().isoformat(timespec="seconds")
+    lines: list[str] = []
+    lines.append("# Skills Hub Lite Index (L1-compact)")
+    lines.append("")
+    lines.append(
+        f"> 전체 {len(entries)}개 중 카테고리별 상위 {args.top}개만 발췌. "
+        "세부 조회는 `00_MASTER_INDEX.md` 또는 `py hub_search.py`를 사용."
+    )
+    lines.append("")
+    lines.append(f"- 생성 시각: {now}")
+    lines.append(f"- 카테고리 버킷: {len(groups)}")
+    lines.append("")
+
+    lines.append("## Category Map")
+    lines.append("")
+    lines.append("| Kind | Category | 전체 | Lite |")
+    lines.append("|---|---|---:|---:|")
+    for (kind, cat) in sorted(groups.keys()):
+        total = len(groups[(kind, cat)])
+        shown = min(total, args.top)
+        lines.append(f"| {kind} | {cat} | {total} | {shown} |")
+    lines.append("")
+
+    lines.append("## 대표 항목 (카테고리별 상위)")
+    lines.append("")
+    for (kind, cat) in sorted(groups.keys()):
+        items = sorted(
+            groups[(kind, cat)],
+            key=lambda e: (-quality_score(e), e.get("name", "")),
+        )[: args.top]
+        lines.append(f"### {kind}/{cat}")
+        lines.append("")
+        for e in items:
+            name = e.get("name", "")
+            desc = clip(e.get("description") or e.get("summary") or "")
+            lines.append(f"- `{name}` — {desc}")
+        lines.append("")
+
+    OUT_PATH.write_text("\n".join(lines), encoding="utf-8")
+    size_kb = OUT_PATH.stat().st_size / 1024
+    print(f"wrote {OUT_PATH} ({len(entries)} entries considered, "
+          f"{sum(min(len(v), args.top) for v in groups.values())} shown, "
+          f"{size_kb:.1f} KB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/bootstrap/tools/_fix_frontmatter.py
+++ b/bootstrap/tools/_fix_frontmatter.py
@@ -1,0 +1,218 @@
+"""프런트매터 자동 보정기.
+
+`_lint_frontmatter.py`가 잡아낸 누락 필드를 안전한 기본값으로 채운다.
+
+보정 대상과 기본값:
+  - name      : 파일 경로(폴더/파일명)에서 추출한 kebab-case
+  - category  : `skills/<cat>/...` 또는 `knowledge/<cat>/...` 경로 세그먼트
+  - version   : "0.1.0-draft"
+  - tags      : 자신 있게 추정 가능한 경우에만 보강 (category 와 name 토큰)
+                그렇지 않으면 건드리지 않고 보고만 한다.
+
+`description` / `summary`는 의미 손실을 막기 위해 자동 채우지 않는다.
+
+사용법:
+    py _fix_frontmatter.py                 # 기본: dry-run (수정 미리보기)
+    py _fix_frontmatter.py --apply         # 실제 파일 덮어쓰기
+    py _fix_frontmatter.py --apply --only-missing=name,version
+
+주의: 원격 clone(`~/.claude/skills-hub/remote`) 내부 파일을 덮어쓰면
+`/hub-sync` 시 충돌이 날 수 있다. 드래프트는 `.skills-draft/`에서 수정 후
+업스트림 PR을 여는 흐름이 권장된다.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+HUB_ROOT = Path.home() / ".claude" / "skills-hub" / "remote"
+SKILL_DIR = HUB_ROOT / "skills"
+KNOWLEDGE_DIR = HUB_ROOT / "knowledge"
+
+DEFAULT_VERSION = "0.1.0-draft"
+SUPPORTED_FIELDS = ("name", "category", "tags", "version")
+
+
+@dataclass
+class Patch:
+    path: Path
+    added: dict[str, str]      # key -> rendered yaml line
+    inferred_tags: list[str]   # 참고용
+    skipped_reasons: list[str]
+
+
+def read_file(path: Path) -> tuple[str, str, str]:
+    """Return (pre, frontmatter_body, post) preserving '---' delimiters."""
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        raise ValueError("missing leading '---'")
+    end = text.find("\n---", 3)
+    if end == -1:
+        raise ValueError("missing closing '---'")
+    body = text[3:end].lstrip("\n")
+    post = text[end:]
+    return "---\n", body, post
+
+
+def parse_keys(body: str) -> dict[str, int]:
+    """Return top-level key names mapped to their first line index."""
+    keys: dict[str, int] = {}
+    for i, line in enumerate(body.splitlines()):
+        if not line or line[0].isspace() or line.startswith("#"):
+            continue
+        if ":" in line:
+            key = line.split(":", 1)[0].strip()
+            keys.setdefault(key, i)
+    return keys
+
+
+def infer_name(path: Path) -> str:
+    if path.name == "SKILL.md":
+        return path.parent.name
+    return path.stem
+
+
+def infer_category(path: Path) -> str | None:
+    try:
+        rel = path.relative_to(HUB_ROOT).parts
+    except ValueError:
+        return None
+    if len(rel) >= 3 and rel[0] in {"skills", "knowledge"}:
+        return rel[1]
+    return None
+
+
+def infer_tags(name: str, category: str | None) -> list[str]:
+    tokens = [t for t in re.split(r"[-_]", name.lower()) if t]
+    if category:
+        tokens = [category, *tokens]
+    # 중복 제거, 짧은 숫자/단문자 제거
+    seen: list[str] = []
+    for t in tokens:
+        if len(t) <= 2 or t.isdigit():
+            continue
+        if t not in seen:
+            seen.append(t)
+    return seen[:6]
+
+
+def build_patch(path: Path, allow: set[str]) -> Patch:
+    pre, body, post = read_file(path)
+    existing = parse_keys(body)
+    added: dict[str, str] = {}
+    skipped: list[str] = []
+    inferred_tags: list[str] = []
+
+    if "name" in allow and "name" not in existing:
+        added["name"] = f"name: {infer_name(path)}"
+    if "category" in allow and "category" not in existing:
+        cat = infer_category(path)
+        if cat:
+            added["category"] = f"category: {cat}"
+        else:
+            skipped.append("category: 경로에서 추정 불가")
+    if "version" in allow and "version" not in existing:
+        added["version"] = f"version: {DEFAULT_VERSION}"
+    if "tags" in allow and "tags" not in existing:
+        cat = infer_category(path)
+        name = infer_name(path)
+        tags = infer_tags(name, cat)
+        if len(tags) >= 3:
+            added["tags"] = "tags: [" + ", ".join(tags) + "]"
+            inferred_tags = tags
+        else:
+            skipped.append("tags: 자동 추정치가 너무 적음")
+
+    return Patch(path=path, added=added, inferred_tags=inferred_tags, skipped_reasons=skipped)
+
+
+def render_updated_file(path: Path, patch: Patch) -> str:
+    pre, body, post = read_file(path)
+    insert_lines = [patch.added[k] for k in ("name", "category", "version", "tags") if k in patch.added]
+    new_body = "\n".join(insert_lines) + ("\n" if insert_lines else "") + body
+    return pre + new_body + post
+
+
+def iter_md_files() -> list[Path]:
+    files: list[Path] = []
+    if SKILL_DIR.exists():
+        files.extend(SKILL_DIR.rglob("SKILL.md"))
+    if KNOWLEDGE_DIR.exists():
+        files.extend(KNOWLEDGE_DIR.rglob("*.md"))
+    return files
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true", help="실제 파일 덮어쓰기")
+    ap.add_argument(
+        "--only-missing",
+        default=",".join(SUPPORTED_FIELDS),
+        help="보정할 필드 (콤마 구분). 기본: name,category,tags,version",
+    )
+    ap.add_argument("--limit", type=int, default=0, help="처리 최대 파일 수 (디버그용)")
+    args = ap.parse_args()
+
+    allow = {f.strip() for f in args.only_missing.split(",") if f.strip()}
+    unknown = allow - set(SUPPORTED_FIELDS)
+    if unknown:
+        print(f"지원하지 않는 필드: {unknown}", file=sys.stderr)
+        return 2
+
+    patches: list[Patch] = []
+    files = iter_md_files()
+    for p in files:
+        try:
+            patch = build_patch(p, allow)
+        except Exception as exc:
+            print(f"SKIP {p}  ({exc})")
+            continue
+        if patch.added or patch.skipped_reasons:
+            patches.append(patch)
+
+    to_fix = [p for p in patches if p.added]
+    print(f"검사한 파일: {len(files)}")
+    print(f"보정 후보 파일: {len(to_fix)} (추가될 필드 기준)")
+    print()
+
+    if args.limit:
+        to_fix = to_fix[: args.limit]
+
+    for patch in to_fix[:20]:
+        rel = patch.path.relative_to(HUB_ROOT)
+        print(f"--- {rel}")
+        for line in patch.added.values():
+            print(f"  + {line}")
+        for reason in patch.skipped_reasons:
+            print(f"  ! {reason}")
+    if len(to_fix) > 20:
+        print(f"... 외 {len(to_fix)-20}건")
+
+    if args.apply:
+        print()
+        print(f"[APPLY] {len(to_fix)}개 파일을 덮어씁니다.")
+        for patch in to_fix:
+            text = render_updated_file(patch.path, patch)
+            patch.path.write_text(text, encoding="utf-8")
+        print("완료.")
+    else:
+        print()
+        print("[DRY-RUN] 실제 수정 없음. 덮어쓰려면 --apply.")
+
+    skipped_only = [p for p in patches if not p.added and p.skipped_reasons]
+    if skipped_only:
+        print()
+        print(f"[수동 확인 필요] {len(skipped_only)}건")
+        for patch in skipped_only[:10]:
+            rel = patch.path.relative_to(HUB_ROOT)
+            print(f"  - {rel} :: {'; '.join(patch.skipped_reasons)}")
+        if len(skipped_only) > 10:
+            print(f"  ... 외 {len(skipped_only)-10}건")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bootstrap/tools/_index_diff.py
+++ b/bootstrap/tools/_index_diff.py
@@ -1,0 +1,145 @@
+"""커밋 기준 인덱스 변경 리포트.
+
+지정된 <base-ref> 커밋 이후로 `index.json`에 추가/제거되었거나
+실제 MD 파일이 수정된 항목만 뽑아 보여준다. 릴리스 노트 초안이나
+`/hub-sync` 후 "무엇이 바뀌었나" 확인용.
+
+사용법:
+    py _index_diff.py                    # 기본: HEAD~1 대비
+    py _index_diff.py ae3e15d            # 특정 커밋 대비
+    py _index_diff.py main               # main 브랜치 대비
+    py _index_diff.py --json HEAD~5      # JSON 결과
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HUB_ROOT = Path.home() / ".claude" / "skills-hub" / "remote"
+INDEX_JSON = HUB_ROOT / "index.json"
+
+
+def git(*args: str) -> str:
+    try:
+        raw = subprocess.check_output(
+            ["git", "-C", str(HUB_ROOT), *args],
+            stderr=subprocess.STDOUT,
+        )
+        return raw.decode("utf-8", errors="replace")
+    except subprocess.CalledProcessError as exc:
+        msg = (exc.output or b"").decode("utf-8", errors="replace").strip()
+        print(f"git error: {msg}", file=sys.stderr)
+        sys.exit(2)
+
+
+def load_index_at(ref: str | None) -> list[dict]:
+    """ref가 None이면 현재 워킹트리의 index.json을 읽는다."""
+    if ref is None:
+        return json.loads(INDEX_JSON.read_text(encoding="utf-8"))
+    raw = git("show", f"{ref}:index.json")
+    return json.loads(raw)
+
+
+def index_by_path(entries: list[dict]) -> dict[str, dict]:
+    return {e.get("path", ""): e for e in entries if e.get("path")}
+
+
+def changed_files(base: str) -> set[str]:
+    """base..HEAD 사이에서 변경된 파일 경로(skills/, knowledge/ 한정)."""
+    raw = git("diff", "--name-only", f"{base}...HEAD")
+    files = set()
+    for line in raw.splitlines():
+        line = line.strip()
+        if line.startswith(("skills/", "knowledge/")):
+            files.add(line)
+    return files
+
+
+def find_entry_for_file(path: str, entries: dict[str, dict]) -> dict | None:
+    """
+    MD 파일 경로(예: skills/ai/foo/SKILL.md)를 index 엔트리로 매핑.
+    index 엔트리의 'path'는 보통 'skills/ai/foo' (디렉터리) 또는
+    'knowledge/api/foo.md' (파일) 이다.
+    """
+    if path in entries:
+        return entries[path]
+    # SKILL.md / content.md 경우: 부모 디렉터리 매치
+    parent = path.rsplit("/", 1)[0]
+    if parent in entries:
+        return entries[parent]
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("base", nargs="?", default="HEAD~1",
+                    help="비교 기준 커밋/ref (기본 HEAD~1)")
+    ap.add_argument("--json", dest="as_json", action="store_true")
+    args = ap.parse_args()
+
+    base = args.base
+    old = index_by_path(load_index_at(base))
+    new = index_by_path(load_index_at(None))
+
+    added_paths = sorted(set(new) - set(old))
+    removed_paths = sorted(set(old) - set(new))
+
+    modified_files = changed_files(base)
+    modified_entries: dict[str, dict] = {}
+    for f in modified_files:
+        entry = find_entry_for_file(f, new)
+        if entry is None:
+            continue
+        p = entry.get("path", "")
+        if p in added_paths:  # 이미 added 로 분류됨
+            continue
+        modified_entries[p] = entry
+
+    def render_entry(e: dict) -> str:
+        return (
+            f"  {e.get('kind','?')}/{e.get('category','') or '-':12} "
+            f"{e.get('name','')}"
+        )
+
+    if args.as_json:
+        result = {
+            "base": base,
+            "added": [new[p] for p in added_paths],
+            "removed": [old[p] for p in removed_paths],
+            "modified": list(modified_entries.values()),
+        }
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+
+    head = git("rev-parse", "--short", "HEAD").strip()
+    base_sha = git("rev-parse", "--short", base).strip()
+    print(f"인덱스 변경 리포트: {base_sha} → {head}")
+    print(f"  추가  {len(added_paths):4}")
+    print(f"  수정  {len(modified_entries):4}")
+    print(f"  제거  {len(removed_paths):4}")
+    print()
+    if added_paths:
+        print("[추가]")
+        for p in added_paths:
+            print(render_entry(new[p]))
+        print()
+    if modified_entries:
+        print("[수정]")
+        for e in modified_entries.values():
+            print(render_entry(e))
+        print()
+    if removed_paths:
+        print("[제거]")
+        for p in removed_paths:
+            print(render_entry(old[p]))
+        print()
+    if not (added_paths or modified_entries or removed_paths):
+        print("변경 없음.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bootstrap/tools/_lint_frontmatter.py
+++ b/bootstrap/tools/_lint_frontmatter.py
@@ -1,0 +1,174 @@
+"""설계 가이드 §3 프런트매터 스키마 린터.
+
+`~/.claude/skills-hub/remote/` 아래 모든 스킬/지식 MD의 YAML 프런트매터가
+필수 필드(name, description|summary, category, tags, version)를 채웠는지 검증한다.
+
+사용법:
+    py _lint_frontmatter.py           # 표준 리포트
+    py _lint_frontmatter.py --strict  # `tags`가 비어 있어도 실패 처리
+    py _lint_frontmatter.py --json    # JSON 결과
+종료 코드:
+    0  — 모든 파일 통과
+    1  — 하나 이상의 위반
+    2  — 구조 에러 (프런트매터 자체가 없음 / 깨짐)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+HUB_ROOT = Path.home() / ".claude" / "skills-hub" / "remote"
+SKILL_DIR = HUB_ROOT / "skills"
+KNOWLEDGE_DIR = HUB_ROOT / "knowledge"
+
+REQUIRED = ["name", "description", "category", "tags", "version"]
+# knowledge files often use `summary` instead of `description`.
+ALIASES = {"description": ("description", "summary")}
+
+
+def extract_frontmatter(text: str) -> tuple[str | None, str | None]:
+    """Return (raw_frontmatter, error). error is None on success."""
+    if not text.startswith("---"):
+        return None, "missing leading '---'"
+    end = text.find("\n---", 3)
+    if end == -1:
+        return None, "missing closing '---'"
+    return text[3:end].lstrip("\n"), None
+
+
+def parse_flat_keys(raw: str) -> dict[str, str]:
+    """Collect only the top-level (column 0) `key:` entries — values stay raw."""
+    out: dict[str, str] = {}
+    current_key: str | None = None
+    buffer: list[str] = []
+    for line in raw.splitlines():
+        if not line:
+            continue
+        if line[0].isspace() or line.startswith("#"):
+            if current_key is not None:
+                buffer.append(line)
+            continue
+        if ":" not in line:
+            continue
+        if current_key is not None:
+            out[current_key] = (out[current_key] + "\n" + "\n".join(buffer)).rstrip()
+            buffer = []
+        key, _, value = line.partition(":")
+        current_key = key.strip()
+        out[current_key] = value.strip()
+    if current_key is not None and buffer:
+        out[current_key] = (out[current_key] + "\n" + "\n".join(buffer)).rstrip()
+    return out
+
+
+def value_is_empty(raw: str) -> bool:
+    if raw is None:
+        return True
+    stripped = raw.strip()
+    if stripped in ("", "[]", "''", '""', "null", "~"):
+        return True
+    return False
+
+
+def scan_file(path: Path) -> dict:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception as exc:
+        return {"path": str(path), "errors": [f"read-failure: {exc}"], "missing": []}
+    raw, err = extract_frontmatter(text)
+    if err:
+        return {"path": str(path), "errors": [err], "missing": REQUIRED[:]}
+    fields = parse_flat_keys(raw)
+    missing: list[str] = []
+    for required in REQUIRED:
+        candidates = ALIASES.get(required, (required,))
+        if not any(c in fields and not value_is_empty(fields[c]) for c in candidates):
+            missing.append(required)
+    return {"path": str(path), "errors": [], "missing": missing, "fields": list(fields)}
+
+
+def iter_md_files() -> list[Path]:
+    files: list[Path] = []
+    if SKILL_DIR.exists():
+        files.extend(SKILL_DIR.rglob("SKILL.md"))
+    if KNOWLEDGE_DIR.exists():
+        files.extend(KNOWLEDGE_DIR.rglob("*.md"))
+    return files
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--strict", action="store_true")
+    ap.add_argument("--json", dest="as_json", action="store_true")
+    args = ap.parse_args()
+
+    files = iter_md_files()
+    results = [scan_file(p) for p in files]
+
+    failures: list[dict] = []
+    structure_errors: list[dict] = []
+    missing_by_field: Counter[str] = Counter()
+    missing_by_category: dict[str, Counter[str]] = defaultdict(Counter)
+
+    for r in results:
+        if r["errors"]:
+            structure_errors.append(r)
+            continue
+        bad = list(r["missing"])
+        if not args.strict and bad == ["tags"]:
+            # 태그는 기본적으로 누락을 경고만 하고 실패로는 올리지 않음
+            continue
+        if bad:
+            failures.append(r)
+            cat = Path(r["path"]).relative_to(HUB_ROOT).parts
+            cat_key = "/".join(cat[:2])  # e.g. skills/ai
+            for field in bad:
+                missing_by_field[field] += 1
+                missing_by_category[cat_key][field] += 1
+
+    if args.as_json:
+        print(json.dumps({
+            "total": len(results),
+            "structure_errors": structure_errors,
+            "failures": failures,
+            "missing_by_field": dict(missing_by_field),
+        }, ensure_ascii=False, indent=2))
+    else:
+        print(f"총 {len(results)}개 파일 검사")
+        if structure_errors:
+            print(f"\n[구조 에러] {len(structure_errors)}건")
+            for r in structure_errors[:10]:
+                print(f"  - {r['path']} :: {'; '.join(r['errors'])}")
+            if len(structure_errors) > 10:
+                print(f"  ... 외 {len(structure_errors)-10}건")
+        print(f"\n[필수 필드 누락] {len(failures)}건")
+        for field, n in missing_by_field.most_common():
+            print(f"  {field:15} {n}")
+        print("\n[카테고리별 누락 상위 10]")
+        cat_totals = sorted(
+            ((cat, sum(c.values())) for cat, c in missing_by_category.items()),
+            key=lambda x: -x[1],
+        )
+        for cat, total in cat_totals[:10]:
+            fields = missing_by_category[cat]
+            detail = ", ".join(f"{k}:{v}" for k, v in fields.most_common())
+            print(f"  {cat:35} {total:4}  ({detail})")
+        if failures:
+            print("\n[샘플 위반 파일 20개]")
+            for r in failures[:20]:
+                print(f"  - {r['path']}")
+                print(f"      missing: {', '.join(r['missing'])}")
+        print()
+    if structure_errors:
+        return 2
+    if failures:
+        return 1
+    print("PASS — 모든 파일이 스키마를 만족합니다.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bootstrap/tools/hub_search.py
+++ b/bootstrap/tools/hub_search.py
@@ -1,0 +1,487 @@
+"""스킬 허브 키워드 검색 CLI (v2).
+
+`~/.claude/skills-hub/remote/index.json`을 대상으로 키워드를 점수화해
+상위 N개 항목을 내보낸다. AI가 "이 주제와 관련된 스킬이 뭐가 있지?"라고
+물을 때 첫 진입점으로 쓰인다.
+
+v2 변경점:
+  - 한글 → 영문 동의어 맵 (스프링→spring, 카프카→kafka …)
+  - 쿼리 토큰 확장 (원본 + 동의어가 모두 검색에 기여)
+  - 부분 일치 보너스 (토큰이 name/description/tags 에 substring으로 등장)
+  - `--synonyms` 로 어떤 확장이 적용됐는지 미리보기
+
+점수 규칙:
+  - name 완전 일치            : +10
+  - name substring 일치        : +6
+  - description 토큰 일치      : +3
+  - tags substring 일치        : +5
+  - triggers 토큰 일치         : +4
+  - 동의어 경유 매칭은 원본 대비 80%로 가중
+
+사용법:
+    py hub_search.py "kafka avro"
+    py hub_search.py "스프링 세션"                    # 한글 쿼리 OK
+    py hub_search.py -n 20 "websocket"
+    py hub_search.py --kind skill "lock"
+    py hub_search.py --category pitfall "mongo"
+    py hub_search.py --json "rate limit"
+    py hub_search.py --synonyms "카프카"              # 확장 경로 점검
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import html
+import json
+import re
+import sys
+from pathlib import Path
+
+HUB_INDEX = Path.home() / ".claude" / "skills-hub" / "remote" / "index.json"
+
+# 한글 (또는 영문 약어) → 정식 영문 키워드 매핑.
+# 값은 공백 구분 가능한 여러 키워드. 양방향 확장을 원하면 역매핑도 추가한다.
+SYNONYMS: dict[str, str] = {
+    # ── 플랫폼 / 언어 ───────────────────────────────
+    "스프링": "spring spring-boot",
+    "스프링부트": "spring-boot spring",
+    "부트": "boot spring-boot",
+    "자바": "java jvm",
+    "자바스크립트": "javascript js",
+    "타입스크립트": "typescript ts",
+    "파이썬": "python",
+    "코틀린": "kotlin",
+    "고": "go golang",
+    "러스트": "rust",
+    "스칼라": "scala",
+    "스위프트": "swift",
+    "리액트": "react reactjs",
+    "리액트네이티브": "react-native",
+    "뷰": "vue vuejs",
+    "앵귤러": "angular",
+    "넥스트": "next nextjs",
+    "노드": "node node.js nodejs",
+    "익스프레스": "express expressjs",
+    "장고": "django",
+    "플라스크": "flask",
+    "라라벨": "laravel",
+    # ── 인프라 / 메시징 / 스토리지 ─────────────────────
+    "카프카": "kafka",
+    "래빗": "rabbitmq",
+    "래빗엠큐": "rabbitmq",
+    "도커": "docker container",
+    "컨테이너": "container docker",
+    "쿠버네티스": "kubernetes k8s",
+    "쿠버": "kubernetes k8s",
+    "헬름": "helm",
+    "테라폼": "terraform iac",
+    "몽고": "mongo mongodb",
+    "몽고디비": "mongodb mongo",
+    "포스트그레": "postgres postgresql",
+    "포스트그리": "postgres postgresql",
+    "마리아": "mariadb mysql",
+    "마리아디비": "mariadb mysql",
+    "마이에스큐엘": "mysql",
+    "오라클": "oracle",
+    "에스큐엘": "sql",
+    "레디스": "redis cache",
+    "엘라스틱": "elasticsearch es",
+    "엘라스틱서치": "elasticsearch",
+    "옵서버빌리티": "observability monitoring tracing",
+    "웹소켓": "websocket stomp",
+    "소켓": "socket websocket",
+    "그라파나": "grafana dashboard",
+    "프로메테우스": "prometheus metrics",
+    "클리아우드": "cloud aws gcp azure",
+    "에이더블유에스": "aws",
+    "지씨피": "gcp google-cloud",
+    "애저": "azure",
+    "엔진엑스": "nginx",
+    "엔진엑스엑스": "nginx",
+    # ── 보안 / 인증 ────────────────────────────────
+    "인증": "auth authentication jwt oauth",
+    "로그인": "login auth authentication session",
+    "토큰인증": "jwt token auth",
+    "권한": "authorization rbac acl",
+    "암호화": "encryption crypto aes rsa",
+    "복호화": "decryption crypto",
+    "해시": "hash sha bcrypt md5",
+    "보안": "security owasp",
+    "취약점": "vulnerability owasp",
+    "주입": "injection sql-injection xss",
+    "씨에스알에프": "csrf xsrf",
+    # ── 데이터 / 모델 ───────────────────────────────
+    "디비": "db database",
+    "데이터베이스": "database db",
+    "스키마": "schema",
+    "마이그레이션": "migration flyway liquibase",
+    "인덱스": "index indexing",
+    "트랜잭션": "transaction tx acid",
+    "복제": "replica replication",
+    "리플리카": "replica replication",
+    "샤딩": "sharding shard",
+    "파티션": "partition partitioning",
+    "이티엘": "etl pipeline",
+    "이벤트소싱": "event-sourcing cqrs",
+    "시디씨": "cdc change-data-capture",
+    "체인지스트림": "change-stream cdc",
+    # ── 아키텍처 / 패턴 ─────────────────────────────
+    "분산": "distributed",
+    "이벤트": "event event-driven",
+    "이벤트드리븐": "event-driven event",
+    "동시성": "concurrency concurrent",
+    "병렬": "parallel",
+    "비동기": "async asynchronous",
+    "락": "lock mutex",
+    "뮤텍스": "mutex lock",
+    "세마포어": "semaphore",
+    "캐시": "cache caching",
+    "캐싱": "caching cache",
+    "레이트": "rate-limit rate",
+    "레이트리밋": "rate-limit rate-limiting",
+    "큐": "queue",
+    "파이프라인": "pipeline etl stream",
+    "상태": "state",
+    "상태머신": "state-machine fsm",
+    "서킷": "circuit-breaker",
+    "서킷브레이커": "circuit-breaker",
+    "사가": "saga",
+    "헥사고날": "hexagonal ports-adapters",
+    "마이크로서비스": "microservice microservices msa",
+    "엠에스에이": "microservice msa",
+    "모놀리스": "monolith monolithic",
+    "스트랭글러": "strangler-fig migration",
+    "벌크헤드": "bulkhead isolation",
+    # ── 테스트 / 빌드 / CI ─────────────────────────
+    "테스트": "test testing",
+    "단위테스트": "unit-test",
+    "통합테스트": "integration-test",
+    "엔드투엔드": "e2e end-to-end",
+    "이투이": "e2e",
+    "플레이라이트": "playwright",
+    "사이프러스": "cypress",
+    "제스트": "jest",
+    "주니트": "junit",
+    "빌드": "build",
+    "그래들": "gradle",
+    "메이븐": "maven",
+    "배포": "deploy deployment",
+    "릴리스": "release",
+    "릴리즈": "release",
+    "씨아이": "ci continuous-integration",
+    "씨디": "cd continuous-deployment",
+    "파이프": "pipeline",
+    "젠킨스": "jenkins",
+    "깃헙액션": "github-actions",
+    "깃랩": "gitlab",
+    # ── UI / 프런트 ───────────────────────────────
+    "디자인": "design",
+    "토큰": "token design-tokens",
+    "디자인토큰": "design-tokens",
+    "컴포넌트": "component",
+    "레이아웃": "layout",
+    "차트": "chart visualization",
+    "그리드": "grid table ag-grid",
+    "에이지그리드": "ag-grid grid",
+    "드래그": "drag drag-and-drop dnd",
+    "디앤디": "dnd drag-and-drop",
+    "테이블": "table grid",
+    "다크모드": "dark-mode theme",
+    "테마": "theme design-tokens",
+    "반응형": "responsive layout",
+    "모달": "modal dialog",
+    "드로어": "drawer",
+    "툴팁": "tooltip",
+    "폼": "form validation",
+    "라우팅": "routing router",
+    "모듈페더레이션": "module-federation mfa",
+    "엠에프에이": "module-federation mfa",
+    # ── 모니터링 / 운영 ─────────────────────────────
+    "로그": "log logging",
+    "로깅": "logging log",
+    "모니터링": "monitoring observability",
+    "트레이싱": "tracing trace",
+    "메트릭": "metric metrics prometheus",
+    "알람": "alert alerting",
+    "에이피엠": "apm",
+    "헬스체크": "health-check liveness readiness",
+    # ── 에이전트 / LLM ──────────────────────────────
+    "에이전트": "agent",
+    "엘엘엠": "llm",
+    "피롬프트": "prompt prompt-engineering",
+    "프롬프트": "prompt prompt-engineering",
+    "임베딩": "embedding vector",
+    "벡터": "vector embedding",
+    "래그": "rag retrieval-augmented",
+    "엠시피": "mcp",
+    "클로드": "claude anthropic",
+    "플러그인": "plugin",
+    "워크플로": "workflow",
+    "워크플로우": "workflow",
+    # ── 도메인 / 비즈니스 ───────────────────────────
+    "멀티테넌트": "multi-tenant tenant",
+    "테넌트": "tenant multi-tenant",
+    "조직": "organization tenant",
+    "결제": "payment billing",
+    "빌링": "billing subscription",
+    "구독": "subscription billing",
+    "알림": "notification push email sms",
+    "이메일": "email smtp",
+    "에스엠에스": "sms",
+    "푸시": "push notification",
+    # ── 게임 ─────────────────────────────────────
+    "가챠": "gacha pity",
+    "피티": "pity gacha",
+    "콤보": "combo",
+    "게임": "game game-dev",
+    "턴": "turn-based combat",
+    "알피지": "rpg",
+    # ── 기타 ─────────────────────────────────────
+    "깃": "git",
+    "깃헙": "github",
+    "리베이스": "rebase",
+    "머지": "merge",
+    "브랜치": "branch",
+    "태그": "tag",
+    "훅": "hook",
+    "사이드카": "sidecar service-mesh",
+    "서비스메시": "service-mesh sidecar istio",
+    "이스티오": "istio service-mesh",
+    "블룸필터": "bloom-filter",
+    "컨시스턴트해싱": "consistent-hashing",
+    "일관성": "consistency",
+    "정합성": "consistency integrity",
+    "멱등성": "idempotency idempotent",
+    "아웃박스": "outbox outbox-pattern",
+    "시디에프씨": "cdc",
+}
+
+
+def tokenize(s: str) -> list[str]:
+    s = (s or "").lower()
+    return [t for t in re.split(r"[^a-z0-9가-힣]+", s) if t]
+
+
+def expand_query(tokens: list[str]) -> list[tuple[str, float]]:
+    """원본 토큰 + 동의어를 (토큰, 가중치) 목록으로 반환.
+    원본 1.0, 동의어 경유 0.8."""
+    expanded: list[tuple[str, float]] = []
+    seen: set[str] = set()
+    for raw in tokens:
+        for piece, weight in ((raw, 1.0), *[(syn, 0.8) for syn in SYNONYMS.get(raw, "").split() if syn]):
+            if piece in seen:
+                continue
+            seen.add(piece)
+            expanded.append((piece, weight))
+    return expanded
+
+
+def score_entry(entry: dict, tokens: list[tuple[str, float]]) -> int:
+    name = (entry.get("name") or "").lower()
+    description = (entry.get("description") or "").lower()
+    desc_tokens = set(tokenize(description))
+    tag_tokens = {t.lower() for t in (entry.get("tags") or [])}
+    trigger_raw = " ".join((entry.get("triggers") or [])).lower()
+    trigger_tokens = set(tokenize(trigger_raw))
+    name_tokens = set(tokenize(name))
+    query_joined = " ".join(t for t, _ in tokens if abs(_ - 1.0) < 0.01)
+
+    score = 0.0
+    if query_joined and query_joined == name:
+        score += 10
+    for tok, weight in tokens:
+        if tok in name:
+            score += 6 * weight
+        if tok in name_tokens:
+            score += 2 * weight
+        if tok in desc_tokens:
+            score += 3 * weight
+        if tok in description:          # substring
+            score += 1 * weight
+        if any(tok in tag for tag in tag_tokens):
+            score += 5 * weight
+        if tok in trigger_tokens:
+            score += 4 * weight
+        if tok in trigger_raw:          # substring of multi-word trigger
+            score += 1 * weight
+    return int(round(score))
+
+
+def render_html(raw_tokens: list[str], expanded: list[tuple[str, float]],
+                top: list[tuple[int, dict]], total: int) -> str:
+    """다크 테마 카드 UI."""
+    now = dt.datetime.now().isoformat(timespec="seconds")
+    expansion = [html.escape(t) for t, w in expanded if w < 1.0]
+    query_line = html.escape(" ".join(raw_tokens))
+
+    cards: list[str] = []
+    for s, e in top:
+        name = html.escape(e.get("name") or "")
+        desc = html.escape((e.get("description") or "").strip())
+        kind = html.escape(e.get("kind") or "")
+        cat = html.escape(e.get("category") or "")
+        path = html.escape(e.get("path") or "")
+        tags = e.get("tags") or []
+        tag_html = "".join(
+            f'<span class="tag">{html.escape(t)}</span>' for t in tags
+        )
+        cards.append(f"""
+<article class="card">
+  <header>
+    <span class="score">{s}</span>
+    <span class="kind">{kind}/{cat}</span>
+    <h2>{name}</h2>
+  </header>
+  <p class="desc">{desc or "<em>(설명 없음)</em>"}</p>
+  <div class="tags">{tag_html}</div>
+  <code class="path">{path}</code>
+</article>""")
+
+    body_cards = "\n".join(cards) if cards else "<p class='empty'>일치하는 항목이 없습니다.</p>"
+    expansion_note = (
+        f"<p class='note'>동의어 확장: {' · '.join(expansion)}</p>"
+        if expansion else ""
+    )
+
+    return f"""<!doctype html>
+<html lang="ko"><head><meta charset="utf-8">
+<title>hub-search · {query_line}</title>
+<style>
+  :root {{ color-scheme: dark; }}
+  body {{ margin: 0; padding: 24px 32px;
+         background: #0b0f14; color: #d7e1ea;
+         font-family: ui-sans-serif, -apple-system, "Segoe UI", sans-serif;
+         font-size: 14px; line-height: 1.45; }}
+  header.top {{ margin-bottom: 20px; }}
+  header.top h1 {{ margin: 0 0 4px; font-size: 22px; }}
+  header.top small {{ color: #8aa0b4; }}
+  p.note {{ color: #86bdf4; font-size: 13px; margin: 4px 0 12px; }}
+  main {{ display: grid; gap: 14px; }}
+  .card {{ background: #141b23; border: 1px solid #263241;
+           border-radius: 10px; padding: 14px 18px; }}
+  .card header {{ display: flex; align-items: baseline; gap: 12px; margin-bottom: 6px; }}
+  .card header h2 {{ margin: 0; font-size: 16px; font-weight: 600; color: #e8edf3; }}
+  .score {{ background: #1f6fd6; color: white; border-radius: 4px;
+            padding: 2px 8px; font-size: 12px; font-weight: 700; min-width: 32px;
+            text-align: center; }}
+  .kind {{ color: #8fb7e0; font-size: 12px; font-family: ui-monospace, monospace; }}
+  .desc {{ margin: 2px 0 8px; color: #c5d0dc; }}
+  .tags {{ display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 8px; }}
+  .tag {{ background: #26344a; color: #8fb7e0; font-size: 11px;
+          padding: 2px 8px; border-radius: 999px; }}
+  .path {{ color: #6a8096; font-size: 12px; font-family: ui-monospace, monospace; }}
+  .empty {{ color: #8aa0b4; }}
+  footer {{ margin-top: 24px; color: #5e7183; font-size: 12px; }}
+</style></head>
+<body>
+<header class="top">
+  <h1>hub-search &nbsp;·&nbsp; <code>{query_line}</code></h1>
+  <small>상위 {len(top)} 카드 · 전체 매칭 {total} · 생성 {now}</small>
+  {expansion_note}
+</header>
+<main>
+{body_cards}
+</main>
+<footer>자동 생성. 원본: <code>~/.claude/skills-hub/remote/</code></footer>
+</body></html>"""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("query", nargs="+", help="키워드 (여러 개 가능)")
+    ap.add_argument("-n", "--top", type=int, default=10)
+    ap.add_argument("--kind", choices=("skill", "knowledge"), default=None)
+    ap.add_argument("--category", default=None)
+    ap.add_argument("--json", dest="as_json", action="store_true")
+    ap.add_argument("--html", dest="as_html", action="store_true",
+                    help="HTML 카드 뷰로 출력")
+    ap.add_argument("--out", default=None,
+                    help="결과를 파일에 저장 (HTML/JSON 모드에서 유용)")
+    ap.add_argument("--synonyms", action="store_true",
+                    help="동의어 확장 결과만 출력하고 종료")
+    args = ap.parse_args()
+
+    raw_tokens = tokenize(" ".join(args.query))
+    if not raw_tokens:
+        print("검색어를 입력해 주세요.", file=sys.stderr)
+        return 2
+
+    expanded = expand_query(raw_tokens)
+    if args.synonyms:
+        print("원본:", raw_tokens)
+        print("확장된 토큰:")
+        for tok, w in expanded:
+            print(f"  {tok:20} weight={w}")
+        return 0
+
+    entries = json.loads(HUB_INDEX.read_text(encoding="utf-8"))
+    scored: list[tuple[int, dict]] = []
+    for e in entries:
+        if args.kind and e.get("kind") != args.kind:
+            continue
+        if args.category and (e.get("category") or "") != args.category:
+            continue
+        s = score_entry(e, expanded)
+        if s > 0:
+            scored.append((s, e))
+    scored.sort(key=lambda pair: (-pair[0], pair[1].get("name", "")))
+    top = scored[: args.top]
+
+    if args.as_json:
+        out = [
+            {
+                "score": s,
+                "kind": e.get("kind"),
+                "category": e.get("category"),
+                "name": e.get("name"),
+                "description": e.get("description", ""),
+                "tags": e.get("tags", []),
+                "path": e.get("path", ""),
+            }
+            for s, e in top
+        ]
+        payload = json.dumps(out, ensure_ascii=False, indent=2)
+        if args.out:
+            Path(args.out).write_text(payload, encoding="utf-8")
+            print(f"wrote {args.out}")
+        else:
+            print(payload)
+        return 0
+
+    if args.as_html:
+        html = render_html(raw_tokens, expanded, top, len(scored))
+        if args.out:
+            Path(args.out).write_text(html, encoding="utf-8")
+            print(f"wrote {args.out}")
+        else:
+            print(html)
+        return 0
+
+    if not top:
+        print(f"'{' '.join(raw_tokens)}' 관련 항목을 찾지 못했습니다.")
+        return 1
+
+    expansion_note = ""
+    if len(expanded) > len(raw_tokens):
+        added = [t for t, w in expanded if w < 1.0]
+        expansion_note = f"  |  동의어 확장: {', '.join(added)}"
+    print(f"키워드: {' '.join(raw_tokens)}{expansion_note}")
+    print(f"상위 {len(top)} / 전체 매칭 {len(scored)}")
+    print()
+    for s, e in top:
+        kind = e.get("kind", "?")
+        cat = e.get("category", "")
+        name = e.get("name", "")
+        desc = (e.get("description") or "").replace("\n", " ")
+        if len(desc) > 160:
+            desc = desc[:159] + "…"
+        path = e.get("path", "")
+        print(f"[{s:3}]  {kind}/{cat:15} {name}")
+        print(f"       {desc}")
+        print(f"       path: {path}")
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bootstrap/tools/install-hooks.sh
+++ b/bootstrap/tools/install-hooks.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# ~/.claude/skills-hub/remote/.git/hooks/ 에 index 재생성 훅을 설치한다.
+#
+# 트리거 이벤트:
+#   post-merge     git pull / merge 뒤
+#   post-commit    로컬 커밋 뒤
+#   post-checkout  브랜치 전환 뒤 (index.json 이 변경됐을 때만)
+#
+# 사용법:
+#   bash ~/.claude/skills-hub/tools/install-hooks.sh
+#
+# 재-clone 후 한 번만 실행하면 된다. 이미 설치되어 있으면 덮어쓰기.
+
+set -euo pipefail
+
+HOOKS_DIR="$HOME/.claude/skills-hub/remote/.git/hooks"
+TOOLS_DIR="$HOME/.claude/skills-hub/tools"
+
+if [[ ! -d "$HOOKS_DIR" ]]; then
+    echo "install-hooks: $HOOKS_DIR does not exist (is the hub cloned?)" >&2
+    exit 1
+fi
+
+write_hook() {
+    local name="$1"
+    local extra_check="$2"
+    local path="$HOOKS_DIR/$name"
+    cat > "$path" <<EOF
+#!/usr/bin/env bash
+# Auto-regenerate hub indexes after mutations. Installed by tools/install-hooks.sh.
+set -e
+${extra_check}
+PYTHONIOENCODING=utf-8 py -3 "$TOOLS_DIR/precheck.py" --skip-lint >/dev/null 2>&1 || true
+EOF
+    chmod +x "$path"
+    echo "  installed: $name"
+}
+
+echo "Installing skills-hub git hooks…"
+
+write_hook "post-merge" ""
+write_hook "post-commit" ""
+# post-checkout: always regen — ensures deleted/stale indexes are rebuilt.
+# Skip if the checkout is a file-level checkout rather than a branch/ref.
+write_hook "post-checkout" \
+'[[ "${3:-}" == "1" ]] || exit 0'
+
+echo "Done. Hooks will run hub-precheck (skip-lint) on merge / commit / branch-switch."

--- a/bootstrap/tools/precheck.py
+++ b/bootstrap/tools/precheck.py
@@ -1,0 +1,68 @@
+"""출판 직전 검증 파이프라인.
+
+다음을 순차 실행하고, 하나라도 실패하면 즉시 비정상 종료한다.
+
+    1. _lint_frontmatter.py   — 모든 MD가 필수 스키마를 만족하는지 검증
+    2. _build_master_index.py — L1 마스터 인덱스 재생성
+    3. _build_category_indexes.py — L2 카테고리별 인덱스 재생성
+
+사용법:
+    py precheck.py              # 세 단계 모두 실행
+    py precheck.py --strict     # 린터에 --strict 전달
+    py precheck.py --skip-lint  # 린트 건너뛰고 인덱스만 갱신
+
+종료 코드:
+    0 — 모든 단계 PASS
+    ≥1 — 첫 실패한 단계의 exit code
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).parent
+
+
+def run(label: str, cmd: list[str]) -> int:
+    print(f"\n=== [{label}] {' '.join(cmd)} ===")
+    start = time.time()
+    res = subprocess.run(cmd, cwd=ROOT)
+    dur = time.time() - start
+    status = "PASS" if res.returncode == 0 else f"FAIL ({res.returncode})"
+    print(f"--- [{label}] {status}  ({dur:.2f}s)")
+    return res.returncode
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--strict", action="store_true", help="린터에 --strict 전달")
+    ap.add_argument("--skip-lint", action="store_true")
+    args = ap.parse_args()
+
+    py = sys.executable or "py"
+
+    steps: list[tuple[str, list[str]]] = []
+    if not args.skip_lint:
+        lint_cmd = [py, "_lint_frontmatter.py"]
+        if args.strict:
+            lint_cmd.append("--strict")
+        steps.append(("lint", lint_cmd))
+    steps.append(("master-index", [py, "_build_master_index.py"]))
+    steps.append(("master-index-lite", [py, "_build_master_index_lite.py"]))
+    steps.append(("category-indexes", [py, "_build_category_indexes.py"]))
+
+    for label, cmd in steps:
+        rc = run(label, cmd)
+        if rc != 0:
+            print(f"\n[ABORT] '{label}' 실패. 이후 단계를 건너뜁니다.")
+            return rc
+
+    print("\n[ALL PASS] 출판 가능 상태.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Lifts the local L1/L2 index / search tooling into the bootstrap so `/hub-init` produces a fully portable installation on any machine.

## Adds
- **`bootstrap/tools/`** — 8 Python helpers:
  `_build_master_index.py` / `_build_master_index_lite.py` / `_build_category_indexes.py` / `_lint_frontmatter.py` / `_fix_frontmatter.py` / `_index_diff.py` / `hub_search.py` / `precheck.py`, plus `install-hooks.sh`.
- **`bootstrap/bin/`** — `hub-search`, `hub-precheck`, `hub-index-diff` wrappers that resolve scripts from their own location (`SCRIPT_DIR/../tools/*.py`).
- **`bootstrap/commands/hub-find.md`** — ranked keyword search with 180+ KO↔EN synonyms.
- **`bootstrap/commands/hub-precheck.md`** — lint + regenerate all three index formats.
- **`bootstrap/commands/hub-index-diff.md`** — per-commit index change report.

## Changes
- **`bootstrap/install.sh`** — copies `tools/` and `bin/` into `~/.claude/skills-hub/`, installs git hooks via `tools/install-hooks.sh` when the remote clone is ready, prints the PATH export hint for the 3 wrappers.

## Why v2.5.0 (minor, not patch)
This is an additive feature bump — brand-new directory trees + 3 new commands. No breaking changes; existing commands keep working.

## How users pick it up
- Existing install: `/hub-commands-update --version=2.5.0` (or bulk update once the tag propagates).
- Fresh install: `/hub-init` + `bash bootstrap/install.sh` gives working `hub-find` / `hub-precheck` / `hub-index-diff` + git hooks out of the box.

## Test plan
- [x] Local `bash bootstrap/install.sh` on a wiped `~/.claude/skills-hub/` produces working tools + bin + hooks.
- [x] `hub-search "카프카" -n 3` returns KO→EN-expanded results.
- [x] `hub-precheck` passes all four gates (< 1.5s).
- [x] `git reset --hard` inside remote/ still leaves indexes consistent because `/hub-sync` (v2.4.4) calls `hub-precheck --skip-lint` at the end.
- [ ] Reviewer verifies install.sh behaviour on a fresh machine.

## Rollback
Revert to `bootstrap/v2.4.4` — no schema migrations or destructive changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)