### PR TITLE
Bootstrap v2.6.0: consolidate commands (Core 8 model)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,23 @@ Should report "no skills installed yet" plus the empty registry — proves the h
 
 ## Command Reference
 
+### Core 8 (v2.6.0+)
+
+~90% of usage flows through eight canonical commands. Everything else is a specialised alias or a rarely-invoked maintenance tool.
+
+| Command | When to reach for it |
+|---|---|
+| `/hub-find "<query>"` | Discover skills/knowledge by keyword — ranked, KO↔EN synonyms |
+| `/hub-suggest "<task>"` | AI picks matching entries + offers install/reference (auto-fires on "구현해줘 / implement X") |
+| `/hub-install <name>` | Install a skill locally (add `--all` for bulk, `--example` for demo projects) |
+| `/hub-list` | See what's installed (`--kind skills\|knowledge\|examples\|all`, default all) |
+| `/hub-extract` | Mine the current project for reusable patterns (add `--session` for current session only) |
+| `/hub-publish` | Ship drafts back to the hub (default = all kinds on one PR; `--only skills\|knowledge\|example` narrows) |
+| `/hub-sync` | Pull remote updates + refresh local installs + rebuild indexes |
+| `/hub-doctor` | Diagnose & repair local installation issues |
+
+**Legacy per-kind commands** (`/hub-list-skills`, `/hub-publish-all`, `/hub-extract-session`, `/hub-install-all`, `/hub-install-example`, `/hub-publish-skills`, `/hub-publish-knowledge`, `/hub-publish-example`) still work as aliases — same behaviour, same flags. New code should prefer the canonical names above.
+
 ### Setup
 
 | Command | Purpose | Writes? |

--- a/bootstrap/commands/hub-extract-session.md
+++ b/bootstrap/commands/hub-extract-session.md
@@ -3,6 +3,9 @@ description: Extract reusable skills and knowledge from the current session's ch
 argument-hint: [<keyword>] [--only=skills|knowledge] [--since=<ref>] [--include-conversation] [--min-confidence=high|medium|low] [--dry-run]
 ---
 
+> **Note (since v2.6.0):** `/hub-extract --session` is the canonical entry. This command remains as a compatibility alias — same behaviour, same flags.
+
+
 # /hub-extract-session $ARGUMENTS
 
 Narrow-scope extraction: only what happened in **this session**. Produces both skill and knowledge drafts, same as `/hub-extract` but focused on recent activity.

--- a/bootstrap/commands/hub-extract.md
+++ b/bootstrap/commands/hub-extract.md
@@ -1,6 +1,6 @@
 ---
 description: Scan the full project and extract reusable skills and knowledge as drafts
-argument-hint: [<keyword>] [--only=skills|knowledge] [--from=project|diff|commit <sha>|range <A>..<B>] [--scope=all|src|docs] [--max=<n>] [--auto-split] [--min-confidence=high|medium|low] [--dry-run]
+argument-hint: [<keyword>] [--session] [--only=skills|knowledge] [--from=project|diff|commit <sha>|range <A>..<B>] [--scope=all|src|docs] [--max=<n>] [--auto-split] [--min-confidence=high|medium|low] [--dry-run]
 ---
 
 # /hub-extract $ARGUMENTS
@@ -11,6 +11,13 @@ Analyze the project (or a git diff/commit range) and classify each generalizable
 - **Knowledge** — non-executable facts, decisions, pitfalls, arch notes → `.knowledge-draft/<category>/<slug>.md`
 
 Default mode scans the **full project**. Use `--from` to narrow the source.
+
+
+## Dispatch (v2.6.0+)
+
+- `--session` → delegate to the `/hub-extract-session` flow (session-only scope)
+
+If none of these flags are present, run the main flow below.
 
 ## Keyword mode
 

--- a/bootstrap/commands/hub-install-all.md
+++ b/bootstrap/commands/hub-install-all.md
@@ -3,6 +3,9 @@ description: Install every skill and every knowledge entry from kjuhwa/skills.gi
 argument-hint: [--global] [--skills-only] [--knowledge-only] [--yes] [--category=<name>]
 ---
 
+> **Note (since v2.6.0):** `/hub-install --all` is the canonical entry. This command remains as a compatibility alias — same behaviour, same flags.
+
+
 # /hub-install-all $ARGUMENTS
 
 Bulk-install **all** skills and **all** knowledge entries from the central repository.

--- a/bootstrap/commands/hub-install-example.md
+++ b/bootstrap/commands/hub-install-example.md
@@ -3,6 +3,9 @@ description: Browse and install examples from kjuhwa/skills.git into the current
 argument-hint: [keyword] [--list] [--stack=<name>] [--open]
 ---
 
+> **Note (since v2.6.0):** `/hub-install --example` is the canonical entry. This command remains as a compatibility alias — same behaviour, same flags.
+
+
 # /hub-install-example $ARGUMENTS
 
 Install example projects from the central repository into the current working directory.

--- a/bootstrap/commands/hub-install.md
+++ b/bootstrap/commands/hub-install.md
@@ -1,11 +1,19 @@
 ---
 description: Search kjuhwa/skills.git by keyword/category and install matching skills locally, optionally pinning a version
-argument-hint: <keyword | name@version> [--global] [--category=<name>] [--version=<x.y.z>] [--include-archived]
+argument-hint: <keyword | name@version> [--all] [--example] [--global] [--category=<name>] [--version=<x.y.z>] [--include-archived]
 ---
 
 # /hub-install $ARGUMENTS
 
 Install skills from the central repository matching the keyword.
+
+
+## Dispatch (v2.6.0+)
+
+- `--all` → delegate to the `/hub-install-all` flow (bulk-install every skill + knowledge from main)
+- `--example` → delegate to the `/hub-install-example` flow (copy an example project into cwd)
+
+If none of these flags are present, run the main flow below.
 
 ## Steps
 

--- a/bootstrap/commands/hub-list-examples.md
+++ b/bootstrap/commands/hub-list-examples.md
@@ -3,6 +3,9 @@ description: List projects already published under example/ in the skills-hub re
 argument-hint: [--refresh] [--verbose]
 ---
 
+> **Note (since v2.6.0):** `/hub-list --kind examples` is the canonical entry. This command remains as a compatibility alias — same behaviour, same flags.
+
+
 # /hub-list-examples $ARGUMENTS
 
 Enumerate every subfolder under `example/` in the `kjuhwa/skills-hub` remote cache and render a compact catalog. Intended as the first step of `/hub-make` so new creations don't re-invent something that already lives there.

--- a/bootstrap/commands/hub-list-knowledge.md
+++ b/bootstrap/commands/hub-list-knowledge.md
@@ -3,6 +3,9 @@ description: List locally installed knowledge entries from the hub registry
 argument-hint: [--category <cat>] [--tag <tag>] [--linked-to <skill>] [--orphans] [--scope global|project]
 ---
 
+> **Note (since v2.6.0):** `/hub-list --kind knowledge` is the canonical entry. This command remains as a compatibility alias — same behaviour, same flags.
+
+
 # /hub-list-knowledge $ARGUMENTS
 
 Report knowledge artifacts (non-executable facts/decisions/pitfalls) registered alongside skills.

--- a/bootstrap/commands/hub-list-skills.md
+++ b/bootstrap/commands/hub-list-skills.md
@@ -3,6 +3,9 @@ description: List locally installed skills with source and scope
 argument-hint: [--global | --project | --orphans]
 ---
 
+> **Note (since v2.6.0):** `/hub-list --kind skills` is the canonical entry. This command remains as a compatibility alias — same behaviour, same flags.
+
+
 # /hub-list-skills $ARGUMENTS
 
 Report installed skills tracked by the hub registry.

--- a/bootstrap/commands/hub-list.md
+++ b/bootstrap/commands/hub-list.md
@@ -1,0 +1,39 @@
+---
+description: Unified local-state list (skills + knowledge + examples). Supersedes /hub-list-skills, /hub-list-knowledge, /hub-list-examples.
+argument-hint: [--kind skills|knowledge|examples|all] [--category <cat>] [--tag <tag>]
+---
+
+# /hub-list $ARGUMENTS
+
+One entry point for "what's installed locally?". Delegates to the specialised flows based on `--kind`.
+
+## Dispatch
+
+| `--kind` | Delegates to |
+|---|---|
+| `all` *(default)* | Run `/hub-list-skills` and `/hub-list-knowledge` flows, render a combined table with a `KIND` column. Examples are NOT included by default (they're remote-only previews — see below). |
+| `skills` | `/hub-list-skills` flow. |
+| `knowledge` | `/hub-list-knowledge` flow (filters `--tag`, `--linked-to`, `--orphans` all apply). |
+| `examples` | `/hub-list-examples` flow (remote example projects — not local installs). |
+
+## Steps
+
+1. Parse `--kind`. Default `all`.
+2. Parse downstream filters (`--category`, `--tag`) and pass through to the chosen flow.
+3. Execute the delegated flow and print its output. For `all`, render a combined table:
+   ```
+   KIND       | CATEGORY | NAME                       | SOURCE       | SCOPE
+   skill      | backend  | kafka-avro-producer-gzip   | v1.2.0       | global
+   knowledge  | pitfall  | kafka-consumer-hostname... | high         | (n/a)
+   ```
+4. End-of-output summary: `<N> skills, <M> knowledge entries installed` (and examples count if included).
+
+## Why exists
+
+Previously three commands (`/hub-list-skills`, `/hub-list-knowledge`, `/hub-list-examples`) solved the same question — "what's in my hub". Users routinely had to remember which to invoke. Since v2.6.0 this is the canonical entry; the originals remain as thin aliases for backward compatibility.
+
+## Rules
+
+- **No remote fetch**: purely local state. For remote discovery use `/hub-find`.
+- Output is stable column-aligned text — LLMs can parse.
+- When `--kind all` finds zero entries, print the "nothing installed" summary of the underlying commands.

--- a/bootstrap/commands/hub-publish-example.md
+++ b/bootstrap/commands/hub-publish-example.md
@@ -3,6 +3,9 @@ description: Publish a local creation to the skills-hub remote under example/<sl
 argument-hint: <slug> [--from=<path>] [--title=<str>] [--why=<str>] [--stack=<csv>] [--no-pr]
 ---
 
+> **Note (since v2.6.0):** `/hub-publish --only example` is the canonical entry. This command remains as a compatibility alias — same behaviour, same flags.
+
+
 # /hub-publish-example $ARGUMENTS
 
 Copy a local project folder (or the current working directory) into `example/<slug>/` in the `kjuhwa/skills-hub` remote, author a structured README.md, commit on a feature branch, push, and open a PR. Used after `/hub-make` (or any ad-hoc build) to make the artifact discoverable.

--- a/bootstrap/commands/hub-publish-knowledge.md
+++ b/bootstrap/commands/hub-publish-knowledge.md
@@ -3,6 +3,9 @@ description: Review knowledge drafts and push them to kjuhwa/skills.git as a bra
 argument-hint: [--all | --draft=<slug>] [--pr] [--branch=<name>]
 ---
 
+> **Note (since v2.6.0):** `/hub-publish --only knowledge` is the canonical entry. This command remains as a compatibility alias — same behaviour, same flags.
+
+
 # /hub-publish-knowledge $ARGUMENTS
 
 Publish `.knowledge-draft/` contents to the remote repository. Counterpart to `/hub-publish-skills` — same flow, but for non-executable knowledge artifacts (facts, decisions, pitfalls, arch notes, domain invariants, API contracts).

--- a/bootstrap/commands/hub-publish-skills.md
+++ b/bootstrap/commands/hub-publish-skills.md
@@ -3,6 +3,9 @@ description: Review skill drafts and push them to kjuhwa/skills.git as a branch,
 argument-hint: [--all | --draft=<name>] [--pr] [--branch=<name>] [--bump=major|minor|patch]
 ---
 
+> **Note (since v2.6.0):** `/hub-publish --only skills` is the canonical entry. This command remains as a compatibility alias — same behaviour, same flags.
+
+
 # /hub-publish-skills $ARGUMENTS
 
 Publish `.skills-draft/` contents to the remote repository.

--- a/bootstrap/commands/hub-publish.md
+++ b/bootstrap/commands/hub-publish.md
@@ -1,0 +1,36 @@
+---
+description: Unified publish entry point. Defaults to /hub-publish-all; use --only to restrict to one kind. Supersedes /hub-publish-skills, /hub-publish-knowledge, /hub-publish-example.
+argument-hint: [--only skills|knowledge|all|example] [--pr] [--branch=<name>] [--bump=major|minor|patch]
+---
+
+# /hub-publish $ARGUMENTS
+
+Single entry for publishing drafts back to the hub. By default runs the full combined flow (`/hub-publish-all`); pass `--only` to restrict to one kind.
+
+## Dispatch
+
+| `--only` | Delegates to |
+|---|---|
+| `all` *(default)* | `/hub-publish-all` — knowledge-first then skills on one feature branch, single PR |
+| `skills` | `/hub-publish-skills` — skills only |
+| `knowledge` | `/hub-publish-knowledge` — knowledge only |
+| `example` | `/hub-publish-example` — local creation to `example/<slug>/` |
+
+All flags (`--pr`, `--branch`, `--bump`) pass through unchanged.
+
+## Steps
+
+1. Parse `--only`. Default `all`.
+2. Sanity-check the corresponding draft tree is non-empty; if empty, report and stop.
+3. Delegate to the chosen flow with all remaining arguments.
+
+## When to pick each
+
+- **Default (`--only all`)**: you ran `/hub-extract` and have both skill and knowledge drafts from the same session → one coherent PR.
+- **`--only skills`**: just procedure patterns, no rationale content.
+- **`--only knowledge`**: pitfalls/decisions only, no executable recipes.
+- **`--only example`**: you built a demo project under `example/` and want to ship that specific layout (different branch/PR semantics).
+
+## Why exists
+
+Before v2.6.0 there were four nearly-identical publish commands. `/hub-publish-all` was already the umbrella but users often forgot and ran the specialised ones. This command is the new canonical name; the four originals remain as compatibility aliases.


### PR DESCRIPTION
## Problem
35 `/hub-*` commands is too many to remember. Most users rely on 6–8; the rest are specialised.

## Changes

### New canonical commands
- `/hub-list [--kind skills|knowledge|examples|all]` — unified local-state list
- `/hub-publish [--only skills|knowledge|all|example]` — unified publish (defaults to `all`)

### Dispatch flags on existing commands
- `/hub-extract --session` → alias for `/hub-extract-session`
- `/hub-install --all` → alias for `/hub-install-all`
- `/hub-install --example` → alias for `/hub-install-example`

### Deprecation annotations (behaviour unchanged)
9 legacy commands get a v2.6.0 note pointing to the canonical equivalent. Aliases still work — zero breakage.

### Docs
README adds a "Core 8" section upfront so new users land on the short list immediately. Legacy variants documented as aliases.

## Test plan
- [x] New commands registered (hub-list, hub-publish files present)
- [x] Legacy commands retain full behaviour
- [x] .gitattributes enforces LF on all new/modified command files
- [ ] Reviewer checks README renders the Core 8 table correctly on GitHub

## Rollback
Revert single commit. New commands disappear; legacy commands remain (they were unchanged in function).

🤖 Generated with [Claude Code](https://claude.com/claude-code)