### PR TITLE
Publish 2 skills + 4 knowledge entries (session 2026-04-18)

### DIFF
--- a/knowledge/decision/squash-merge-orphans-release-branch-tags.md
+++ b/knowledge/decision/squash-merge-orphans-release-branch-tags.md
@@ -1,0 +1,64 @@
+---
+name: squash-merge-orphans-release-branch-tags
+type: knowledge
+category: decision
+tags: [git, tags, squash-merge, release, versioning, bootstrap]
+summary: When a tag is created on a release branch and the PR is squash-merged to main, the tag points at a commit that is no longer reachable from main. Decision - re-tag at the squash commit on main (force-push) to keep tags discoverable.
+source: { kind: session, ref: hub-bootstrap-v2.4.4-v2.5.x-releases }
+confidence: high
+linked_skills: []
+supersedes: null
+extracted_at: 2026-04-18
+---
+
+## Fact
+
+Creating an annotated tag (e.g. `bootstrap/v2.5.0`) on a release branch (`bootstrap/release-v2.5.0`) **before** squash-merging the PR to main leaves the tag pointing at a commit that never lands on main. The resulting state:
+
+- `git merge-base --is-ancestor bootstrap/v2.5.0 main` → **no** (tag is orphaned).
+- `git log main` → never shows the tagged commit; shows only the squash-merge commit.
+- `git show bootstrap/v2.5.0:path/to/file` still works because the commit is retained by the tag ref.
+- But future git garbage collection on local clones can prune the blob if the tag gets deleted — fragile.
+
+Our decision: **after squash-merge, delete the pre-merge tag and re-create it at the squash commit on main (force-push)**.
+
+## Context / Why
+
+Semantic tag releases (`bootstrap/v<semver>`) are the anchor for `/hub-commands-update --version=<x.y.z>`. If the tag orphans off main, users can still install at that version, but:
+1. Browsing history from `main` misses the tag context.
+2. Shields.io badges that filter `bootstrap/v*` tags still work.
+3. GitHub's "Commits since this release" counter shows inflated numbers because main doesn't contain the tagged commit.
+4. `git describe` on main returns the nearest reachable tag, which may be out of date.
+
+Re-tagging at the squash-merge commit makes the tag a first-class citizen of main's history.
+
+## Evidence
+
+```bash
+# During PR #1020 (v2.5.0):
+git tag bootstrap/v2.5.0 <release-branch-tip>   # tag 9309c46 (pre-squash)
+# Merge PR with squash → main HEAD = 4d98dfa
+
+# After merge, tag is orphaned:
+$ git merge-base --is-ancestor bootstrap/v2.5.0 main && echo yes || echo no
+no
+
+# Fix: retag at main tip, force-push
+git tag -d bootstrap/v2.5.0
+git tag -a bootstrap/v2.5.0 main -m "..."
+git push --force origin bootstrap/v2.5.0
+# Now the tag is on main, reachable, discoverable.
+```
+
+## Applies when
+
+- You maintain a repo with semantic-versioned tags on top of squash-merge PR flow.
+- You care about `git describe` accuracy, GitHub release page linkage, or badge correctness.
+- You run an "install version X" command that parses tags (like `/hub-commands-update --version=2.5.0`).
+
+## Counter / Caveats
+
+- **Force-push on tags is a minor destructive action** — users who already fetched the pre-squash tag will see "forced update" on next fetch. Acceptable trade-off when tags are hours old and before wide distribution.
+- If you use **merge commits** (not squash), this problem doesn't arise — the release branch's tagged commit is reachable from main through the merge.
+- Alternative: **tag after merge**. Create branch, PR, squash-merge, then tag `main` tip. Simpler but requires discipline (don't tag on the branch).
+- Never force-push tags that have been distributed for > ~24h or signed by others.

--- a/knowledge/pitfall/claude-code-slash-command-crlf-breaks-yaml-parser.md
+++ b/knowledge/pitfall/claude-code-slash-command-crlf-breaks-yaml-parser.md
@@ -1,0 +1,58 @@
+---
+name: claude-code-slash-command-crlf-breaks-yaml-parser
+type: knowledge
+category: pitfall
+tags: [claude-code, slash-command, yaml, crlf, windows, frontmatter, silent-failure]
+summary: Claude Code's slash-command YAML frontmatter parser silently falls back to the H1 body when files have CRLF line endings, and also hides argument-hint completely.
+source: { kind: session, ref: hub-v2.5.3-release }
+confidence: high
+linked_skills: []
+supersedes: null
+extracted_at: 2026-04-18
+---
+
+## Fact
+
+Slash-command definition files at `~/.claude/commands/*.md` must use **LF** line endings, not CRLF. When a file has CRLF:
+
+1. The parser reads `description: <value>\r` — the trailing `\r` stays inside the string value.
+2. The parser then *silently* discards the value (no error surfaced).
+3. UI falls back to the markdown body's H1 line (e.g. `# /hub-foo $ARGUMENTS`) as the displayed description.
+4. `argument-hint` is not rendered in the tab-completion popover at all.
+
+## Context / Why
+
+- YAML 1.1/1.2 allows `\r\n` line endings, but Claude Code's parser (as of 2026-04) treats `\r` as part of the scalar value when reading line-by-line. The trailing `\r` then fails a downstream validation / whitespace check.
+- The failure is silent — no log, no toast. The symptom is the description showing literal `/<name> $ARGUMENTS` and no parameter hints.
+- Default `git config core.autocrlf=true` on Windows reintroduces CRLF on every checkout, so naive `sed -i 's/\r$//'` fixes get reverted by the next `/hub-commands-update` or `git pull`.
+
+## Evidence
+
+```bash
+$ od -c ~/.claude/commands/hub-precheck.md | head -1
+0000000   -   -   -  \r  \n   d   e   s   c   r   i   p   t   i   o   n
+
+$ # Before fix: command palette shows "/hub-precheck $ARGUMENTS"
+$ sed -i 's/\r$//' ~/.claude/commands/hub-precheck.md
+$ # After fix: "스킬 허브 사전 검증 (lint + master/lite/category 인덱스 재생성)"
+```
+
+Affected about 20+ commands during this session's bootstrap v2.5.x work until the root cause was identified.
+
+## Applies when
+
+- You author or ship slash commands on Windows.
+- You distribute slash commands via a git repo cloned on mixed-OS machines.
+- You notice descriptions rendering as `/<name> $ARGUMENTS` or missing argument-hint tooltips.
+
+## Counter / Caveats
+
+- Fix strategy must be **at the repo level** via `.gitattributes`:
+  ```gitattributes
+  bootstrap/commands/*.md text eol=lf
+  bootstrap/tools/*.{py,sh} text eol=lf
+  bootstrap/bin/* text eol=lf
+  ```
+- One-shot local cleanup: `find ~/.claude/commands -name 'hub-*.md' -exec sed -i 's/\r$//' {} +`
+- Verify with `od -c <file> | head -1` — the sentinel `---` should be followed by `\n`, not `\r\n`.
+- BOM (byte-order mark) at file start would cause a different failure mode (parser rejects frontmatter entirely). Not the same issue.

--- a/knowledge/pitfall/git-reset-hard-bypasses-all-hooks.md
+++ b/knowledge/pitfall/git-reset-hard-bypasses-all-hooks.md
@@ -1,0 +1,50 @@
+---
+name: git-reset-hard-bypasses-all-hooks
+type: knowledge
+category: pitfall
+tags: [git, hooks, reset, post-merge, post-commit, post-checkout, invariant]
+summary: `git reset --hard` does NOT trigger post-merge, post-commit, or post-checkout hooks — workflows that rely on hooks to regenerate derived artifacts become silently stale after a reset.
+source: { kind: session, ref: hub-v2.4.4-hub-sync-reindex }
+confidence: high
+linked_skills: []
+supersedes: null
+extracted_at: 2026-04-18
+---
+
+## Fact
+
+Git's standard hooks (`post-commit`, `post-merge`, `post-checkout`, `post-rewrite`) are **not** fired by `git reset --hard`. Only:
+
+- `post-commit` fires on `git commit` (and `merge --no-ff` which creates a commit).
+- `post-merge` fires on merges that actually execute (including `git pull` with ff-merge).
+- `post-checkout` fires on `git checkout <ref>` and `git clone`.
+- `post-rewrite` fires on `rebase` / `commit --amend`.
+
+`reset` is intentionally excluded because it's meant to be a low-level pointer movement. There is no `post-reset` hook in standard Git (hook extensions like `reference-transaction` exist from 2.28+ but are rarely wired up).
+
+## Context / Why
+
+We wired git hooks at `~/.claude/skills-hub/remote/.git/hooks/{post-merge,post-commit,post-checkout}` to run `precheck.py --skip-lint` so the L1/L2 index auto-regenerates after every mutation. `/hub-sync` uses `git fetch --tags --prune` + `git reset --hard origin/main` to avoid merge conflicts on the cache. That advances HEAD (the working tree changes) but fires **no hooks**, so the indexes went stale silently after every `/hub-sync`.
+
+## Evidence
+
+Reproduction in this session:
+```bash
+# Given: post-commit hook regenerates indexes/
+echo "test" > foo.txt && git add foo.txt && git commit -m "x"
+# Hook fires → indexes/ mtime updates  ✅
+
+git reset --hard HEAD~1
+# Hook does NOT fire → indexes/ stale  ❌
+```
+
+## Applies when
+
+- Your workflow uses post-* hooks to keep derived artifacts (indexes, caches, generated code) in sync.
+- You or a tool ever runs `git reset --hard`, `git restore --source`, or shell-scripts the ref pointer directly.
+
+## Counter / Caveats
+
+- Workaround in our stack: `/hub-sync` now explicitly calls `hub-precheck --skip-lint` at the end (see PR #1019, bootstrap v2.4.4). Rule codified in global CLAUDE.md: "mutation commands must go through `git commit` OR call `hub-precheck`."
+- Alternative for power users: configure `reference-transaction` hook (Git 2.28+) which DOES fire on `reset`. More invasive setup.
+- Do NOT rely on `git merge --ff-only` firing post-merge — it does, but only because it's still technically a merge, not because of ref movement. `reset` is different.

--- a/knowledge/pitfall/windows-rm-rf-device-busy-retry-pattern.md
+++ b/knowledge/pitfall/windows-rm-rf-device-busy-retry-pattern.md
@@ -1,0 +1,76 @@
+---
+name: windows-rm-rf-device-busy-retry-pattern
+type: knowledge
+category: pitfall
+tags: [windows, msys, rm-rf, file-lock, retry, cleanup, claude-code]
+summary: On Windows + Git Bash/MSYS, `rm -rf` on a directory containing git pack files or helper sidecar outputs often fails with "Device or resource busy" because background processes hold file handles. Mitigation - retry 2-3x with short sleeps, or ensure cwd and child processes are outside the target.
+source: { kind: session, ref: wipe-skills-hub-script-test }
+confidence: medium
+linked_skills: []
+supersedes: null
+extracted_at: 2026-04-18
+---
+
+## Fact
+
+`rm -rf ~/.claude/skills-hub/remote` on Windows (under Git Bash / MSYS) frequently fails with:
+
+```
+rm: cannot remove '<path>': Device or resource busy
+```
+
+even when the current shell is not inside the target directory and no obvious process has it open. Common culprits:
+
+1. **Antivirus** scanning `.git/objects/pack/*.pack` files mid-delete.
+2. **File Explorer** preview pane holding a handle.
+3. **Claude Code's own sidecar** (`.omc/` inside the working tree) running a helper process.
+4. **Git long-running processes** (fsmonitor, credential helper daemons).
+
+`set -e` plus a single-shot `rm -rf` in a wipe script will abort halfway, leaving a partially-deleted directory tree that is *also* harder to clean because only some files are gone.
+
+## Context / Why
+
+The pattern surfaced while testing the skills-hub wipe-and-reinstall flow. First attempt aborted mid-delete; second attempt (same shell) still failed. Waiting ~30 seconds and retrying finally succeeded, suggesting lock-holder was transient.
+
+Linux/macOS don't surface this because:
+- They use advisory locking, not mandatory.
+- They allow deleting open files (the file disappears when the last fd closes).
+- Antivirus is less likely to hold open handles.
+
+## Evidence
+
+```bash
+# Failure mode:
+$ rm -rf ~/.claude/skills-hub/remote
+rm: cannot remove '.../remote': Device or resource busy
+# set -e aborts wipe script here; partial state left behind.
+
+# Retry pattern that worked:
+safe_rm() {
+    local target="$1" attempt=1
+    while [[ $attempt -le 3 ]]; do
+        if rm -rf "$target" 2>/tmp/err.log; then return 0; fi
+        if grep -q "busy\|being used" /tmp/err.log; then
+            sleep 2
+            attempt=$((attempt + 1))
+            continue
+        fi
+        return 1
+    done
+    return 1
+}
+```
+
+## Applies when
+
+- You write cleanup / wipe / reinstall scripts that must run on Windows.
+- Your target directory contains `.git/`, `node_modules/`, or other high-churn subtrees.
+- The target may have live sidecar processes (OMC, fsmonitor, Dropbox, OneDrive).
+
+## Counter / Caveats
+
+- **Always `cd` out of the target first** before `rm -rf`. The session test first failed partly because a child shell was rooted inside the doomed dir.
+- **Retry with `sleep 2` × 3** is usually enough for antivirus/explorer to release. Longer loops help fight OneDrive re-hydration.
+- Don't mask the error permanently — if 3 retries fail, report it clearly and tell the user to close Explorer / kill sidecars.
+- `set -e` should NOT cover the rm call — wrap in `|| true` within the retry function and handle failure explicitly.
+- On paths with Unicode or long names, Windows path-length limit (260 chars) can *also* cause "cannot remove" errors — different root cause, different fix (`git config --global core.longpaths true`).

--- a/skills/workflow/md-corpus-l1-l2-index-with-auto-regen/SKILL.md
+++ b/skills/workflow/md-corpus-l1-l2-index-with-auto-regen/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: md-corpus-l1-l2-index-with-auto-regen
+description: Build a two-tier markdown index over a large MD corpus (skills, notes, docs) so LLMs can discover entries without reading every file. L1 compact + L1 full + per-category L2, regenerated via git hooks after every mutation so the index never goes stale.
+category: workflow
+tags: [index, markdown, corpus, llm-context, git-hooks, auto-regen, portable]
+triggers: [skill registry, knowledge base, MD index, search-before-you-code, corpus discovery]
+source_project: skills-hub-bootstrap-v2.5.x
+version: 0.1.0
+---
+
+# md-corpus-l1-l2-index-with-auto-regen
+
+## Problem
+
+You have a growing corpus of markdown entries (skills, knowledge snippets, design notes — 500+ files). Two competing needs:
+
+1. **LLMs need to find things fast** — but loading every MD into context is ~300 KB of irrelevant text.
+2. **The index must stay in sync** — anyone (or any tool) that adds/edits an entry shouldn't have to remember a separate regen step.
+
+A naive single flat index works for small corpora but balloons past ~50 KB and hurts token budget.
+
+## Pattern
+
+Three-tier layout, generated from frontmatter:
+
+```
+~/.claude/skills-hub/
+├── remote/                        # source of truth (git clone)
+│   └── index.json                 # flat catalog (one record per entry)
+├── tools/
+│   ├── _build_master_index.py     # L1 full  (~310 KB: every entry + desc + tags)
+│   ├── _build_master_index_lite.py # L1 compact (~18 KB: 5 reps per category)
+│   ├── _build_category_indexes.py  # L2 (per-category INDEX.md)
+│   └── precheck.py                 # wraps lint + all three rebuilds
+└── indexes/                       # generated artifacts (not committed)
+    ├── 00_MASTER_INDEX.md          # L1 full
+    ├── 00_MASTER_INDEX_LITE.md     # L1 compact (lead here first)
+    └── category_indexes/
+        └── <kind>/<category>/INDEX.md   # L2
+```
+
+Each generator:
+- Reads `index.json`.
+- Groups by `(kind, category)`.
+- Writes a predictable markdown table so grep/Ctrl-F/LLM can pick what they need.
+- Self-relative paths (`Path(__file__).resolve().parent.parent`) so the same script runs from any checkout.
+
+Auto-regen via git hooks in `remote/.git/hooks/`:
+
+```bash
+# post-merge, post-commit, post-checkout (all three):
+#!/usr/bin/env bash
+set -e
+PYTHONIOENCODING=utf-8 py -3 "$HOME/.claude/skills-hub/tools/precheck.py" --skip-lint >/dev/null 2>&1 || true
+```
+
+Provide an `install-hooks.sh` that recreates them after re-clone. Reference it from the installer (`install.sh`) so fresh installs get hooks automatically.
+
+## When to use
+
+- You're curating a corpus of >100 MD entries that multiple people/tools will query.
+- The primary consumer is an LLM (token cost matters → lite + full split).
+- Mutations happen via `git commit` / `git merge` / `git checkout` (hooks fire) or through commands that can call the regen explicitly.
+
+## Discovery contract (LLM side)
+
+Teach the LLM in the project's top-level instructions (CLAUDE.md, system prompt, …):
+
+1. For a question like "what skill fits X?", **skim the L1 lite first** — it tells you the shape of the corpus in 18 KB.
+2. If lite doesn't answer, Ctrl-F the L1 full.
+3. For deeper dives into a single category, open `category_indexes/<kind>/<category>/INDEX.md`.
+4. Only read the actual MD body at `remote/<path>` when citing.
+
+## Pitfalls
+
+- **`git reset --hard` bypasses hooks.** Any command in your stack that uses `reset --hard` to jump to a ref (common for "sync to latest" flows) must call the regen explicitly. See pitfall `git-reset-hard-bypasses-all-hooks`.
+- **CRLF on Windows breaks YAML frontmatter parsing** for consumer tools (`.gitattributes` with `eol=lf` for command/tool/bin files). See pitfall `claude-code-slash-command-crlf-breaks-yaml-parser`.
+- **Index files live under a git-ignored directory** (`indexes/`) or inherit `.gitignore` — they're derived, committing them causes merge noise.
+- **Compact (L1 lite) needs a quality score** — don't just alphabetize. Prefer entries with populated description, >= 3 tags, and version. One-entry-categories get included whole; large categories get the top N by quality.
+
+## Example quality score (L1 lite)
+
+```python
+score = 0
+if description:             score += 3
+if tags:                    score += min(len(tags), 5) + 2
+if version:                 score += 1
+if 80 <= len(description) <= 220: score += 1
+if 3 <= len(name_tokens) <= 8:    score += 1
+# top-5 per category → 18 KB total
+```

--- a/skills/workflow/rollback-anchor-tag-before-destructive-op/SKILL.md
+++ b/skills/workflow/rollback-anchor-tag-before-destructive-op/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: rollback-anchor-tag-before-destructive-op
+description: Before running any large or destructive operation on a shared git repo (bulk edit + merge, force-push, reset --hard on main), create and push an annotated tag at the pre-change state. Cheap insurance, immediate rollback path, no ambiguity about "where was it before".
+category: workflow
+tags: [git, tags, rollback, safety, destructive-ops, pr-flow]
+triggers: [force-push, reset --hard, bulk edit, backfill, mass rewrite, "before I", "rollback to"]
+source_project: skills-hub-bootstrap-v2.4.x-releases
+version: 0.1.0
+---
+
+# rollback-anchor-tag-before-destructive-op
+
+## Problem
+
+You're about to run something that touches many files or shared refs:
+
+- Bulk frontmatter backfill across 500+ files.
+- Force-push to a branch others may have pulled.
+- `git reset --hard` on main.
+- Mass rename or refactor that goes through `git add -A` + `git commit`.
+
+If it goes wrong, "where was main before" becomes fuzzy. `reflog` helps *you* but not teammates, and expires. Branch names can drift. The commit hash is easy to lose in a shell scrollback.
+
+## Pattern
+
+**Pre-step 0 of any destructive op: create an annotated, push it, reference it in the PR body.**
+
+```bash
+# Before the op:
+git tag -a backup/pre-<operation>-<yyyymmdd> <commit-before-change> \
+    -m "Rollback anchor before <operation> (<date>)"
+git push origin backup/pre-<operation>-<yyyymmdd>
+
+# Now do the op.
+
+# In the PR description, include a "Rollback" section:
+# git reset --hard backup/pre-<operation>-<yyyymmdd>
+# git push --force-with-lease origin HEAD:main
+```
+
+Naming convention: `backup/pre-<short-operation-name>-<yyyymmdd>`.
+
+- `backup/` namespace keeps anchors separate from release tags.
+- `pre-` prefix signals intent ("this is the before state").
+- Date disambiguates multiple anchors per day by operation name.
+
+## Example
+
+During the skills-hub frontmatter backfill (532 files touched):
+
+```bash
+# Pre-backfill anchor (before the first PR touched files):
+git tag -a backup/pre-frontmatter-backfill-20260418 main \
+    -m "Rollback anchor before frontmatter backfill (main @ 71f6a63, 2026-04-18)"
+git push origin backup/pre-frontmatter-backfill-20260418
+
+# Second anchor right before release → main merge (because main moved meanwhile):
+git tag -a backup/pre-backfill-merge-main-20260418 6db940e \
+    -m "Rollback anchor: main tip right before frontmatter-backfill merge"
+git push origin backup/pre-backfill-merge-main-20260418
+```
+
+Both anchors included in the PR description with ready-to-paste rollback commands. Zero ambiguity when anyone later asks "can we undo this?"
+
+## When to use
+
+- Any PR that touches more than ~50 files.
+- Any `--force`, `--force-with-lease`, `reset --hard` on a shared branch.
+- Bulk automated edits (linter auto-fix, codemod, formatter migration).
+- Schema / directory structure migrations.
+- Right before merging a large PR to main, add a second anchor at main's current tip — because main may have advanced since the first anchor was created.
+
+## Pitfalls
+
+- **Don't confuse anchor tags with release tags.** Use different namespaces (`backup/*` vs `bootstrap/v*`, `skills/.../v*`).
+- **Push the anchor before the op.** Local-only tags don't help teammates.
+- **Document the rollback command in the PR description.** A tag is just a label; the command is the escape hatch.
+- **Clean up stale anchors** after a few weeks (once you're confident the change is stable) to keep the tag list readable. `git push origin --delete backup/pre-foo-20260401`.
+- **Don't anchor-tag for small PRs.** Single-commit, fully-reviewable PRs have git revert; anchor tags are overkill.


### PR DESCRIPTION
## Source
Extracted from the skills-hub bootstrap v2.4.4 → v2.5.3 release cycle (PRs #1017–#1026). All entries reflect problems that surfaced and resolutions that were tested in this session.

## Skills (2)

| Category | Name | Version | Summary |
|---|---|---|---|
| workflow | `rollback-anchor-tag-before-destructive-op` | v0.1.0 | Create `backup/pre-<op>-<date>` annotated tag → push → reference in PR body, before any bulk/destructive operation. |
| workflow | `md-corpus-l1-l2-index-with-auto-regen` | v0.1.0 | Two-tier (L1 compact + L1 full + L2 per-category) markdown index over a large corpus, regenerated via post-merge / post-commit / post-checkout git hooks. |

## Knowledge (4)

| Category | Name | Confidence | Summary |
|---|---|---|---|
| pitfall | `claude-code-slash-command-crlf-breaks-yaml-parser` | high | CRLF in `~/.claude/commands/*.md` silently breaks YAML frontmatter parsing → UI falls back to H1 body, argument-hint disappears. `.gitattributes` with `eol=lf` fixes it. |
| pitfall | `git-reset-hard-bypasses-all-hooks` | high | `git reset --hard` does NOT fire post-merge / post-commit / post-checkout hooks. Hook-reliant workflows go silently stale. |
| pitfall | `windows-rm-rf-device-busy-retry-pattern` | medium | On Windows + Git Bash, `rm -rf` on `.git/` / sidecar dirs can fail with "Device or resource busy" due to AV / Explorer / fsmonitor. Retry with `sleep 2` × 3. |
| decision | `squash-merge-orphans-release-branch-tags` | high | Tag created on a release branch becomes orphaned (not reachable from main) after squash-merge. Resolution — delete and re-tag at the squash commit on main, force-push. |

## Cross-links

None declared in this round. (Skill drafts didn't name `linked_knowledge`; knowledge drafts didn't name `linked_skills`.)

## Tags created

- `skills/rollback-anchor-tag-before-destructive-op/v0.1.0`
- `skills/md-corpus-l1-l2-index-with-auto-regen/v0.1.0`

## Commit order

Knowledge first (4 commits), then skills (2 commits) — so skills committed later can still reference knowledge slugs if cross-links are added in a future revision.

## Test plan
- [x] Each entry represents a real issue encountered in this session with a verified fix.
- [x] Sanitization: no project-specific names, credentials, or internal URLs.
- [ ] Reviewer spot-checks one skill body + one knowledge body for clarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)