### PR TITLE
Bootstrap v2.5.1: install.ps1 parity with v2.5.0

### DIFF
--- a/bootstrap/install.ps1
+++ b/bootstrap/install.ps1
@@ -5,10 +5,14 @@ $ErrorActionPreference = "Stop"
 
 $ClaudeDir = if ($env:CLAUDE_DIR) { $env:CLAUDE_DIR } else { "$HOME\.claude" }
 $RepoDir = Split-Path -Parent $PSScriptRoot
+$HubDir = Join-Path $ClaudeDir "skills-hub"
 
-New-Item -ItemType Directory -Force -Path "$ClaudeDir\commands" | Out-Null
+New-Item -ItemType Directory -Force -Path "$ClaudeDir\commands"      | Out-Null
 New-Item -ItemType Directory -Force -Path "$ClaudeDir\skills\skills-hub" | Out-Null
-New-Item -ItemType Directory -Force -Path "$ClaudeDir\skills-hub" | Out-Null
+New-Item -ItemType Directory -Force -Path "$HubDir"                  | Out-Null
+New-Item -ItemType Directory -Force -Path "$HubDir\tools"            | Out-Null
+New-Item -ItemType Directory -Force -Path "$HubDir\bin"              | Out-Null
+New-Item -ItemType Directory -Force -Path "$HubDir\indexes"          | Out-Null
 
 Write-Host "Installing slash commands -> $ClaudeDir\commands\"
 Copy-Item "$RepoDir\bootstrap\commands\*.md" "$ClaudeDir\commands\" -Force
@@ -16,19 +20,50 @@ Copy-Item "$RepoDir\bootstrap\commands\*.md" "$ClaudeDir\commands\" -Force
 Write-Host "Installing skills-hub skill -> $ClaudeDir\skills\skills-hub\"
 Copy-Item "$RepoDir\bootstrap\skills\skills-hub\SKILL.md" "$ClaudeDir\skills\skills-hub\SKILL.md" -Force
 
-if (-not (Test-Path "$ClaudeDir\skills-hub\remote\.git")) {
-    Write-Host "Note: runtime remote cache not present at $ClaudeDir\skills-hub\remote\"
+# v2.5.0+: tools / bin / git hooks
+if (Test-Path "$RepoDir\bootstrap\tools") {
+    Write-Host "Installing tools -> $HubDir\tools\"
+    Copy-Item "$RepoDir\bootstrap\tools\*.py" "$HubDir\tools\" -Force
+    if (Test-Path "$RepoDir\bootstrap\tools\install-hooks.sh") {
+        Copy-Item "$RepoDir\bootstrap\tools\install-hooks.sh" "$HubDir\tools\install-hooks.sh" -Force
+    }
+}
+
+if (Test-Path "$RepoDir\bootstrap\bin") {
+    Write-Host "Installing CLI wrappers -> $HubDir\bin\"
+    Get-ChildItem "$RepoDir\bootstrap\bin\" -File |
+        Where-Object { $_.Name -like "hub-*" } |
+        ForEach-Object { Copy-Item $_.FullName "$HubDir\bin\" -Force }
+}
+
+if (-not (Test-Path "$HubDir\remote\.git")) {
+    Write-Host "Note: runtime remote cache not present at $HubDir\remote\"
     Write-Host "      Either clone the repo there, or a /skills_* command will clone on first run."
 }
 
-if (-not (Test-Path "$ClaudeDir\skills-hub\registry.json")) {
-    "{}" | Out-File -FilePath "$ClaudeDir\skills-hub\registry.json" -Encoding utf8 -NoNewline
+if (-not (Test-Path "$HubDir\registry.json")) {
+    "{}" | Out-File -FilePath "$HubDir\registry.json" -Encoding utf8 -NoNewline
 }
+
+# Install git hooks if remote is ready and a POSIX bash exists.
+if ((Test-Path "$HubDir\remote\.git") -and (Test-Path "$HubDir\tools\install-hooks.sh")) {
+    $bash = Get-Command bash -ErrorAction SilentlyContinue
+    if ($bash) {
+        Write-Host "Installing git hooks (auto re-index on merge / commit / checkout)"
+        & bash "$HubDir\tools\install-hooks.sh"
+    } else {
+        Write-Host "Note: bash not found; run 'bash $HubDir/tools/install-hooks.sh' manually to enable hooks."
+    }
+}
+
+Write-Host ""
+Write-Host "To use 'hub-search', 'hub-precheck', 'hub-index-diff' from any shell, add to your PowerShell profile:"
+Write-Host "  `$env:Path = `"`$HOME\.claude\skills-hub\bin;`" + `$env:Path"
 
 Write-Host ""
 Write-Host "Done. Installed commands:"
 Get-ChildItem "$ClaudeDir\commands\" -Filter "*.md" |
-    Where-Object { $_.Name -match "^(init_skills|skills_)" } |
+    Where-Object { $_.Name -match "^(init_skills|skills_|hub-)" } |
     ForEach-Object { Write-Host "  $($_.Name)" }
 Write-Host ""
 Write-Host "Restart Claude Code to pick up the new slash commands."


### PR DESCRIPTION
## Summary
Mirror the v2.5.0 bash install changes into the PowerShell installer so Windows-first installations get the full toolchain.

## Changes
- **`bootstrap/install.ps1`** — copies `bootstrap/tools/` and `bootstrap/bin/` into `$HOME\.claude\skills-hub\`, runs `install-hooks.sh` via Git Bash when available, prints PowerShell profile PATH hint, broadens the installed-commands summary to include `hub-*`.

## Why v2.5.1 (patch, not minor)
Installer-only fix — no new features or behaviour changes vs v2.5.0. Just brings Windows to parity.

## Test plan
- [ ] Fresh PowerShell install: `powershell -ExecutionPolicy Bypass -File install.ps1` produces working tools / bin / hooks and same slash command set as bash installer.
- [ ] Without bash on PATH, script prints a graceful note instead of failing.

## Rollback
Revert single commit `ca479a9`; no data migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)