### PR TITLE
Bootstrap v2.6.1: delegate bulk scans to Explore subagent

### DIFF
--- a/bootstrap/commands/hub-cleanup.md
+++ b/bootstrap/commands/hub-cleanup.md
@@ -7,6 +7,30 @@ argument-hint: [--apply] [--dedupe] [--reindex] [--stale-days=<n>]
 
 Remote repository maintenance. **Dry-run is the default.**
 
+## Execution strategy (v2.6.1+)
+
+Bulk scanning MUST be delegated to an `Explore` subagent. The main thread only synthesises drafts from the returned candidate list.
+
+```
+Agent(
+  subagent_type="Explore",
+  description="<short task name>",
+  prompt="""
+Scan ~/.claude/skills-hub/remote/ for integrity issues:
+  stale: entries with no updates in 180+ days AND flagged as low-confidence
+  orphan_registry: registry.json entries with no matching file on disk
+  broken_links: linked_skills/linked_knowledge references to missing slugs
+  malformed_frontmatter: missing required fields (name, category, version)
+Return findings grouped by category with file paths.
+
+Return a ranked list (top N per `--max-*` flag or sensible default) with: name, kind (skill|knowledge), category, 1-line description, source path(s), confidence. Drop anything project-specific or non-generalizable.
+""",
+)
+```
+
+After the subagent returns, read **only** the few MDs needed to write final drafts. Do **not** iterate `Read` across dozens of files in the main thread — it burns tokens, fragments history, and produces no better result than delegation. (v2.6.1 added this rule after a `/hub-import` run did 73 tool calls to scan one repo.)
+
+
 ## Steps
 
 1. **Refresh cache** to latest `main`.

--- a/bootstrap/commands/hub-condense.md
+++ b/bootstrap/commands/hub-condense.md
@@ -14,6 +14,28 @@ Produces drafts under `.skills-draft/` (and a `_CONDENSE_PATCHES.yaml` aggregate
 
 Different axis from `/hub-cleanup` (which handles metadata hygiene: malformed frontmatter, orphan files, name collisions, index drift) and from `/hub-refactor` (which consolidates whole entries via merge / splits oversized entries / archives low-value ones). `/hub-condense` operates on the **text inside** entries.
 
+## Execution strategy (v2.6.1+)
+
+Bulk scanning MUST be delegated to an `Explore` subagent. The main thread only synthesises drafts from the returned candidate list.
+
+```
+Agent(
+  subagent_type="Explore",
+  description="<short task name>",
+  prompt="""
+Scan ~/.claude/skills-hub/remote/skills/** and knowledge/** for:
+  dedup_candidates: identical or near-identical chunks that appear in multiple entries (copy-paste patterns)
+  compress_candidates: single entries with redundant prose, verbose examples, or oversized sections that can shrink without losing meaning
+Include a diff-like snippet showing what would be removed for each.
+
+Return a ranked list (top N per `--max-*` flag or sensible default) with: name, kind (skill|knowledge), category, 1-line description, source path(s), confidence. Drop anything project-specific or non-generalizable.
+""",
+)
+```
+
+After the subagent returns, read **only** the few MDs needed to write final drafts. Do **not** iterate `Read` across dozens of files in the main thread — it burns tokens, fragments history, and produces no better result than delegation. (v2.6.1 added this rule after a `/hub-import` run did 73 tool calls to scan one repo.)
+
+
 ## Arguments
 
 - `--mode=dedup|compress|auto` — which pass(es) to run. Default `auto` (both).

--- a/bootstrap/commands/hub-extract.md
+++ b/bootstrap/commands/hub-extract.md
@@ -13,6 +13,25 @@ Analyze the project (or a git diff/commit range) and classify each generalizable
 Default mode scans the **full project**. Use `--from` to narrow the source.
 
 
+## Execution strategy (v2.6.1+)
+
+Bulk scanning MUST be delegated to an `Explore` subagent. The main thread only synthesises drafts from the returned candidate list.
+
+```
+Agent(
+  subagent_type="Explore",
+  description="<short task name>",
+  prompt="""
+Scan the current project working directory — git tree + uncommitted changes + recent commits (last 7 days or --from range). Identify reusable skill and knowledge candidates from source files, commit messages, and README/docs. Same generalisation bar as hub-import: drop one-off code, business names, credentials. Prioritize patterns mentioned in user corrections or debugging workarounds discovered in the session.
+
+Return a ranked list (top N per `--max-*` flag or sensible default) with: name, kind (skill|knowledge), category, 1-line description, source path(s), confidence. Drop anything project-specific or non-generalizable.
+""",
+)
+```
+
+After the subagent returns, read **only** the few MDs needed to write final drafts. Do **not** iterate `Read` across dozens of files in the main thread — it burns tokens, fragments history, and produces no better result than delegation. (v2.6.1 added this rule after a `/hub-import` run did 73 tool calls to scan one repo.)
+
+
 ## Dispatch (v2.6.0+)
 
 - `--session` → delegate to the `/hub-extract-session` flow (session-only scope)

--- a/bootstrap/commands/hub-import.md
+++ b/bootstrap/commands/hub-import.md
@@ -11,6 +11,25 @@ Fetch skills and knowledge from an external git repository (not `kjuhwa/skills.g
 
 **Pipeline:** `clone → (authored SKILL.md / knowledge *.md found?) → stage as drafts` **OR** `(none found) → /hub-extract against the clone → stage drafts in this project`. The second path lets you turn arbitrary source repositories (application code, docs) into publishable drafts.
 
+## Execution strategy (v2.6.1+)
+
+Bulk scanning MUST be delegated to an `Explore` subagent. The main thread only synthesises drafts from the returned candidate list.
+
+```
+Agent(
+  subagent_type="Explore",
+  description="<short task name>",
+  prompt="""
+Scan the cloned external repository at ~/.claude/skills-hub/external/<slug>/. Identify reusable skill and knowledge candidates. Criteria: patterns that appear across multiple files, non-trivial setup/integration, documented decisions or pitfalls. Drop project-specific names, internal URLs, credentials, framework defaults. Read the repo's README, CONTRIBUTING, and top-level directory structure first to shape the scan.
+
+Return a ranked list (top N per `--max-*` flag or sensible default) with: name, kind (skill|knowledge), category, 1-line description, source path(s), confidence. Drop anything project-specific or non-generalizable.
+""",
+)
+```
+
+After the subagent returns, read **only** the few MDs needed to write final drafts. Do **not** iterate `Read` across dozens of files in the main thread — it burns tokens, fragments history, and produces no better result than delegation. (v2.6.1 added this rule after a `/hub-import` run did 73 tool calls to scan one repo.)
+
+
 ## Arguments
 
 - `<git-url>` (required) — HTTPS or SSH git URL (e.g. `https://github.com/acme/team-skills.git`).

--- a/bootstrap/commands/hub-refactor.md
+++ b/bootstrap/commands/hub-refactor.md
@@ -15,6 +15,28 @@ For merge/split candidates, produces a draft in `.skills-draft/` / `.knowledge-d
 
 Use this periodically (monthly, or after a burst of `/hub-publish-skills` activity) to keep the remote registry coherent. For targeted single-operation refactors, use `/hub-merge` or `/hub-split` directly.
 
+## Execution strategy (v2.6.1+)
+
+Bulk scanning MUST be delegated to an `Explore` subagent. The main thread only synthesises drafts from the returned candidate list.
+
+```
+Agent(
+  subagent_type="Explore",
+  description="<short task name>",
+  prompt="""
+Scan ~/.claude/skills-hub/remote/skills/** and knowledge/** for two lists:
+  merge_candidates: clusters of entries with high semantic overlap (title, description, tag overlap) suitable for consolidation
+  split_candidates: entries >= 400 body lines with >= 2 distinct topical clusters (content, tags, or section headers)
+For each: name, kind, category, reason, proposed action.
+
+Return a ranked list (top N per `--max-*` flag or sensible default) with: name, kind (skill|knowledge), category, 1-line description, source path(s), confidence. Drop anything project-specific or non-generalizable.
+""",
+)
+```
+
+After the subagent returns, read **only** the few MDs needed to write final drafts. Do **not** iterate `Read` across dozens of files in the main thread — it burns tokens, fragments history, and produces no better result than delegation. (v2.6.1 added this rule after a `/hub-import` run did 73 tool calls to scan one repo.)
+
+
 ## Arguments
 
 - `--scope=all|<category>` — restrict the scan. Default `all`.

--- a/bootstrap/commands/hub-research.md
+++ b/bootstrap/commands/hub-research.md
@@ -14,6 +14,25 @@ Two modes:
 
 **No direct installs.** Nothing is written to `~/.claude/skills/`, `.claude/skills/`, `~/.claude/skills-hub/knowledge/`, `.claude/knowledge/`, or `registry.json`. Review drafts, then ship them with `/hub-publish-skills`, `/hub-publish-knowledge`, or `/hub-publish-all`.
 
+## Execution strategy (v2.6.1+)
+
+Bulk scanning MUST be delegated to an `Explore` subagent. The main thread only synthesises drafts from the returned candidate list.
+
+```
+Agent(
+  subagent_type="Explore",
+  description="<short task name>",
+  prompt="""
+Research the given keyword across authoritative sources (official docs, well-cited blog posts, vendor engineering blogs). Synthesize skill and knowledge candidates with evidence links. Prefer primary sources over aggregators. Mark confidence: high (official docs or multiple independent confirmations) / medium (single reputable source) / low (community forum).
+
+Return a ranked list (top N per `--max-*` flag or sensible default) with: name, kind (skill|knowledge), category, 1-line description, source path(s), confidence. Drop anything project-specific or non-generalizable.
+""",
+)
+```
+
+After the subagent returns, read **only** the few MDs needed to write final drafts. Do **not** iterate `Read` across dozens of files in the main thread — it burns tokens, fragments history, and produces no better result than delegation. (v2.6.1 added this rule after a `/hub-import` run did 73 tool calls to scan one repo.)
+
+
 ## Arguments
 
 - `<keyword>` (optional) — topic, library, pattern, or problem. If omitted, switch to trend mode.


### PR DESCRIPTION
## Problem
Scan-heavy commands (`/hub-import`, `/hub-extract`, etc.) were iterating `Read` from the main thread across dozens of files. A single `/hub-import` run produced ~70 tool calls, fragmented conversation history, and burned tokens for zero quality benefit.

## Fix
Inject an explicit MUST-level directive into six commands telling the AI to delegate bulk scanning to an `Explore` subagent and synthesise drafts from the returned candidate list.

## Commands updated
- `/hub-import` — external repo scan
- `/hub-extract` — current project scan
- `/hub-research` — web research
- `/hub-refactor` — remote corpus merge/split scan
- `/hub-condense` — remote corpus dedup scan
- `/hub-cleanup` — remote integrity scan

Each gets a command-specific brief inside the directive block so the subagent knows exactly what criteria to apply.

## Expected impact
Tool-call count for a typical `/hub-import` should drop from ~70 to ~5 (one Agent, a handful of Write + final verify).

## Rollback
Revert single commit. Commands revert to their pre-v2.6.1 behaviour (slow but functional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)