### PR TITLE
Bootstrap v2.5.3: force LF for commands/tools/bin (fixes slash-command description rendering)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Bootstrap command files and tools must stay LF — Claude Code's YAML
+# frontmatter parser fails on CRLF (description falls back to the H1 body,
+# and argument-hint stops rendering in the UI).
+bootstrap/commands/*.md text eol=lf
+bootstrap/tools/*.py    text eol=lf
+bootstrap/tools/*.sh    text eol=lf
+bootstrap/bin/*         text eol=lf
+bootstrap/install.sh    text eol=lf


### PR DESCRIPTION
## Problem
Claude Code's slash-command YAML parser breaks on CRLF line endings:

- `description:` value picks up a trailing `\r`, so the parser drops it.
- UI falls back to the H1 body, so the descriptor in the command palette becomes literally \`/hub-xxx \$ARGUMENTS\`.
- `argument-hint` never renders (because YAML block terminates early).

Repro: clone on Windows with default `core.autocrlf=true` → `/hub-commands-update` → open command palette → most `/hub-*` descriptions show the argument placeholder.

## Fix
- `.gitattributes` added at repo root forcing `eol=lf` for:
  - `bootstrap/commands/*.md`
  - `bootstrap/tools/*.{py,sh}`
  - `bootstrap/bin/*`
  - `bootstrap/install.sh`

Existing working-tree files are already LF in the repo (verified via \`od -c\`), so no content changes in this PR — only the .gitattributes guarantee.

## User action for existing installs
Either
```bash
find ~/.claude/commands -name 'hub-*.md' -exec sed -i 's/\r$//' {} +
```
or run `/hub-commands-update` once this PR merges and the v2.5.3 tag propagates.

## Test plan
- [x] Verified: after stripping CR locally, command palette shows full Korean/English descriptions + argument-hint for `/hub-find`, `/hub-precheck`, `/hub-suggest`, `/hub-index-diff`, `/hub-cleanup`, `/hub-doctor`, etc.
- [ ] Reviewer clones fresh on Windows with default autocrlf and confirms descriptions render correctly.

## Rollback
Revert single commit; removing `.gitattributes` restores prior behaviour (but reintroduces the rendering bug on Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)