### PR TITLE
Publish 2 skills + 2 knowledge entries (session 2026-04-18 part 2)

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,13 +1,43 @@
 [
   {
     "kind": "knowledge",
+    "name": "sandstorm-erosion-accumulator-buffer",
+    "slug": "sandstorm-erosion-accumulator-buffer",
+    "category": "algorithms",
+    "description": "Simulate progressive erosion/burial by accumulating wind deltas into a persistent height buffer sampled at render time.",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/algorithms/sandstorm-erosion-accumulator-buffer.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "twin-body-orbital-phase-offset",
+    "slug": "twin-body-orbital-phase-offset",
+    "category": "algorithms",
+    "description": "Render two orbiting bodies convincingly by phase-offsetting a shared sine driver rather than independent timers.",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/algorithms/twin-body-orbital-phase-offset.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "actuator-path-dual-compatibility",
     "slug": "actuator-path-dual-compatibility",
     "category": "api",
     "description": "Actuator endpoints must respond at both /actuator/** and /actuator/{appName}/** for deployment compatibility.",
-    "tags": [],
+    "tags": [
+      "api",
+      "actuator",
+      "path",
+      "dual",
+      "compatibility"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/api/actuator-path-dual-compatibility.md",
     "has_content": true
   },
@@ -17,9 +47,16 @@
     "slug": "claude-code-routines-cloud-automation-model",
     "category": "api",
     "description": "Claude Code Routines (research preview) are saved cloud sessions — prompt + repos + connectors + environment — triggered by schedule, HTTP POST, or GitHub events. One routine can combine all three. Daily run cap per account; branch pushes restricted to `claude/*` by default.",
-    "tags": [],
+    "tags": [
+      "api",
+      "claude",
+      "code",
+      "routines",
+      "cloud",
+      "automation"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/api/claude-code-routines-cloud-automation-model.md",
     "has_content": true
   },
@@ -29,9 +66,14 @@
     "slug": "confid-vs-resourceid-routing",
     "category": "api",
     "description": "Queries support both `configIds` (tenant/policy scope) and `resourceId` (agent scope); filter routes to different Mongo match fields",
-    "tags": [],
+    "tags": [
+      "api",
+      "confid",
+      "resourceid",
+      "routing"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/api/confid-vs-resourceid-routing.md",
     "has_content": true
   },
@@ -41,9 +83,15 @@
     "slug": "endpoint-service-dual-pattern",
     "category": "api",
     "description": "Two coexisting API service patterns — factory functions (apmServices) and direct functional exports (alarmService) — with centralized endpoint constants",
-    "tags": [],
+    "tags": [
+      "api",
+      "endpoint",
+      "service",
+      "dual",
+      "pattern"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/api/endpoint-service-dual-pattern.md",
     "has_content": true
   },
@@ -53,9 +101,15 @@
     "slug": "es-xpack-transport-vs-rest-ssl",
     "category": "api",
     "description": "Elasticsearch transport SSL and REST SSL are independent X-Pack configs; enabling one does not enable the other",
-    "tags": [],
+    "tags": [
+      "api",
+      "xpack",
+      "transport",
+      "rest",
+      "ssl"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/api/es-xpack-transport-vs-rest-ssl.md",
     "has_content": true
   },
@@ -65,9 +119,16 @@
     "slug": "kafka-avro-change-flag-contract",
     "category": "api",
     "description": "Every Configuration-domain Avro event carries an `actionType` enum (INSERT/UPDATE/DELETE) plus boolean change flags per mutable section (e.g. `parentChanged`, `tagFiltersChanged`, `configurationsChanged`) rather than full before/after payloads.",
-    "tags": [],
+    "tags": [
+      "api",
+      "kafka",
+      "avro",
+      "change",
+      "flag",
+      "contract"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/api/kafka-avro-change-flag-contract.md",
     "has_content": true
   },
@@ -77,9 +138,15 @@
     "slug": "kafka-organization-id-record-header",
     "category": "api",
     "description": "Place organizationId (tenant) in the Kafka record header, not only in the payload — downstream consumers route by header before deserializing.",
-    "tags": [],
+    "tags": [
+      "api",
+      "kafka",
+      "organization",
+      "record",
+      "header"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/api/kafka-organization-id-record-header.md",
     "has_content": true
   },
@@ -89,9 +156,15 @@
     "slug": "live-chart-timestamp-normalization",
     "category": "api",
     "description": "LIVE charts accept `normalizeTimestamp` + `normalizeIntervalMs` to align per-agent millisecond offsets into a single x-axis",
-    "tags": [],
+    "tags": [
+      "api",
+      "live",
+      "chart",
+      "timestamp",
+      "normalization"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/api/live-chart-timestamp-normalization.md",
     "has_content": true
   },
@@ -101,9 +174,15 @@
     "slug": "stomp-heartbeat-10s-bidirectional",
     "category": "api",
     "description": "STOMP broker heartbeat set to 10s/10s (client↔server) is a reasonable default for detecting dead WebSocket sessions within ~20s",
-    "tags": [],
+    "tags": [
+      "api",
+      "stomp",
+      "heartbeat",
+      "10s",
+      "bidirectional"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/api/stomp-heartbeat-10s-bidirectional.md",
     "has_content": true
   },
@@ -113,9 +192,16 @@
     "slug": "timeselector-mode-interval-range-mapping",
     "category": "api",
     "description": "Clients send a `mode` enum (RAW..YEAR); the server maps it to a (bin-interval, query-range) pair and picks the right pre-aggregated collection",
-    "tags": [],
+    "tags": [
+      "api",
+      "timeselector",
+      "mode",
+      "interval",
+      "range",
+      "mapping"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/api/timeselector-mode-interval-range-mapping.md",
     "has_content": true
   },
@@ -133,7 +219,7 @@
       "scouter"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/api/xlog-extended-transaction-trace-with-compression.md",
     "has_content": true
   },
@@ -142,7 +228,7 @@
     "name": "additive-registry-schema-versioning",
     "slug": "additive-registry-schema-versioning",
     "category": "arch",
-    "description": "JSON registry 진화는 version bump + 새 키 empty container + 첫 쓰기 시 자동 마이그레이션으로 하라",
+    "description": "\"JSON registry 진화는 version bump + 새 키 empty container + 첫 쓰기 시 자동 마이그레이션으로 하라\"",
     "tags": [
       "registry",
       "schema",
@@ -151,7 +237,7 @@
       "backwards-compat"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/additive-registry-schema-versioning.md",
     "has_content": true
   },
@@ -161,9 +247,15 @@
     "slug": "agent-memory-binding-vs-recall",
     "category": "arch",
     "description": "Agent memory systems that ace retrieval benchmarks still fail operationally because stored skills aren't *bound* to the episodes that validated them. Fix is a memory bundle — skill record + episode record + bidirectional link — returned together on recall.",
-    "tags": [],
+    "tags": [
+      "arch",
+      "agent",
+      "memory",
+      "binding",
+      "recall"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/agent-memory-binding-vs-recall.md",
     "has_content": true
   },
@@ -181,7 +273,7 @@
       "rbac"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/annotation-driven-authz-via-function-id.md",
     "has_content": true
   },
@@ -191,9 +283,15 @@
     "slug": "archon-deterministic-ai-coding-harness",
     "category": "arch",
     "description": "Archon enforces deterministic AI-assisted coding by encoding workflows as YAML DAGs — deterministic nodes (tests, git ops) bracket AI-driven nodes (plan, implement, review), each run isolated in its own git worktree. The pattern generalizes beyond Archon itself.",
-    "tags": [],
+    "tags": [
+      "arch",
+      "archon",
+      "deterministic",
+      "coding",
+      "harness"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/archon-deterministic-ai-coding-harness.md",
     "has_content": true
   },
@@ -211,7 +309,7 @@
       "phased-validation"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/assumeutxo-snapshot-chainstate-phases.md",
     "has_content": true
   },
@@ -229,7 +327,7 @@
       "ui"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/bilingual-user-facing-strings.md",
     "has_content": true
   },
@@ -247,7 +345,7 @@
       "skeleton"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/boilerplate-generated-business-logic-manual.md",
     "has_content": true
   },
@@ -256,10 +354,16 @@
     "name": "claude-plugin-skill-md-is-sufficient",
     "slug": "claude-plugin-skill-md-is-sufficient",
     "category": "arch",
-    "description": "스킬 = SKILL.md 하나. 코드, 빌드, 의존성, 스크립트 없이도 완전히 동작한다.",
-    "tags": [],
+    "description": "\"스킬 = SKILL.md 하나. 코드, 빌드, 의존성, 스크립트 없이도 완전히 동작한다.\"",
+    "tags": [
+      "arch",
+      "claude",
+      "plugin",
+      "skill",
+      "sufficient"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/claude-plugin-skill-md-is-sufficient.md",
     "has_content": true
   },
@@ -269,9 +373,15 @@
     "slug": "commons-logging-exclusion-strategy",
     "category": "arch",
     "description": "Globally exclude commons-logging, log4j, and slf4j-log4j12 in Gradle so SLF4J+Logback is the only logging backend on the classpath",
-    "tags": [],
+    "tags": [
+      "arch",
+      "commons",
+      "logging",
+      "exclusion",
+      "strategy"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/commons-logging-exclusion-strategy.md",
     "has_content": true
   },
@@ -281,9 +391,16 @@
     "slug": "data-patch-package-for-migrations",
     "category": "arch",
     "description": "One-off data patches (backfills, embedded→referenced splits, field additions) are grouped under a `patch` package so they're isolated from day-to-day service code and easy to audit/remove after a release.",
-    "tags": [],
+    "tags": [
+      "arch",
+      "data",
+      "patch",
+      "package",
+      "for",
+      "migrations"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/data-patch-package-for-migrations.md",
     "has_content": true
   },
@@ -301,7 +418,7 @@
       "local-config"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/domain-registry-plus-projects-yaml.md",
     "has_content": true
   },
@@ -311,9 +428,15 @@
     "slug": "dual-design-token-pipeline-arch",
     "category": "arch",
     "description": "Project runs two parallel design token pipelines — legacy SD v3→SCSS for sirius/Ant Design and modern SD v5→CSS @theme for AI Portal/Tailwind v4",
-    "tags": [],
+    "tags": [
+      "arch",
+      "dual",
+      "design",
+      "token",
+      "pipeline"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/dual-design-token-pipeline-arch.md",
     "has_content": true
   },
@@ -323,9 +446,16 @@
     "slug": "dual-redis-lock-vs-access-control",
     "category": "arch",
     "description": "The service connects to two separate Redis instances: Lock Control (default port 6399) and Access Control (default port 6389). They are not interchangeable.",
-    "tags": [],
+    "tags": [
+      "arch",
+      "dual",
+      "redis",
+      "lock",
+      "access",
+      "control"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/dual-redis-lock-vs-access-control.md",
     "has_content": true
   },
@@ -335,9 +465,15 @@
     "slug": "duckdb-vectorized-analytical-execution",
     "category": "arch",
     "description": "DuckDB's design has five separable pillars — vectorized execution, pipelined operators, explicit memory + grouped aggregation, ART indexing, and a dedicated query rewriter — distinguishing it from row-at-a-time OLTP engines.",
-    "tags": [],
+    "tags": [
+      "arch",
+      "duckdb",
+      "vectorized",
+      "analytical",
+      "execution"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/duckdb-vectorized-analytical-execution.md",
     "has_content": true
   },
@@ -347,9 +483,16 @@
     "slug": "env-override-last-wins-chain",
     "category": "arch",
     "description": "Environment variables resolve across four sources with \"last wins\" precedence.",
-    "tags": [],
+    "tags": [
+      "arch",
+      "env",
+      "override",
+      "last",
+      "wins",
+      "chain"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/env-override-last-wins-chain.md",
     "has_content": true
   },
@@ -359,9 +502,16 @@
     "slug": "event-driven-init-wait-for-services",
     "category": "arch",
     "description": "Initialization work is deferred until leader status and dependent-service readiness are confirmed via a `@WaitForServices` event listener",
-    "tags": [],
+    "tags": [
+      "arch",
+      "event",
+      "driven",
+      "init",
+      "wait",
+      "for"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/event-driven-init-wait-for-services.md",
     "has_content": true
   },
@@ -371,9 +521,15 @@
     "slug": "gradle-avro-plugin-config",
     "category": "arch",
     "description": "davidmc24 avro-gradle-plugin config — createSetters=false + fieldVisibility=PRIVATE enforces immutable generated event schemas",
-    "tags": [],
+    "tags": [
+      "arch",
+      "gradle",
+      "avro",
+      "plugin",
+      "config"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/gradle-avro-plugin-config.md",
     "has_content": true
   },
@@ -382,10 +538,15 @@
     "name": "hierarchical-agents-md-catalog",
     "slug": "hierarchical-agents-md-catalog",
     "category": "arch",
-    "description": "루트 AGENTS.md(프로젝트 개요) + `skills/AGENTS.md`(스킬 카탈로그) 2계층 구조. 하위는 상위를 `<!-- Parent: ../AGENTS.md -->` 주석으로 가리킨다.",
-    "tags": [],
+    "description": "\"루트 AGENTS.md(프로젝트 개요) + `skills/AGENTS.md`(스킬 카탈로그) 2계층 구조. 하위는 상위를 `<!-- Parent: ../AGENTS.md -->` 주석으로 가리킨다.\"",
+    "tags": [
+      "arch",
+      "hierarchical",
+      "agents",
+      "catalog"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/hierarchical-agents-md-catalog.md",
     "has_content": true
   },
@@ -403,7 +564,7 @@
       "dependency-inversion"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/interface-abstraction-for-modularity.md",
     "has_content": true
   },
@@ -413,9 +574,16 @@
     "slug": "jar-task-disabled-bootjar-only",
     "category": "arch",
     "description": "Gradle `jar` task is disabled so only `bootJar` produces an artifact — CI/Docker consumers never receive an ambiguous plain JAR",
-    "tags": [],
+    "tags": [
+      "arch",
+      "jar",
+      "task",
+      "disabled",
+      "bootjar",
+      "only"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/jar-task-disabled-bootjar-only.md",
     "has_content": true
   },
@@ -425,9 +593,16 @@
     "slug": "jvm-module-opens-java21-spring-kafka",
     "category": "arch",
     "description": "Java 21 runs Spring Boot + Kafka/MongoDB clients under strict module access; two --add-opens flags are required or reflective serializers fail at runtime.",
-    "tags": [],
+    "tags": [
+      "arch",
+      "jvm",
+      "module",
+      "opens",
+      "java21",
+      "spring"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/jvm-module-opens-java21-spring-kafka.md",
     "has_content": true
   },
@@ -436,7 +611,7 @@
     "name": "k-git-tag-registry-versioning",
     "slug": "k-git-tag-registry-versioning",
     "category": "arch",
-    "description": "Git tag를 semver registry로 쓰면 별도 version manifest 없이 rollback·pinning을 얻는다",
+    "description": "\"Git tag를 semver registry로 쓰면 별도 version manifest 없이 rollback·pinning을 얻는다\"",
     "tags": [
       "git",
       "versioning",
@@ -445,7 +620,7 @@
       "semver"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/k-git-tag-registry-versioning.md",
     "has_content": true
   },
@@ -455,9 +630,16 @@
     "slug": "kafka-1h-topic-and-nonmetric-pool",
     "category": "arch",
     "description": "Raw alarm path uses a 1-hour-retention Kafka topic and a dedicated non-metric thread pool — isolates alarm latency from batch ingest",
-    "tags": [],
+    "tags": [
+      "arch",
+      "kafka",
+      "topic",
+      "and",
+      "nonmetric",
+      "pool"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/kafka-1h-topic-and-nonmetric-pool.md",
     "has_content": true
   },
@@ -467,9 +649,16 @@
     "slug": "kafka-avro-schedule-event-chain",
     "category": "arch",
     "description": "Collection scheduling decouples Kafka ingress from per-DBMS handlers via four typed BlockingQueues",
-    "tags": [],
+    "tags": [
+      "arch",
+      "kafka",
+      "avro",
+      "schedule",
+      "event",
+      "chain"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/kafka-avro-schedule-event-chain.md",
     "has_content": true
   },
@@ -479,9 +668,16 @@
     "slug": "kafka-avro-schema-registry-env-topology",
     "category": "arch",
     "description": "Kafka uses Avro + Confluent Schema Registry; partition and replication counts are environment-driven.",
-    "tags": [],
+    "tags": [
+      "arch",
+      "kafka",
+      "avro",
+      "schema",
+      "registry",
+      "env"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/kafka-avro-schema-registry-env-topology.md",
     "has_content": true
   },
@@ -499,7 +695,7 @@
       "concurrency"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/kafka-partition-topology-design.md",
     "has_content": true
   },
@@ -509,9 +705,15 @@
     "slug": "live-mode-aggregation-exceptions",
     "category": "arch",
     "description": "LIVE mode reads raw data by default, but equalizer / multi-resource / TopN charts still aggregate raw at query time",
-    "tags": [],
+    "tags": [
+      "arch",
+      "live",
+      "mode",
+      "aggregation",
+      "exceptions"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/live-mode-aggregation-exceptions.md",
     "has_content": true
   },
@@ -521,9 +723,16 @@
     "slug": "llm-tool-calling-mxn-wire-format-problem",
     "category": "arch",
     "description": "Open-source LLMs each encode tool calls in a different wire format (special tokens, XML, channel notation, JSON blocks), so M inference apps × N models = M×N parsers. Fix is declarative tool-call specs shipped with the model and consumed by both grammar engines and parsers.",
-    "tags": [],
+    "tags": [
+      "arch",
+      "llm",
+      "tool",
+      "calling",
+      "mxn",
+      "wire"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/llm-tool-calling-mxn-wire-format-problem.md",
     "has_content": true
   },
@@ -533,9 +742,15 @@
     "slug": "lucida-framework-gate-annotations",
     "category": "arch",
     "description": "Internal framework (lucida-framework-*) uses opt-in annotations (@EnabledMessage, @EnableDataExport, @EnableSchedule, @EnableCommand) on the Application class to gate auto-config; omitting one silently disables the feature.",
-    "tags": [],
+    "tags": [
+      "arch",
+      "lucida",
+      "framework",
+      "gate",
+      "annotations"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/lucida-framework-gate-annotations.md",
     "has_content": true
   },
@@ -544,7 +759,7 @@
     "name": "lucida-ui-design-token-reference",
     "slug": "lucida-ui-design-token-reference",
     "category": "arch",
-    "description": "lucida-ui 프로젝트의 실제 디자인 토큰 값 참조표 — 팔레트, 시맨틱, 사이즈, 타이포, 컴포넌트 스타일",
+    "description": "\"lucida-ui 프로젝트의 실제 디자인 토큰 값 참조표 — 팔레트, 시맨틱, 사이즈, 타이포, 컴포넌트 스타일\"",
     "tags": [
       "lucida-ui",
       "nds",
@@ -554,7 +769,7 @@
       "figma"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/lucida-ui-design-token-reference.md",
     "has_content": true
   },
@@ -564,9 +779,15 @@
     "slug": "mf-cross-remote-import-forbidden",
     "category": "arch",
     "description": "In a Module Federation monorepo with per-remote webpack aliases, remotes must not import from sibling remotes directly — share code through `shared/` or through MF exposes.",
-    "tags": [],
+    "tags": [
+      "arch",
+      "cross",
+      "remote",
+      "import",
+      "forbidden"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/mf-cross-remote-import-forbidden.md",
     "has_content": true
   },
@@ -576,9 +797,15 @@
     "slug": "mf-expose-requires-memoryrouter-wrapper",
     "category": "arch",
     "description": "Components exposed via Module Federation that use react-router hooks must be wrapped in MemoryRouter at the expose boundary, not BrowserRouter and not a full-app router wrapper.",
-    "tags": [],
+    "tags": [
+      "arch",
+      "expose",
+      "requires",
+      "memoryrouter",
+      "wrapper"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/mf-expose-requires-memoryrouter-wrapper.md",
     "has_content": true
   },
@@ -588,9 +815,14 @@
     "slug": "mf-shared-singleton-config",
     "category": "arch",
     "description": "227 shared dependencies configured as Webpack Module Federation singletons with strict versioning; react-router-dom intentionally excluded",
-    "tags": [],
+    "tags": [
+      "arch",
+      "shared",
+      "singleton",
+      "config"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/mf-shared-singleton-config.md",
     "has_content": true
   },
@@ -607,7 +839,7 @@
       "time-series"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/mongodb-aggregated-stats-as-views.md",
     "has_content": true
   },
@@ -625,7 +857,7 @@
       "cross-domain"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/multi-domain-split-via-domain-mapping.md",
     "has_content": true
   },
@@ -635,9 +867,15 @@
     "slug": "multi-layer-css-architecture",
     "category": "arch",
     "description": "Four-layer CSS architecture — SCSS (sirius design system), LESS (Ant Design vars), Tailwind v4 (AI Portal with scope isolation), plain CSS — each with distinct webpack rules and toolchains",
-    "tags": [],
+    "tags": [
+      "arch",
+      "multi",
+      "layer",
+      "css",
+      "architecture"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/multi-layer-css-architecture.md",
     "has_content": true
   },
@@ -655,7 +893,7 @@
       "codegen"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/multiprocess-architecture-via-ipc.md",
     "has_content": true
   },
@@ -665,9 +903,16 @@
     "slug": "nfs-backed-volumes-for-docker-swarm",
     "category": "arch",
     "description": "Cross-node Docker Swarm persistence via a single NFS share mounted at the same host path on every swarm node",
-    "tags": [],
+    "tags": [
+      "arch",
+      "nfs",
+      "backed",
+      "volumes",
+      "for",
+      "docker"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/nfs-backed-volumes-for-docker-swarm.md",
     "has_content": true
   },
@@ -676,7 +921,7 @@
     "name": "oh-my-claudecode-ai-slop-cleaner",
     "slug": "oh-my-claudecode-ai-slop-cleaner",
     "category": "arch",
-    "description": "OMC implements \\\"ai-slop-cleaner\\\" as: Clean AI-generated code slop with a regression-safe, deletion-first workflow and optional reviewer-only mode",
+    "description": "\"OMC implements \\\"ai-slop-cleaner\\\" as: Clean AI-generated code slop with a regression-safe, deletion-first workflow and optional reviewer-only mode\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -685,7 +930,7 @@
       "ai-slop-cleaner"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-ai-slop-cleaner.md",
     "has_content": true
   },
@@ -694,7 +939,7 @@
     "name": "oh-my-claudecode-ask",
     "slug": "oh-my-claudecode-ask",
     "category": "arch",
-    "description": "OMC implements \\\"ask\\\" as: Process-first advisor routing for Claude, Codex, or Gemini via `omc ask`, with artifact capture and no raw CLI assembly",
+    "description": "\"OMC implements \\\"ask\\\" as: Process-first advisor routing for Claude, Codex, or Gemini via `omc ask`, with artifact capture and no raw CLI assembly\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -703,7 +948,7 @@
       "ask"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-ask.md",
     "has_content": true
   },
@@ -712,7 +957,7 @@
     "name": "oh-my-claudecode-autopilot",
     "slug": "oh-my-claudecode-autopilot",
     "category": "arch",
-    "description": "OMC implements \\\"autopilot\\\" as: Full autonomous execution from idea to working code",
+    "description": "\"OMC implements \\\"autopilot\\\" as: Full autonomous execution from idea to working code\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -721,7 +966,7 @@
       "autopilot"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-autopilot.md",
     "has_content": true
   },
@@ -730,7 +975,7 @@
     "name": "oh-my-claudecode-cancel",
     "slug": "oh-my-claudecode-cancel",
     "category": "arch",
-    "description": "OMC implements \\\"cancel\\\" as: Cancel any active OMC mode (autopilot, ralph, ultrawork, ultraqa, swarm, ultrapilot, pipeline, team)",
+    "description": "\"OMC implements \\\"cancel\\\" as: Cancel any active OMC mode (autopilot, ralph, ultrawork, ultraqa, swarm, ultrapilot, pipeline, team)\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -739,7 +984,7 @@
       "cancel"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-cancel.md",
     "has_content": true
   },
@@ -748,7 +993,7 @@
     "name": "oh-my-claudecode-ccg",
     "slug": "oh-my-claudecode-ccg",
     "category": "arch",
-    "description": "OMC implements \\\"ccg\\\" as: Claude-Codex-Gemini tri-model orchestration via /ask codex + /ask gemini, then Claude synthesizes results",
+    "description": "\"OMC implements \\\"ccg\\\" as: Claude-Codex-Gemini tri-model orchestration via /ask codex + /ask gemini, then Claude synthesizes results\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -757,7 +1002,7 @@
       "ccg"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-ccg.md",
     "has_content": true
   },
@@ -766,7 +1011,7 @@
     "name": "oh-my-claudecode-configure-notifications",
     "slug": "oh-my-claudecode-configure-notifications",
     "category": "arch",
-    "description": "OMC implements \\\"configure-notifications\\\" as: Configure notification integrations (Telegram, Discord, Slack) via natural language",
+    "description": "\"OMC implements \\\"configure-notifications\\\" as: Configure notification integrations (Telegram, Discord, Slack) via natural language\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -775,7 +1020,7 @@
       "configure-notifications"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-configure-notifications.md",
     "has_content": true
   },
@@ -784,7 +1029,7 @@
     "name": "oh-my-claudecode-debug",
     "slug": "oh-my-claudecode-debug",
     "category": "arch",
-    "description": "OMC implements \\\"debug\\\" as: Diagnose the current OMC session or repo state using logs, traces, state, and focused reproduction",
+    "description": "\"OMC implements \\\"debug\\\" as: Diagnose the current OMC session or repo state using logs, traces, state, and focused reproduction\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -793,7 +1038,7 @@
       "debug"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-debug.md",
     "has_content": true
   },
@@ -802,7 +1047,7 @@
     "name": "oh-my-claudecode-deep-dive",
     "slug": "oh-my-claudecode-deep-dive",
     "category": "arch",
-    "description": "OMC implements \\\"deep-dive\\\" as: 2-stage pipeline: trace (causal investigation) -> deep-interview (requirements crystallization) with 3-point injection",
+    "description": "\"OMC implements \\\"deep-dive\\\" as: 2-stage pipeline: trace (causal investigation) -> deep-interview (requirements crystallization) with 3-point injection\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -811,7 +1056,7 @@
       "deep-dive"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-deep-dive.md",
     "has_content": true
   },
@@ -820,7 +1065,7 @@
     "name": "oh-my-claudecode-deep-interview",
     "slug": "oh-my-claudecode-deep-interview",
     "category": "arch",
-    "description": "OMC implements \\\"deep-interview\\\" as: Socratic deep interview with mathematical ambiguity gating before autonomous execution",
+    "description": "\"OMC implements \\\"deep-interview\\\" as: Socratic deep interview with mathematical ambiguity gating before autonomous execution\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -829,7 +1074,7 @@
       "deep-interview"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-deep-interview.md",
     "has_content": true
   },
@@ -838,7 +1083,7 @@
     "name": "oh-my-claudecode-deepinit",
     "slug": "oh-my-claudecode-deepinit",
     "category": "arch",
-    "description": "OMC implements \\\"deepinit\\\" as: Deep codebase initialization with hierarchical AGENTS.md documentation",
+    "description": "\"OMC implements \\\"deepinit\\\" as: Deep codebase initialization with hierarchical AGENTS.md documentation\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -847,7 +1092,7 @@
       "deepinit"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-deepinit.md",
     "has_content": true
   },
@@ -856,7 +1101,7 @@
     "name": "oh-my-claudecode-external-context",
     "slug": "oh-my-claudecode-external-context",
     "category": "arch",
-    "description": "OMC implements \\\"external-context\\\" as: Invoke parallel document-specialist agents for external web searches and documentation lookup",
+    "description": "\"OMC implements \\\"external-context\\\" as: Invoke parallel document-specialist agents for external web searches and documentation lookup\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -865,7 +1110,7 @@
       "external-context"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-external-context.md",
     "has_content": true
   },
@@ -874,7 +1119,7 @@
     "name": "oh-my-claudecode-hud",
     "slug": "oh-my-claudecode-hud",
     "category": "arch",
-    "description": "OMC implements \\\"hud\\\" as: Configure HUD display options (layout, presets, display elements)",
+    "description": "\"OMC implements \\\"hud\\\" as: Configure HUD display options (layout, presets, display elements)\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -883,7 +1128,7 @@
       "hud"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-hud.md",
     "has_content": true
   },
@@ -892,7 +1137,7 @@
     "name": "oh-my-claudecode-learner",
     "slug": "oh-my-claudecode-learner",
     "category": "arch",
-    "description": "OMC implements \\\"learner\\\" as: Extract a learned skill from the current conversation",
+    "description": "\"OMC implements \\\"learner\\\" as: Extract a learned skill from the current conversation\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -901,7 +1146,7 @@
       "learner"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-learner.md",
     "has_content": true
   },
@@ -910,7 +1155,7 @@
     "name": "oh-my-claudecode-mcp-setup",
     "slug": "oh-my-claudecode-mcp-setup",
     "category": "arch",
-    "description": "OMC implements \\\"mcp-setup\\\" as: Configure popular MCP servers for enhanced agent capabilities",
+    "description": "\"OMC implements \\\"mcp-setup\\\" as: Configure popular MCP servers for enhanced agent capabilities\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -919,7 +1164,7 @@
       "mcp-setup"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-mcp-setup.md",
     "has_content": true
   },
@@ -928,7 +1173,7 @@
     "name": "oh-my-claudecode-omc-doctor",
     "slug": "oh-my-claudecode-omc-doctor",
     "category": "arch",
-    "description": "OMC implements \\\"omc-doctor\\\" as: Diagnose and fix oh-my-claudecode installation issues",
+    "description": "\"OMC implements \\\"omc-doctor\\\" as: Diagnose and fix oh-my-claudecode installation issues\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -937,7 +1182,7 @@
       "omc-doctor"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-omc-doctor.md",
     "has_content": true
   },
@@ -946,7 +1191,7 @@
     "name": "oh-my-claudecode-omc-reference",
     "slug": "oh-my-claudecode-omc-reference",
     "category": "arch",
-    "description": "OMC implements \\\"omc-reference\\\" as: OMC agent catalog, available tools, team pipeline routing, commit protocol, and skills registry. Auto-loads when delegating to agents, using OMC tools, orchestrating teams, making commits, or invoking skills.",
+    "description": "\"OMC implements \\\"omc-reference\\\" as: OMC agent catalog, available tools, team pipeline routing, commit protocol, and skills registry. Auto-loads when delegating to agents, using OMC tools, orchestrating teams, making commits, or invoking skills.\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -955,7 +1200,7 @@
       "omc-reference"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-omc-reference.md",
     "has_content": true
   },
@@ -964,7 +1209,7 @@
     "name": "oh-my-claudecode-omc-setup",
     "slug": "oh-my-claudecode-omc-setup",
     "category": "arch",
-    "description": "OMC implements \\\"omc-setup\\\" as: Install or refresh oh-my-claudecode for plugin, npm, and local-dev setups from the canonical setup flow",
+    "description": "\"OMC implements \\\"omc-setup\\\" as: Install or refresh oh-my-claudecode for plugin, npm, and local-dev setups from the canonical setup flow\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -973,7 +1218,7 @@
       "omc-setup"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-omc-setup.md",
     "has_content": true
   },
@@ -982,7 +1227,7 @@
     "name": "oh-my-claudecode-omc-teams",
     "slug": "oh-my-claudecode-omc-teams",
     "category": "arch",
-    "description": "OMC implements \\\"omc-teams\\\" as: CLI-team runtime for claude, codex, or gemini workers in tmux panes when you need process-based parallel execution",
+    "description": "\"OMC implements \\\"omc-teams\\\" as: CLI-team runtime for claude, codex, or gemini workers in tmux panes when you need process-based parallel execution\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -991,7 +1236,7 @@
       "omc-teams"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-omc-teams.md",
     "has_content": true
   },
@@ -1000,7 +1245,7 @@
     "name": "oh-my-claudecode-plan",
     "slug": "oh-my-claudecode-plan",
     "category": "arch",
-    "description": "OMC implements \\\"plan\\\" as: Strategic planning with optional interview workflow",
+    "description": "\"OMC implements \\\"plan\\\" as: Strategic planning with optional interview workflow\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -1009,7 +1254,7 @@
       "plan"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-plan.md",
     "has_content": true
   },
@@ -1018,7 +1263,7 @@
     "name": "oh-my-claudecode-project-session-manager",
     "slug": "oh-my-claudecode-project-session-manager",
     "category": "arch",
-    "description": "OMC implements \\\"project-session-manager\\\" as: Worktree-first dev environment manager for issues, PRs, and features with optional tmux sessions",
+    "description": "\"OMC implements \\\"project-session-manager\\\" as: Worktree-first dev environment manager for issues, PRs, and features with optional tmux sessions\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -1027,7 +1272,7 @@
       "project-session-manager"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-project-session-manager.md",
     "has_content": true
   },
@@ -1036,7 +1281,7 @@
     "name": "oh-my-claudecode-ralph",
     "slug": "oh-my-claudecode-ralph",
     "category": "arch",
-    "description": "OMC implements \\\"ralph\\\" as: Self-referential loop until task completion with configurable verification reviewer",
+    "description": "\"OMC implements \\\"ralph\\\" as: Self-referential loop until task completion with configurable verification reviewer\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -1045,7 +1290,7 @@
       "ralph"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-ralph.md",
     "has_content": true
   },
@@ -1054,7 +1299,7 @@
     "name": "oh-my-claudecode-ralplan",
     "slug": "oh-my-claudecode-ralplan",
     "category": "arch",
-    "description": "OMC implements \\\"ralplan\\\" as: Consensus planning entrypoint that auto-gates vague ralph/autopilot/team requests before execution",
+    "description": "\"OMC implements \\\"ralplan\\\" as: Consensus planning entrypoint that auto-gates vague ralph/autopilot/team requests before execution\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -1063,7 +1308,7 @@
       "ralplan"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-ralplan.md",
     "has_content": true
   },
@@ -1072,7 +1317,7 @@
     "name": "oh-my-claudecode-release",
     "slug": "oh-my-claudecode-release",
     "category": "arch",
-    "description": "OMC implements \\\"release\\\" as: Generic release assistant — analyzes repo release rules, caches them in .omc/RELEASE_RULE.md, then guides the release",
+    "description": "\"OMC implements \\\"release\\\" as: Generic release assistant — analyzes repo release rules, caches them in .omc/RELEASE_RULE.md, then guides the release\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -1081,7 +1326,7 @@
       "release"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-release.md",
     "has_content": true
   },
@@ -1090,7 +1335,7 @@
     "name": "oh-my-claudecode-remember",
     "slug": "oh-my-claudecode-remember",
     "category": "arch",
-    "description": "OMC implements \\\"remember\\\" as: Review reusable project knowledge and decide what belongs in project memory, notepad, or durable docs",
+    "description": "\"OMC implements \\\"remember\\\" as: Review reusable project knowledge and decide what belongs in project memory, notepad, or durable docs\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -1099,7 +1344,7 @@
       "remember"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-remember.md",
     "has_content": true
   },
@@ -1108,7 +1353,7 @@
     "name": "oh-my-claudecode-sciomc",
     "slug": "oh-my-claudecode-sciomc",
     "category": "arch",
-    "description": "OMC implements \\\"sciomc\\\" as: Orchestrate parallel scientist agents for comprehensive analysis with AUTO mode",
+    "description": "\"OMC implements \\\"sciomc\\\" as: Orchestrate parallel scientist agents for comprehensive analysis with AUTO mode\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -1117,7 +1362,7 @@
       "sciomc"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-sciomc.md",
     "has_content": true
   },
@@ -1126,7 +1371,7 @@
     "name": "oh-my-claudecode-self-improve",
     "slug": "oh-my-claudecode-self-improve",
     "category": "arch",
-    "description": "OMC implements \\\"self-improve\\\" as: Autonomous evolutionary code improvement engine with tournament selection",
+    "description": "\"OMC implements \\\"self-improve\\\" as: Autonomous evolutionary code improvement engine with tournament selection\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -1135,7 +1380,7 @@
       "self-improve"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-self-improve.md",
     "has_content": true
   },
@@ -1144,7 +1389,7 @@
     "name": "oh-my-claudecode-setup",
     "slug": "oh-my-claudecode-setup",
     "category": "arch",
-    "description": "OMC implements \\\"setup\\\" as: Use first for install/update routing — sends setup, doctor, or MCP requests to the correct OMC setup flow",
+    "description": "\"OMC implements \\\"setup\\\" as: Use first for install/update routing — sends setup, doctor, or MCP requests to the correct OMC setup flow\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -1153,7 +1398,7 @@
       "setup"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-setup.md",
     "has_content": true
   },
@@ -1162,7 +1407,7 @@
     "name": "oh-my-claudecode-skill",
     "slug": "oh-my-claudecode-skill",
     "category": "arch",
-    "description": "OMC implements \\\"skill\\\" as: Manage local skills - list, add, remove, search, edit, setup wizard",
+    "description": "\"OMC implements \\\"skill\\\" as: Manage local skills - list, add, remove, search, edit, setup wizard\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -1171,7 +1416,7 @@
       "skill"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-skill.md",
     "has_content": true
   },
@@ -1180,7 +1425,7 @@
     "name": "oh-my-claudecode-skillify",
     "slug": "oh-my-claudecode-skillify",
     "category": "arch",
-    "description": "OMC implements \\\"skillify\\\" as: Turn a repeatable workflow from the current session into a reusable OMC skill draft",
+    "description": "\"OMC implements \\\"skillify\\\" as: Turn a repeatable workflow from the current session into a reusable OMC skill draft\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -1189,7 +1434,7 @@
       "skillify"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-skillify.md",
     "has_content": true
   },
@@ -1198,7 +1443,7 @@
     "name": "oh-my-claudecode-team",
     "slug": "oh-my-claudecode-team",
     "category": "arch",
-    "description": "OMC implements \\\"team\\\" as: N coordinated agents on shared task list using Claude Code native teams",
+    "description": "\"OMC implements \\\"team\\\" as: N coordinated agents on shared task list using Claude Code native teams\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -1207,7 +1452,7 @@
       "team"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-team.md",
     "has_content": true
   },
@@ -1216,7 +1461,7 @@
     "name": "oh-my-claudecode-trace",
     "slug": "oh-my-claudecode-trace",
     "category": "arch",
-    "description": "OMC implements \\\"trace\\\" as: Evidence-driven tracing lane that orchestrates competing tracer hypotheses in Claude built-in team mode",
+    "description": "\"OMC implements \\\"trace\\\" as: Evidence-driven tracing lane that orchestrates competing tracer hypotheses in Claude built-in team mode\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -1225,7 +1470,7 @@
       "trace"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-trace.md",
     "has_content": true
   },
@@ -1234,7 +1479,7 @@
     "name": "oh-my-claudecode-ultraqa",
     "slug": "oh-my-claudecode-ultraqa",
     "category": "arch",
-    "description": "OMC implements \\\"ultraqa\\\" as: QA cycling workflow - test, verify, fix, repeat until goal met",
+    "description": "\"OMC implements \\\"ultraqa\\\" as: QA cycling workflow - test, verify, fix, repeat until goal met\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -1243,7 +1488,7 @@
       "ultraqa"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-ultraqa.md",
     "has_content": true
   },
@@ -1252,7 +1497,7 @@
     "name": "oh-my-claudecode-ultrawork",
     "slug": "oh-my-claudecode-ultrawork",
     "category": "arch",
-    "description": "OMC implements \\\"ultrawork\\\" as: Parallel execution engine for high-throughput task completion",
+    "description": "\"OMC implements \\\"ultrawork\\\" as: Parallel execution engine for high-throughput task completion\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -1261,7 +1506,7 @@
       "ultrawork"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-ultrawork.md",
     "has_content": true
   },
@@ -1270,7 +1515,7 @@
     "name": "oh-my-claudecode-verify",
     "slug": "oh-my-claudecode-verify",
     "category": "arch",
-    "description": "OMC implements \\\"verify\\\" as: Verify that a change really works before you claim completion",
+    "description": "\"OMC implements \\\"verify\\\" as: Verify that a change really works before you claim completion\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -1279,7 +1524,7 @@
       "verify"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-verify.md",
     "has_content": true
   },
@@ -1288,7 +1533,7 @@
     "name": "oh-my-claudecode-visual-verdict",
     "slug": "oh-my-claudecode-visual-verdict",
     "category": "arch",
-    "description": "OMC implements \\\"visual-verdict\\\" as: Structured visual QA verdict for screenshot-to-reference comparisons",
+    "description": "\"OMC implements \\\"visual-verdict\\\" as: Structured visual QA verdict for screenshot-to-reference comparisons\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -1297,7 +1542,7 @@
       "visual-verdict"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-visual-verdict.md",
     "has_content": true
   },
@@ -1306,7 +1551,7 @@
     "name": "oh-my-claudecode-wiki",
     "slug": "oh-my-claudecode-wiki",
     "category": "arch",
-    "description": "OMC implements \\\"wiki\\\" as: LLM Wiki — persistent markdown knowledge base that compounds across sessions (Karpathy model)",
+    "description": "\"OMC implements \\\"wiki\\\" as: LLM Wiki — persistent markdown knowledge base that compounds across sessions (Karpathy model)\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -1315,7 +1560,7 @@
       "wiki"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-wiki.md",
     "has_content": true
   },
@@ -1324,7 +1569,7 @@
     "name": "oh-my-claudecode-writer-memory",
     "slug": "oh-my-claudecode-writer-memory",
     "category": "arch",
-    "description": "OMC implements \\\"writer-memory\\\" as: Agentic memory system for writers - track characters, relationships, scenes, and themes",
+    "description": "\"OMC implements \\\"writer-memory\\\" as: Agentic memory system for writers - track characters, relationships, scenes, and themes\"",
     "tags": [
       "external-reference",
       "oh-my-claudecode",
@@ -1333,7 +1578,7 @@
       "writer-memory"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/oh-my-claudecode-writer-memory.md",
     "has_content": true
   },
@@ -1351,7 +1596,7 @@
       "interop"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/openapi-as-single-fe-be-contract.md",
     "has_content": true
   },
@@ -1367,7 +1612,7 @@
       "scouter"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/plugin-architecture-runtime-vs-startup-loading.md",
     "has_content": true
   },
@@ -1386,7 +1631,7 @@
       "content-type"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/polymorphic-metadata-via-enum-switch.md",
     "has_content": true
   },
@@ -1404,7 +1649,7 @@
       "error-code"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/port-out-no-optional-raise-in-adapter.md",
     "has_content": true
   },
@@ -1414,9 +1659,15 @@
     "slug": "published-vs-realtime-view-pages",
     "category": "arch",
     "description": "PublishedViewPage renders a frozen deploy snapshot; RealTimeViewPage renders the live editable dashboard",
-    "tags": [],
+    "tags": [
+      "arch",
+      "published",
+      "realtime",
+      "view",
+      "pages"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/published-vs-realtime-view-pages.md",
     "has_content": true
   },
@@ -1426,9 +1677,16 @@
     "slug": "redis-change-counter-for-versioning-trigger",
     "category": "arch",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "arch",
+      "redis",
+      "change",
+      "counter",
+      "for",
+      "versioning"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/redis-change-counter-for-versioning-trigger.md",
     "has_content": true
   },
@@ -1445,7 +1703,7 @@
       "scouter"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/scouter-three-tier-architecture.md",
     "has_content": true
   },
@@ -1455,9 +1713,16 @@
     "slug": "scss-css-variable-theme-system",
     "category": "arch",
     "description": "Architecture decision — SCSS + CSS custom properties + data-theme attribute for dark/light theming in a large React monorepo",
-    "tags": [],
+    "tags": [
+      "arch",
+      "scss",
+      "css",
+      "variable",
+      "theme",
+      "system"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/scss-css-variable-theme-system.md",
     "has_content": true
   },
@@ -1466,10 +1731,17 @@
     "name": "shallow-clone-mktemp-cleanup-pattern",
     "slug": "shallow-clone-mktemp-cleanup-pattern",
     "category": "arch",
-    "description": "publish/install/원격 목록 조회처럼 원격 git repo를 만질 때는 `mktemp -d → git clone --depth 1 → 작업 → rm -rf`. 작업 디렉토리를 오염시키지 않는다.",
-    "tags": [],
+    "description": "\"publish/install/원격 목록 조회처럼 원격 git repo를 만질 때는 `mktemp -d → git clone --depth 1 → 작업 → rm -rf`. 작업 디렉토리를 오염시키지 않는다.\"",
+    "tags": [
+      "arch",
+      "shallow",
+      "clone",
+      "mktemp",
+      "cleanup",
+      "pattern"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/shallow-clone-mktemp-cleanup-pattern.md",
     "has_content": true
   },
@@ -1479,9 +1751,14 @@
     "slug": "sirius-component-taxonomy",
     "category": "arch",
     "description": "Sirius design system (@nkia/sirius) organizes 200+ components into 5 categories — data-display, data-entry, feedback, layout, navigation",
-    "tags": [],
+    "tags": [
+      "arch",
+      "sirius",
+      "component",
+      "taxonomy"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/sirius-component-taxonomy.md",
     "has_content": true
   },
@@ -1491,9 +1768,16 @@
     "slug": "sirius-wraps-antd-design-system",
     "category": "arch",
     "description": "Sirius design system wraps Ant Design components instead of replacing them — rationale, extension pattern, and upgrade implications",
-    "tags": [],
+    "tags": [
+      "arch",
+      "sirius",
+      "wraps",
+      "antd",
+      "design",
+      "system"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/sirius-wraps-antd-design-system.md",
     "has_content": true
   },
@@ -1511,7 +1795,7 @@
       "mongodb"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/tenant-context-per-request-interceptor.md",
     "has_content": true
   },
@@ -1530,7 +1814,7 @@
       "event-driven"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/wait-for-services-eureka-startup-init.md",
     "has_content": true
   },
@@ -1540,9 +1824,15 @@
     "slug": "widget-is-frozen-group-snapshot",
     "category": "arch",
     "description": "Widgets are snapshots of a group at save time; later edits to the source group do not propagate",
-    "tags": [],
+    "tags": [
+      "arch",
+      "widget",
+      "frozen",
+      "group",
+      "snapshot"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/widget-is-frozen-group-snapshot.md",
     "has_content": true
   },
@@ -1552,9 +1842,15 @@
     "slug": "yorkie-team-server-split",
     "category": "arch",
     "description": "Yorkie holds live canvas state; the team server holds metadata (projects, assets, datasources) — never mix",
-    "tags": [],
+    "tags": [
+      "arch",
+      "yorkie",
+      "team",
+      "server",
+      "split"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/arch/yorkie-team-server-split.md",
     "has_content": true
   },
@@ -1564,9 +1860,16 @@
     "slug": "actuator-endpoints-skip-auth-by-design",
     "category": "decision",
     "description": "In a monitoring collector, target-level BASIC/BEARER auth is stored but intentionally NOT applied when calling /actuator/health and /actuator/metrics.",
-    "tags": [],
+    "tags": [
+      "decision",
+      "actuator",
+      "endpoints",
+      "skip",
+      "auth",
+      "design"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/actuator-endpoints-skip-auth-by-design.md",
     "has_content": true
   },
@@ -1576,9 +1879,15 @@
     "slug": "admin-role-disabled-secretkey",
     "category": "decision",
     "description": "Default `admins` role is disabled and the shared `SecretKey` was removed from `config.properties` — never re-enable without a per-install key",
-    "tags": [],
+    "tags": [
+      "decision",
+      "admin",
+      "role",
+      "disabled",
+      "secretkey"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/admin-role-disabled-secretkey.md",
     "has_content": true
   },
@@ -1588,9 +1897,16 @@
     "slug": "alarm-raw-over-1min-aggregate",
     "category": "decision",
     "description": "Alarm judgement reads raw metrics, not 1-minute aggregates — accuracy over storage cost",
-    "tags": [],
+    "tags": [
+      "decision",
+      "alarm",
+      "raw",
+      "over",
+      "1min",
+      "aggregate"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/alarm-raw-over-1min-aggregate.md",
     "has_content": true
   },
@@ -1599,7 +1915,7 @@
     "name": "always-pr-branch-never-direct-push",
     "slug": "always-pr-branch-never-direct-push",
     "category": "decision",
-    "description": "Always create a feature branch and PR for shared repos — never push directly to main, even for 'obvious' additions",
+    "description": "\"Always create a feature branch and PR for shared repos — never push directly to main, even for 'obvious' additions\"",
     "tags": [
       "git",
       "pr",
@@ -1608,7 +1924,7 @@
       "review"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/always-pr-branch-never-direct-push.md",
     "has_content": true
   },
@@ -1625,7 +1941,7 @@
       "design"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/assume-semantics-for-compiler-hints.md",
     "has_content": true
   },
@@ -1635,10 +1951,28 @@
     "slug": "avro-private-fields-no-setters",
     "category": "decision",
     "description": "Avro-generated classes are configured with `fieldVisibility=PRIVATE` and `createSetters=false` to enforce immutability on event payloads",
-    "tags": [],
+    "tags": [
+      "decision",
+      "avro",
+      "private",
+      "fields",
+      "setters"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/avro-private-fields-no-setters.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "base-offset-filename-as-ordering-source-of-truth",
+    "slug": "base-offset-filename-as-ordering-source-of-truth",
+    "category": "decision",
+    "description": "Encode segment base offset in the filename so directory listing alone reconstructs ordering after crash.",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/decision/base-offset-filename-as-ordering-source-of-truth.md",
     "has_content": true
   },
   {
@@ -1647,10 +1981,29 @@
     "slug": "cache-even-when-enable-false",
     "category": "decision",
     "description": "Notification configs with `enable=false` are still loaded into the cache manager rather than skipped, so toggling enable on/off doesn't require a cache reload",
-    "tags": [],
+    "tags": [
+      "decision",
+      "cache",
+      "even",
+      "when",
+      "enable",
+      "false"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/cache-even-when-enable-false.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "canvas-trail-fade-vs-clear",
+    "slug": "canvas-trail-fade-vs-clear",
+    "category": "decision",
+    "description": "Use alpha-rect overpaint instead of clearRect for motion-trail visuals; faster and looks better.",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/decision/canvas-trail-fade-vs-clear.md",
     "has_content": true
   },
   {
@@ -1658,7 +2011,7 @@
     "name": "caveats-absence-confidence-cap",
     "slug": "caveats-absence-confidence-cap",
     "category": "decision",
-    "description": "반증 조건(Counter/Caveats)이 비어 있는 knowledge는 confidence 최대 medium으로 강등한다 — 미확인 = 과신 위험",
+    "description": "\"반증 조건(Counter/Caveats)이 비어 있는 knowledge는 confidence 최대 medium으로 강등한다 — 미확인 = 과신 위험\"",
     "tags": [
       "calibration",
       "confidence",
@@ -1666,7 +2019,7 @@
       "knowledge-quality"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/caveats-absence-confidence-cap.md",
     "has_content": true
   },
@@ -1684,7 +2037,7 @@
       "ci"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/circular-dependency-detection-script.md",
     "has_content": true
   },
@@ -1694,9 +2047,16 @@
     "slug": "confid-only-query-over-resource-tuple",
     "category": "decision",
     "description": "Performance queries key off `confId` (config id) whenever available, falling back to (resourceType, resourceName) only when confId is absent",
-    "tags": [],
+    "tags": [
+      "decision",
+      "confid",
+      "only",
+      "query",
+      "over",
+      "resource"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/confid-only-query-over-resource-tuple.md",
     "has_content": true
   },
@@ -1706,9 +2066,15 @@
     "slug": "copy-naming-suffix-numbered",
     "category": "decision",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "decision",
+      "copy",
+      "naming",
+      "suffix",
+      "numbered"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/copy-naming-suffix-numbered.md",
     "has_content": true
   },
@@ -1718,9 +2084,16 @@
     "slug": "cors-allow-credentials-star-origin",
     "category": "decision",
     "description": "서비스 레벨 allowCredentials=true + allowedOriginPatterns(\"*\") 유지 — 엣지(Traefik/Istio)에서 CORS를 제어하는 아키텍처 전제",
-    "tags": [],
+    "tags": [
+      "decision",
+      "cors",
+      "allow",
+      "credentials",
+      "star",
+      "origin"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/cors-allow-credentials-star-origin.md",
     "has_content": true
   },
@@ -1730,9 +2103,15 @@
     "slug": "csp-frame-ancestors-required",
     "category": "decision",
     "description": "Send a Content-Security-Policy header (including `frame-ancestors`) on every response to block clickjacking",
-    "tags": [],
+    "tags": [
+      "decision",
+      "csp",
+      "frame",
+      "ancestors",
+      "required"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/csp-frame-ancestors-required.md",
     "has_content": true
   },
@@ -1742,14 +2121,9 @@
     "slug": "dashboard-decoration-vs-evidence",
     "category": "decision",
     "description": "When designing monitoring dashboards for automation pipelines, prioritize visible evidence of system behavior over decorative animations",
-    "tags": [
-      "ui",
-      "dashboards",
-      "monitoring",
-      "automation"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/dashboard-decoration-vs-evidence.md",
     "has_content": true
   },
@@ -1759,9 +2133,15 @@
     "slug": "dataavro-json-wrapper-pattern",
     "category": "decision",
     "description": "여러 이벤트 타입마다 Avro 스키마를 만들지 않고 DataAvro{jsonData,jsonDataClass} 하나로 통일 — TCM 선례 채택",
-    "tags": [],
+    "tags": [
+      "decision",
+      "dataavro",
+      "json",
+      "wrapper",
+      "pattern"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/dataavro-json-wrapper-pattern.md",
     "has_content": true
   },
@@ -1779,7 +2159,7 @@
       "review-gate"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/do-not-ask-planners-for-api-design.md",
     "has_content": true
   },
@@ -1789,9 +2169,14 @@
     "slug": "drawer-over-modal",
     "category": "decision",
     "description": "Decision to use side drawers (463 files) instead of centered modals (10 usages) as the primary overlay pattern",
-    "tags": [],
+    "tags": [
+      "decision",
+      "drawer",
+      "over",
+      "modal"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/drawer-over-modal.md",
     "has_content": true
   },
@@ -1809,7 +2194,7 @@
       "hexagonal"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/existing-code-patterns-over-standard-rules.md",
     "has_content": true
   },
@@ -1819,9 +2204,16 @@
     "slug": "fifth-normal-form-join-dependency-tradeoff",
     "category": "decision",
     "description": "5NF catches join dependencies that 4NF/BCNF miss, but in practice you rarely reason about it directly — design from business entities, recognize AB-BC-AC triangles vs ABC+D stars, and let 5NF fall out.",
-    "tags": [],
+    "tags": [
+      "decision",
+      "fifth",
+      "normal",
+      "form",
+      "join",
+      "dependency"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/fifth-normal-form-join-dependency-tradeoff.md",
     "has_content": true
   },
@@ -1831,13 +2223,9 @@
     "slug": "flat-vs-categorized-folder-structure",
     "category": "decision",
     "description": "When a content folder crosses ~100 entries, flat structure becomes unnavigable — categorize into ~15–30 semantic buckets even if the tool doesn't require it",
-    "tags": [
-      "directory-structure",
-      "scalability",
-      "content-organization"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/flat-vs-categorized-folder-structure.md",
     "has_content": true
   },
@@ -1846,7 +2234,7 @@
     "name": "god-controller-split-by-resource",
     "slug": "god-controller-split-by-resource",
     "category": "decision",
-    "description": "Split an oversized controller along URL sub-resource boundaries (one controller per sub-path like /page, /widget, /file) and keep the common @RequestMapping prefix — clearer per-class responsibility without breaking the external API surface.",
+    "description": "\"Split an oversized controller along URL sub-resource boundaries (one controller per sub-path like /page, /widget, /file) and keep the common @RequestMapping prefix — clearer per-class responsibility without breaking the external API surface.\"",
     "tags": [
       "refactor",
       "controller",
@@ -1854,7 +2242,7 @@
       "spring"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/god-controller-split-by-resource.md",
     "has_content": true
   },
@@ -1863,7 +2251,7 @@
     "name": "hub-soft-delete-via-frontmatter-flag",
     "slug": "hub-soft-delete-via-frontmatter-flag",
     "category": "decision",
-    "description": "Skills-hub retires low-value entries via an `archived: true` frontmatter flag — never via file deletion. Installers and sync commands skip archived entries; git history remains intact for auditability and un-archive.",
+    "description": "\"Skills-hub retires low-value entries via an `archived: true` frontmatter flag — never via file deletion. Installers and sync commands skip archived entries; git history remains intact for auditability and un-archive.\"",
     "tags": [
       "skills-hub",
       "archive",
@@ -1872,7 +2260,7 @@
       "decision"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/hub-soft-delete-via-frontmatter-flag.md",
     "has_content": true
   },
@@ -1889,7 +2277,7 @@
       "scouter"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/hyperloglog-for-unique-user-counting.md",
     "has_content": true
   },
@@ -1899,9 +2287,15 @@
     "slug": "jacoco-exclude-business-layers",
     "category": "decision",
     "description": "In this project's Jacoco config, nearly every layer (service, repository, dto, entity, kafka, config, constants, helper, exception, schedule, provider) is excluded from coverage measurement — only controllers/business orchestration code is measured.",
-    "tags": [],
+    "tags": [
+      "decision",
+      "jacoco",
+      "exclude",
+      "business",
+      "layers"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/jacoco-exclude-business-layers.md",
     "has_content": true
   },
@@ -1911,9 +2305,15 @@
     "slug": "jacoco-sonar-exclusion-policy",
     "category": "decision",
     "description": "Single exclusion list drives Jacoco + Sonar + test excludes; generated/boilerplate code never counts toward coverage",
-    "tags": [],
+    "tags": [
+      "decision",
+      "jacoco",
+      "sonar",
+      "exclusion",
+      "policy"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/jacoco-sonar-exclusion-policy.md",
     "has_content": true
   },
@@ -1923,9 +2323,15 @@
     "slug": "jacoco-sonar-exclusion-rationale",
     "category": "decision",
     "description": "Classes under config/, dto/, entity/, kafka/, avro/, exception/, advice/, schedule/, service/websocket/, and generated Q-classes are excluded from Jacoco coverage gates. Only business logic (routers, guards, services) is measured.",
-    "tags": [],
+    "tags": [
+      "decision",
+      "jacoco",
+      "sonar",
+      "exclusion",
+      "rationale"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/jacoco-sonar-exclusion-rationale.md",
     "has_content": true
   },
@@ -1935,9 +2341,14 @@
     "slug": "java-21-upgrade-rationale",
     "category": "decision",
     "description": "Java 17 → 21 + Spring Boot 3.5.x upgrade rationale and required Gradle/JVM flag adjustments",
-    "tags": [],
+    "tags": [
+      "decision",
+      "java",
+      "upgrade",
+      "rationale"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/java-21-upgrade-rationale.md",
     "has_content": true
   },
@@ -1947,9 +2358,14 @@
     "slug": "jest-coverage-80-threshold",
     "category": "decision",
     "description": "Global Jest coverage threshold is 80% on branches, functions, lines, and statements",
-    "tags": [],
+    "tags": [
+      "decision",
+      "jest",
+      "coverage",
+      "threshold"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/jest-coverage-80-threshold.md",
     "has_content": true
   },
@@ -1959,12 +2375,9 @@
     "slug": "json-clone-reducer-state-constraint",
     "category": "decision",
     "description": "`JSON.parse(JSON.stringify(state))` is sufficient for pure-reducer immutability only when state is JSON-safe — it silently drops `Date`, `Map`, `Set`, `RegExp`, functions, and `undefined`.",
-    "tags": [
-      "canvas",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/json-clone-reducer-state-constraint.md",
     "has_content": true
   },
@@ -1974,9 +2387,16 @@
     "slug": "jwt-stateless-refresh-24h-default",
     "category": "decision",
     "description": "JWT stateless auth with 1h access / 24h refresh token defaults, both env-tunable.",
-    "tags": [],
+    "tags": [
+      "decision",
+      "jwt",
+      "stateless",
+      "refresh",
+      "24h",
+      "default"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/jwt-stateless-refresh-24h-default.md",
     "has_content": true
   },
@@ -1985,7 +2405,7 @@
     "name": "k-kafka-message-header-metadata",
     "slug": "k-kafka-message-header-metadata",
     "category": "decision",
-    "description": "멀티테넌트 Kafka routing 메타는 payload 대신 RecordHeader에 두어 business schema 오염을 막는다",
+    "description": "\"멀티테넌트 Kafka routing 메타는 payload 대신 RecordHeader에 두어 business schema 오염을 막는다\"",
     "tags": [
       "kafka",
       "multi-tenant",
@@ -1993,7 +2413,7 @@
       "message-schema"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/k-kafka-message-header-metadata.md",
     "has_content": true
   },
@@ -2011,7 +2431,7 @@
       "rebalance"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/kafka-batch-size-timeout-tuning.md",
     "has_content": true
   },
@@ -2021,9 +2441,16 @@
     "slug": "large-range-query-raw-collections",
     "category": "decision",
     "description": "For long time-range analytics over day-partitioned data, query the daily raw collections directly rather than going through an aggregated view to avoid query timeouts.",
-    "tags": [],
+    "tags": [
+      "decision",
+      "large",
+      "range",
+      "query",
+      "raw",
+      "collections"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/large-range-query-raw-collections.md",
     "has_content": true
   },
@@ -2033,9 +2460,15 @@
     "slug": "less-antd-theme-only",
     "category": "decision",
     "description": "LESS files (71 total) and less-loader exist solely for Ant Design modifyVars theming — LESS is not a general-purpose styling choice in this project",
-    "tags": [],
+    "tags": [
+      "decision",
+      "less",
+      "antd",
+      "theme",
+      "only"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/less-antd-theme-only.md",
     "has_content": true
   },
@@ -2045,9 +2478,15 @@
     "slug": "license-apply-window-15d",
     "category": "decision",
     "description": "Issued licenses must be applied within 15 days; expired licenses are immutable.",
-    "tags": [],
+    "tags": [
+      "decision",
+      "license",
+      "apply",
+      "window",
+      "15d"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/license-apply-window-15d.md",
     "has_content": true
   },
@@ -2057,10 +2496,29 @@
     "slug": "measurement-batch-send-per-config",
     "category": "decision",
     "description": "Send one bundled Kafka message per target per tick containing all metrics, instead of one message per (target, metric).",
-    "tags": [],
+    "tags": [
+      "decision",
+      "measurement",
+      "batch",
+      "send",
+      "per",
+      "config"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/measurement-batch-send-per-config.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "merkle-tree-range-leaf-vs-point-leaf-tradeoff",
+    "slug": "merkle-tree-range-leaf-vs-point-leaf-tradeoff",
+    "category": "decision",
+    "description": "Whether Merkle leaves should hash individual keys or key ranges determines whether divergence localization scales with dataset size or with divergence size.",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/decision/merkle-tree-range-leaf-vs-point-leaf-tradeoff.md",
     "has_content": true
   },
   {
@@ -2069,9 +2527,16 @@
     "slug": "node-npm-pin-matches-jenkins",
     "category": "decision",
     "description": "UI build is pinned to Node 24.6.0 + npm 11.5.1 to match the Jenkins build environment",
-    "tags": [],
+    "tags": [
+      "decision",
+      "node",
+      "npm",
+      "pin",
+      "matches",
+      "jenkins"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/node-npm-pin-matches-jenkins.md",
     "has_content": true
   },
@@ -2081,10 +2546,29 @@
     "slug": "organization-soft-delete-grace-period",
     "category": "decision",
     "description": "Organization deletion uses a 30-day grace period before permanent removal (DELETE_ORGANIZATION_INTERVAL_DAYS).",
-    "tags": [],
+    "tags": [
+      "decision",
+      "organization",
+      "soft",
+      "delete",
+      "grace",
+      "period"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/organization-soft-delete-grace-period.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "phi-accrual-failure-detector-over-binary-timeout",
+    "slug": "phi-accrual-failure-detector-over-binary-timeout",
+    "category": "decision",
+    "description": "Use phi-accrual suspicion score instead of binary alive/dead for heartbeat visualizations",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/decision/phi-accrual-failure-detector-over-binary-timeout.md",
     "has_content": true
   },
   {
@@ -2101,7 +2585,7 @@
       "single-source"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/planning-doc-in-issue-description.md",
     "has_content": true
   },
@@ -2110,10 +2594,17 @@
     "name": "plugin-repo-scope-generic-skills-only",
     "slug": "plugin-repo-scope-generic-skills-only",
     "category": "decision",
-    "description": "nkia-skills 같은 공용 플러그인에는 범용 스킬만. 프로젝트 특화 스킬은 각 프로젝트의 `.claude/skills/`에 둔다.",
-    "tags": [],
+    "description": "\"nkia-skills 같은 공용 플러그인에는 범용 스킬만. 프로젝트 특화 스킬은 각 프로젝트의 `.claude/skills/`에 둔다.\"",
+    "tags": [
+      "decision",
+      "plugin",
+      "repo",
+      "scope",
+      "generic",
+      "skills"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/plugin-repo-scope-generic-skills-only.md",
     "has_content": true
   },
@@ -2123,9 +2614,15 @@
     "slug": "postgres-version-rolling-support",
     "category": "decision",
     "description": "Roll PostgreSQL major-version support forward incrementally (9.x → 18) rather than pinning one LTS",
-    "tags": [],
+    "tags": [
+      "decision",
+      "postgres",
+      "version",
+      "rolling",
+      "support"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/postgres-version-rolling-support.md",
     "has_content": true
   },
@@ -2134,7 +2631,7 @@
     "name": "prefer-static-import-over-constant-inheritance",
     "slug": "prefer-static-import-over-constant-inheritance",
     "category": "decision",
-    "description": "Access shared constants via `import static SomeConstants.*` instead of `extends SomeConstants` — inheritance for constants pollutes the single-inheritance slot, leaks protected visibility, and makes subclasses nonsensically \\\"is-a\\\" a constants bag.",
+    "description": "\"Access shared constants via `import static SomeConstants.*` instead of `extends SomeConstants` — inheritance for constants pollutes the single-inheritance slot, leaks protected visibility, and makes subclasses nonsensically \\\"is-a\\\" a constants bag.\"",
     "tags": [
       "java",
       "refactor",
@@ -2142,7 +2639,7 @@
       "constants"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/prefer-static-import-over-constant-inheritance.md",
     "has_content": true
   },
@@ -2152,9 +2649,16 @@
     "slug": "push-local-removed-use-doc-update",
     "category": "decision",
     "description": "pushLocalChangesIntoRemote and its action-mapping helpers were removed; mutate Yorkie via doc.update directly",
-    "tags": [],
+    "tags": [
+      "decision",
+      "push",
+      "local",
+      "removed",
+      "use",
+      "doc"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/push-local-removed-use-doc-update.md",
     "has_content": true
   },
@@ -2164,9 +2668,16 @@
     "slug": "query-manager-version-conversion-fallback",
     "category": "decision",
     "description": "Unknown target RDBMS versions fall back to a documented default bucket rather than erroring, keeping collection alive",
-    "tags": [],
+    "tags": [
+      "decision",
+      "query",
+      "manager",
+      "version",
+      "conversion",
+      "fallback"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/query-manager-version-conversion-fallback.md",
     "has_content": true
   },
@@ -2184,7 +2695,7 @@
       "scouter"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/rcp-desktop-client-design-rationale-vs-saas-web.md",
     "has_content": true
   },
@@ -2194,9 +2705,14 @@
     "slug": "recoil-over-redux",
     "category": "decision",
     "description": "Decision to use Recoil atoms (2697 usages, 53 store files) as sole state management instead of Redux in a 25-remote MFA monorepo",
-    "tags": [],
+    "tags": [
+      "decision",
+      "recoil",
+      "over",
+      "redux"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/recoil-over-redux.md",
     "has_content": true
   },
@@ -2206,9 +2722,16 @@
     "slug": "resource-mount-unmount-use-jar-defaults",
     "category": "decision",
     "description": "Don't bind-mount i18n/exception/menu resource files into Spring Boot containers; let the jar ship its own defaults",
-    "tags": [],
+    "tags": [
+      "decision",
+      "resource",
+      "mount",
+      "unmount",
+      "use",
+      "jar"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/resource-mount-unmount-use-jar-defaults.md",
     "has_content": true
   },
@@ -2218,9 +2741,16 @@
     "slug": "save-child-only-when-changed",
     "category": "decision",
     "description": "When reconciling parent→child configurations, persistence is conditional on \"new\" or \"resourceName/tags changed\". Unconditional save caused unnecessary write load and spurious change events.",
-    "tags": [],
+    "tags": [
+      "decision",
+      "save",
+      "child",
+      "only",
+      "when",
+      "changed"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/save-child-only-when-changed.md",
     "has_content": true
   },
@@ -2230,10 +2760,28 @@
     "slug": "scatter-topic-1min-retention",
     "category": "decision",
     "description": "Per-tenant scatter-plot/summary topics use 60s retention; metric-history topics use the cluster default. Class-of-data drives retention, not tenant.",
-    "tags": [],
+    "tags": [
+      "decision",
+      "scatter",
+      "topic",
+      "1min",
+      "retention"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/scatter-topic-1min-retention.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "single-file-html-for-file-protocol",
+    "slug": "single-file-html-for-file-protocol",
+    "category": "decision",
+    "description": "Generate single-file HTML apps (inline CSS+JS) to avoid CORS errors when opened via file:// protocol",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/decision/single-file-html-for-file-protocol.md",
     "has_content": true
   },
   {
@@ -2241,10 +2789,16 @@
     "name": "skill-registry-vs-skill-config-split",
     "slug": "skill-registry-vs-skill-config-split",
     "category": "decision",
-    "description": "원격 저장소 정보는 `.claude/skill-registry.yaml`, 스킬별 런타임 옵션(출력 경로 등)은 `.claude/skill-config.yaml`. 파일 단위로 관심사 분리.",
-    "tags": [],
+    "description": "\"원격 저장소 정보는 `.claude/skill-registry.yaml`, 스킬별 런타임 옵션(출력 경로 등)은 `.claude/skill-config.yaml`. 파일 단위로 관심사 분리.\"",
+    "tags": [
+      "decision",
+      "skill",
+      "registry",
+      "config",
+      "split"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/skill-registry-vs-skill-config-split.md",
     "has_content": true
   },
@@ -2281,8 +2835,20 @@
       "service-layer"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/stub-in-service-unblocks-fe-parallelism.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "symlog-for-lag-metrics-near-zero",
+    "slug": "symlog-for-lag-metrics-near-zero",
+    "category": "decision",
+    "description": "Use symlog (not log) for consumer lag axes so healthy near-zero state stays visible alongside million-message spikes.",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/decision/symlog-for-lag-metrics-near-zero.md",
     "has_content": true
   },
   {
@@ -2291,9 +2857,16 @@
     "slug": "system-notification-shared-with-2fa-and-password-find",
     "category": "decision",
     "description": "The `system_notification` config (SMTP/SMS credentials) is intentionally shared between 2FA and password-find flows rather than duplicated per flow",
-    "tags": [],
+    "tags": [
+      "decision",
+      "system",
+      "notification",
+      "shared",
+      "with",
+      "2fa"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/system-notification-shared-with-2fa-and-password-find.md",
     "has_content": true
   },
@@ -2303,9 +2876,16 @@
     "slug": "tabular-metric-excluded-from-list",
     "category": "decision",
     "description": "TABULAR measurement type is intentionally excluded from searchable metric-definition list endpoints",
-    "tags": [],
+    "tags": [
+      "decision",
+      "tabular",
+      "metric",
+      "excluded",
+      "from",
+      "list"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/tabular-metric-excluded-from-list.md",
     "has_content": true
   },
@@ -2315,9 +2895,15 @@
     "slug": "tag-values-separate-collection",
     "category": "decision",
     "description": "TagValueInfo's `values` array was extracted from the parent tag document into a separate `tag_value_detail` collection to bound document size and index cost.",
-    "tags": [],
+    "tags": [
+      "decision",
+      "tag",
+      "values",
+      "separate",
+      "collection"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/tag-values-separate-collection.md",
     "has_content": true
   },
@@ -2327,9 +2913,16 @@
     "slug": "tomcat-request-timeout-1h-for-oz-report",
     "category": "decision",
     "description": "Report-generation services should raise Tomcat connection/read timeout to ~1 hour because export of large OZ/Jasper reports is genuinely long-running",
-    "tags": [],
+    "tags": [
+      "decision",
+      "tomcat",
+      "request",
+      "timeout",
+      "for",
+      "report"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/tomcat-request-timeout-1h-for-oz-report.md",
     "has_content": true
   },
@@ -2339,9 +2932,15 @@
     "slug": "triple-styling-paradigm-coexistence",
     "category": "decision",
     "description": "Why Tailwind CSS, SCSS modules, and styled-components coexist in the same codebase — migration path, isolation needs, and legacy constraints",
-    "tags": [],
+    "tags": [
+      "decision",
+      "triple",
+      "styling",
+      "paradigm",
+      "coexistence"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/triple-styling-paradigm-coexistence.md",
     "has_content": true
   },
@@ -2351,9 +2950,16 @@
     "slug": "typed-wikilinks-for-llm-knowledge-base",
     "category": "decision",
     "description": "Flat `[[wikilinks]]` carry one bit of information. For an LLM-facing knowledge base, tag every link with a relationship type (supersedes, contradicts, causes, supports) so the graph is queryable rather than just traversable.",
-    "tags": [],
+    "tags": [
+      "decision",
+      "typed",
+      "wikilinks",
+      "for",
+      "llm",
+      "knowledge"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/typed-wikilinks-for-llm-knowledge-base.md",
     "has_content": true
   },
@@ -2371,7 +2977,7 @@
       "apm"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/udp-for-throughput-tcp-for-reliability.md",
     "has_content": true
   },
@@ -2389,7 +2995,7 @@
       "scouter"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/variable-length-integer-encoding-for-metrics-bandwidth.md",
     "has_content": true
   },
@@ -2399,9 +3005,16 @@
     "slug": "vllm-kv-cache-fp8-with-mtp",
     "category": "decision",
     "description": "vLLM serving chose fp8_e4m3 KV cache + prefix caching + MTP speculative decoding for Qwen3.5 throughput",
-    "tags": [],
+    "tags": [
+      "decision",
+      "vllm",
+      "cache",
+      "fp8",
+      "with",
+      "mtp"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/vllm-kv-cache-fp8-with-mtp.md",
     "has_content": true
   },
@@ -2411,9 +3024,15 @@
     "slug": "account-lockout-configurable-threshold",
     "category": "domain",
     "description": "Failed-login counter locks the account after a configurable threshold (ACCOUNT_LOCKOUT, default 10).",
-    "tags": [],
+    "tags": [
+      "domain",
+      "account",
+      "lockout",
+      "configurable",
+      "threshold"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/domain/account-lockout-configurable-threshold.md",
     "has_content": true
   },
@@ -2423,9 +3042,15 @@
     "slug": "encrypted-pii-decode-on-export",
     "category": "domain",
     "description": "PII fields (phone, email) are stored encrypted; only decrypted for explicit export/API response, never for logs.",
-    "tags": [],
+    "tags": [
+      "domain",
+      "encrypted",
+      "pii",
+      "decode",
+      "export"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/domain/encrypted-pii-decode-on-export.md",
     "has_content": true
   },
@@ -2435,9 +3060,15 @@
     "slug": "mongodb-exclude-system-databases",
     "category": "domain",
     "description": "When enumerating tenant databases in a shared MongoDB cluster, filter out admin/config/local plus third-party DBs (yorkie-meta, migration) to avoid touching shared state",
-    "tags": [],
+    "tags": [
+      "domain",
+      "mongodb",
+      "exclude",
+      "system",
+      "databases"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/domain/mongodb-exclude-system-databases.md",
     "has_content": true
   },
@@ -2447,9 +3078,16 @@
     "slug": "mysql-mariadb-performance-schema-detection",
     "category": "domain",
     "description": "MySQL/MariaDB metric availability depends on per-instance Performance Schema state; detect at runtime, don't assume",
-    "tags": [],
+    "tags": [
+      "domain",
+      "mysql",
+      "mariadb",
+      "performance",
+      "schema",
+      "detection"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/domain/mysql-mariadb-performance-schema-detection.md",
     "has_content": true
   },
@@ -2459,9 +3097,16 @@
     "slug": "one-default-template-per-type-rule",
     "category": "domain",
     "description": "Exactly one default message template may exist per notification type; creating a second default is rejected, but editing the existing default is allowed",
-    "tags": [],
+    "tags": [
+      "domain",
+      "one",
+      "default",
+      "template",
+      "per",
+      "type"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/domain/one-default-template-per-type-rule.md",
     "has_content": true
   },
@@ -2471,9 +3116,15 @@
     "slug": "period-interval-naming-convention",
     "category": "domain",
     "description": "Period.Mode names encode both unit and multiplier (MIN_15, MONTH_2); monthly modes densify at 24h, not the unit itself",
-    "tags": [],
+    "tags": [
+      "domain",
+      "period",
+      "interval",
+      "naming",
+      "convention"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/domain/period-interval-naming-convention.md",
     "has_content": true
   },
@@ -2482,10 +3133,17 @@
     "name": "pims-write-requires-dryrun-confirm",
     "slug": "pims-write-requires-dryrun-confirm",
     "category": "domain",
-    "description": "PIMS 시간 기록/제출/일괄 갱신 등 모든 쓰기 API는 미리보기 → 사용자 확인 → 재시도 가능한 실행 플로우를 반드시 거친다. `--dry-run`은 API 쓰기 호출 자체가 금지.",
-    "tags": [],
+    "description": "\"PIMS 시간 기록/제출/일괄 갱신 등 모든 쓰기 API는 미리보기 → 사용자 확인 → 재시도 가능한 실행 플로우를 반드시 거친다. `--dry-run`은 API 쓰기 호출 자체가 금지.\"",
+    "tags": [
+      "domain",
+      "pims",
+      "write",
+      "requires",
+      "dryrun",
+      "confirm"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/domain/pims-write-requires-dryrun-confirm.md",
     "has_content": true
   },
@@ -2495,9 +3153,15 @@
     "slug": "root-span-error-propagation",
     "category": "domain",
     "description": "A trace's root-span isError flag must aggregate descendant span errors; otherwise scatter and list views disagree about which traces errored.",
-    "tags": [],
+    "tags": [
+      "domain",
+      "root",
+      "span",
+      "error",
+      "propagation"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/domain/root-span-error-propagation.md",
     "has_content": true
   },
@@ -2507,9 +3171,15 @@
     "slug": "topresource-immediate-generation-invariant",
     "category": "domain",
     "description": "In report immediate-generation, the topResource flag decides whether to query by resource-id (fast path) or the full conf-id set (slow path)",
-    "tags": [],
+    "tags": [
+      "domain",
+      "topresource",
+      "immediate",
+      "generation",
+      "invariant"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/domain/topresource-immediate-generation-invariant.md",
     "has_content": true
   },
@@ -2519,12 +3189,9 @@
     "slug": "actor-model-implementation-pitfall",
     "category": "pitfall",
     "description": "Shared mutable state and blocking calls silently break actor-model guarantees",
-    "tags": [
-      "actor",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/actor-model-implementation-pitfall.md",
     "has_content": true
   },
@@ -2534,9 +3201,16 @@
     "slug": "actuator-metric-call-aggressive-timeout",
     "category": "pitfall",
     "description": "Use aggressive HTTP timeouts (100ms–1s) for /actuator/health and /actuator/metrics polling, but keep long timeouts for /actuator/threaddump and /actuator/heapdump — mixing them stalls the collector.",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "actuator",
+      "metric",
+      "call",
+      "aggressive",
+      "timeout"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/actuator-metric-call-aggressive-timeout.md",
     "has_content": true
   },
@@ -2554,7 +3228,7 @@
       "transparency"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/ai-guess-mark-and-review-checklist.md",
     "has_content": true
   },
@@ -2563,10 +3237,16 @@
     "name": "anonymize-examples-in-skill-docs",
     "slug": "anonymize-examples-in-skill-docs",
     "category": "pitfall",
-    "description": "실사 티켓 번호·실명·프로젝트명이 예시에 들어가면 보안 감사에서 지적됨. 공용 repo 기준 모든 예시는 익명 더미여야 한다.",
-    "tags": [],
+    "description": "\"실사 티켓 번호·실명·프로젝트명이 예시에 들어가면 보안 감사에서 지적됨. 공용 repo 기준 모든 예시는 익명 더미여야 한다.\"",
+    "tags": [
+      "pitfall",
+      "anonymize",
+      "examples",
+      "skill",
+      "docs"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/anonymize-examples-in-skill-docs.md",
     "has_content": true
   },
@@ -2576,12 +3256,9 @@
     "slug": "api-gateway-pattern-implementation-pitfall",
     "category": "pitfall",
     "description": "Conflating gateway-added latency with backend latency and letting rate-limit state leak across gateway replicas",
-    "tags": [
-      "api",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/api-gateway-pattern-implementation-pitfall.md",
     "has_content": true
   },
@@ -2591,12 +3268,9 @@
     "slug": "api-versioning-implementation-pitfall",
     "category": "pitfall",
     "description": "Common traps when building API version visualizations: off-by-one lifecycle states, diff semantic loss, and traffic share math",
-    "tags": [
-      "api",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/api-versioning-implementation-pitfall.md",
     "has_content": true
   },
@@ -2606,14 +3280,9 @@
     "slug": "arbitrary-display-caps-hide-signal",
     "category": "pitfall",
     "description": "Hardcoded `slice(0, N)` display limits in UI code silently cap counts below actual data, making users distrust the pipeline even when it works correctly",
-    "tags": [
-      "ui",
-      "dashboards",
-      "monitoring",
-      "debugging"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/arbitrary-display-caps-hide-signal.md",
     "has_content": true
   },
@@ -2631,7 +3300,7 @@
       "jvm"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/asm-based-classloader-instrumentation-caveats.md",
     "has_content": true
   },
@@ -2641,9 +3310,16 @@
     "slug": "audit-changed-prev-after-field-swap-bug",
     "category": "pitfall",
     "description": "Audit diff logic had before/after swapped — iterating the wrong doc and putting the wrong value into changedPrev corrupted the audit trail silently",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "audit",
+      "changed",
+      "prev",
+      "after",
+      "field"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/audit-changed-prev-after-field-swap-bug.md",
     "has_content": true
   },
@@ -2653,12 +3329,9 @@
     "slug": "auto-default-until-user-edit-dataset-flag",
     "category": "pitfall",
     "description": "Track whether a prefilled form field is still \"auto\" via a dataset flag so regeneration doesn't clobber user edits.",
-    "tags": [
-      "fnv1a",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/auto-default-until-user-edit-dataset-flag.md",
     "has_content": true
   },
@@ -2668,9 +3341,16 @@
     "slug": "auto-lock-must-not-bump-lastEditedTime",
     "category": "pitfall",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "auto",
+      "lock",
+      "must",
+      "not",
+      "bump"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/auto-lock-must-not-bump-lastEditedTime.md",
     "has_content": true
   },
@@ -2680,12 +3360,9 @@
     "slug": "backpressure-implementation-pitfall",
     "category": "pitfall",
     "description": "Conflating rate limiting with backpressure hides the upstream feedback loop that defines it",
-    "tags": [
-      "backpressure",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/backpressure-implementation-pitfall.md",
     "has_content": true
   },
@@ -2695,12 +3372,9 @@
     "slug": "bff-pattern-implementation-pitfall",
     "category": "pitfall",
     "description": "BFFs silently become distributed monoliths when teams share one BFF across clients or let it accumulate business logic",
-    "tags": [
-      "bff",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/bff-pattern-implementation-pitfall.md",
     "has_content": true
   },
@@ -2710,10 +3384,28 @@
     "slug": "binsize-zero-fallback-to-one",
     "category": "pitfall",
     "description": "Substitute binSize=1 whenever the computed interval is 0 in MongoDB time-bucket aggregation",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "binsize",
+      "zero",
+      "fallback",
+      "one"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/binsize-zero-fallback-to-one.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "bloom-filter-false-positive-saturation-cliff",
+    "slug": "bloom-filter-false-positive-saturation-cliff",
+    "category": "pitfall",
+    "description": "Bloom filters silently degrade to ~100% false-positive rate once load exceeds design capacity, breaking set-diff reconciliation.",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/pitfall/bloom-filter-false-positive-saturation-cliff.md",
     "has_content": true
   },
   {
@@ -2722,12 +3414,9 @@
     "slug": "bloom-filter-implementation-pitfall",
     "category": "pitfall",
     "description": "Hash independence, bit-array indexing, and removal semantics are the common breakage points",
-    "tags": [
-      "bloom",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/bloom-filter-implementation-pitfall.md",
     "has_content": true
   },
@@ -2737,12 +3426,9 @@
     "slug": "blue-green-deploy-implementation-pitfall",
     "category": "pitfall",
     "description": "Common modeling mistakes when visualizing blue-green cutovers — instant flip, color-coded active state, ignored drain phase",
-    "tags": [
-      "blue",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/blue-green-deploy-implementation-pitfall.md",
     "has_content": true
   },
@@ -2752,12 +3438,9 @@
     "slug": "bulkhead-implementation-pitfall",
     "category": "pitfall",
     "description": "Common mistakes that silently defeat bulkhead isolation in visualizations and real systems",
-    "tags": [
-      "bulkhead",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/bulkhead-implementation-pitfall.md",
     "has_content": true
   },
@@ -2767,12 +3450,9 @@
     "slug": "canary-release-implementation-pitfall",
     "category": "pitfall",
     "description": "Common traps when modeling canary releases — low-volume gate noise, symmetric SLOs, and instant weight shifts",
-    "tags": [
-      "canary",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/canary-release-implementation-pitfall.md",
     "has_content": true
   },
@@ -2782,12 +3462,9 @@
     "slug": "canvas-event-coord-devicepixel-rescale",
     "category": "pitfall",
     "description": "Pointer coords on a responsive canvas must be rescaled by `canvas.width / rect.width` — using raw `clientX - rect.left` mis-hits whenever CSS size differs from the backing store size.",
-    "tags": [
-      "canvas",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/canvas-event-coord-devicepixel-rescale.md",
     "has_content": true
   },
@@ -2797,9 +3474,15 @@
     "slug": "catalina-urlencoder-internal-api",
     "category": "pitfall",
     "description": "org.apache.catalina.util.URLEncoder는 톰캣 내부 API — 컨테이너 교체/버전업에 깨지기 쉽다. java.net.URLEncoder 또는 Spring UriUtils 사용",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "catalina",
+      "urlencoder",
+      "internal",
+      "api"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/catalina-urlencoder-internal-api.md",
     "has_content": true
   },
@@ -2809,12 +3492,9 @@
     "slug": "cdc-implementation-pitfall",
     "category": "pitfall",
     "description": "Common CDC mistakes: losing position state, mishandling tombstones, and breaking transaction boundaries",
-    "tags": [
-      "cdc",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/cdc-implementation-pitfall.md",
     "has_content": true
   },
@@ -2824,12 +3504,9 @@
     "slug": "chaos-engineering-implementation-pitfall",
     "category": "pitfall",
     "description": "Common mistakes when building chaos-engineering tooling that make it unsafe or untrustworthy",
-    "tags": [
-      "chaos",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/chaos-engineering-implementation-pitfall.md",
     "has_content": true
   },
@@ -2839,14 +3516,9 @@
     "slug": "child-claude-inherits-parent-hooks",
     "category": "pitfall",
     "description": "When spawning Claude CLI from a Node process, the child inherits OMC/session hooks that can hijack the output into side-channels — you only see a confirmation string",
-    "tags": [
-      "claude-cli",
-      "subprocess",
-      "hooks",
-      "orchestration"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/child-claude-inherits-parent-hooks.md",
     "has_content": true
   },
@@ -2856,12 +3528,9 @@
     "slug": "circuit-breaker-implementation-pitfall",
     "category": "pitfall",
     "description": "Common bugs when implementing the HALF_OPEN probe state and failure window accounting",
-    "tags": [
-      "circuit",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/circuit-breaker-implementation-pitfall.md",
     "has_content": true
   },
@@ -2870,7 +3539,7 @@
     "name": "classifier-both-verdict-self-reference",
     "slug": "classifier-both-verdict-self-reference",
     "category": "pitfall",
-    "description": "LLM classifier의 both-verdict에 suggested_links를 허용하면 자기 자신을 가리키는 self-link가 나온다 — 링크는 post-process에서 붙일 것",
+    "description": "\"LLM classifier의 both-verdict에 suggested_links를 허용하면 자기 자신을 가리키는 self-link가 나온다 — 링크는 post-process에서 붙일 것\"",
     "tags": [
       "llm",
       "classifier",
@@ -2879,8 +3548,32 @@
       "linking"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/classifier-both-verdict-self-reference.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "claude-cli-bare-flag-disables-oauth",
+    "slug": "claude-cli-bare-flag-disables-oauth",
+    "category": "pitfall",
+    "description": "\"`claude -p --bare` returns exit 1 with empty stderr when the user is OAuth-authenticated — `--bare` explicitly disables OAuth and keychain reads.\"",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/pitfall/claude-cli-bare-flag-disables-oauth.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "claude-cli-single-response-output-limit",
+    "slug": "claude-cli-single-response-output-limit",
+    "category": "pitfall",
+    "description": "Claude CLI practical output limit is ~500-800 lines per code artifact when generating multiple items in one call",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/pitfall/claude-cli-single-response-output-limit.md",
     "has_content": true
   },
   {
@@ -2908,10 +3601,17 @@
     "name": "claude-plugin-marketplace-owner-required",
     "slug": "claude-plugin-marketplace-owner-required",
     "category": "pitfall",
-    "description": "플러그인 설치 스키마 오류: marketplace.json 최상위에 `owner` 객체 없으면 플러그인 설치가 실패.",
-    "tags": [],
+    "description": "\"플러그인 설치 스키마 오류: marketplace.json 최상위에 `owner` 객체 없으면 플러그인 설치가 실패.\"",
+    "tags": [
+      "pitfall",
+      "claude",
+      "plugin",
+      "marketplace",
+      "owner",
+      "required"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/claude-plugin-marketplace-owner-required.md",
     "has_content": true
   },
@@ -2921,12 +3621,9 @@
     "slug": "command-query-implementation-pitfall",
     "category": "pitfall",
     "description": "Common traps when building CQRS command-query separation apps — leaky reads, sync assumptions, and unbounded projections",
-    "tags": [
-      "command",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/command-query-implementation-pitfall.md",
     "has_content": true
   },
@@ -2944,7 +3641,7 @@
       "silent-failure"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/common-alarm-policy-init-gotcha.md",
     "has_content": true
   },
@@ -2954,9 +3651,16 @@
     "slug": "compare-counts-exclude-added-deleted",
     "category": "pitfall",
     "description": "An earlier query filtered change-count by `latest` / `added` / `deleted` flags, which silently dropped newly-added resources from the \"number of changes between two points in time\" metric.",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "compare",
+      "counts",
+      "exclude",
+      "added",
+      "deleted"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/compare-counts-exclude-added-deleted.md",
     "has_content": true
   },
@@ -2966,10 +3670,29 @@
     "slug": "composite-alarm-all-deleted-npe",
     "category": "pitfall",
     "description": "Composite/aggregated monitors must validate their child set before reducing — empty aggregation throws NPE",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "composite",
+      "alarm",
+      "all",
+      "deleted",
+      "npe"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/composite-alarm-all-deleted-npe.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "concurrent-edge-detection-without-full-clock-compare",
+    "slug": "concurrent-edge-detection-without-full-clock-compare",
+    "category": "pitfall",
+    "description": "Rendering \"concurrent\" edges in a DAG viz requires comparing every pair, not just adjacent events — O(n²) is the correct cost.",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/pitfall/concurrent-edge-detection-without-full-clock-compare.md",
     "has_content": true
   },
   {
@@ -2978,9 +3701,16 @@
     "slug": "conf-info-may-lack-resource-type",
     "category": "pitfall",
     "description": "The `conf_info` collection is NOT guaranteed to carry `resourceType` for every metric; criteria builders must tolerate missing field",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "conf",
+      "info",
+      "may",
+      "lack",
+      "resource"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/conf-info-may-lack-resource-type.md",
     "has_content": true
   },
@@ -2990,12 +3720,9 @@
     "slug": "connection-pool-implementation-pitfall",
     "category": "pitfall",
     "description": "Common errors when modeling or implementing connection pool visualizers, simulators, and config labs",
-    "tags": [
-      "connection",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/connection-pool-implementation-pitfall.md",
     "has_content": true
   },
@@ -3005,12 +3732,9 @@
     "slug": "consistent-hashing-implementation-pitfall",
     "category": "pitfall",
     "description": "Common correctness and distribution pitfalls when implementing consistent hashing rings and virtual nodes",
-    "tags": [
-      "consistent",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/consistent-hashing-implementation-pitfall.md",
     "has_content": true
   },
@@ -3020,12 +3744,9 @@
     "slug": "cqrs-implementation-pitfall",
     "category": "pitfall",
     "description": "Treating CQRS as \"just split read/write DBs\" and ignoring projector idempotency, ordering, and rebuild cost.",
-    "tags": [
-      "cqrs",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/cqrs-implementation-pitfall.md",
     "has_content": true
   },
@@ -3035,12 +3756,9 @@
     "slug": "crdt-implementation-pitfall",
     "category": "pitfall",
     "description": "Common CRDT bugs: naive LWW tiebreaking, OR-Set tag reuse, and counter double-counting on replay",
-    "tags": [
-      "crdt",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/crdt-implementation-pitfall.md",
     "has_content": true
   },
@@ -3049,10 +3767,17 @@
     "name": "crypto-randomuuid-requires-secure-context",
     "slug": "crypto-randomuuid-requires-secure-context",
     "category": "pitfall",
-    "description": "`crypto.randomUUID()` is only defined in secure contexts (HTTPS or localhost); plain-HTTP dev or intranet deployments need an explicit UUID fallback.",
-    "tags": [],
+    "description": "\"`crypto.randomUUID()` is only defined in secure contexts (HTTPS or localhost); plain-HTTP dev or intranet deployments need an explicit UUID fallback.\"",
+    "tags": [
+      "pitfall",
+      "crypto",
+      "randomuuid",
+      "requires",
+      "secure",
+      "context"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/crypto-randomuuid-requires-secure-context.md",
     "has_content": true
   },
@@ -3062,12 +3787,9 @@
     "slug": "data-pipeline-implementation-pitfall",
     "category": "pitfall",
     "description": "Common mistakes that make pipeline visualizations look broken, lie about state, or degrade at scale",
-    "tags": [
-      "data",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/data-pipeline-implementation-pitfall.md",
     "has_content": true
   },
@@ -3077,12 +3799,9 @@
     "slug": "database-sharding-implementation-pitfall",
     "category": "pitfall",
     "description": "Modulo sharding's rebalance cost trap and virtual node undersizing cause visualizers to mislead operators about real-world behavior",
-    "tags": [
-      "database",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/database-sharding-implementation-pitfall.md",
     "has_content": true
   },
@@ -3092,12 +3811,9 @@
     "slug": "dead-letter-queue-implementation-pitfall",
     "category": "pitfall",
     "description": "Common failure modes when building DLQ tooling: replay loops, payload loss, and silent growth",
-    "tags": [
-      "dead",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/dead-letter-queue-implementation-pitfall.md",
     "has_content": true
   },
@@ -3107,13 +3823,28 @@
     "slug": "distributed-tracing-implementation-pitfall",
     "category": "pitfall",
     "description": "Clock skew, orphan spans, and sampling bias break tracing visualizations in ways that look like UI bugs",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/pitfall/distributed-tracing-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "divide-by-zero-rate-guard",
+    "slug": "divide-by-zero-rate-guard",
+    "category": "pitfall",
+    "description": "Rate/throughput computations over rolling windows silently explode when the window contains only one sample or zero elapsed time.",
     "tags": [
-      "distributed",
-      "auto-loop"
+      "pitfall",
+      "divide",
+      "zero",
+      "rate",
+      "guard"
     ],
     "triggers": [],
-    "version": "",
-    "path": "knowledge/pitfall/distributed-tracing-implementation-pitfall.md",
+    "version": "0.1.0-draft",
+    "path": "knowledge/pitfall/divide-by-zero-rate-guard.md",
     "has_content": true
   },
   {
@@ -3122,9 +3853,16 @@
     "slug": "docker-engine-29-requires-traefik-upgrade",
     "category": "pitfall",
     "description": "Docker Engine 29.x raises the minimum client API to 1.44, breaking older Traefik versions that pin an older API",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "docker",
+      "engine",
+      "requires",
+      "traefik",
+      "upgrade"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/docker-engine-29-requires-traefik-upgrade.md",
     "has_content": true
   },
@@ -3134,12 +3872,9 @@
     "slug": "domain-driven-implementation-pitfall",
     "category": "pitfall",
     "description": "Common failure modes when building tools that model bounded contexts, aggregates, and ubiquitous language",
-    "tags": [
-      "domain",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/domain-driven-implementation-pitfall.md",
     "has_content": true
   },
@@ -3149,9 +3884,14 @@
     "slug": "enum-notnull-comparison-pitfall",
     "category": "pitfall",
     "description": "In Java, comparing an enum field with `==` without a null guard NPEs on the left operand; prefer constant-on-the-left or an explicit @NotNull contract",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "enum",
+      "notnull",
+      "comparison"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/enum-notnull-comparison-pitfall.md",
     "has_content": true
   },
@@ -3169,7 +3909,7 @@
       "zap"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/enum-whitelist-blocks-time-based-sqli.md",
     "has_content": true
   },
@@ -3179,12 +3919,9 @@
     "slug": "etl-implementation-pitfall",
     "category": "pitfall",
     "description": "Common failures when building ETL visualization UIs that feel wrong to data engineers",
-    "tags": [
-      "etl",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/etl-implementation-pitfall.md",
     "has_content": true
   },
@@ -3194,12 +3931,9 @@
     "slug": "event-sourcing-implementation-pitfall",
     "category": "pitfall",
     "description": "Schema evolution and non-deterministic projections break replay guarantees",
-    "tags": [
-      "event",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/event-sourcing-implementation-pitfall.md",
     "has_content": true
   },
@@ -3209,16 +3943,22 @@
     "slug": "executor-agent-bash-permission",
     "category": "pitfall",
     "description": "Executor sub-agents may not have Bash tool permissions, causing git/shell operations to fail silently",
-    "tags": [
-      "agents",
-      "permissions",
-      "bash",
-      "git",
-      "publishing"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/executor-agent-bash-permission.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "feature-branch-install-stale-content",
+    "slug": "feature-branch-install-stale-content",
+    "category": "pitfall",
+    "description": "Installing from example/* or skill/* feature branches delivers outdated content — always use main",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/pitfall/feature-branch-install-stale-content.md",
     "has_content": true
   },
   {
@@ -3227,12 +3967,9 @@
     "slug": "feature-flags-implementation-pitfall",
     "category": "pitfall",
     "description": "Common correctness traps when building feature-flag rollout, dependency, and A/B UIs",
-    "tags": [
-      "feature",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/feature-flags-implementation-pitfall.md",
     "has_content": true
   },
@@ -3242,12 +3979,9 @@
     "slug": "finite-state-machine-implementation-pitfall",
     "category": "pitfall",
     "description": "Common FSM bugs: undefined-transition silent no-ops, guard side effects, and async timer drift during state changes.",
-    "tags": [
-      "finite",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/finite-state-machine-implementation-pitfall.md",
     "has_content": true
   },
@@ -3256,7 +3990,7 @@
     "name": "gh-pr-create-race-with-auto-merge",
     "slug": "gh-pr-create-race-with-auto-merge",
     "category": "pitfall",
-    "description": "On repos with auto-merge enabled, `gh pr create` can fail with \\\"No commits between main and <branch>\\\" because the PR was already created AND merged by automation in the time between `git push` and `gh pr create`. Detect this by checking `git merge-base --is-ancestor <branch> origin/main` before assuming failure.",
+    "description": "\"On repos with auto-merge enabled, `gh pr create` can fail with \\\"No commits between main and <branch>\\\" because the PR was already created AND merged by automation in the time between `git push` and `gh pr create`. Detect this by checking `git merge-base --is-ancestor <branch> origin/main` before assuming failure.\"",
     "tags": [
       "gh-cli",
       "pull-request",
@@ -3265,7 +3999,7 @@
       "pitfall"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/gh-pr-create-race-with-auto-merge.md",
     "has_content": true
   },
@@ -3295,12 +4029,9 @@
     "slug": "graphql-implementation-pitfall",
     "category": "pitfall",
     "description": "Common failures when rendering schemas, building queries, and handling subscription streams in GraphQL UIs",
-    "tags": [
-      "graphql",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/graphql-implementation-pitfall.md",
     "has_content": true
   },
@@ -3310,9 +4041,16 @@
     "slug": "gridfs-template-upload-data-loss-pitfall",
     "category": "pitfall",
     "description": "MongoDB GridFS uploads can silently drop file bytes if the bucket/db selection or stream flush is wrong — always verify metadata size equals input size",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "gridfs",
+      "template",
+      "upload",
+      "data",
+      "loss"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/gridfs-template-upload-data-loss-pitfall.md",
     "has_content": true
   },
@@ -3322,12 +4060,9 @@
     "slug": "health-check-implementation-pitfall",
     "category": "pitfall",
     "description": "Common failure modes when building health-check systems: self-check blind spots, probe-induced load, and stale-cache green lies",
-    "tags": [
-      "health",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/health-check-implementation-pitfall.md",
     "has_content": true
   },
@@ -3337,12 +4072,9 @@
     "slug": "hexagonal-architecture-implementation-pitfall",
     "category": "pitfall",
     "description": "Ports become leaky DTO pass-throughs and adapters accumulate domain logic, collapsing the hexagon into layered architecture",
-    "tags": [
-      "hexagonal",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/hexagonal-architecture-implementation-pitfall.md",
     "has_content": true
   },
@@ -3352,9 +4084,15 @@
     "slug": "hibernate-date-format-lowercase",
     "category": "pitfall",
     "description": "Use lowercase `yyyy` for calendar year — `YYYY` is ISO week-year and produces wrong values near Jan 1 / Dec 31",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "hibernate",
+      "date",
+      "format",
+      "lowercase"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/hibernate-date-format-lowercase.md",
     "has_content": true
   },
@@ -3364,9 +4102,15 @@
     "slug": "history-view-yearly-partition-pitfall",
     "category": "pitfall",
     "description": "A history/reporting view or materialized collection created with a year-bounded clause silently stops returning rows when the calendar year rolls over",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "history",
+      "view",
+      "yearly",
+      "partition"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/history-view-yearly-partition-pitfall.md",
     "has_content": true
   },
@@ -3375,7 +4119,7 @@
     "name": "hub-scan-must-exclude-external-imports",
     "slug": "hub-scan-must-exclude-external-imports",
     "category": "pitfall",
-    "description": "Any cross-corpus heuristic scan (/hub-refactor, /hub-condense, /hub-cleanup) that modifies entries must exclude externally-imported content by default, or it will propose changes that diverge from upstream and break /hub-sync.",
+    "description": "\"Any cross-corpus heuristic scan (/hub-refactor, /hub-condense, /hub-cleanup) that modifies entries must exclude externally-imported content by default, or it will propose changes that diverge from upstream and break /hub-sync.\"",
     "tags": [
       "skills-hub",
       "heuristic",
@@ -3384,7 +4128,7 @@
       "pitfall"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/hub-scan-must-exclude-external-imports.md",
     "has_content": true
   },
@@ -3394,12 +4138,9 @@
     "slug": "idempotency-implementation-pitfall",
     "category": "pitfall",
     "description": "Common failure modes when implementing idempotency keys — race conditions, improper scope, and caching the wrong response.",
-    "tags": [
-      "idempotency",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/idempotency-implementation-pitfall.md",
     "has_content": true
   },
@@ -3409,9 +4150,15 @@
     "slug": "injectmocks-generics-type-erasure",
     "category": "pitfall",
     "description": "@InjectMocks가 제네릭 필드에 Mock을 주입할 때 타입 소거로 잘못된 후보를 고르는 flaky 원인",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "injectmocks",
+      "generics",
+      "type",
+      "erasure"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/injectmocks-generics-type-erasure.md",
     "has_content": true
   },
@@ -3421,9 +4168,15 @@
     "slug": "ipv6-colon-detection-edge",
     "category": "pitfall",
     "description": "Detecting IPv6 by colon count breaks on compressed notation — use a regex character class",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "ipv6",
+      "colon",
+      "detection",
+      "edge"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/ipv6-colon-detection-edge.md",
     "has_content": true
   },
@@ -3433,9 +4186,15 @@
     "slug": "jackson-version-pinning-2.17.1",
     "category": "pitfall",
     "description": "Jackson must be pinned via Gradle resolutionStrategy across all com.fasterxml.jackson.* groups to avoid NoSuchMethodError from transitive version drift",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "jackson",
+      "version",
+      "pinning",
+      "2.17.1"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/jackson-version-pinning-2.17.1.md",
     "has_content": true
   },
@@ -3445,9 +4204,16 @@
     "slug": "jdbc-template-var-xml-escape-bypass",
     "category": "pitfall",
     "description": "When the template engine XML-escapes values but the downstream channel is raw SQL / plain text, the escaped `&amp; &lt; &gt;` leaks into stored data",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "jdbc",
+      "template",
+      "var",
+      "xml",
+      "escape"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/jdbc-template-var-xml-escape-bypass.md",
     "has_content": true
   },
@@ -3457,9 +4223,15 @@
     "slug": "k8s-clusterrole-aggregation-npe",
     "category": "pitfall",
     "description": "ClusterRole `aggregationRule` and its `clusterRoleSelectors` are both nullable — iterate only after null-check",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "k8s",
+      "clusterrole",
+      "aggregation",
+      "npe"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/k8s-clusterrole-aggregation-npe.md",
     "has_content": true
   },
@@ -3469,9 +4241,16 @@
     "slug": "kafka-consumer-group-id-hostname-not-timezone",
     "category": "pitfall",
     "description": "Kafka consumer group-id must derive from a stable node identifier (hostname), never from a timezone/locale string — a silent typo will split consumers into unintended groups.",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "kafka",
+      "consumer",
+      "group",
+      "hostname",
+      "not"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/kafka-consumer-group-id-hostname-not-timezone.md",
     "has_content": true
   },
@@ -3481,9 +4260,16 @@
     "slug": "kafka-error-handling-deserializer-fallback",
     "category": "pitfall",
     "description": "Wrap Avro/JSON deserializers in ErrorHandlingDeserializer so a single bad record doesn't poison the consumer and crash-loop the container",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "kafka",
+      "error",
+      "handling",
+      "deserializer",
+      "fallback"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/kafka-error-handling-deserializer-fallback.md",
     "has_content": true
   },
@@ -3493,9 +4279,16 @@
     "slug": "kafka-sticky-partitioner-key-null",
     "category": "pitfall",
     "description": "ProducerRecord key=null일 때 Sticky Partitioner가 batch.size 동안 한 파티션에 몰리는 성질 — 소규모 환경에서 Pod 분산 안 보이는 원인",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "kafka",
+      "sticky",
+      "partitioner",
+      "key",
+      "null"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/kafka-sticky-partitioner-key-null.md",
     "has_content": true
   },
@@ -3505,9 +4298,15 @@
     "slug": "konva-center-coord-system",
     "category": "pitfall",
     "description": "Konva node coordinates can be center-based; when converting to top-left boxes subtract half width/height",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "konva",
+      "center",
+      "coord",
+      "system"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/konva-center-coord-system.md",
     "has_content": true
   },
@@ -3517,12 +4316,9 @@
     "slug": "lantern-implementation-pitfall",
     "category": "pitfall",
     "description": "Common failure modes when building lantern visualizations: additive-blend saturation, flicker desync, and ember leak",
-    "tags": [
-      "lantern",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/lantern-implementation-pitfall.md",
     "has_content": true
   },
@@ -3532,9 +4328,15 @@
     "slug": "latest-availability-deletion-risk",
     "category": "pitfall",
     "description": "Latest-availability collection can lose data when upstream source is stale but not actually missing",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "latest",
+      "availability",
+      "deletion",
+      "risk"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/latest-availability-deletion-risk.md",
     "has_content": true
   },
@@ -3544,9 +4346,16 @@
     "slug": "lean-verification-spec-coverage-gap",
     "category": "pitfall",
     "description": "Formal proofs cover exactly what the spec formalizes — untrusted parsers and the language runtime, which are usually *not* in the spec, routinely contain the bugs a \"proven correct\" library claims to have eliminated.",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "lean",
+      "verification",
+      "spec",
+      "coverage",
+      "gap"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/lean-verification-spec-coverage-gap.md",
     "has_content": true
   },
@@ -3555,10 +4364,15 @@
     "name": "legacy-datasource-naming",
     "slug": "legacy-datasource-naming",
     "category": "pitfall",
-    "description": "`dataSource` / `dataSourceFilter` in the codebase actually mean data-pipeline-select and data-pipeline-filter — not datasource",
-    "tags": [],
+    "description": "\"`dataSource` / `dataSourceFilter` in the codebase actually mean data-pipeline-select and data-pipeline-filter — not datasource\"",
+    "tags": [
+      "pitfall",
+      "legacy",
+      "datasource",
+      "naming"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/legacy-datasource-naming.md",
     "has_content": true
   },
@@ -3568,12 +4382,9 @@
     "slug": "load-balancer-implementation-pitfall",
     "category": "pitfall",
     "description": "Common bugs when implementing load balancer algorithms in a simulation, especially consistent hashing and least-connections",
-    "tags": [
-      "load",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/load-balancer-implementation-pitfall.md",
     "has_content": true
   },
@@ -3583,12 +4394,9 @@
     "slug": "log-aggregation-implementation-pitfall",
     "category": "pitfall",
     "description": "Common failure modes when building log aggregation visualizations: memory blowup, scroll jank, and meaningless heatmaps",
-    "tags": [
-      "log",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/log-aggregation-implementation-pitfall.md",
     "has_content": true
   },
@@ -3598,13 +4406,22 @@
     "slug": "materialized-view-implementation-pitfall",
     "category": "pitfall",
     "description": "Common mistakes when visualizing or simulating materialized-view refresh semantics",
-    "tags": [
-      "materialized",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/materialized-view-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "merged-pr-branch-orphan-commits",
+    "slug": "merged-pr-branch-orphan-commits",
+    "category": "pitfall",
+    "description": "Commits pushed to a PR branch after merge do NOT reach main — they become orphaned",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/pitfall/merged-pr-branch-orphan-commits.md",
     "has_content": true
   },
   {
@@ -3613,12 +4430,9 @@
     "slug": "message-queue-implementation-pitfall",
     "category": "pitfall",
     "description": "Common correctness bugs when implementing queue semantics in browser-based demos",
-    "tags": [
-      "message",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/message-queue-implementation-pitfall.md",
     "has_content": true
   },
@@ -3628,9 +4442,16 @@
     "slug": "mf-select-unstable-options-infinite-loop",
     "category": "pitfall",
     "description": "Custom Select/Dropdown components that accept an `options` array and diff it by reference can infinite-loop when consumed across a Module Federation boundary; prefer pure HTML selects or stabilize the array.",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "select",
+      "unstable",
+      "options",
+      "infinite",
+      "loop"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/mf-select-unstable-options-infinite-loop.md",
     "has_content": true
   },
@@ -3640,9 +4461,15 @@
     "slug": "mongo-direct-connection-flag",
     "category": "pitfall",
     "description": "MongoDB datasource connectionString requires directConnection=true in this deployment",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "mongo",
+      "direct",
+      "connection",
+      "flag"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/mongo-direct-connection-flag.md",
     "has_content": true
   },
@@ -3651,7 +4478,7 @@
     "name": "mongo-timeseries-forced-hint-kills-pushdown",
     "slug": "mongo-timeseries-forced-hint-kills-pushdown",
     "category": "pitfall",
-    "description": "Forcing `hint(indexName)` on a MongoDB time-series aggregation bypasses the optimizer's bucket-index rewrite — the plan scans every bucket with `control.min/max.timestamp = [MinKey, MaxKey]` instead of honoring the timestamp predicate.",
+    "description": "\"Forcing `hint(indexName)` on a MongoDB time-series aggregation bypasses the optimizer's bucket-index rewrite — the plan scans every bucket with `control.min/max.timestamp = [MinKey, MaxKey]` instead of honoring the timestamp predicate.\"",
     "tags": [
       "mongodb",
       "time-series",
@@ -3659,7 +4486,7 @@
       "query-optimization"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/mongo-timeseries-forced-hint-kills-pushdown.md",
     "has_content": true
   },
@@ -3668,7 +4495,7 @@
     "name": "mongo-timeseries-match-split-for-pushdown",
     "slug": "mongo-timeseries-match-split-for-pushdown",
     "category": "pitfall",
-    "description": "On MongoDB time-series collections, combining timestamp range + metadata filters in a single `$match` disables bucket-level push-down — split into two sequential `$match` stages (timestamp first, metadata second) so the optimizer can synthesize `control.*.timestamp` bounds.",
+    "description": "\"On MongoDB time-series collections, combining timestamp range + metadata filters in a single `$match` disables bucket-level push-down — split into two sequential `$match` stages (timestamp first, metadata second) so the optimizer can synthesize `control.*.timestamp` bounds.\"",
     "tags": [
       "mongodb",
       "time-series",
@@ -3676,7 +4503,7 @@
       "aggregation"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/mongo-timeseries-match-split-for-pushdown.md",
     "has_content": true
   },
@@ -3685,7 +4512,7 @@
     "name": "mongo-timeseries-view-pushdown-broken-8_2_3",
     "slug": "mongo-timeseries-view-pushdown-broken-8_2_3",
     "category": "pitfall",
-    "description": "On MongoDB 8.2.3, aggregations run against a view whose source is a time-series collection lose the timestamp bucket-index push-down — hot queries must target the base collection directly. Retest after server upgrades.",
+    "description": "\"On MongoDB 8.2.3, aggregations run against a view whose source is a time-series collection lose the timestamp bucket-index push-down — hot queries must target the base collection directly. Retest after server upgrades.\"",
     "tags": [
       "mongodb",
       "time-series",
@@ -3694,7 +4521,7 @@
       "version-specific"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/mongo-timeseries-view-pushdown-broken-8_2_3.md",
     "has_content": true
   },
@@ -3712,7 +4539,7 @@
       "resumetoken"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/mongodb-changestream-resubscribe.md",
     "has_content": true
   },
@@ -3722,9 +4549,15 @@
     "slug": "mongodb-compound-index-on-views",
     "category": "pitfall",
     "description": "Spring Data @CompoundIndex annotations on a view-backed @Document class are silently ignored — the annotation must live on the collection-backed class or the collection stays unindexed.",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "mongodb",
+      "compound",
+      "index",
+      "views"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/mongodb-compound-index-on-views.md",
     "has_content": true
   },
@@ -3743,7 +4576,7 @@
       "lookup"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/mongodb-documentreference-lazy-removal.md",
     "has_content": true
   },
@@ -3753,9 +4586,16 @@
     "slug": "mongodb-field-name-underscore-to-dot",
     "category": "pitfall",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "mongodb",
+      "field",
+      "name",
+      "underscore",
+      "dot"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/mongodb-field-name-underscore-to-dot.md",
     "has_content": true
   },
@@ -3765,9 +4605,15 @@
     "slug": "mongodb-single-node-directconnection",
     "category": "pitfall",
     "description": "MongoDB clients must pass directConnection=true when connecting to a single-node replSet, otherwise they hang on primary discovery",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "mongodb",
+      "single",
+      "node",
+      "directconnection"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/mongodb-single-node-directconnection.md",
     "has_content": true
   },
@@ -3777,9 +4623,16 @@
     "slug": "mongodb-string-id-field-type-mapping",
     "category": "pitfall",
     "description": "Spring Data MongoDB coerces 24-char-hex @Id String values to ObjectId unless @Field(targetType = FieldType.STRING) is set",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "mongodb",
+      "string",
+      "field",
+      "type",
+      "mapping"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/mongodb-string-id-field-type-mapping.md",
     "has_content": true
   },
@@ -3789,12 +4642,9 @@
     "slug": "oauth-implementation-pitfall",
     "category": "pitfall",
     "description": "Common mistakes when building OAuth visualizers and educational tools that misrepresent the protocol",
-    "tags": [
-      "oauth",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/oauth-implementation-pitfall.md",
     "has_content": true
   },
@@ -3804,12 +4654,9 @@
     "slug": "object-storage-implementation-pitfall",
     "category": "pitfall",
     "description": "Common mistakes when modeling object storage semantics in visualizations and simulators",
-    "tags": [
-      "object",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/object-storage-implementation-pitfall.md",
     "has_content": true
   },
@@ -3819,12 +4666,9 @@
     "slug": "outbox-pattern-implementation-pitfall",
     "category": "pitfall",
     "description": "Common outbox implementation failures around ordering, stuck rows, and at-least-once semantics",
-    "tags": [
-      "outbox",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/outbox-pattern-implementation-pitfall.md",
     "has_content": true
   },
@@ -3834,9 +4678,16 @@
     "slug": "oz-license-file-placement-flip-flop",
     "category": "pitfall",
     "description": "Vendor engines (OZ Report, Crystal, Jasper-Pro) often hard-code license file search paths — pin the path in the image and document it, or you will ship it broken repeatedly",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "license",
+      "file",
+      "placement",
+      "flip",
+      "flop"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/oz-license-file-placement-flip-flop.md",
     "has_content": true
   },
@@ -3846,9 +4697,16 @@
     "slug": "page-map-returns-new-instance",
     "category": "pitfall",
     "description": "Spring Data Page는 불변 — Page.map()은 새 인스턴스를 반환하므로 호출 결과를 반드시 재할당해야 한다",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "page",
+      "map",
+      "returns",
+      "new",
+      "instance"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/page-map-returns-new-instance.md",
     "has_content": true
   },
@@ -3858,14 +4716,9 @@
     "slug": "pixel-smooth-style-mismatch",
     "category": "pitfall",
     "description": "Mixing pixel-art character with smooth vector illustration creates jarring visual mismatch — both layers need the same aesthetic",
-    "tags": [
-      "design",
-      "pixel-art",
-      "visual-language",
-      "consistency"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/pixel-smooth-style-mismatch.md",
     "has_content": true
   },
@@ -3875,9 +4728,15 @@
     "slug": "policy-edit-saveraw-loss",
     "category": "pitfall",
     "description": "Editing a common collection policy can silently drop individual `saveRaw`/interval settings if not re-applied",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "policy",
+      "edit",
+      "saveraw",
+      "loss"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/policy-edit-saveraw-loss.md",
     "has_content": true
   },
@@ -3887,13 +4746,30 @@
     "slug": "pub-sub-implementation-pitfall",
     "category": "pitfall",
     "description": "Synchronous in-loop dispatch causes slow subscribers to block publishers and starve fast ones",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/pitfall/pub-sub-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "publish-pipelines-must-rebuild-derived-artifacts",
+    "slug": "publish-pipelines-must-rebuild-derived-artifacts",
+    "category": "pitfall",
+    "description": "A publish flow that commits new source files but doesn't regenerate derived artifacts (flat catalog, search index, registry cache) leaves downstream consumers (search, suggestion, discovery) unable to see the new entries. Every publish pipeline needs an explicit reindex step.",
     "tags": [
-      "pub",
-      "auto-loop"
+      "publish-pipeline",
+      "index",
+      "registry",
+      "derived-artifact",
+      "stale-cache",
+      "search",
+      "silent-failure"
     ],
     "triggers": [],
     "version": "",
-    "path": "knowledge/pitfall/pub-sub-implementation-pitfall.md",
+    "path": "knowledge/pitfall/publish-pipelines-must-rebuild-derived-artifacts.md",
     "has_content": true
   },
   {
@@ -3902,16 +4778,34 @@
     "slug": "python-regex-dotall-spans-java-method-blocks",
     "category": "pitfall",
     "description": "Python re.sub에서 DOTALL + .*? 로 Java 메서드를 batch 편집하면 non-greedy여도 인접 메서드 블록을 건너뛰어 잘못된 위치에 annotation이 삽입된다",
-    "tags": [
-      "python",
-      "regex",
-      "java",
-      "annotation-batch",
-      "swagger-ai-optimization"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/python-regex-dotall-spans-java-method-blocks.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "quorum-visualization-off-by-one",
+    "slug": "quorum-visualization-off-by-one",
+    "category": "pitfall",
+    "description": "Byzantine quorum threshold is ⌊2N/3⌋+1, not ⌈2N/3⌉ — the two diverge at N=3,6,9...",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/pitfall/quorum-visualization-off-by-one.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "quorum-visualization-phantom-partition-tick",
+    "slug": "quorum-visualization-phantom-partition-tick",
+    "category": "pitfall",
+    "description": "Simulated network partitions must gate heartbeat delivery at tick-boundary, not message-enqueue time",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/pitfall/quorum-visualization-phantom-partition-tick.md",
     "has_content": true
   },
   {
@@ -3920,12 +4814,9 @@
     "slug": "raft-consensus-implementation-pitfall",
     "category": "pitfall",
     "description": "Common correctness bugs when modeling or implementing Raft, especially around term handling and commit safety",
-    "tags": [
-      "raft",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/raft-consensus-implementation-pitfall.md",
     "has_content": true
   },
@@ -3935,12 +4826,9 @@
     "slug": "rate-limiter-implementation-pitfall",
     "category": "pitfall",
     "description": "Common correctness bugs in rate limiter algorithms that only surface under specific traffic patterns",
-    "tags": [
-      "rate",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/rate-limiter-implementation-pitfall.md",
     "has_content": true
   },
@@ -3950,12 +4838,9 @@
     "slug": "read-replica-implementation-pitfall",
     "category": "pitfall",
     "description": "Common mistakes when modeling read-replica lag, routing, and consistency guarantees in a simulator",
-    "tags": [
-      "read",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/read-replica-implementation-pitfall.md",
     "has_content": true
   },
@@ -3965,9 +4850,15 @@
     "slug": "refresh-token-do-not-regenerate",
     "category": "pitfall",
     "description": "A refresh call must issue a new ACCESS token only, never a new refresh token.",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "refresh",
+      "token",
+      "not",
+      "regenerate"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/refresh-token-do-not-regenerate.md",
     "has_content": true
   },
@@ -3976,7 +4867,7 @@
     "name": "registry-json-dict-not-list",
     "slug": "registry-json-dict-not-list",
     "category": "pitfall",
-    "description": "skills-hub registry.json stores skills and knowledge as dicts keyed by name, not arrays — list.append() fails silently or throws",
+    "description": "\"skills-hub registry.json stores skills and knowledge as dicts keyed by name, not arrays — list.append() fails silently or throws\"",
     "tags": [
       "registry",
       "json",
@@ -3984,8 +4875,20 @@
       "skills-hub"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/registry-json-dict-not-list.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "replication-factor-distinct-physical-walk",
+    "slug": "replication-factor-distinct-physical-walk",
+    "category": "pitfall",
+    "description": "Walking the ring for N replicas must skip virtual nodes belonging to already-selected physical nodes, not just take the next N vnodes.",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/pitfall/replication-factor-distinct-physical-walk.md",
     "has_content": true
   },
   {
@@ -3994,12 +4897,9 @@
     "slug": "retry-strategy-implementation-pitfall",
     "category": "pitfall",
     "description": "Common failure modes when building retry strategy demos: unbounded growth, jitter miscalculation, and thundering herd blind spots",
-    "tags": [
-      "retry",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/retry-strategy-implementation-pitfall.md",
     "has_content": true
   },
@@ -4009,12 +4909,9 @@
     "slug": "saga-pattern-implementation-pitfall",
     "category": "pitfall",
     "description": "Common saga failures around non-compensatable pivot steps, lost compensations, and non-idempotent retries",
-    "tags": [
-      "saga",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/saga-pattern-implementation-pitfall.md",
     "has_content": true
   },
@@ -4024,12 +4921,9 @@
     "slug": "schema-registry-implementation-pitfall",
     "category": "pitfall",
     "description": "Common mistakes when modeling compatibility checks and version semantics in registry tools",
-    "tags": [
-      "schema",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/schema-registry-implementation-pitfall.md",
     "has_content": true
   },
@@ -4047,7 +4941,7 @@
       "review-gate"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/serial-pipeline-failure-compounding.md",
     "has_content": true
   },
@@ -4057,12 +4951,9 @@
     "slug": "service-mesh-implementation-pitfall",
     "category": "pitfall",
     "description": "Common traps when building service mesh tooling: stale config, identity confusion, and sidecar startup races",
-    "tags": [
-      "service",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/service-mesh-implementation-pitfall.md",
     "has_content": true
   },
@@ -4072,14 +4963,9 @@
     "slug": "shared-repo-sequential-branching",
     "category": "pitfall",
     "description": "Git operations on a shared repo clone must be sequential — parallel branch creation causes working tree conflicts",
-    "tags": [
-      "git",
-      "parallel",
-      "branching",
-      "skills-hub"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/shared-repo-sequential-branching.md",
     "has_content": true
   },
@@ -4089,9 +4975,15 @@
     "slug": "sibling-scoped-name-uniqueness",
     "category": "pitfall",
     "description": "A global unique index on group `name` was present and had to be dropped; uniqueness is correct only within the same parent.",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "sibling",
+      "scoped",
+      "name",
+      "uniqueness"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/sibling-scoped-name-uniqueness.md",
     "has_content": true
   },
@@ -4101,12 +4993,9 @@
     "slug": "sidecar-proxy-implementation-pitfall",
     "category": "pitfall",
     "description": "Common sidecar-proxy modeling mistakes that break the mental model and produce misleading metrics.",
-    "tags": [
-      "sidecar",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/sidecar-proxy-implementation-pitfall.md",
     "has_content": true
   },
@@ -4116,9 +5005,15 @@
     "slug": "simpledateformat-not-thread-safe",
     "category": "pitfall",
     "description": "SimpleDateFormat은 스레드 안전하지 않아 공유 인스턴스 사용 시 포맷 깨짐/예외 발생 — java.time.DateTimeFormatter로 교체",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "simpledateformat",
+      "not",
+      "thread",
+      "safe"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/simpledateformat-not-thread-safe.md",
     "has_content": true
   },
@@ -4128,14 +5023,9 @@
     "slug": "single-keyword-formulaic-llm-output",
     "category": "pitfall",
     "description": "A single-word theme given to an LLM produces formulaic, generic output — evocative 10–20 word phrases unlock variety",
-    "tags": [
-      "llm",
-      "prompt-engineering",
-      "creativity",
-      "theme-design"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/single-keyword-formulaic-llm-output.md",
     "has_content": true
   },
@@ -4144,7 +5034,7 @@
     "name": "skill-md-plus-content-md-body-counting",
     "slug": "skill-md-plus-content-md-body-counting",
     "category": "pitfall",
-    "description": "Heuristic scanners that compute body_lines from SKILL.md alone will flag every frontmatter-only skill (body in content.md) as a perma-stub. Always sum SKILL.md body + content.md body for size-based conditions.",
+    "description": "\"Heuristic scanners that compute body_lines from SKILL.md alone will flag every frontmatter-only skill (body in content.md) as a perma-stub. Always sum SKILL.md body + content.md body for size-based conditions.\"",
     "tags": [
       "skills-hub",
       "body-size",
@@ -4153,7 +5043,7 @@
       "pitfall"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/skill-md-plus-content-md-body-counting.md",
     "has_content": true
   },
@@ -4163,9 +5053,15 @@
     "slug": "skip-schedule-if-previous-running",
     "category": "pitfall",
     "description": "When a periodic tick arrives and the previous execution for the same job is still running, skip the new tick — never queue it.",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "skip",
+      "schedule",
+      "previous",
+      "running"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/skip-schedule-if-previous-running.md",
     "has_content": true
   },
@@ -4175,9 +5071,15 @@
     "slug": "snmp-ifindex-not-stable",
     "category": "pitfall",
     "description": "SNMP `ifIndex` can change across device reboot/reconfig — never use it as a stable identifier",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "snmp",
+      "ifindex",
+      "not",
+      "stable"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/snmp-ifindex-not-stable.md",
     "has_content": true
   },
@@ -4187,9 +5089,16 @@
     "slug": "sonar-token-hardcoded-build-gradle",
     "category": "pitfall",
     "description": "Hardcoded SonarQube login token in build.gradle plus `allowInsecureProtocol = true` on an internal Nexus are two common DevSecOps anti-patterns to fix together",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "sonar",
+      "token",
+      "hardcoded",
+      "build",
+      "gradle"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/sonar-token-hardcoded-build-gradle.md",
     "has_content": true
   },
@@ -4199,9 +5108,14 @@
     "slug": "span-hash-determinism",
     "category": "pitfall",
     "description": "Span-dedup hash must be deterministic and stable; changing the hash definition produces duplicate rows during rollout and poisons historical joins.",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "span",
+      "hash",
+      "determinism"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/span-hash-determinism.md",
     "has_content": true
   },
@@ -4219,7 +5133,7 @@
       "undefined-behavior"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/span-lifetime-safety-documentation.md",
     "has_content": true
   },
@@ -4229,9 +5143,15 @@
     "slug": "spec-excluded-from-jest",
     "category": "pitfall",
     "description": ".spec.ts files are excluded from the Jest runner in this project — only .test.ts is discovered",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "spec",
+      "excluded",
+      "from",
+      "jest"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/spec-excluded-from-jest.md",
     "has_content": true
   },
@@ -4241,15 +5161,9 @@
     "slug": "springdoc-dto-schema-orphan-when-unexposed",
     "category": "pitfall",
     "description": "springdoc는 컨트롤러 시그니처를 walk하므로 ApiResponseData<Object> 반환 DTO에 달린 @Schema·x-lookup은 스펙에 반영되지 않는다",
-    "tags": [
-      "springdoc",
-      "openapi",
-      "java",
-      "schema",
-      "swagger-ai-optimization"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/springdoc-dto-schema-orphan-when-unexposed.md",
     "has_content": true
   },
@@ -4259,9 +5173,15 @@
     "slug": "sql-hash-unsigned-integer",
     "category": "pitfall",
     "description": "MySQL/MariaDB SQL digest hashes fit in an unsigned 32-bit range but arrive as signed Java int — negatives are legal and must not be dropped",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "sql",
+      "hash",
+      "unsigned",
+      "integer"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/sql-hash-unsigned-integer.md",
     "has_content": true
   },
@@ -4271,9 +5191,16 @@
     "slug": "sql-text-null-check-session-history-consistency",
     "category": "pitfall",
     "description": "Session history rows must omit sqlHash and queryTime when SQL text is missing, else they orphan in downstream joins",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "sql",
+      "text",
+      "null",
+      "check",
+      "session"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/sql-text-null-check-session-history-consistency.md",
     "has_content": true
   },
@@ -4283,9 +5210,15 @@
     "slug": "sqlserver-sqltextinfo-index-constraint",
     "category": "pitfall",
     "description": "Do not put a unique index on sqlHash for SQL Server text-info collection — duplicates are legitimate",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "sqlserver",
+      "sqltextinfo",
+      "index",
+      "constraint"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/sqlserver-sqltextinfo-index-constraint.md",
     "has_content": true
   },
@@ -4295,9 +5228,16 @@
     "slug": "static-value-injection-race-condition",
     "category": "pitfall",
     "description": "static 필드에 @Value 주입은 setter 호출 타이밍과 멀티스레드 가시성으로 레이스 컨디션을 유발 — 인스턴스 필드로 직접 주입하라",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "static",
+      "value",
+      "injection",
+      "race",
+      "condition"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/static-value-injection-race-condition.md",
     "has_content": true
   },
@@ -4307,12 +5247,9 @@
     "slug": "strangler-fig-implementation-pitfall",
     "category": "pitfall",
     "description": "Common failure modes when building strangler-fig migration tooling: premature legacy retirement, shadow drift, dependency blindness",
-    "tags": [
-      "strangler",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/strangler-fig-implementation-pitfall.md",
     "has_content": true
   },
@@ -4321,7 +5258,7 @@
     "name": "subagent-permission-denial-fallback",
     "slug": "subagent-permission-denial-fallback",
     "category": "pitfall",
-    "description": "Claude Code subagents (Agent tool) cannot obtain Write/Bash permissions independently — if user hasn't pre-granted them, all 3 agents fail and you must build directly",
+    "description": "\"Claude Code subagents (Agent tool) cannot obtain Write/Bash permissions independently — if user hasn't pre-granted them, all 3 agents fail and you must build directly\"",
     "tags": [
       "claude-code",
       "subagent",
@@ -4330,8 +5267,28 @@
       "parallel"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/subagent-permission-denial-fallback.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "subagent-scan-results-need-sanity-check",
+    "slug": "subagent-scan-results-need-sanity-check",
+    "category": "pitfall",
+    "description": "Explore subagent scans can silently return garbage — duplicated metrics, zero-line false positives, empty arrays — while reporting \"success.\" Always embed a self-verification step in the brief and gate on its output before acting.",
+    "tags": [
+      "claude-code",
+      "subagent",
+      "explore",
+      "scan",
+      "verification",
+      "silent-failure",
+      "heuristic"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/subagent-scan-results-need-sanity-check.md",
     "has_content": true
   },
   {
@@ -4340,9 +5297,16 @@
     "slug": "tailwind-mfa-css-isolation-pitfalls",
     "category": "pitfall",
     "description": "CSS isolation failures when using Tailwind CSS in Module Federation — preflight leaks, portal scope loss, postcss-prefix-selector parse errors",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "tailwind",
+      "mfa",
+      "css",
+      "isolation",
+      "pitfalls"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/tailwind-mfa-css-isolation-pitfalls.md",
     "has_content": true
   },
@@ -4352,9 +5316,16 @@
     "slug": "tenant-context-clear-after-completion",
     "category": "pitfall",
     "description": "Multi-tenant thread-locals must be cleared in a HandlerInterceptor `afterCompletion`, regardless of request outcome",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "tenant",
+      "context",
+      "clear",
+      "after",
+      "completion"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/tenant-context-clear-after-completion.md",
     "has_content": true
   },
@@ -4364,9 +5335,16 @@
     "slug": "tenant-flag-over-name-detection",
     "category": "pitfall",
     "description": "Identify special/system tenants by a boolean flag on the entity, never by matching on name.",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "tenant",
+      "flag",
+      "over",
+      "name",
+      "detection"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/tenant-flag-over-name-detection.md",
     "has_content": true
   },
@@ -4376,9 +5354,15 @@
     "slug": "testcontainers-springboot-cache-conflict",
     "category": "pitfall",
     "description": "@Testcontainers + @SpringBootTest 컨텍스트 캐싱 충돌 — @DynamicPropertySource + static start() 패턴으로 대체",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "testcontainers",
+      "springboot",
+      "cache",
+      "conflict"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/testcontainers-springboot-cache-conflict.md",
     "has_content": true
   },
@@ -4388,12 +5372,9 @@
     "slug": "time-series-db-implementation-pitfall",
     "category": "pitfall",
     "description": "TSDB tools frequently corrupt their own UX by misusing timestamp precision, time zones, and rollup boundaries.",
-    "tags": [
-      "time",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/time-series-db-implementation-pitfall.md",
     "has_content": true
   },
@@ -4403,10 +5384,27 @@
     "slug": "time-unit-consistency-us-ms-ns",
     "category": "pitfall",
     "description": "Mixed time units (ns/μs/ms) across OTLP ingestion, storage, filters, and UI are a recurring high-severity bug class — pick one canonical internal unit and convert only at edges.",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "time",
+      "unit",
+      "consistency"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/time-unit-consistency-us-ms-ns.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "token-range-ownership-requires-wrap-around-arc",
+    "slug": "token-range-ownership-requires-wrap-around-arc",
+    "category": "pitfall",
+    "description": "Token ranges on a hash ring are arcs, not intervals — the last vnode owns the arc that wraps past 2^32 back to the first.",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/pitfall/token-range-ownership-requires-wrap-around-arc.md",
     "has_content": true
   },
   {
@@ -4415,9 +5413,16 @@
     "slug": "top-bottom-widest-collection-range",
     "category": "pitfall",
     "description": "For Top/Bottom selection queries, pick the collection whose bin granularity covers the widest range, not the finest-grained one",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "top",
+      "bottom",
+      "widest",
+      "collection",
+      "range"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/top-bottom-widest-collection-range.md",
     "has_content": true
   },
@@ -4427,9 +5432,15 @@
     "slug": "topn-unwind-match-to-filter",
     "category": "pitfall",
     "description": "TopN Mongo pipeline using `$unwind`+`$match` explodes documents; push predicate into `$filter` first",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "topn",
+      "unwind",
+      "match",
+      "filter"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/topn-unwind-match-to-filter.md",
     "has_content": true
   },
@@ -4447,7 +5458,7 @@
       "scouter"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/trace-context-async-execution-propagation.md",
     "has_content": true
   },
@@ -4457,9 +5468,16 @@
     "slug": "traefik-2.11-requires-explicit-idletimeout",
     "category": "pitfall",
     "description": "Traefik 2.11 silently drops idle backend connections without an explicit idleTimeout on the entrypoint/serversTransport",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "traefik",
+      "2.11",
+      "requires",
+      "explicit",
+      "idletimeout"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/traefik-2.11-requires-explicit-idletimeout.md",
     "has_content": true
   },
@@ -4469,9 +5487,16 @@
     "slug": "udp-receiver-needs-large-socket-buffer",
     "category": "pitfall",
     "description": "UDP collectors behind Traefik/containers must raise SO_RCVBUF well above the 8KB default or drop packets under burst load",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "udp",
+      "receiver",
+      "needs",
+      "large",
+      "socket"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/udp-receiver-needs-large-socket-buffer.md",
     "has_content": true
   },
@@ -4488,7 +5513,7 @@
       "observability"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/unit-enum-silent-filter.md",
     "has_content": true
   },
@@ -4497,7 +5522,7 @@
     "name": "user-sql-source-requires-select-only-and-readonly",
     "slug": "user-sql-source-requires-select-only-and-readonly",
     "category": "pitfall",
-    "description": "When a feature lets end-users paste raw SQL for display, no single guard is enough — layer four defenses: SELECT-only keyword allow-list, token-aware destructive-keyword blocklist, JDBC `setReadOnly(true)`, and `setQueryTimeout` + `setMaxRows` caps.",
+    "description": "\"When a feature lets end-users paste raw SQL for display, no single guard is enough — layer four defenses: SELECT-only keyword allow-list, token-aware destructive-keyword blocklist, JDBC `setReadOnly(true)`, and `setQueryTimeout` + `setMaxRows` caps.\"",
     "tags": [
       "security",
       "jdbc",
@@ -4505,7 +5530,7 @@
       "data-source"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/user-sql-source-requires-select-only-and-readonly.md",
     "has_content": true
   },
@@ -4515,12 +5540,9 @@
     "slug": "websocket-implementation-pitfall",
     "category": "pitfall",
     "description": "Common WebSocket mistakes: missing masking, ignored close codes, no heartbeat, reconnect storms",
-    "tags": [
-      "websocket",
-      "auto-loop"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/websocket-implementation-pitfall.md",
     "has_content": true
   },
@@ -4530,10 +5552,29 @@
     "slug": "widget-high-prop-count-debt",
     "category": "pitfall",
     "description": "Dashboard CardChart components accumulate 100+ props making them hard to maintain, version, and test — known tech debt with no current mitigation",
-    "tags": [],
+    "tags": [
+      "pitfall",
+      "widget",
+      "high",
+      "prop",
+      "count",
+      "debt"
+    ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/widget-high-prop-count-debt.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "windows-crlf-git-show-extraction",
+    "slug": "windows-crlf-git-show-extraction",
+    "category": "pitfall",
+    "description": "git show on Windows outputs LF while working tree has CRLF, causing false diffs on all extracted files",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/pitfall/windows-crlf-git-show-extraction.md",
     "has_content": true
   },
   {
@@ -4541,7 +5582,7 @@
     "name": "windows-python-utf8-explicit",
     "slug": "windows-python-utf8-explicit",
     "category": "pitfall",
-    "description": "On Windows, Python defaults to cp949/cp1252 locale encoding — all file I/O on UTF-8 content (JSON with em-dashes, CJK text) must specify encoding='utf-8' explicitly",
+    "description": "\"On Windows, Python defaults to cp949/cp1252 locale encoding — all file I/O on UTF-8 content (JSON with em-dashes, CJK text) must specify encoding='utf-8' explicitly\"",
     "tags": [
       "windows",
       "python",
@@ -4550,7 +5591,7 @@
       "cp949"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/windows-python-utf8-explicit.md",
     "has_content": true
   },
@@ -4579,7 +5620,7 @@
     "name": "yaml-block-scalar-frontmatter-parsing",
     "slug": "yaml-block-scalar-frontmatter-parsing",
     "category": "pitfall",
-    "description": "Regex-based frontmatter parsers that treat every `key: value` line as a scalar will collapse `description: |` (YAML block scalar) to the single character `|`, causing downstream metadata-empty heuristics to over-fire on fully-written entries.",
+    "description": "\"Regex-based frontmatter parsers that treat every `key: value` line as a scalar will collapse `description: |` (YAML block scalar) to the single character `|`, causing downstream metadata-empty heuristics to over-fire on fully-written entries.\"",
     "tags": [
       "yaml",
       "frontmatter",
@@ -4588,8 +5629,20 @@
       "pitfall"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/yaml-block-scalar-frontmatter-parsing.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "vector-clock-ui-dominance-tri-state-color",
+    "slug": "vector-clock-ui-dominance-tri-state-color",
+    "category": "reference",
+    "description": "Render vector-clock comparisons as a three-state (before/after/concurrent) badge, never a boolean.",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/reference/vector-clock-ui-dominance-tri-state-color.md",
     "has_content": true
   },
   {
@@ -4598,496 +5651,35 @@
     "slug": "batch-pr-conflict-recovery",
     "category": "workflow",
     "description": "When N auto-generated PRs all touch the same catalog file and serially conflict, close them all and batch-cherry-pick the content into one PR",
-    "tags": [
-      "git",
-      "github",
-      "automation",
-      "conflict-resolution"
-    ],
+    "tags": "",
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/workflow/batch-pr-conflict-recovery.md",
     "has_content": true
   },
   {
-    "kind": "skill",
-    "name": "autoplan",
-    "slug": "autoplan",
-    "category": "",
-    "description": "|",
-    "tags": [],
+    "kind": "knowledge",
+    "name": "dropin-module-reality-check-before-wire",
+    "slug": "dropin-module-reality-check-before-wire",
+    "category": "workflow",
+    "description": "Before wiring a drop-in module into a target project, map every path/marker/regex in the module to what the target actually stores on disk — the module's README describes its author's assumed layout, not yours.",
+    "tags": "",
     "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/autoplan",
-    "has_content": false
+    "version": "0.1.0-draft",
+    "path": "knowledge/workflow/dropin-module-reality-check-before-wire.md",
+    "has_content": true
   },
   {
-    "kind": "skill",
-    "name": "benchmark",
-    "slug": "benchmark",
-    "category": "",
-    "description": "|",
-    "tags": [],
+    "kind": "knowledge",
+    "name": "repeated-look-again-means-retract-not-escalate",
+    "slug": "repeated-look-again-means-retract-not-escalate",
+    "category": "workflow",
+    "description": "Repeated \"look again\" from the user after multiple findings is a signal to retract over-reaching claims, not to propose more findings.",
+    "tags": "",
     "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/benchmark",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "browse",
-    "slug": "browse",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.1.0",
-    "path": "skills/cli/gstack/browse",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "canary",
-    "slug": "canary",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/canary",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "careful",
-    "slug": "careful",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0",
-    "path": "skills/cli/gstack/careful",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "checkpoint",
-    "slug": "checkpoint",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/checkpoint",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "codex",
-    "slug": "codex",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/codex",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "cso",
-    "slug": "cso",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "2.0.0",
-    "path": "skills/cli/gstack/cso",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "design-consultation",
-    "slug": "design-consultation",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/design-consultation",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "design-html",
-    "slug": "design-html",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/design-html",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "design-review",
-    "slug": "design-review",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "2.0.0",
-    "path": "skills/cli/gstack/design-review",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "design-shotgun",
-    "slug": "design-shotgun",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/design-shotgun",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "devex-review",
-    "slug": "devex-review",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/devex-review",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "document-release",
-    "slug": "document-release",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/document-release",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "freeze",
-    "slug": "freeze",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0",
-    "path": "skills/cli/gstack/freeze",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "gstack-openclaw-ceo-review",
-    "slug": "gstack-openclaw-ceo-review",
-    "category": "",
-    "description": "CEO/founder-mode plan review. Rethink the problem, find the 10-star product, challenge premises, expand scope when it creates a better product. Four modes: SCOPE EXPANSION (dream big), SELECTIVE EXPANSION (hold scope + cherry-pick), HOLD SCOPE (maximum rigor), SCOPE REDUCTION (strip to essentials). Use when asked to review a plan, challenge this, CEO review, poke holes, think bigger, or expand scope.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/openclaw/skills/gstack-openclaw-ceo-review",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "gstack-openclaw-investigate",
-    "slug": "gstack-openclaw-investigate",
-    "category": "",
-    "description": "Systematic debugging with root cause investigation. Four phases: investigate, analyze, hypothesize, implement. Iron Law: no fixes without root cause. Use when asked to debug, fix a bug, investigate an error, or root cause analysis. Proactively use when user reports errors, stack traces, unexpected behavior, or says something stopped working.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/openclaw/skills/gstack-openclaw-investigate",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "gstack-openclaw-office-hours",
-    "slug": "gstack-openclaw-office-hours",
-    "category": "",
-    "description": "Product interrogation with six forcing questions. Two modes: startup diagnostic (demand reality, status quo, desperate specificity, narrowest wedge, observation, future-fit) and builder brainstorm. Use when asked to brainstorm, \"is this worth building\", \"I have an idea\", \"office hours\", or \"help me think through this\". Proactively use when user describes a new product idea or wants to think through design decisions before any code is written.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/openclaw/skills/gstack-openclaw-office-hours",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "gstack-openclaw-retro",
-    "slug": "gstack-openclaw-retro",
-    "category": "",
-    "description": "Weekly engineering retrospective. Analyzes commit history, work patterns, and code quality metrics with persistent history and trend tracking. Team-aware with per-person contributions, praise, and growth areas. Use when asked for weekly retro, what shipped this week, or engineering retrospective.",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/openclaw/skills/gstack-openclaw-retro",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "gstack-upgrade",
-    "slug": "gstack-upgrade",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.1.0",
-    "path": "skills/cli/gstack/gstack-upgrade",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "guard",
-    "slug": "guard",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0",
-    "path": "skills/cli/gstack/guard",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "health",
-    "slug": "health",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/health",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "investigate",
-    "slug": "investigate",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/investigate",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "land-and-deploy",
-    "slug": "land-and-deploy",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/land-and-deploy",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "learn",
-    "slug": "learn",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/learn",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "office-hours",
-    "slug": "office-hours",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "2.0.0",
-    "path": "skills/cli/gstack/office-hours",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "open-gstack-browser",
-    "slug": "open-gstack-browser",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "0.2.0",
-    "path": "skills/cli/gstack/open-gstack-browser",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "pair-agent",
-    "slug": "pair-agent",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0",
-    "path": "skills/cli/gstack/pair-agent",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "plan-ceo-review",
-    "slug": "plan-ceo-review",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/plan-ceo-review",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "plan-design-review",
-    "slug": "plan-design-review",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "2.0.0",
-    "path": "skills/cli/gstack/plan-design-review",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "plan-devex-review",
-    "slug": "plan-devex-review",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "2.0.0",
-    "path": "skills/cli/gstack/plan-devex-review",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "plan-eng-review",
-    "slug": "plan-eng-review",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/plan-eng-review",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "qa",
-    "slug": "qa",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "2.0.0",
-    "path": "skills/cli/gstack/qa",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "qa-only",
-    "slug": "qa-only",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/qa-only",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "retro",
-    "slug": "retro",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "2.0.0",
-    "path": "skills/cli/gstack/retro",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "review",
-    "slug": "review",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/review",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "setup-browser-cookies",
-    "slug": "setup-browser-cookies",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/setup-browser-cookies",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "setup-deploy",
-    "slug": "setup-deploy",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/setup-deploy",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "ship",
-    "slug": "ship",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/cli/gstack/ship",
-    "has_content": false
-  },
-  {
-    "kind": "skill",
-    "name": "unfreeze",
-    "slug": "unfreeze",
-    "category": "",
-    "description": "|",
-    "tags": [],
-    "triggers": [],
-    "version": "0.1.0",
-    "path": "skills/cli/gstack/unfreeze",
-    "has_content": false
+    "version": "0.1.0-draft",
+    "path": "knowledge/workflow/repeated-look-again-means-retract-not-escalate.md",
+    "has_content": true
   },
   {
     "kind": "skill",
@@ -5200,11 +5792,28 @@
   },
   {
     "kind": "skill",
+    "name": "claude-cli-subprocess-adapter",
+    "slug": "claude-cli-subprocess-adapter",
+    "category": "ai",
+    "description": "Embed Claude inference in a zero-dep Node.js tool by spawning `claude -p` as a subprocess with a stdin-piped prompt, `--output-format text`, and a timeout guard.",
+    "tags": "",
+    "triggers": "",
+    "version": "0.1.0-draft",
+    "path": "skills/ai/claude-cli-subprocess-adapter",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "codex",
     "slug": "codex",
     "category": "ai",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "ai",
+      "codex",
+      "openai",
+      "cli"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/ai/codex",
@@ -5248,12 +5857,7 @@
       "json-rpc",
       "tool-design"
     ],
-    "triggers": [
-      "refresh prompts",
-      "update mcp prompts at runtime",
-      "prompts list_changed",
-      "mcp hot reload"
-    ],
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/ai/mcp-runtime-prompt-refresh",
     "has_content": true
@@ -5271,12 +5875,7 @@
       "schema",
       "json-schema"
     ],
-    "triggers": [
-      "openapi to mcp",
-      "swagger to mcp",
-      "generate mcp tools",
-      "tag based tool grouping"
-    ],
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/ai/openapi-to-mcp-tag-grouping",
     "has_content": true
@@ -5287,7 +5886,11 @@
     "slug": "pair-agent",
     "category": "ai",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "ai",
+      "agent",
+      "pair-programming"
+    ],
     "triggers": [],
     "version": "0.1.0",
     "path": "skills/ai/pair-agent",
@@ -5326,11 +5929,37 @@
     "slug": "vllm-nginx-tls-single-port-routing",
     "category": "ai",
     "description": "Serve multiple vLLM OpenAI-API backends behind one Nginx TLS proxy on 443 using path-based routing",
-    "tags": [],
+    "tags": [
+      "vllm",
+      "nginx",
+      "tls",
+      "single",
+      "port",
+      "routing"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/ai/vllm-nginx-tls-single-port-routing",
     "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "canvas-flowfield-particle-advection",
+    "slug": "canvas-flowfield-particle-advection",
+    "category": "algorithms",
+    "description": "Render drifting \"currents\" by advecting particles through a cached noise-based vector field with trail fade.",
+    "tags": [
+      "algorithms",
+      "canvas",
+      "flowfield",
+      "particle",
+      "advection",
+      "cache"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/algorithms/canvas-flowfield-particle-advection",
+    "has_content": false
   },
   {
     "kind": "skill",
@@ -5339,13 +5968,53 @@
     "category": "algorithms",
     "description": "Derive a normalized movement vector from any clicked grid cell via `Math.sign(target-current)` on each axis — one click handler covers all 8 directions.",
     "tags": [
-      "auto-loop"
+      "algorithms",
+      "click",
+      "relative",
+      "direction",
+      "sign"
     ],
-    "triggers": [
-      "click to relative direction sign"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/algorithms/click-to-relative-direction-sign",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "concurrent-edit-merge-arbitration-table",
+    "slug": "concurrent-edit-merge-arbitration-table",
+    "category": "algorithms",
+    "description": "Resolve concurrent replica writes via a deterministic tie-breaker table keyed on causal-compare results plus a stable replica priority.",
+    "tags": [
+      "algorithms",
+      "concurrent",
+      "edit",
+      "merge",
+      "arbitration",
+      "table"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/algorithms/concurrent-edit-merge-arbitration-table",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "consistent-hash-ring-virtual-node-placement",
+    "slug": "consistent-hash-ring-virtual-node-placement",
+    "category": "algorithms",
+    "description": "Place virtual nodes on a hash ring using salted hashes to smooth load distribution across physical shards.",
+    "tags": [
+      "algorithms",
+      "consistent",
+      "hash",
+      "ring",
+      "virtual",
+      "node"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/algorithms/consistent-hash-ring-virtual-node-placement",
     "has_content": false
   },
   {
@@ -5355,13 +6024,183 @@
     "category": "algorithms",
     "description": "Deterministically turn any user text into repeatable procedural layouts using FNV-1a + xorshift32.",
     "tags": [
-      "auto-loop"
+      "algorithms",
+      "fnv1a",
+      "xorshift",
+      "text",
+      "procedural",
+      "seed"
     ],
-    "triggers": [
-      "fnv1a xorshift text to procedural seed"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/algorithms/fnv1a-xorshift-text-to-procedural-seed",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "gossip-round-rng-seeded-reproducible-sim",
+    "slug": "gossip-round-rng-seeded-reproducible-sim",
+    "category": "algorithms",
+    "description": "Seed a PRNG per gossip round so randomized peer selection is reproducible across replays and snapshots.",
+    "tags": [
+      "algorithms",
+      "gossip",
+      "round",
+      "rng",
+      "seeded",
+      "reproducible"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/algorithms/gossip-round-rng-seeded-reproducible-sim",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "hybrid-logical-clock-merge",
+    "slug": "hybrid-logical-clock-merge",
+    "category": "algorithms",
+    "description": "Merge wall-clock time with logical counter to get monotonic timestamps that survive clock skew and concurrent events.",
+    "tags": [
+      "algorithms",
+      "hybrid",
+      "logical",
+      "clock",
+      "merge"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/algorithms/hybrid-logical-clock-merge",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "lease-epoch-fencing-token-monotonic-guard",
+    "slug": "lease-epoch-fencing-token-monotonic-guard",
+    "category": "algorithms",
+    "description": "Reject stale leader writes using a monotonic epoch/fencing token rather than just liveness checks",
+    "tags": [
+      "algorithms",
+      "lease",
+      "epoch",
+      "fencing",
+      "token",
+      "monotonic"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/algorithms/lease-epoch-fencing-token-monotonic-guard",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "minimal-key-movement-rebalance-diff",
+    "slug": "minimal-key-movement-rebalance-diff",
+    "category": "algorithms",
+    "description": "Compute the set of keys that must move when a shard is added/removed by diffing ring ownership before and after.",
+    "tags": [
+      "algorithms",
+      "minimal",
+      "key",
+      "movement",
+      "rebalance",
+      "diff"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/algorithms/minimal-key-movement-rebalance-diff",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "rolling-hash-chunk-boundary-detector",
+    "slug": "rolling-hash-chunk-boundary-detector",
+    "category": "algorithms",
+    "description": "Use content-defined chunking via rolling hash to produce stable segment boundaries across divergent replicas before diffing.",
+    "tags": [
+      "algorithms",
+      "rolling",
+      "hash",
+      "chunk",
+      "boundary",
+      "detector"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/algorithms/rolling-hash-chunk-boundary-detector",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "segment-sealed-immutable-with-sparse-offset-index",
+    "slug": "segment-sealed-immutable-with-sparse-offset-index",
+    "category": "algorithms",
+    "description": "Append-only segments become immutable when sealed, with a sparse offset index built at seal time for O(log n) lookup without scanning.",
+    "tags": [
+      "algorithms",
+      "segment",
+      "sealed",
+      "immutable",
+      "sparse",
+      "offset"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/algorithms/segment-sealed-immutable-with-sparse-offset-index",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "tombstone-horizon-with-snapshot-pinned-retention",
+    "slug": "tombstone-horizon-with-snapshot-pinned-retention",
+    "category": "algorithms",
+    "description": "Tombstones can only be GC'd once no snapshot or reader lease still needs them, tracked via a monotonic horizon watermark.",
+    "tags": [
+      "algorithms",
+      "tombstone",
+      "horizon",
+      "snapshot",
+      "pinned",
+      "retention"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/algorithms/tombstone-horizon-with-snapshot-pinned-retention",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "watermark-aligned-window-emitter",
+    "slug": "watermark-aligned-window-emitter",
+    "category": "algorithms",
+    "description": "Emit windowed aggregates only when the minimum watermark across all input partitions advances past the window close edge.",
+    "tags": [
+      "algorithms",
+      "watermark",
+      "aligned",
+      "window",
+      "emitter"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/algorithms/watermark-aligned-window-emitter",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "webaudio-whalesong-fm-drone",
+    "slug": "webaudio-whalesong-fm-drone",
+    "category": "algorithms",
+    "description": "Synthesize whale-song-like drones via low-frequency FM with slow pitch glides and amplitude swells in WebAudio.",
+    "tags": [
+      "algorithms",
+      "webaudio",
+      "whalesong",
+      "drone"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/algorithms/webaudio-whalesong-fm-drone",
     "has_content": false
   },
   {
@@ -5469,13 +6308,7 @@
       "concurrenthashmap",
       "performance"
     ],
-    "triggers": [
-      "static helper cache",
-      "ConcurrentHashMap static cache",
-      "PostConstruct populate static map",
-      "definition helper lookup",
-      "zero allocation hot path cache"
-    ],
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/arch/definition-registry-helper-cache",
     "has_content": false
@@ -5514,11 +6347,13 @@
     "category": "arch",
     "description": "State reducer that returns `{state, events, done}` so UI layer renders new state and appends to a log in one pass without the reducer touching DOM.",
     "tags": [
-      "auto-loop"
+      "arch",
+      "event",
+      "returning",
+      "pure",
+      "reducer"
     ],
-    "triggers": [
-      "event returning pure reducer"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/arch/event-returning-pure-reducer",
     "has_content": false
@@ -5556,7 +6391,14 @@
     "slug": "gradle-bootjar-conditional-archive-bundle",
     "category": "arch",
     "description": "Gradle Spring Boot build that conditionally bundles the fat JAR plus externalized resources into a dated zip/tar for on-prem delivery, gated by a flag",
-    "tags": [],
+    "tags": [
+      "arch",
+      "gradle",
+      "bootjar",
+      "conditional",
+      "archive",
+      "bundle"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/arch/gradle-bootjar-conditional-archive-bundle",
@@ -5568,21 +6410,8 @@
     "slug": "immutable-action-event-log",
     "category": "arch",
     "description": "Model state transitions as `(state, action) → (newState, List<Event>)` where the event list is an append-only, serializable log. Enables deterministic replay, audit trails, cheat detection, and UI choreography without coupling engine to presentation.",
-    "tags": [
-      "event-sourcing",
-      "immutable-state",
-      "action-log",
-      "deterministic",
-      "replay",
-      "audit"
-    ],
-    "triggers": [
-      "action result log",
-      "state transition events",
-      "replay log",
-      "deterministic engine",
-      "audit trail events"
-    ],
+    "tags": "",
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/arch/immutable-action-event-log",
     "has_content": true
@@ -5593,7 +6422,14 @@
     "slug": "kafka-avro-topic-auto-create-config",
     "category": "arch",
     "description": "Spring Boot Kafka config bean that auto-creates topics on startup via ApplicationRunner, with Avro serde, manual-ack listener, and bounded concurrency",
-    "tags": [],
+    "tags": [
+      "arch",
+      "kafka",
+      "avro",
+      "topic",
+      "auto",
+      "create"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/arch/kafka-avro-topic-auto-create-config",
@@ -5605,7 +6441,14 @@
     "slug": "kafka-engine-distributed-job-framework",
     "category": "arch",
     "description": "Kafka 이벤트 기반 분산 작업 실행 프레임워크 스켈레톤 — Publisher→Topic→Consumer→Queue→Worker + Admission Control + Strategy SPI",
-    "tags": [],
+    "tags": [
+      "arch",
+      "kafka",
+      "engine",
+      "distributed",
+      "job",
+      "framework"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/arch/kafka-engine-distributed-job-framework",
@@ -5672,7 +6515,13 @@
     "slug": "optional-outbound-adapter-no-op-port",
     "category": "arch",
     "description": "Register a No-Op implementation of an optional outbound port with @ConditionalOnMissingBean so services boot when the real adapter (Kafka audit, tracing, notifications) is absent.",
-    "tags": [],
+    "tags": [
+      "arch",
+      "optional",
+      "outbound",
+      "adapter",
+      "port"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/arch/optional-outbound-adapter-no-op-port",
@@ -5684,7 +6533,13 @@
     "slug": "pluggable-sender-factory-pattern",
     "category": "arch",
     "description": "Register multiple notification/transport backends (SMS, EMAIL, SMTP, JDBC, REST, SLACK, SOCKET) behind a single FactoryBean that dispatches by enum type",
-    "tags": [],
+    "tags": [
+      "arch",
+      "pluggable",
+      "sender",
+      "factory",
+      "pattern"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/arch/pluggable-sender-factory-pattern",
@@ -5696,11 +6551,14 @@
     "slug": "plugin-resource-provider-architecture",
     "category": "arch",
     "description": "Stable `ResourceProvider` SPI loaded via Spring component scan; each new device/resource type is a separate Gradle-module JAR packaged into the WAR — zero core edits",
-    "tags": [],
-    "triggers": [
-      "extensible monitoring/management platform",
-      "vendor support must be pluggable per deployment"
+    "tags": [
+      "arch",
+      "plugin",
+      "resource",
+      "provider",
+      "architecture"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/arch/plugin-resource-provider-architecture",
     "has_content": true
@@ -5718,12 +6576,7 @@
       "interface",
       "component"
     ],
-    "triggers": [
-      "plugin registry",
-      "provider lookup by type",
-      "auto-discovered handlers",
-      "resource provider pattern"
-    ],
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/arch/resource-provider-registry",
     "has_content": false
@@ -5743,14 +6596,7 @@
       "widget",
       "summary"
     ],
-    "triggers": [
-      "resource summary",
-      "리소스 요약",
-      "resolve override template",
-      "dashboard override",
-      "resourceSummary",
-      "composition override"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/arch/resource-summary-resolve-override-template",
     "has_content": false
@@ -5786,11 +6632,15 @@
     "slug": "site-per-customer-override-modules",
     "category": "arch",
     "description": "One Gradle module per customer (`<product>-site-<customer>`) overrides core beans, auth, notification channels, and assets — keeps core customer-agnostic and scales to dozens of deployments",
-    "tags": [],
-    "triggers": [
-      "B2B product delivered to many customers with bespoke requirements",
-      "feature-flag soup is polluting core"
+    "tags": [
+      "arch",
+      "site",
+      "per",
+      "customer",
+      "override",
+      "modules"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/arch/site-per-customer-override-modules",
     "has_content": true
@@ -5808,13 +6658,7 @@
       "mongodb",
       "isolation"
     ],
-    "triggers": [
-      "TenantContextHolder",
-      "tenant context propagation",
-      "multi-tenant thread local",
-      "MONGODB_TEMPLATE_ISOLATION",
-      "tenant isolation mongodb"
-    ],
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/arch/tenant-context-holder-propagation",
     "has_content": false
@@ -5853,7 +6697,14 @@
     "slug": "audit-change-data-capture-pattern",
     "category": "backend",
     "description": "Compute before/after diffs for audit logs by comparing two BSON/JSON documents field-by-field — always iterate the BEFORE doc and read from AFTER to avoid prev/after swap bugs",
-    "tags": [],
+    "tags": [
+      "backend",
+      "audit",
+      "change",
+      "data",
+      "capture",
+      "pattern"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/audit-change-data-capture-pattern",
@@ -5865,7 +6716,13 @@
     "slug": "availability-ttl-punctuate-processor",
     "category": "backend",
     "description": "Kafka Streams processor schedules a wall-clock `punctuate` for TTL eviction of the state store, and emits downstream only on value change. Wall-clock (not stream-time) so idle inputs still trigger cleanup.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "availability",
+      "ttl",
+      "punctuate",
+      "processor"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/availability-ttl-punctuate-processor",
@@ -5877,7 +6734,13 @@
     "slug": "avro-event-with-change-flags",
     "category": "backend",
     "description": "Design Kafka Avro event schemas that carry an actionType enum plus boolean \"changed\" flags per mutable section so consumers can branch cheaply without diffing payloads.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "avro",
+      "event",
+      "change",
+      "flags"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/avro-event-change-flags",
@@ -5889,7 +6752,14 @@
     "slug": "avro-gradle-kafka-schema-pipeline",
     "category": "backend",
     "description": "Wire the davidmc24 Avro Gradle plugin so .avsc schemas generate Java sources consumed by Kafka producers/consumers with Confluent Schema Registry",
-    "tags": [],
+    "tags": [
+      "backend",
+      "avro",
+      "gradle",
+      "kafka",
+      "schema",
+      "pipeline"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/avro-gradle-kafka-schema-pipeline",
@@ -5901,17 +6771,35 @@
     "slug": "axios-token-refresh-queue",
     "category": "backend",
     "description": "Axios interceptor with window-scoped request queue during JWT token refresh to prevent concurrent refresh races",
-    "tags": [],
-    "triggers": [
-      "token refresh",
-      "axios interceptor",
-      "jwt refresh",
-      "401 retry",
-      "authentication interceptor"
+    "tags": [
+      "backend",
+      "axios",
+      "token",
+      "refresh",
+      "queue"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/backend/axios-token-refresh-queue",
     "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "barrier-alignment-buffer-spill",
+    "slug": "barrier-alignment-buffer-spill",
+    "category": "backend",
+    "description": "Buffer post-barrier records from fast channels while waiting for slow channels, spilling to disk when buffer exceeds threshold.",
+    "tags": [
+      "backend",
+      "barrier",
+      "alignment",
+      "buffer",
+      "spill"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/backend/barrier-alignment-buffer-spill",
+    "has_content": false
   },
   {
     "kind": "skill",
@@ -5919,7 +6807,13 @@
     "slug": "baseline-historical-comparison-threshold",
     "category": "backend",
     "description": "Evaluate a current metric against a historical baseline (prev hour/day/week/month/year, with MIN/AVG/MAX aggregation) as a dynamic threshold; supports RATE or VALUE change modes and dampening.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "baseline",
+      "historical",
+      "comparison",
+      "threshold"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/baseline-historical-comparison-threshold",
@@ -5931,7 +6825,14 @@
     "slug": "bootrun-jvmargs-jdwp-opens-java21",
     "category": "backend",
     "description": "Bake JDWP debug port and required --add-opens flags into Gradle bootRun so every dev gets the same Java 17/21-compatible local runtime",
-    "tags": [],
+    "tags": [
+      "backend",
+      "bootrun",
+      "jvmargs",
+      "jdwp",
+      "opens",
+      "java21"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/bootrun-jvmargs-jdwp-opens-java21",
@@ -5943,7 +6844,14 @@
     "slug": "byte-aware-sms-truncation-with-ellipsis",
     "category": "backend",
     "description": "Truncate SMS message body to a byte budget (not char count) per charset, appending '...' without exceeding the budget",
-    "tags": [],
+    "tags": [
+      "backend",
+      "byte",
+      "aware",
+      "sms",
+      "truncation",
+      "with"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/byte-aware-sms-truncation-with-ellipsis",
@@ -5955,7 +6863,13 @@
     "slug": "cache-variance-ttl-jitter",
     "category": "backend",
     "description": "Add ±N% random jitter to cache TTLs so keys written together don't all expire in the same tick, avoiding synchronized recompute storms",
-    "tags": [],
+    "tags": [
+      "backend",
+      "cache",
+      "variance",
+      "ttl",
+      "jitter"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/cache-variance-ttl-jitter",
@@ -5967,7 +6881,13 @@
     "slug": "calendar-cron-vs-spring-cron-migration",
     "category": "backend",
     "description": "Convert between Spring 6-field cron and Quartz/calendar 7-field cron without DST/leap-year regressions",
-    "tags": [],
+    "tags": [
+      "backend",
+      "calendar",
+      "cron",
+      "spring",
+      "migration"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/calendar-cron-vs-spring-cron-migration",
@@ -5979,7 +6899,14 @@
     "slug": "challenge-response-auth-redis-ttl",
     "category": "backend",
     "description": "Replay-resistant two-step login — server issues a short-lived random challenge stored in Redis with TTL, client signs/hashes response, bounded attempts per key",
-    "tags": [],
+    "tags": [
+      "backend",
+      "challenge",
+      "response",
+      "auth",
+      "redis",
+      "ttl"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/challenge-response-auth-redis-ttl",
@@ -5987,16 +6914,36 @@
   },
   {
     "kind": "skill",
+    "name": "changelog-compaction-tombstone-retention",
+    "slug": "changelog-compaction-tombstone-retention",
+    "category": "backend",
+    "description": "State-backend changelog topics need tombstone retention longer than compaction interval to survive consumer rebalance gaps.",
+    "tags": [
+      "backend",
+      "changelog",
+      "compaction",
+      "tombstone",
+      "retention"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/backend/changelog-compaction-tombstone-retention",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "chunked-resource-id-batch-fetch",
     "slug": "chunked-resource-id-batch-fetch",
     "category": "backend",
     "description": "Split large ID lists into ~1000-item chunks before querying DB or Elasticsearch to avoid bind-parameter limits (MSSQL 2100, Oracle 1000) and OOM on bulk responses",
-    "tags": [],
-    "triggers": [
-      "`WHERE id IN (?, ?, …)` with thousands of IDs",
-      "ES `terms` query near 65536-item ceiling",
-      "monitor/report accepts an unbounded target ID list"
+    "tags": [
+      "backend",
+      "chunked",
+      "resource",
+      "batch",
+      "fetch"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/backend/chunked-resource-id-batch-fetch",
     "has_content": true
@@ -6007,7 +6954,12 @@
     "slug": "collection-routing-by-period",
     "category": "backend",
     "description": "Single resolver maps `(Period.Mode, from, to)` → time-series collection (raw view / 1-min / hour-with-monthly-suffix / day). Callers never hardcode collection names.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "collection",
+      "routing",
+      "period"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/collection-routing-by-period",
@@ -6038,7 +6990,14 @@
     "slug": "concurrent-jdbc-pool-datasource-lifecycle",
     "category": "backend",
     "description": "Manage a pool of short-lived JDBC targets for monitoring agents with dual maps (active vs all) and periodic revalidation",
-    "tags": [],
+    "tags": [
+      "backend",
+      "concurrent",
+      "jdbc",
+      "pool",
+      "datasource",
+      "lifecycle"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/concurrent-jdbc-pool-datasource-lifecycle",
@@ -6050,7 +7009,13 @@
     "slug": "conditional-feature-flag-rollout",
     "category": "backend",
     "description": "@ConditionalOnProperty로 구/신 구현을 공존시키고 런타임 속성 하나로 전환하는 점진적 롤아웃 패턴",
-    "tags": [],
+    "tags": [
+      "backend",
+      "conditional",
+      "feature",
+      "flag",
+      "rollout"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/conditional-feature-flag-rollout",
@@ -6062,22 +7027,16 @@
     "slug": "custom-actuator-command-whitelist",
     "category": "backend",
     "description": "Expose safe remote OS command execution on a Spring Boot service via a custom Actuator endpoint, restricted by a command whitelist, an argument sanitizer, and an execution timeout.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "custom",
+      "actuator",
+      "command",
+      "whitelist"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/custom-actuator-command-whitelist",
-    "has_content": true
-  },
-  {
-    "kind": "skill",
-    "name": "dev-controller-tenant-wrapping-helper",
-    "slug": "dev-controller-tenant-wrapping-helper",
-    "category": "backend",
-    "description": "Dev/로컬 전용 컨트롤러의 테넌트+JWT 반복 래핑을 함수형 인터페이스 + 헬퍼 컴포넌트로 추출",
-    "tags": [],
-    "triggers": [],
-    "version": "1.0.0",
-    "path": "skills/backend/dev-controller-tenant-wrapping-helper",
     "has_content": true
   },
   {
@@ -6086,7 +7045,12 @@
     "slug": "distributed-lock-mongodb",
     "category": "backend",
     "description": "MongoDB findAndModify-based distributed lock with TTL expiry, owner tagging, and retry loop for multi-instance Spring Boot services.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "distributed",
+      "lock",
+      "mongodb"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/distributed-lock-mongodb",
@@ -6098,7 +7062,13 @@
     "slug": "divide-by-zero-rate-guard",
     "category": "backend",
     "description": "Guard rate/percentage calculations against zero denominators to prevent NaN from poisoning downstream metrics and serialization.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "divide",
+      "zero",
+      "rate",
+      "guard"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/divide-by-zero-rate-guard",
@@ -6137,8 +7107,15 @@
     "name": "dry-run-confirm-retry-write-flow",
     "slug": "dry-run-confirm-retry-write-flow",
     "category": "backend",
-    "description": "[Backend] 트래커/외부 API 쓰기 작업에 적용하는 공통 플로우: 미리보기 → 사용자 확인 → 쓰기 → 재시도.",
-    "tags": [],
+    "description": "\"[Backend] 트래커/외부 API 쓰기 작업에 적용하는 공통 플로우: 미리보기 → 사용자 확인 → 쓰기 → 재시도.\"",
+    "tags": [
+      "backend",
+      "dry",
+      "run",
+      "confirm",
+      "retry",
+      "write"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/dry-run-confirm-retry-write-flow",
@@ -6150,7 +7127,14 @@
     "slug": "dynamic-gridfs-template-multi-tenant",
     "category": "backend",
     "description": "Resolve MongoDB GridFsTemplate per (tenant-db, bucket) pair with lazy caching, for storing large binary assets per tenant",
-    "tags": [],
+    "tags": [
+      "backend",
+      "dynamic",
+      "gridfs",
+      "template",
+      "multi",
+      "tenant"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/dynamic-gridfs-template-multi-tenant",
@@ -6162,11 +7146,14 @@
     "slug": "elasticsearch-xpack-ssl-transport",
     "category": "backend",
     "description": "Gate `PreBuiltXPackTransportClient` vs `PreBuiltTransportClient` on auth flag (not SSL flag) and configure keystore/truststore as independent ES X-Pack settings",
-    "tags": [],
-    "triggers": [
-      "connect Java client to X-Pack-secured Elasticsearch cluster",
-      "production ES requires auth and optional transport TLS"
+    "tags": [
+      "backend",
+      "elasticsearch",
+      "xpack",
+      "ssl",
+      "transport"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/backend/elasticsearch-xpack-ssl-transport",
     "has_content": true
@@ -6177,7 +7164,13 @@
     "slug": "enable-async-tenant-aware",
     "category": "backend",
     "description": "Place @EnableAsync on a dedicated @Configuration that extends a tenant-aware AsyncConfigurer, so tenant/MDC context propagates across the executor boundary",
-    "tags": [],
+    "tags": [
+      "backend",
+      "enable",
+      "async",
+      "tenant",
+      "aware"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/enable-async-tenant-aware",
@@ -6189,7 +7182,14 @@
     "slug": "encrypted-pii-decrypt-before-send",
     "category": "backend",
     "description": "Store user email/phone encrypted at rest; decrypt only inside the sender, never in cache/DTO/log boundaries",
-    "tags": [],
+    "tags": [
+      "backend",
+      "encrypted",
+      "pii",
+      "decrypt",
+      "before",
+      "send"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/encrypted-pii-decrypt-before-send",
@@ -6201,7 +7201,14 @@
     "slug": "eureka-service-discovery-wait-annotation",
     "category": "backend",
     "description": "Declarative @WaitForServices annotation on @EventListener methods — blocks initialization until named Eureka services are healthy, with optional leader-only execution",
-    "tags": [],
+    "tags": [
+      "backend",
+      "eureka",
+      "service",
+      "discovery",
+      "wait",
+      "annotation"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/eureka-service-discovery-wait-annotation",
@@ -6213,7 +7220,13 @@
     "slug": "event-driven-kafka-scheduling",
     "category": "backend",
     "description": "Replace Spring @Scheduled with a Kafka-delivered JobExecuteNotice so a central scheduler service fans out tick events — with a skip-if-previous-still-running guard to prevent pile-up.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "event",
+      "driven",
+      "kafka",
+      "scheduling"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/event-driven-kafka-scheduling",
@@ -6225,7 +7238,14 @@
     "slug": "excel-download-null-date-range-handling",
     "category": "backend",
     "description": "Defensive pattern for grid/list excel-export endpoints — null-check every filter value and normalize field names before querying",
-    "tags": [],
+    "tags": [
+      "backend",
+      "excel",
+      "download",
+      "null",
+      "date",
+      "range"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/excel-download-null-date-range-handling",
@@ -6244,13 +7264,7 @@
       "enum",
       "controller"
     ],
-    "triggers": [
-      "excel export enum replace",
-      "DataToBeReplace",
-      "ExcelExportManager",
-      "objectToExcelAndDownload",
-      "excel download controller"
-    ],
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/backend/excel-export-enum-replacer",
     "has_content": false
@@ -6261,7 +7275,12 @@
     "slug": "feed-envelope-frame",
     "category": "backend",
     "description": "Uniform WebSocket payload wrapper with Type (ACK/SNAPSHOT/DELTA/ERROR), PayloadKind, and correlation requestId, including null-safe factory methods",
-    "tags": [],
+    "tags": [
+      "backend",
+      "feed",
+      "envelope",
+      "frame"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/feed-envelope-frame",
@@ -6273,7 +7292,14 @@
     "slug": "freemarker-two-phase-expression-subst",
     "category": "backend",
     "description": "Render templates by first replacing raw ${var} placeholders via string-replace, then running FreeMarker for expression-object binding, avoiding double-evaluation and escape conflicts",
-    "tags": [],
+    "tags": [
+      "backend",
+      "freemarker",
+      "two",
+      "phase",
+      "expression",
+      "subst"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/freemarker-two-phase-expression-subst",
@@ -6285,7 +7311,13 @@
     "slug": "frozen-detection-consecutive-count",
     "category": "backend",
     "description": "Detect a stuck/frozen metric (identical value for N consecutive samples) by CONSECUTIVE-dampening equality check; catches sensor/collector failures that threshold alarms miss.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "frozen",
+      "detection",
+      "consecutive",
+      "count"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/frozen-detection-consecutive-count",
@@ -6305,13 +7337,7 @@
       "pagination",
       "grid"
     ],
-    "triggers": [
-      "grid filter to criteria",
-      "FiltersPageableDto",
-      "CriteriaMakeHelper",
-      "mongodb dynamic filter",
-      "UI filter to query"
-    ],
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/backend/grid-filter-to-criteria-converter",
     "has_content": false
@@ -6322,12 +7348,14 @@
     "slug": "hibernate-multi-dialect-swap",
     "category": "backend",
     "description": "Ship one WAR that connects to Oracle, PostgreSQL, MSSQL, Tibero, DB2, or MariaDB based on Spring profile — all JDBC drivers bundled, dialect and datasource resolved from externalized config",
-    "tags": [],
-    "triggers": [
-      "one deployable must support multiple RDBMS vendors without rebuild",
-      "hibernate dialect chosen at startup, not compile time",
-      "customer deployments dictate DB vendor"
+    "tags": [
+      "backend",
+      "hibernate",
+      "multi",
+      "dialect",
+      "swap"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/backend/hibernate-multi-dialect-swap",
     "has_content": true
@@ -6338,7 +7366,12 @@
     "slug": "hierarchical-group-entity-mongo",
     "category": "backend",
     "description": "Model a tree-structured group entity in MongoDB with parentId + path + pathIds + level, plus recursive child-path update on move and cycle detection.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "hierarchical",
+      "group",
+      "entity"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/hierarchical-group-entity",
@@ -6356,12 +7389,7 @@
       "naming",
       "collision-avoidance"
     ],
-    "triggers": [
-      "name too long",
-      "identifier length limit",
-      "shorten tool name",
-      "truncate unique"
-    ],
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/backend/identifier-truncate-with-hash-suffix",
     "has_content": true
@@ -6372,7 +7400,12 @@
     "slug": "init-deadline-guard",
     "category": "backend",
     "description": "Watchdog that force-exits a Spring Boot service if startup initialization (external discovery, topic creation, warmup) does not complete within a deadline",
-    "tags": [],
+    "tags": [
+      "backend",
+      "init",
+      "deadline",
+      "guard"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/init-deadline-guard",
@@ -6384,7 +7417,12 @@
     "slug": "ip-allowlist-cidr-validator",
     "category": "backend",
     "description": "Validate client IPs against user-supplied allow-lists accepting mixed notations — plain IPv4, CIDR, octet wildcards (192.168.*.*), and octet ranges (192.168.10-20.*)",
-    "tags": [],
+    "tags": [
+      "backend",
+      "allowlist",
+      "cidr",
+      "validator"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/ip-allowlist-cidr-validator",
@@ -6396,7 +7434,13 @@
     "slug": "jacoco-exclude-boilerplate-layers",
     "category": "backend",
     "description": "Configure JaCoCo + SonarQube to exclude generated/boilerplate layers (avro, config, dto, entity, kafka, *Dev) from coverage so coverage % reflects business logic only",
-    "tags": [],
+    "tags": [
+      "backend",
+      "jacoco",
+      "exclude",
+      "boilerplate",
+      "layers"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/jacoco-exclude-boilerplate-layers",
@@ -6408,7 +7452,14 @@
     "slug": "jacoco-sonar-shared-exclusion-list",
     "category": "backend",
     "description": "Define coverage/quality exclusions once in ext.exclusionPatterns and reuse across jacoco, sonar, and packaging tasks to prevent report drift",
-    "tags": [],
+    "tags": [
+      "backend",
+      "jacoco",
+      "sonar",
+      "shared",
+      "exclusion",
+      "list"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/jacoco-sonar-shared-exclusion-list",
@@ -6439,7 +7490,14 @@
     "slug": "jdbc-configurable-sql-insert-sender",
     "category": "backend",
     "description": "Ship a notification/integration channel that writes to a user-configured external DB via user-supplied INSERT SQL with ${var} placeholders",
-    "tags": [],
+    "tags": [
+      "backend",
+      "jdbc",
+      "configurable",
+      "sql",
+      "insert",
+      "sender"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/jdbc-configurable-sql-insert-sender",
@@ -6451,22 +7509,8 @@
     "slug": "json-seeded-jpa-loader",
     "category": "backend",
     "description": "Idempotent reference-data seeding for Spring Boot — Flyway owns DDL, CommandLineRunner reads `resources/data/*.json`, maps to JPA entities, and saves only if the table is empty. Keeps static content in editable JSON without bloating migrations.",
-    "tags": [
-      "spring-boot",
-      "jpa",
-      "seeding",
-      "flyway",
-      "commandlinerunner",
-      "jackson",
-      "reference-data"
-    ],
-    "triggers": [
-      "seed reference data spring",
-      "CommandLineRunner JSON",
-      "populate static content",
-      "data initializer spring",
-      "load catalog JSON"
-    ],
+    "tags": "",
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/backend/json-seeded-jpa-loader",
     "has_content": true
@@ -6484,11 +7528,7 @@
       "refactor",
       "base-class"
     ],
-    "triggers": [
-      "jwt extraction controller duplication",
-      "base controller jwt",
-      "getXxxFromBearerToken 중복 제거"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/backend/jwt-extraction-via-base-controller",
     "has_content": false
@@ -6499,11 +7539,14 @@
     "slug": "k8s-health-via-getnodelist",
     "category": "backend",
     "description": "Use `listNode()` with readiness check for Kubernetes cluster health — `getVersion()` succeeds on degraded clusters that will fail real work",
-    "tags": [],
-    "triggers": [
-      "cluster liveness probe before running a collector pass",
-      "guard against API-server flaps"
+    "tags": [
+      "backend",
+      "k8s",
+      "health",
+      "via",
+      "getnodelist"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/backend/k8s-health-via-getnodelist",
     "has_content": true
@@ -6532,7 +7575,14 @@
     "slug": "kafka-batch-consumer-partition-tuning",
     "category": "backend",
     "description": "Size Kafka partition count + max-poll-records per topic volume so heavy-processing batch consumers avoid max.poll.interval.ms breaches and maintain throughput via per-partition concurrency.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "kafka",
+      "batch",
+      "consumer",
+      "partition",
+      "tuning"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/kafka-batch-consumer-partition-tuning",
@@ -6544,7 +7594,13 @@
     "slug": "kafka-consumer-config-3-factories",
     "category": "backend",
     "description": "Spring Kafka consumer setup with three ListenerContainerFactory variants (standard / batch / UUID-group) and autoStartup=false to allow topic bootstrap before listeners attach",
-    "tags": [],
+    "tags": [
+      "backend",
+      "kafka",
+      "consumer",
+      "config",
+      "factories"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/kafka-consumer-config-3-factories",
@@ -6574,7 +7630,13 @@
     "slug": "kafka-consumer-semaphore-chunking",
     "category": "backend",
     "description": "Bound in-flight async work from a Kafka consumer with `Semaphore(poolSize + queueCapacity - 2)` plus fixed-size chunks; release in `whenComplete` on both success and failure.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "kafka",
+      "consumer",
+      "semaphore",
+      "chunking"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/kafka-consumer-semaphore-chunking",
@@ -6586,7 +7648,14 @@
     "slug": "kafka-consumer-tenant-fan-out",
     "category": "backend",
     "description": "@KafkaListener pattern consuming a topicPattern across tenants, using a record header for tenant identity and routing to per-tenant downstream streams",
-    "tags": [],
+    "tags": [
+      "backend",
+      "kafka",
+      "consumer",
+      "tenant",
+      "fan",
+      "out"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/kafka-consumer-tenant-fan-out",
@@ -6598,7 +7667,13 @@
     "slug": "kafka-debounce-event-coalescing",
     "category": "backend",
     "description": "Coalesce bursts of change events into one Kafka event per tenant per debounce window using Redis state (first/last change time + changed-tenant SET), with a MAX_WAIT fallback so a never-quiet stream still fires.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "kafka",
+      "debounce",
+      "event",
+      "coalescing"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/kafka-debounce-event-coalescing",
@@ -6617,13 +7692,7 @@
       "headers",
       "spring"
     ],
-    "triggers": [
-      "kafka record headers",
-      "ProducerRecord headers",
-      "organization-id header kafka",
-      "multi-tenant kafka routing",
-      "RecordHeader metadata"
-    ],
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/backend/kafka-message-header-metadata",
     "has_content": false
@@ -6634,7 +7703,13 @@
     "slug": "kafka-producer-async-callback",
     "category": "backend",
     "description": "Fire-and-log Kafka send pattern using CompletableFuture.whenComplete() for audit/event topics where the caller should not block",
-    "tags": [],
+    "tags": [
+      "backend",
+      "kafka",
+      "producer",
+      "async",
+      "callback"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/kafka-producer-async-callback",
@@ -6646,7 +7721,14 @@
     "slug": "kafka-producer-config-avro-schema-registry",
     "category": "backend",
     "description": "Kafka producer config template for Avro + Confluent Schema Registry with LZ4 compression, 30MB max request size, and acks=1",
-    "tags": [],
+    "tags": [
+      "backend",
+      "kafka",
+      "producer",
+      "config",
+      "avro",
+      "schema"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/kafka-producer-config-avro-schema-registry",
@@ -6664,12 +7746,7 @@
       "capability-negotiation",
       "handshake"
     ],
-    "triggers": [
-      "mcp initialize",
-      "capability negotiation",
-      "server capabilities",
-      "prompts/resources not showing"
-    ],
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/backend/mcp-capability-negotiated-initialize",
     "has_content": true
@@ -6680,7 +7757,12 @@
     "slug": "measurement-grouping-combiner",
     "category": "backend",
     "description": "Group rows by `(resourceId, metricId, bucketTs)` into `Map<K, List<T>>`, then a per-granularity pure `combine…ByKey` merges each list into one composite record. One combiner per granularity (raw/1m/5m/hour/day).",
-    "tags": [],
+    "tags": [
+      "backend",
+      "measurement",
+      "grouping",
+      "combiner"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/measurement-grouping-combiner",
@@ -6692,7 +7774,14 @@
     "slug": "message-loader-gated-on-database-ready",
     "category": "backend",
     "description": "Gate i18n/seed loading on database readiness + per-tenant distributed lock so the first instance wins initialization in a multi-replica rollout.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "message",
+      "loader",
+      "gated",
+      "database",
+      "ready"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/message-loader-gated-on-database-ready",
@@ -6712,12 +7801,7 @@
       "multi-tenant",
       "mongodb"
     ],
-    "triggers": [
-      "migration processor",
-      "data migration pipeline",
-      "legacy data import",
-      "migration with kafka"
-    ],
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/backend/migration-processor-pipeline",
     "has_content": false
@@ -6728,7 +7812,13 @@
     "slug": "mongo-aggregation-filter-optimization",
     "category": "backend",
     "description": "Replace `$unwind`+`$match` on array sub-documents with inline `$filter` so array elements are pruned before any downstream stage — avoids N× document explosion.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "mongo",
+      "aggregation",
+      "filter",
+      "optimization"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/mongo-aggregation-filter-optimization",
@@ -6740,12 +7830,15 @@
     "slug": "mongo-criteria-maker-elemmatch-and-or",
     "category": "backend",
     "description": "Compose dynamic MongoDB Criteria with mixed AND/OR groups and elemMatch on tag-array fields using a stack-based builder",
-    "tags": [],
-    "triggers": [
-      "building MongoDB queries with user-defined AND/OR filter rows",
-      "matching key/value pairs inside an array field (tags, labels, attributes)",
-      "replacing string-concatenated Mongo queries with type-safe Criteria"
+    "tags": [
+      "backend",
+      "mongo",
+      "criteria",
+      "maker",
+      "elemmatch",
+      "and"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/backend/mongo-criteria-maker-elemmatch-and-or",
     "has_content": true
@@ -6756,7 +7849,12 @@
     "slug": "mongo-timestamp-densification",
     "category": "backend",
     "description": "Fill sparse time-series gaps with `$dateTrunc` + `$densify` in Mongo, then a residual Java gap-fill loop for LIVE windows. Partition by series to keep multi-line charts aligned.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "mongo",
+      "timestamp",
+      "densification"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/mongo-timestamp-densification",
@@ -6768,7 +7866,14 @@
     "slug": "mongo-ttl-with-aggregation-delta",
     "category": "backend",
     "description": "Store short-lived counter snapshots in MongoDB with a TTL index for auto-expiry and compute delta-from-previous at read time via an aggregation $subtract pipeline.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "mongo",
+      "ttl",
+      "with",
+      "aggregation",
+      "delta"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/mongo-ttl-with-aggregation-delta",
@@ -6780,7 +7885,13 @@
     "slug": "mongodb-changestream-field-filter",
     "category": "backend",
     "description": "Filter MongoDB change stream UPDATE events by inspecting updateDescription.updatedFields so irrelevant mutations do not trigger downstream work; INSERT/DELETE fall through as always-relevant.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "mongodb",
+      "changestream",
+      "field",
+      "filter"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/mongodb-changestream-field-filter",
@@ -6792,7 +7903,14 @@
     "slug": "mongodb-compound-index-esr-rule",
     "category": "backend",
     "description": "Order MongoDB compound-index fields as Equality → Sort → Range so the query planner keeps a tight IXSCAN and avoids in-memory sorts.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "mongodb",
+      "compound",
+      "index",
+      "esr",
+      "rule"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/mongodb-compound-index-esr-rule",
@@ -6821,7 +7939,14 @@
     "slug": "multi-dbms-resource-provider-pattern",
     "category": "backend",
     "description": "Structure a polyglot RDBMS monitoring agent with one ResourceProvider + entity/dto/service per DBMS, sharing a common base",
-    "tags": [],
+    "tags": [
+      "backend",
+      "multi",
+      "dbms",
+      "resource",
+      "provider",
+      "pattern"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/multi-dbms-resource-provider-pattern",
@@ -6833,7 +7958,13 @@
     "slug": "multi-resource-or-batch-query",
     "category": "backend",
     "description": "Collapse N per-resource Mongo queries into one pipeline using `Criteria.orOperator` (or `$in`) over resourceId, projecting a synthetic `key` field for service-side de-multiplexing. Chunk at ~200 for index-friendly `$or`.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "multi",
+      "resource",
+      "batch",
+      "query"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/multi-resource-or-batch-query",
@@ -6845,7 +7976,14 @@
     "slug": "multi-tenant-kafka-header-organization-context",
     "category": "backend",
     "description": "Propagate tenant/organization id from Kafka headers through async handler threads via a ThreadLocal context holder",
-    "tags": [],
+    "tags": [
+      "backend",
+      "multi",
+      "tenant",
+      "kafka",
+      "header",
+      "organization"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/multi-tenant-kafka-header-organization-context",
@@ -6857,7 +7995,13 @@
     "slug": "multi-tenant-scheduler-iteration",
     "category": "backend",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "backend",
+      "multi",
+      "tenant",
+      "scheduler",
+      "iteration"
+    ],
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "skills/backend/multi-tenant-scheduler-iteration",
@@ -6869,11 +8013,14 @@
     "slug": "netty-tcp-reconnect-backoff",
     "category": "backend",
     "description": "On Netty `channelInactive`/EOF/read-timeout, reconnect with exponential backoff (100ms → 30s cap), reset on success, keep SO_KEEPALIVE + TCP_NODELAY",
-    "tags": [],
-    "triggers": [
-      "long-lived TCP client to a device or broker that drops silently",
-      "need to survive peer restarts without crashing the collector"
+    "tags": [
+      "backend",
+      "netty",
+      "tcp",
+      "reconnect",
+      "backoff"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/backend/netty-tcp-reconnect-backoff",
     "has_content": true
@@ -6884,7 +8031,14 @@
     "slug": "non-metric-saveraw-null-rule",
     "category": "backend",
     "description": "Treat `saveRaw` as tri-state `Boolean` — `null` for non-METRIC types (Availability/Trait), `true`/`false` only for METRIC. Re-apply the rule on every policy mutation path.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "non",
+      "metric",
+      "saveraw",
+      "null",
+      "rule"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/non-metric-saveraw-null-rule",
@@ -6896,7 +8050,14 @@
     "slug": "org-scoped-kafka-topic-bootstrap",
     "category": "backend",
     "description": "On-startup and on-event creation of per-tenant Kafka topics, with retention overrides per topic class and a service-readiness gate",
-    "tags": [],
+    "tags": [
+      "backend",
+      "org",
+      "scoped",
+      "kafka",
+      "topic",
+      "bootstrap"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/org-scoped-kafka-topic-bootstrap",
@@ -6908,7 +8069,13 @@
     "slug": "parallel-tasks-generic-extraction",
     "category": "backend",
     "description": "invokeAll + Callable 반복 패턴을 제네릭 executeParallelTasks + TaskFactory로 추출",
-    "tags": [],
+    "tags": [
+      "backend",
+      "parallel",
+      "tasks",
+      "generic",
+      "extraction"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/parallel-tasks-generic-extraction",
@@ -6920,7 +8087,13 @@
     "slug": "period-mode-enum-config",
     "category": "backend",
     "description": "One enum `Mode` holds all (intervalMs, isFullData, dateFormat, retention, chartFormat) tuples for every time-series granularity — single source of truth across repository/service/chart layers.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "period",
+      "mode",
+      "enum",
+      "config"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/period-mode-enum-config",
@@ -6976,7 +8149,14 @@
     "slug": "policy-target-evaluation-with-groups-tags",
     "category": "backend",
     "description": "Evaluate whether a resource matches a policy via direct IDs + static/dynamic groups + tag filters, with explicit exclusion rules that take precedence over includes.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "policy",
+      "target",
+      "evaluation",
+      "with",
+      "groups"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/policy-target-evaluation-with-groups-tags",
@@ -7011,7 +8191,13 @@
     "slug": "reactive-webclient-ssl-jdk",
     "category": "backend",
     "description": "Force reactor-netty WebClient to SslProvider.JDK so SSL works in slim containers that lack netty-tcnative native libraries.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "reactive",
+      "webclient",
+      "ssl",
+      "jdk"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/reactive-webclient-ssl-jdk",
@@ -7023,7 +8209,13 @@
     "slug": "reactor-subscription-router-backpressure",
     "category": "backend",
     "description": "Per-session, per-destination Reactor Flux router with bounded buffer + DROP_LATEST backpressure and automatic cleanup on session disconnect",
-    "tags": [],
+    "tags": [
+      "backend",
+      "reactor",
+      "subscription",
+      "router",
+      "backpressure"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/reactor-subscription-router-backpressure",
@@ -7035,11 +8227,13 @@
     "slug": "realtime-vs-polling-fallback",
     "category": "backend",
     "description": "Let each resource type declare `supportsRealtime`; scheduler runs push-mode at the realtime interval and falls back to a safe polling interval (e.g., 60s) otherwise",
-    "tags": [],
-    "triggers": [
-      "mixed collection pipeline (some resources push, some pull)",
-      "avoid hammering APIs that do not support realtime"
+    "tags": [
+      "backend",
+      "realtime",
+      "polling",
+      "fallback"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/backend/realtime-vs-polling-fallback",
     "has_content": true
@@ -7050,7 +8244,14 @@
     "slug": "redis-lock-recheck-flag-pattern",
     "category": "backend",
     "description": "Distributed Redis lock with a \"recheck\" flag so concurrent events arriving while the lock is held force the holder to run a second pass, instead of being silently dropped.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "redis",
+      "lock",
+      "recheck",
+      "flag",
+      "pattern"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/redis-lock-recheck-flag-pattern",
@@ -7062,7 +8263,13 @@
     "slug": "second-aggregation-snapshot-merge",
     "category": "backend",
     "description": "Per-second metric aggregation using in-memory counters + Flux.interval snapshot-and-reset + bounded parallel publish, to decouple request latency from downstream health.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "second",
+      "aggregation",
+      "snapshot",
+      "merge"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/second-aggregation-snapshot-merge",
@@ -7092,7 +8299,14 @@
     "slug": "service-discovery-replica-leader-tracking",
     "category": "backend",
     "description": "Track Eureka replica UP/DOWN events and emit ServiceLeaderElected / ServiceReplicaAllDown Spring events for cluster-aware init",
-    "tags": [],
+    "tags": [
+      "backend",
+      "service",
+      "discovery",
+      "replica",
+      "leader",
+      "tracking"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/service-discovery-replica-leader-tracking",
@@ -7104,7 +8318,14 @@
     "slug": "service-readiness-event-listener-pattern",
     "category": "backend",
     "description": "Two-phase startup where each instance initializes locally, but only the leader runs global one-time work (seed data, default report creation)",
-    "tags": [],
+    "tags": [
+      "backend",
+      "service",
+      "readiness",
+      "event",
+      "listener",
+      "pattern"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/service-readiness-event-listener-pattern",
@@ -7116,7 +8337,13 @@
     "slug": "service-status-provider-actuator",
     "category": "backend",
     "description": "Spring Boot 3.5 ServiceStatusProvider that reports RUNNING vs READY based on MongoDB ping + Kafka listener container liveness",
-    "tags": [],
+    "tags": [
+      "backend",
+      "service",
+      "status",
+      "provider",
+      "actuator"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/service-status-provider-actuator",
@@ -7128,7 +8355,13 @@
     "slug": "servicejar-embeddable-library-task",
     "category": "backend",
     "description": "Gradle task that builds a library JAR alongside bootJar for embedding inside a host Spring Boot app — excludes Application class, web/OpenAPI configs, and bundled resources",
-    "tags": [],
+    "tags": [
+      "backend",
+      "servicejar",
+      "embeddable",
+      "library",
+      "task"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/servicejar-embeddable-library-task",
@@ -7140,7 +8373,14 @@
     "slug": "session-lock-tree-blocking-chain-modeling",
     "category": "backend",
     "description": "Model RDBMS blocking sessions as a directed graph and persist the resolved lock tree alongside the session snapshot",
-    "tags": [],
+    "tags": [
+      "backend",
+      "session",
+      "lock",
+      "tree",
+      "blocking",
+      "chain"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/session-lock-tree-blocking-chain-modeling",
@@ -7152,7 +8392,13 @@
     "slug": "spring-actuator-health-collector",
     "category": "backend",
     "description": "Poll remote Spring Boot services via Actuator (/health + /metrics/{name}) using OkHttp with per-target timeouts and a configurable metric whitelist, publishing results to a downstream bus.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "spring",
+      "actuator",
+      "health",
+      "collector"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/spring-actuator-health-collector",
@@ -7164,7 +8410,13 @@
     "slug": "spring-applicationrunner-system-seed",
     "category": "backend",
     "description": "Use ApplicationRunner to seed required system/root records on startup, guarded by an exists-check and marked with a systemFlag so they can't be deleted or moved by users.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "system",
+      "data",
+      "initializer",
+      "runner"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/system-data-initializer-runner",
@@ -7176,7 +8428,14 @@
     "slug": "spring-data-mongo-repository-custom-split",
     "category": "backend",
     "description": "Standard 3-file split for MongoRepository — the base interface, a *Custom interface for handwritten queries, and a *Impl class that uses MongoTemplate — so complex queries live beside the CRUD without breaking derived-query inference.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "mongo",
+      "repository",
+      "custom",
+      "impl",
+      "split"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/mongo-repository-custom-impl-split",
@@ -7188,22 +8447,8 @@
     "slug": "spring-dual-profile-flyway",
     "category": "backend",
     "description": "Spring Boot dual-profile setup — H2 file-mode for dev (zero install, console enabled), PostgreSQL for prod — with Flyway managing DDL and JPA set to validate-only. The profile split that keeps local dev fast without drifting from prod schema.",
-    "tags": [
-      "spring-boot",
-      "flyway",
-      "h2",
-      "postgresql",
-      "profiles",
-      "migrations",
-      "jpa"
-    ],
-    "triggers": [
-      "spring profiles dev prod",
-      "flyway migrations spring",
-      "h2 file mode dev",
-      "ddl-auto validate",
-      "postgresql production profile"
-    ],
+    "tags": "",
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/backend/spring-dual-profile-flyway",
     "has_content": true
@@ -7221,11 +8466,7 @@
       "annotation-driven",
       "idempotent"
     ],
-    "triggers": [
-      "mongo migration spring boot",
-      "mongock 없이 마이그레이션",
-      "annotation-based mongo migration"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/backend/spring-mongo-lightweight-migration",
     "has_content": true
@@ -7236,11 +8477,14 @@
     "slug": "spring-profile-datasource-activation",
     "category": "backend",
     "description": "Select DB/Hibernate/logging config at JVM startup via `spring.profiles.active` so one build ships to dev, test, and prod without branching in code",
-    "tags": [],
-    "triggers": [
-      "same WAR goes to multiple environments",
-      "Spring profile chooses datasource and credentials"
+    "tags": [
+      "backend",
+      "spring",
+      "profile",
+      "datasource",
+      "activation"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/backend/spring-profile-datasource-activation",
     "has_content": true
@@ -7251,20 +8495,8 @@
     "slug": "spring-typed-config-properties",
     "category": "backend",
     "description": "Type-safe, nested `@ConfigurationProperties` pattern for Spring Boot — centralizes tunable constants (rate limits, formula coefficients, balance numbers) in YAML with a single injected POJO tree. Beats scattered `@Value` strings.",
-    "tags": [
-      "spring-boot",
-      "configuration-properties",
-      "yaml",
-      "typed-config",
-      "constructor-binding"
-    ],
-    "triggers": [
-      "ConfigurationProperties nested",
-      "centralize tunable constants",
-      "spring typed config",
-      "balance config",
-      "constructor binding yaml"
-    ],
+    "tags": "",
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/backend/spring-typed-config-properties",
     "has_content": true
@@ -7283,11 +8515,7 @@
       "yaml",
       "refactor"
     ],
-    "triggers": [
-      "swagger externalize annotations",
-      "move swagger description to yaml",
-      "OperationCustomizer"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/backend/springdoc-yaml-externalization",
     "has_content": false
@@ -7298,7 +8526,14 @@
     "slug": "stack-parse-tag-filter-to-mongo-criteria",
     "category": "backend",
     "description": "Parse a tokenized boolean filter expression (key=value, AND, OR, parens) into a MongoDB Criteria tree using a shunting-yard/stack algorithm, with elemMatch for array-of-tag subdocs.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "stack",
+      "tag",
+      "filter",
+      "mongo",
+      "criteria"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/stack-tag-filter-to-mongo-criteria",
@@ -7310,7 +8545,13 @@
     "slug": "stomp-cookie-auth-handshake",
     "category": "backend",
     "description": "Authenticate STOMP WebSocket upgrade using an HttpOnly cookie extracted during the handshake, then bind identity to the STOMP session",
-    "tags": [],
+    "tags": [
+      "backend",
+      "stomp",
+      "cookie",
+      "auth",
+      "handshake"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/stomp-cookie-auth-handshake",
@@ -7322,7 +8563,13 @@
     "slug": "stomp-principal-jwt-channel",
     "category": "backend",
     "description": "STOMP ChannelInterceptor that validates a JWT on CONNECT and binds a multi-tenant Principal (orgId + userId + sessionId) for downstream routing",
-    "tags": [],
+    "tags": [
+      "backend",
+      "stomp",
+      "principal",
+      "jwt",
+      "channel"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/stomp-principal-jwt-channel",
@@ -7334,7 +8581,14 @@
     "slug": "strategy-spi-list-to-map-autoinject",
     "category": "backend",
     "description": "Spring이 자동 주입하는 List<T>를 생성자에서 Map<Key,T>로 변환해 Strategy를 enum 키로 O(1) 디스패치하는 패턴",
-    "tags": [],
+    "tags": [
+      "backend",
+      "strategy",
+      "spi",
+      "list",
+      "map",
+      "autoinject"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/strategy-spi-list-to-map-autoinject",
@@ -7346,7 +8600,14 @@
     "slug": "tenant-context-try-finally-on-worker",
     "category": "backend",
     "description": "Kafka/Queue Worker에서 멀티테넌트 ThreadLocal 컨텍스트를 try-finally로 안전하게 세팅/정리하는 패턴",
-    "tags": [],
+    "tags": [
+      "backend",
+      "tenant",
+      "context",
+      "try",
+      "finally",
+      "worker"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/tenant-context-try-finally-on-worker",
@@ -7358,7 +8619,12 @@
     "slug": "tenant-db-initialization-on-startup",
     "category": "backend",
     "description": "On leader startup, fetch tenant/org list from metadata service and provision per-tenant MongoDB databases — idempotent, leader-only",
-    "tags": [],
+    "tags": [
+      "backend",
+      "tenant",
+      "initialization",
+      "startup"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/tenant-db-initialization-on-startup",
@@ -7370,7 +8636,13 @@
     "slug": "tenant-isolated-mongo-collection",
     "category": "backend",
     "description": "Route each tenant to its own MongoDB collection (or collection-name suffix) via a custom annotation resolved at repository/template layer, so application code stays tenant-agnostic.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "tenant",
+      "isolated",
+      "mongo",
+      "collection"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/tenant-isolated-mongo-collection",
@@ -7382,7 +8654,14 @@
     "slug": "tenant-per-database-mongo-routing",
     "category": "backend",
     "description": "Route Spring Data Mongo operations to per-tenant databases via a ThreadLocal tenant holder and two MongoTemplate beans (isolated vs shared collections).",
-    "tags": [],
+    "tags": [
+      "backend",
+      "tenant",
+      "per",
+      "database",
+      "mongo",
+      "routing"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/tenant-per-database-mongo-routing",
@@ -7394,7 +8673,14 @@
     "slug": "testcontainers-mongo-kafka-abstract-base",
     "category": "backend",
     "description": "Abstract test base classes that spin up MongoDB + Kafka via Testcontainers with static start() and reuse=true, exposing mapped ports via System.setProperty",
-    "tags": [],
+    "tags": [
+      "backend",
+      "testcontainers",
+      "mongo",
+      "kafka",
+      "abstract",
+      "base"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/testcontainers-mongo-kafka-abstract-base",
@@ -7406,7 +8692,12 @@
     "slug": "testcontainers-reuse-disabled",
     "category": "backend",
     "description": "Set TESTCONTAINERS_REUSE_ENABLE=false on the Gradle test task so CI and shared dev machines never inherit stale container state across suites",
-    "tags": [],
+    "tags": [
+      "backend",
+      "testcontainers",
+      "reuse",
+      "disabled"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/testcontainers-reuse-disabled",
@@ -7418,7 +8709,14 @@
     "slug": "thread-pool-config-tenant-aware",
     "category": "backend",
     "description": "Property-driven ThreadPoolTaskExecutor + Scheduler config that extends TenantAsyncConfigurerSupport so @Async tasks inherit tenant context",
-    "tags": [],
+    "tags": [
+      "backend",
+      "thread",
+      "pool",
+      "config",
+      "tenant",
+      "aware"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/thread-pool-config-tenant-aware",
@@ -7430,7 +8728,13 @@
     "slug": "thread-pool-queue-backpressure",
     "category": "backend",
     "description": "Bounded in-memory queue between Kafka consumer and async thread pool, with hysteretic pause/resume thresholds driving Spring Kafka container pause()/resume() so bursts do not OOM the JVM.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "thread",
+      "pool",
+      "queue",
+      "backpressure"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/thread-pool-queue-backpressure",
@@ -7442,7 +8746,13 @@
     "slug": "tsv-driven-permission-bootstrap",
     "category": "backend",
     "description": "Treat a version-controlled TSV file as source of truth for the Function/Permission/Menu catalog; the service reconciles the DB against it on startup",
-    "tags": [],
+    "tags": [
+      "backend",
+      "tsv",
+      "driven",
+      "permission",
+      "bootstrap"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/tsv-driven-permission-bootstrap",
@@ -7472,7 +8782,14 @@
     "slug": "version-specific-sql-map-selection",
     "category": "backend",
     "description": "Select MyBatis-style SQL maps at runtime by DBMS + version with graceful fallback to a default supported version",
-    "tags": [],
+    "tags": [
+      "backend",
+      "version",
+      "specific",
+      "sql",
+      "map",
+      "selection"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/version-specific-sql-map-selection",
@@ -7484,7 +8801,14 @@
     "slug": "websocket-stomp-channel-pool-config",
     "category": "backend",
     "description": "Spring WebSocket STOMP config with separate inbound/outbound task executors and raised transport buffer limits, sized for burst notification fan-out to many role-filtered subscribers.",
-    "tags": [],
+    "tags": [
+      "backend",
+      "websocket",
+      "stomp",
+      "channel",
+      "pool",
+      "config"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/websocket-stomp-channel-pool-config",
@@ -7496,11 +8820,266 @@
     "slug": "yorkie-crdt-sync-pattern",
     "category": "backend",
     "description": "Apply a single doc.update callback for local mutations and pullRemoteChangesIntoLocal(WithNodeIds) for remote→local sync in Yorkie-backed apps",
-    "tags": [],
+    "tags": [
+      "backend",
+      "yorkie",
+      "crdt",
+      "sync",
+      "pattern"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/backend/yorkie-crdt-sync-pattern",
     "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "autoplan",
+    "slug": "autoplan",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "gstack",
+      "cli",
+      "autoplan",
+      "review"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/autoplan",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "benchmark",
+    "slug": "benchmark",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "gstack",
+      "cli",
+      "benchmark",
+      "performance"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/benchmark",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "browse",
+    "slug": "browse",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "gstack",
+      "cli",
+      "browse",
+      "playwright"
+    ],
+    "triggers": [],
+    "version": "1.1.0",
+    "path": "skills/cli/gstack/browse",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "canary",
+    "slug": "canary",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "gstack",
+      "cli",
+      "canary",
+      "deploy"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/canary",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "careful",
+    "slug": "careful",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "gstack",
+      "cli",
+      "careful",
+      "safety"
+    ],
+    "triggers": [],
+    "version": "0.1.0",
+    "path": "skills/cli/gstack/careful",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "checkpoint",
+    "slug": "checkpoint",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "gstack",
+      "cli",
+      "checkpoint",
+      "state"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/checkpoint",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "codex",
+    "slug": "codex",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "gstack",
+      "cli",
+      "codex",
+      "ai"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/codex",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "cso",
+    "slug": "cso",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "gstack",
+      "cli",
+      "cso",
+      "security"
+    ],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/cli/gstack/cso",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "design-consultation",
+    "slug": "design-consultation",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "cli",
+      "design",
+      "consultation"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/design-consultation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "design-html",
+    "slug": "design-html",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "cli",
+      "design",
+      "html"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/design-html",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "design-review",
+    "slug": "design-review",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "cli",
+      "design",
+      "review"
+    ],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/cli/gstack/design-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "design-shotgun",
+    "slug": "design-shotgun",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "cli",
+      "design",
+      "shotgun"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/design-shotgun",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "devex-review",
+    "slug": "devex-review",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "cli",
+      "devex",
+      "review"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/devex-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "document-release",
+    "slug": "document-release",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "cli",
+      "document",
+      "release"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/document-release",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "freeze",
+    "slug": "freeze",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "gstack",
+      "cli",
+      "freeze",
+      "safety"
+    ],
+    "triggers": [],
+    "version": "0.1.0",
+    "path": "skills/cli/gstack/freeze",
+    "has_content": false
   },
   {
     "kind": "skill",
@@ -7526,10 +9105,85 @@
     "slug": "gstack",
     "category": "cli",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "gstack",
+      "cli",
+      "workflow",
+      "meta"
+    ],
     "triggers": [],
     "version": "1.1.0",
     "path": "skills/cli/gstack",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "gstack-openclaw-ceo-review",
+    "slug": "gstack-openclaw-ceo-review",
+    "category": "cli",
+    "description": "CEO/founder-mode plan review. Rethink the problem, find the 10-star product, challenge premises, expand scope when it creates a better product. Four modes: SCOPE EXPANSION (dream big), SELECTIVE EXPANSION (hold scope + cherry-pick), HOLD SCOPE (maximum rigor), SCOPE REDUCTION (strip to essentials). Use when asked to review a plan, challenge this, CEO review, poke holes, think bigger, or expand scope.",
+    "tags": [
+      "cli",
+      "gstack",
+      "openclaw",
+      "ceo",
+      "review"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/openclaw/skills/gstack-openclaw-ceo-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "gstack-openclaw-investigate",
+    "slug": "gstack-openclaw-investigate",
+    "category": "cli",
+    "description": "Systematic debugging with root cause investigation. Four phases: investigate, analyze, hypothesize, implement. Iron Law: no fixes without root cause. Use when asked to debug, fix a bug, investigate an error, or root cause analysis. Proactively use when user reports errors, stack traces, unexpected behavior, or says something stopped working.",
+    "tags": [
+      "cli",
+      "gstack",
+      "openclaw",
+      "investigate"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/openclaw/skills/gstack-openclaw-investigate",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "gstack-openclaw-office-hours",
+    "slug": "gstack-openclaw-office-hours",
+    "category": "cli",
+    "description": "Product interrogation with six forcing questions. Two modes: startup diagnostic (demand reality, status quo, desperate specificity, narrowest wedge, observation, future-fit) and builder brainstorm. Use when asked to brainstorm, \"is this worth building\", \"I have an idea\", \"office hours\", or \"help me think through this\". Proactively use when user describes a new product idea or wants to think through design decisions before any code is written.",
+    "tags": [
+      "cli",
+      "gstack",
+      "openclaw",
+      "office",
+      "hours"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/openclaw/skills/gstack-openclaw-office-hours",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "gstack-openclaw-retro",
+    "slug": "gstack-openclaw-retro",
+    "category": "cli",
+    "description": "Weekly engineering retrospective. Analyzes commit history, work patterns, and code quality metrics with persistent history and trend tracking. Team-aware with per-person contributions, praise, and growth areas. Use when asked for weekly retro, what shipped this week, or engineering retrospective.",
+    "tags": [
+      "cli",
+      "gstack",
+      "openclaw",
+      "retro"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/openclaw/skills/gstack-openclaw-retro",
     "has_content": false
   },
   {
@@ -7538,10 +9192,131 @@
     "slug": "gstack-upgrade",
     "category": "cli",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "cli",
+      "gstack",
+      "upgrade"
+    ],
+    "triggers": [],
+    "version": "1.1.0",
+    "path": "skills/cli/gstack/gstack-upgrade",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "gstack-upgrade",
+    "slug": "gstack-upgrade",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "cli",
+      "gstack",
+      "upgrade"
+    ],
     "triggers": [],
     "version": "1.1.0",
     "path": "skills/cli/gstack-upgrade",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "guard",
+    "slug": "guard",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "gstack",
+      "cli",
+      "guard",
+      "safety"
+    ],
+    "triggers": [],
+    "version": "0.1.0",
+    "path": "skills/cli/gstack/guard",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "health",
+    "slug": "health",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "gstack",
+      "cli",
+      "health",
+      "quality"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/health",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "investigate",
+    "slug": "investigate",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "gstack",
+      "cli",
+      "investigate",
+      "debug"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/investigate",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "land-and-deploy",
+    "slug": "land-and-deploy",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "cli",
+      "land",
+      "and",
+      "deploy"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/land-and-deploy",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "learn",
+    "slug": "learn",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "gstack",
+      "cli",
+      "learn",
+      "knowledge"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/learn",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "office-hours",
+    "slug": "office-hours",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "cli",
+      "office",
+      "hours"
+    ],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/cli/gstack/office-hours",
     "has_content": false
   },
   {
@@ -7550,10 +9325,48 @@
     "slug": "open-gstack-browser",
     "category": "cli",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "cli",
+      "open",
+      "gstack",
+      "browser"
+    ],
+    "triggers": [],
+    "version": "0.2.0",
+    "path": "skills/cli/gstack/open-gstack-browser",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "open-gstack-browser",
+    "slug": "open-gstack-browser",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "cli",
+      "open",
+      "gstack",
+      "browser"
+    ],
     "triggers": [],
     "version": "0.2.0",
     "path": "skills/cli/open-gstack-browser",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "pair-agent",
+    "slug": "pair-agent",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "cli",
+      "pair",
+      "agent"
+    ],
+    "triggers": [],
+    "version": "0.1.0",
+    "path": "skills/cli/gstack/pair-agent",
     "has_content": false
   },
   {
@@ -7568,15 +9381,147 @@
       "multi-instance",
       "config"
     ],
-    "triggers": [
-      "multiple config pairs",
-      "repeated flag",
-      "paired cli args",
-      "multi-spec cli"
-    ],
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/cli/paired-flag-multi-instance-registration",
     "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "plan-ceo-review",
+    "slug": "plan-ceo-review",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "cli",
+      "plan",
+      "ceo",
+      "review"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/plan-ceo-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "plan-design-review",
+    "slug": "plan-design-review",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "cli",
+      "plan",
+      "design",
+      "review"
+    ],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/cli/gstack/plan-design-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "plan-devex-review",
+    "slug": "plan-devex-review",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "cli",
+      "plan",
+      "devex",
+      "review"
+    ],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/cli/gstack/plan-devex-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "plan-eng-review",
+    "slug": "plan-eng-review",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "cli",
+      "plan",
+      "eng",
+      "review"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/plan-eng-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "qa",
+    "slug": "qa",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "gstack",
+      "cli",
+      "qa",
+      "testing"
+    ],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/cli/gstack/qa",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "qa-only",
+    "slug": "qa-only",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "gstack",
+      "cli",
+      "qa",
+      "testing",
+      "report-only"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/qa-only",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "retro",
+    "slug": "retro",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "gstack",
+      "cli",
+      "retro",
+      "retrospective"
+    ],
+    "triggers": [],
+    "version": "2.0.0",
+    "path": "skills/cli/gstack/retro",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "review",
+    "slug": "review",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "gstack",
+      "cli",
+      "review",
+      "pr"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/review",
+    "has_content": false
   },
   {
     "kind": "skill",
@@ -7584,10 +9529,48 @@
     "slug": "setup-browser-cookies",
     "category": "cli",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "cli",
+      "setup",
+      "browser",
+      "cookies"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/setup-browser-cookies",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "setup-browser-cookies",
+    "slug": "setup-browser-cookies",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "cli",
+      "setup",
+      "browser",
+      "cookies"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/cli/setup-browser-cookies",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "setup-deploy",
+    "slug": "setup-deploy",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "cli",
+      "setup",
+      "deploy"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/setup-deploy",
     "has_content": false
   },
   {
@@ -7606,6 +9589,40 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "skills/cli/setup-pre-commit",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "ship",
+    "slug": "ship",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "gstack",
+      "cli",
+      "ship",
+      "deploy"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/gstack/ship",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "unfreeze",
+    "slug": "unfreeze",
+    "category": "cli",
+    "description": "|",
+    "tags": [
+      "gstack",
+      "cli",
+      "unfreeze",
+      "safety"
+    ],
+    "triggers": [],
+    "version": "0.1.0",
+    "path": "skills/cli/gstack/unfreeze",
     "has_content": false
   },
   {
@@ -7657,7 +9674,11 @@
     "slug": "investigate",
     "category": "debug",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "debug",
+      "gstack",
+      "investigate"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/debug/investigate",
@@ -7710,11 +9731,12 @@
     "category": "design",
     "description": "Render actor mailboxes, supervision trees, and message flows as live, inspectable graphs",
     "tags": [
-      "auto-loop"
+      "design",
+      "actor",
+      "model",
+      "visualization"
     ],
-    "triggers": [
-      "actor model visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/actor-model-visualization-pattern",
     "has_content": false
@@ -7725,7 +9747,13 @@
     "slug": "ag-grid-custom-filter-system",
     "category": "design",
     "description": "ag-grid Enterprise wrapper with GridContext provider, custom filter components (Boolean, Number, DateRange, SelectMulti), and pagination state management",
-    "tags": [],
+    "tags": [
+      "design",
+      "grid",
+      "custom",
+      "filter",
+      "system"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/design/ag-grid-custom-filter-system",
@@ -7737,7 +9765,13 @@
     "slug": "antd-wrapper-component-pattern",
     "category": "design",
     "description": "Wrap Ant Design components with a custom design system layer (Sirius pattern) that extends props, enforces standards, and maintains upgrade compatibility",
-    "tags": [],
+    "tags": [
+      "design",
+      "antd",
+      "wrapper",
+      "component",
+      "pattern"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/design/antd-wrapper-component-pattern",
@@ -7750,11 +9784,12 @@
     "category": "design",
     "description": "Single-pane visualization showing client traffic funneling through a gateway layer that fans out to backend services with per-hop status",
     "tags": [
-      "auto-loop"
+      "design",
+      "api",
+      "gateway",
+      "visualization"
     ],
-    "triggers": [
-      "api gateway pattern visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/api-gateway-pattern-visualization-pattern",
     "has_content": false
@@ -7766,11 +9801,13 @@
     "category": "design",
     "description": "Multi-view composition for rendering API version lifecycles, schema diffs, and traffic splits side-by-side",
     "tags": [
-      "auto-loop"
+      "design",
+      "api",
+      "versioning",
+      "visualization",
+      "schema"
     ],
-    "triggers": [
-      "api versioning visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/api-versioning-visualization-pattern",
     "has_content": false
@@ -7782,11 +9819,12 @@
     "category": "design",
     "description": "Visualize producer/consumer rate mismatch with buffer fill gauges, drop counters, and upstream signal arrows",
     "tags": [
-      "auto-loop"
+      "design",
+      "backpressure",
+      "visualization",
+      "visualize"
     ],
-    "triggers": [
-      "backpressure visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/backpressure-visualization-pattern",
     "has_content": false
@@ -7798,11 +9836,12 @@
     "category": "design",
     "description": "Visualize BFF fan-out by rendering per-client gateways as distinct swim lanes that aggregate multiple backend service calls into a single client response",
     "tags": [
-      "auto-loop"
+      "design",
+      "bff",
+      "visualization",
+      "visualize"
     ],
-    "triggers": [
-      "bff pattern visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/bff-pattern-visualization-pattern",
     "has_content": false
@@ -7814,11 +9853,12 @@
     "category": "design",
     "description": "Visualizing bloom filter bit arrays, hash function mappings, and false-positive regions for interactive exploration",
     "tags": [
-      "auto-loop"
+      "design",
+      "bloom",
+      "filter",
+      "visualization"
     ],
-    "triggers": [
-      "bloom filter visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/bloom-filter-visualization-pattern",
     "has_content": false
@@ -7830,11 +9870,14 @@
     "category": "design",
     "description": "Dual-environment (Blue/Active vs Green/Idle) side-by-side canvas with traffic-router arrow and version badges for blue-green deployment dashboards",
     "tags": [
-      "auto-loop"
+      "design",
+      "blue",
+      "green",
+      "deploy",
+      "visualization",
+      "deployment"
     ],
-    "triggers": [
-      "blue green deploy visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/blue-green-deploy-visualization-pattern",
     "has_content": false
@@ -7846,11 +9889,11 @@
     "category": "design",
     "description": "Visual layout conventions for rendering isolated resource pools side-by-side with saturation indicators",
     "tags": [
-      "auto-loop"
+      "design",
+      "bulkhead",
+      "visualization"
     ],
-    "triggers": [
-      "bulkhead visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/bulkhead-visualization-pattern",
     "has_content": false
@@ -7862,11 +9905,12 @@
     "category": "design",
     "description": "Split-lane visualization showing stable vs canary traffic flow with weighted percentage bands and promotion gates",
     "tags": [
-      "auto-loop"
+      "design",
+      "canary",
+      "release",
+      "visualization"
     ],
-    "triggers": [
-      "canary release visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/canary-release-visualization-pattern",
     "has_content": false
@@ -7877,18 +9921,8 @@
     "slug": "canvas-chromakey-bg-removal",
     "category": "design",
     "description": "Browser-side background removal for sprite sheets and JPEG assets using canvas pixel data with white/color key to transparency",
-    "tags": [
-      "canvas",
-      "image-processing",
-      "chroma-key",
-      "transparency"
-    ],
-    "triggers": [
-      "remove white background",
-      "chroma key browser",
-      "sprite sheet transparent",
-      "make image background transparent css"
-    ],
+    "tags": "",
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/canvas-chromakey-bg-removal",
     "has_content": false
@@ -7900,11 +9934,11 @@
     "category": "design",
     "description": "Visualizing CDC event flow from source database through log capture to downstream consumers with row-level change granularity",
     "tags": [
-      "auto-loop"
+      "design",
+      "cdc",
+      "visualization"
     ],
-    "triggers": [
-      "cdc visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/cdc-visualization-pattern",
     "has_content": false
@@ -7916,11 +9950,12 @@
     "category": "design",
     "description": "Visualizing blast radius, failure propagation, and steady-state deviation in chaos experiments",
     "tags": [
-      "auto-loop"
+      "design",
+      "chaos",
+      "engineering",
+      "visualization"
     ],
-    "triggers": [
-      "chaos engineering visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/chaos-engineering-visualization-pattern",
     "has_content": false
@@ -7932,11 +9967,14 @@
     "category": "design",
     "description": "Three-state circuit breaker visualization using color-coded state machine with real-time metrics dashboard",
     "tags": [
-      "auto-loop"
+      "design",
+      "circuit",
+      "breaker",
+      "visualization",
+      "metrics",
+      "dashboard"
     ],
-    "triggers": [
-      "circuit breaker visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/circuit-breaker-visualization-pattern",
     "has_content": false
@@ -7947,18 +9985,8 @@
     "slug": "click-to-inspect-corpus-from-dashboard",
     "category": "design",
     "description": "Make every corpus item (skill, doc, reference) clickable in a dashboard and open its source .md content in a modal via a server endpoint",
-    "tags": [
-      "dashboard",
-      "ux",
-      "modal",
-      "sse"
-    ],
-    "triggers": [
-      "skill preview modal",
-      "inspect corpus item",
-      "dashboard item drilldown",
-      "clickable reference list"
-    ],
+    "tags": "",
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/click-to-inspect-corpus-from-dashboard",
     "has_content": false
@@ -7970,11 +9998,13 @@
     "category": "design",
     "description": "Split-pane UI that visually separates command write paths from query read paths in CQRS systems",
     "tags": [
-      "auto-loop"
+      "design",
+      "command",
+      "query",
+      "visualization",
+      "cqrs"
     ],
-    "triggers": [
-      "command query visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/command-query-visualization-pattern",
     "has_content": false
@@ -7986,11 +10016,13 @@
     "category": "design",
     "description": "Visual conventions for rendering connection pool state, connection lifecycles, and waiter queues in real-time dashboards",
     "tags": [
-      "auto-loop"
+      "design",
+      "connection",
+      "pool",
+      "visualization",
+      "dashboard"
     ],
-    "triggers": [
-      "connection pool visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/connection-pool-visualization-pattern",
     "has_content": false
@@ -8002,11 +10034,14 @@
     "category": "design",
     "description": "Ring-based SVG/Canvas rendering pattern for visualizing consistent hashing node placement and key distribution",
     "tags": [
-      "auto-loop"
+      "design",
+      "consistent",
+      "hashing",
+      "visualization",
+      "node",
+      "canvas"
     ],
-    "triggers": [
-      "consistent hashing visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/consistent-hashing-visualization-pattern",
     "has_content": false
@@ -8018,11 +10053,11 @@
     "category": "design",
     "description": "Split-panel visualization showing command-side writes and query-side reads as distinct, independently-scaling lanes with a projection bridge between them.",
     "tags": [
-      "auto-loop"
+      "design",
+      "cqrs",
+      "visualization"
     ],
-    "triggers": [
-      "cqrs visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/cqrs-visualization-pattern",
     "has_content": false
@@ -8034,11 +10069,11 @@
     "category": "design",
     "description": "Side-by-side replica panels with convergence indicators for visualizing CRDT state synchronization",
     "tags": [
-      "auto-loop"
+      "design",
+      "crdt",
+      "visualization"
     ],
-    "triggers": [
-      "crdt visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/crdt-visualization-pattern",
     "has_content": false
@@ -8049,18 +10084,8 @@
     "slug": "css-sprite-sheet-phase-row-switch",
     "category": "design",
     "description": "Single CSS sprite sheet animated via steps() on X, with inline-style row switch on Y for phase-specific animations",
-    "tags": [
-      "css",
-      "animation",
-      "sprite-sheet",
-      "pixel-art"
-    ],
-    "triggers": [
-      "css sprite animation",
-      "sprite sheet phase",
-      "pixel art character animation",
-      "game-style sprite"
-    ],
+    "tags": "",
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/css-sprite-sheet-phase-row-switch",
     "has_content": false
@@ -8072,11 +10097,12 @@
     "category": "design",
     "description": "Visual patterns for rendering multi-stage data pipelines with flow direction, stage health, and throughput indicators",
     "tags": [
-      "auto-loop"
+      "design",
+      "data",
+      "pipeline",
+      "visualization"
     ],
-    "triggers": [
-      "data pipeline visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/data-pipeline-visualization-pattern",
     "has_content": false
@@ -8088,11 +10114,13 @@
     "category": "design",
     "description": "Canvas-based rendering pattern for visualizing shard topology, key distribution, and routing decisions in database sharding systems",
     "tags": [
-      "auto-loop"
+      "design",
+      "database",
+      "sharding",
+      "visualization",
+      "canvas"
     ],
-    "triggers": [
-      "database sharding visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/database-sharding-visualization-pattern",
     "has_content": false
@@ -8104,11 +10132,13 @@
     "category": "design",
     "description": "Visual patterns for surfacing DLQ message flow, failure reasons, and replay decisions in triage UIs",
     "tags": [
-      "auto-loop"
+      "design",
+      "dead",
+      "letter",
+      "queue",
+      "visualization"
     ],
-    "triggers": [
-      "dead letter queue visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/dead-letter-queue-visualization-pattern",
     "has_content": false
@@ -8119,7 +10149,12 @@
     "slug": "design-consultation",
     "category": "design",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "design",
+      "gstack",
+      "consultation",
+      "review"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/design/design-consultation",
@@ -8131,7 +10166,12 @@
     "slug": "design-html",
     "category": "design",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "design",
+      "gstack",
+      "html",
+      "mockup"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/design/design-html",
@@ -8143,7 +10183,12 @@
     "slug": "design-review",
     "category": "design",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "design",
+      "gstack",
+      "review",
+      "qa"
+    ],
     "triggers": [],
     "version": "2.0.0",
     "path": "skills/design/design-review",
@@ -8155,7 +10200,12 @@
     "slug": "design-shotgun",
     "category": "design",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "design",
+      "gstack",
+      "shotgun",
+      "exploration"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/design/design-shotgun",
@@ -8168,11 +10218,12 @@
     "category": "design",
     "description": "Three complementary views (waterfall, service graph, latency heatmap) for reasoning about distributed traces",
     "tags": [
-      "auto-loop"
+      "design",
+      "distributed",
+      "tracing",
+      "visualization"
     ],
-    "triggers": [
-      "distributed tracing visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/distributed-tracing-visualization-pattern",
     "has_content": false
@@ -8183,7 +10234,13 @@
     "slug": "dnd-kit-tab-reordering",
     "category": "design",
     "description": "Implement horizontal tab drag reordering using @dnd-kit/core + @dnd-kit/sortable with PointerSensor and CSS.Transform",
-    "tags": [],
+    "tags": [
+      "design",
+      "dnd",
+      "kit",
+      "tab",
+      "reordering"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/design/dnd-kit-tab-reordering",
@@ -8196,11 +10253,12 @@
     "category": "design",
     "description": "Rendering bounded contexts, aggregates, and ubiquitous language as navigable maps with relationship overlays",
     "tags": [
-      "auto-loop"
+      "design",
+      "domain",
+      "driven",
+      "visualization"
     ],
-    "triggers": [
-      "domain driven visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/domain-driven-visualization-pattern",
     "has_content": false
@@ -8211,7 +10269,13 @@
     "slug": "drawer-resizable-mouse-drag",
     "category": "design",
     "description": "Make Ant Design Drawer resizable via mouse drag with styled-components handle, min/max width constraints, and transition suppression during drag",
-    "tags": [],
+    "tags": [
+      "design",
+      "drawer",
+      "resizable",
+      "mouse",
+      "drag"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/design/drawer-resizable-mouse-drag",
@@ -8223,7 +10287,13 @@
     "slug": "echarts-svg-worker-chart",
     "category": "design",
     "description": "High-performance chart component using ECharts with custom SVG overlays (markLine/markArea/markPoint), worker thread data processing, and brush selection interaction",
-    "tags": [],
+    "tags": [
+      "design",
+      "echarts",
+      "svg",
+      "worker",
+      "chart"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/design/echarts-svg-worker-chart",
@@ -8236,11 +10306,13 @@
     "category": "design",
     "description": "Canvas-based visual representations for ETL flow, rules, and lineage with node-edge topology",
     "tags": [
-      "auto-loop"
+      "design",
+      "etl",
+      "visualization",
+      "node",
+      "canvas"
     ],
-    "triggers": [
-      "etl visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/etl-visualization-pattern",
     "has_content": false
@@ -8252,11 +10324,12 @@
     "category": "design",
     "description": "Render append-only event logs alongside derived state projections with replay scrubber controls",
     "tags": [
-      "auto-loop"
+      "design",
+      "event",
+      "sourcing",
+      "visualization"
     ],
-    "triggers": [
-      "event sourcing visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/event-sourcing-visualization-pattern",
     "has_content": false
@@ -8268,11 +10341,13 @@
     "category": "design",
     "description": "Visualization pattern for feature-flag rollout, dependency, and A/B experiment dashboards",
     "tags": [
-      "auto-loop"
+      "design",
+      "feature",
+      "flags",
+      "visualization",
+      "dashboard"
     ],
-    "triggers": [
-      "feature flags visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/feature-flags-visualization-pattern",
     "has_content": false
@@ -8283,7 +10358,13 @@
     "slug": "figma-token-to-tailwind-theme",
     "category": "design",
     "description": "Pipeline from Figma Token Studio JSON exports through Style Dictionary v5 to Tailwind v4 @theme CSS custom properties, with dark/light/contrast mode support and breaking change detection",
-    "tags": [],
+    "tags": [
+      "design",
+      "figma",
+      "token",
+      "tailwind",
+      "theme"
+    ],
     "triggers": [],
     "version": "1.1.0",
     "path": "skills/design/figma-token-to-tailwind-theme",
@@ -8296,11 +10377,14 @@
     "category": "design",
     "description": "Render FSM states as a node graph with animated active-state highlighting and transition edge pulses driven by the current state variable.",
     "tags": [
-      "auto-loop"
+      "design",
+      "finite",
+      "state",
+      "machine",
+      "visualization",
+      "node"
     ],
-    "triggers": [
-      "finite state machine visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/finite-state-machine-visualization-pattern",
     "has_content": false
@@ -8312,11 +10396,13 @@
     "category": "design",
     "description": "Visualizing GraphQL operations (queries, schemas, subscriptions) through interactive node-graph and live-feed UIs",
     "tags": [
-      "auto-loop"
+      "design",
+      "graphql",
+      "visualization",
+      "node",
+      "schema"
     ],
-    "triggers": [
-      "graphql visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/graphql-visualization-pattern",
     "has_content": false
@@ -8328,11 +10414,13 @@
     "category": "design",
     "description": "Dashboard layout pattern for rendering heterogeneous health-check signals into a single at-a-glance status surface",
     "tags": [
-      "auto-loop"
+      "design",
+      "health",
+      "check",
+      "visualization",
+      "dashboard"
     ],
-    "triggers": [
-      "health check visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/health-check-visualization-pattern",
     "has_content": false
@@ -8344,11 +10432,12 @@
     "category": "design",
     "description": "Render the hexagon with domain core centered and ports/adapters radiating outward through driving/driven lanes",
     "tags": [
-      "auto-loop"
+      "design",
+      "hexagonal",
+      "architecture",
+      "visualization"
     ],
-    "triggers": [
-      "hexagonal architecture visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/hexagonal-architecture-visualization-pattern",
     "has_content": false
@@ -8359,18 +10448,8 @@
     "slug": "hue-rotate-sprite-identity",
     "category": "design",
     "description": "Create distinct named character variants from a single sprite sheet using CSS hue-rotate + data attributes",
-    "tags": [
-      "css",
-      "sprite",
-      "palette-swap",
-      "game-ui"
-    ],
-    "triggers": [
-      "character variants sprite",
-      "palette swap",
-      "hue rotation identity",
-      "npc color variants"
-    ],
+    "tags": "",
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/hue-rotate-sprite-identity",
     "has_content": false
@@ -8382,11 +10461,11 @@
     "category": "design",
     "description": "Visual patterns for demonstrating idempotency guarantees through request replay, key-based deduplication, and state convergence animations.",
     "tags": [
-      "auto-loop"
+      "design",
+      "idempotency",
+      "visualization"
     ],
-    "triggers": [
-      "idempotency visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/idempotency-visualization-pattern",
     "has_content": false
@@ -8398,11 +10477,12 @@
     "category": "design",
     "description": "Canvas-based lantern rendering with flicker, glow halos, and ember particle systems for atmospheric visualization",
     "tags": [
-      "auto-loop"
+      "design",
+      "lantern",
+      "visualization",
+      "canvas"
     ],
-    "triggers": [
-      "lantern visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/lantern-visualization-pattern",
     "has_content": false
@@ -8413,18 +10493,8 @@
     "slug": "layout-stable-hover-via-inset-shadow",
     "category": "design",
     "description": "Replace transform-based hover effects (translate, scale) with inset box-shadow to avoid layout shifts and horizontal-scrollbar flicker",
-    "tags": [
-      "css",
-      "hover",
-      "scrollbar",
-      "layout"
-    ],
-    "triggers": [
-      "hover causes scrollbar",
-      "hover layout shift",
-      "translate hover flicker",
-      "scrollbar flashes on hover"
-    ],
+    "tags": "",
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/layout-stable-hover-via-inset-shadow",
     "has_content": false
@@ -8436,11 +10506,14 @@
     "category": "design",
     "description": "Canvas/SVG-based real-time visualization for load balancer request distribution across backend pools",
     "tags": [
-      "auto-loop"
+      "design",
+      "load",
+      "balancer",
+      "visualization",
+      "canvas",
+      "svg"
     ],
-    "triggers": [
-      "load balancer visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/load-balancer-visualization-pattern",
     "has_content": false
@@ -8452,11 +10525,13 @@
     "category": "design",
     "description": "Visual patterns for rendering streaming logs, heatmap density, and query-filtered timelines in log aggregation UIs",
     "tags": [
-      "auto-loop"
+      "design",
+      "log",
+      "aggregation",
+      "visualization",
+      "streaming"
     ],
-    "triggers": [
-      "log aggregation visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/log-aggregation-visualization-pattern",
     "has_content": false
@@ -8468,11 +10543,12 @@
     "category": "design",
     "description": "Visual layout conventions for rendering materialized view lifecycle (base tables → MV → queries) with staleness indicators",
     "tags": [
-      "auto-loop"
+      "design",
+      "materialized",
+      "view",
+      "visualization"
     ],
-    "triggers": [
-      "materialized view visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/materialized-view-visualization-pattern",
     "has_content": false
@@ -8484,11 +10560,13 @@
     "category": "design",
     "description": "Canvas-based rendering pattern for animating message flow through producers, queues, and consumers",
     "tags": [
-      "auto-loop"
+      "design",
+      "message",
+      "queue",
+      "visualization",
+      "canvas"
     ],
-    "triggers": [
-      "message queue visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/message-queue-visualization-pattern",
     "has_content": false
@@ -8499,7 +10577,13 @@
     "slug": "mfa-portal-css-isolation",
     "category": "design",
     "description": "Isolate Tailwind CSS in Module Federation portals using lazyStyleTag injection, postcss-prefix-selector with :where() specificity control, scoped root elements, and Headless UI PortalGroup",
-    "tags": [],
+    "tags": [
+      "design",
+      "mfa",
+      "portal",
+      "css",
+      "isolation"
+    ],
     "triggers": [],
     "version": "1.1.0",
     "path": "skills/design/mfa-portal-css-isolation",
@@ -8511,14 +10595,15 @@
     "slug": "nds-html-mockup-from-tokens",
     "category": "design",
     "description": "lucida-ui 디자인 토큰을 추출하여 실제 제품과 동일한 스타일의 static HTML 목업 생성",
-    "tags": [],
-    "triggers": [
-      "HTML 목업",
-      "디자인 목업",
-      "NDS 스타일 HTML",
-      "lucida 디자인으로 HTML",
-      "화면 프로토타입"
+    "tags": [
+      "design",
+      "nds",
+      "html",
+      "mockup",
+      "from",
+      "tokens"
     ],
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/design/nds-html-mockup-from-tokens",
     "has_content": false
@@ -8530,11 +10615,13 @@
     "category": "design",
     "description": "Visualizing OAuth flows, JWT structure, and scope relationships through staged, interactive diagrams",
     "tags": [
-      "auto-loop"
+      "design",
+      "oauth",
+      "visualization",
+      "auth",
+      "jwt"
     ],
-    "triggers": [
-      "oauth visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/oauth-visualization-pattern",
     "has_content": false
@@ -8546,11 +10633,14 @@
     "category": "design",
     "description": "Canvas/SVG patterns for visualizing object storage buckets, objects, and replication topologies",
     "tags": [
-      "auto-loop"
+      "design",
+      "object",
+      "storage",
+      "visualization",
+      "replication",
+      "canvas"
     ],
-    "triggers": [
-      "object storage visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/object-storage-visualization-pattern",
     "has_content": false
@@ -8562,11 +10652,12 @@
     "category": "design",
     "description": "Three-lane visualization showing business transaction, outbox table, and relay publisher for outbox pattern demos",
     "tags": [
-      "auto-loop"
+      "design",
+      "outbox",
+      "visualization",
+      "transaction"
     ],
-    "triggers": [
-      "outbox pattern visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/outbox-pattern-visualization-pattern",
     "has_content": false
@@ -8578,11 +10669,13 @@
     "category": "design",
     "description": "Multi-layer animated horizon backdrop built from 3-N sine-displaced silhouette polygons with decreasing opacity and rising baselines for cheap parallax depth.",
     "tags": [
-      "auto-loop"
+      "design",
+      "parallax",
+      "sine",
+      "silhouette",
+      "horizon"
     ],
-    "triggers": [
-      "parallax sine silhouette horizon"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/parallax-sine-silhouette-horizon",
     "has_content": false
@@ -8593,7 +10686,11 @@
     "slug": "plan-design-review",
     "category": "design",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "design",
+      "plan",
+      "review"
+    ],
     "triggers": [],
     "version": "2.0.0",
     "path": "skills/design/plan-design-review",
@@ -8606,11 +10703,13 @@
     "category": "design",
     "description": "Canvas-based visualization showing topic channels, publishers fanning out messages to multiple subscribers with animated message particles",
     "tags": [
-      "auto-loop"
+      "design",
+      "pub",
+      "sub",
+      "visualization",
+      "canvas"
     ],
-    "triggers": [
-      "pub sub visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/pub-sub-visualization-pattern",
     "has_content": false
@@ -8622,11 +10721,13 @@
     "category": "design",
     "description": "Multi-panel layout for visualizing Raft consensus state across leader election, log replication, and term progression",
     "tags": [
-      "auto-loop"
+      "design",
+      "raft",
+      "consensus",
+      "visualization",
+      "replication"
     ],
-    "triggers": [
-      "raft consensus visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/raft-consensus-visualization-pattern",
     "has_content": false
@@ -8638,11 +10739,13 @@
     "category": "design",
     "description": "Visual patterns for rendering token buckets, sliding windows, and quota consumption in real-time dashboards",
     "tags": [
-      "auto-loop"
+      "design",
+      "rate",
+      "limiter",
+      "visualization",
+      "dashboard"
     ],
-    "triggers": [
-      "rate limiter visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/rate-limiter-visualization-pattern",
     "has_content": false
@@ -8654,11 +10757,13 @@
     "category": "design",
     "description": "Canvas-based topology visualization for primary-replica clusters with lag indicators and routing flows",
     "tags": [
-      "auto-loop"
+      "design",
+      "read",
+      "replica",
+      "visualization",
+      "canvas"
     ],
-    "triggers": [
-      "read replica visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/read-replica-visualization-pattern",
     "has_content": false
@@ -8670,11 +10775,13 @@
     "category": "design",
     "description": "Visualize retry attempts as timeline tracks with backoff intervals, jitter bands, and terminal outcome markers",
     "tags": [
-      "auto-loop"
+      "design",
+      "retry",
+      "strategy",
+      "visualization",
+      "visualize"
     ],
-    "triggers": [
-      "retry strategy visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/retry-strategy-visualization-pattern",
     "has_content": false
@@ -8686,11 +10793,13 @@
     "category": "design",
     "description": "Visualize saga transaction flows with step states, compensation paths, and forward/backward progress indicators",
     "tags": [
-      "auto-loop"
+      "design",
+      "saga",
+      "visualization",
+      "transaction",
+      "visualize"
     ],
-    "triggers": [
-      "saga pattern visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/saga-pattern-visualization-pattern",
     "has_content": false
@@ -8702,11 +10811,12 @@
     "category": "design",
     "description": "Visualization patterns for schema registry evolution, compatibility, and dependency graphs",
     "tags": [
-      "auto-loop"
+      "design",
+      "schema",
+      "registry",
+      "visualization"
     ],
-    "triggers": [
-      "schema registry visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/schema-registry-visualization-pattern",
     "has_content": false
@@ -8718,11 +10828,12 @@
     "category": "design",
     "description": "Rendering sidecar proxies, control plane, and east-west traffic flows as an interactive topology graph",
     "tags": [
-      "auto-loop"
+      "design",
+      "service",
+      "mesh",
+      "visualization"
     ],
-    "triggers": [
-      "service mesh visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/service-mesh-visualization-pattern",
     "has_content": false
@@ -8734,11 +10845,14 @@
     "category": "design",
     "description": "Visualize sidecar proxy topology as paired app+proxy nodes with intercepted traffic flows and policy overlays.",
     "tags": [
-      "auto-loop"
+      "design",
+      "sidecar",
+      "proxy",
+      "visualization",
+      "node",
+      "visualize"
     ],
-    "triggers": [
-      "sidecar proxy visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/sidecar-proxy-visualization-pattern",
     "has_content": false
@@ -8750,11 +10864,13 @@
     "category": "design",
     "description": "Side-by-side legacy/new system visualization with traffic routing overlay for strangler-fig migration apps",
     "tags": [
-      "auto-loop"
+      "design",
+      "strangler",
+      "fig",
+      "visualization",
+      "migration"
     ],
-    "triggers": [
-      "strangler fig visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/strangler-fig-visualization-pattern",
     "has_content": false
@@ -8766,11 +10882,13 @@
     "category": "design",
     "description": "Render time-series data as a scrolling multi-series canvas chart with downsampled LTTB buckets and a brushable overview band.",
     "tags": [
-      "auto-loop"
+      "design",
+      "time",
+      "series",
+      "visualization",
+      "canvas"
     ],
-    "triggers": [
-      "time series db visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/time-series-db-visualization-pattern",
     "has_content": false
@@ -8782,11 +10900,13 @@
     "category": "design",
     "description": "Canvas/SVG-based frame-level visualization for WebSocket protocol state, handshake phases, and message flow",
     "tags": [
-      "auto-loop"
+      "design",
+      "websocket",
+      "visualization",
+      "canvas",
+      "svg"
     ],
-    "triggers": [
-      "websocket visualization pattern"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/design/websocket-visualization-pattern",
     "has_content": false
@@ -8797,7 +10917,12 @@
     "slug": "widget-card-composition",
     "category": "design",
     "description": "Dashboard widget composition pattern using a CardWidget chrome wrapper with domain-specific Card* content components, resize tracking, and popover menus",
-    "tags": [],
+    "tags": [
+      "design",
+      "widget",
+      "card",
+      "composition"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/design/widget-card-composition",
@@ -8809,21 +10934,8 @@
     "slug": "zero-dep-dark-html-app",
     "category": "design",
     "description": "Scaffold a zero-dependency dark-theme HTML+CSS+JS interactive app with canvas charts, tab navigation, and detail panels",
-    "tags": [
-      "html",
-      "css",
-      "vanilla-js",
-      "canvas",
-      "dark-theme",
-      "zero-dependency"
-    ],
-    "triggers": [
-      "zero-dep html app",
-      "dark theme dashboard",
-      "self-contained html tool",
-      "vanilla js interactive app",
-      "canvas visualization app"
-    ],
+    "tags": "",
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/zero-dep-dark-html-app",
     "has_content": false
@@ -8851,8 +10963,14 @@
     "name": "claude-code-skill-scaffold",
     "slug": "claude-code-skill-scaffold",
     "category": "devops",
-    "description": "[Tooling] Claude Code 스킬 표준 구조(SKILL.md + prompts/ + scripts/ + references/)를 자동 생성하는 스캐폴딩.",
-    "tags": [],
+    "description": "\"[Tooling] Claude Code 스킬 표준 구조(SKILL.md + prompts/ + scripts/ + references/)를 자동 생성하는 스캐폴딩.\"",
+    "tags": [
+      "devops",
+      "claude",
+      "code",
+      "skill",
+      "scaffold"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/devops/claude-code-skill-scaffold",
@@ -8863,8 +10981,14 @@
     "name": "claude-plugin-catalog-publish",
     "slug": "claude-plugin-catalog-publish",
     "category": "devops",
-    "description": "[Tooling] 로컬 스킬을 원격 Git repo에 배포하고 AGENTS.md 카탈로그를 자동 갱신하는 publish 플로우.",
-    "tags": [],
+    "description": "\"[Tooling] 로컬 스킬을 원격 Git repo에 배포하고 AGENTS.md 카탈로그를 자동 갱신하는 publish 플로우.\"",
+    "tags": [
+      "devops",
+      "claude",
+      "plugin",
+      "catalog",
+      "publish"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/devops/claude-plugin-catalog-publish",
@@ -8876,7 +11000,14 @@
     "slug": "docker-compose-service-inventory-files",
     "category": "devops",
     "description": "Manage large Docker Compose service fleets using flat inventory files with '#' as an EX (exclude) marker",
-    "tags": [],
+    "tags": [
+      "devops",
+      "docker",
+      "compose",
+      "service",
+      "inventory",
+      "files"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/devops/docker-compose-service-inventory-files",
@@ -8888,7 +11019,13 @@
     "slug": "docker-compose-v1-v2-auto-detect",
     "category": "devops",
     "description": "Shell helper that prefers `docker compose` (v2) over `docker-compose` (v1) with graceful fallback",
-    "tags": [],
+    "tags": [
+      "devops",
+      "docker",
+      "compose",
+      "auto",
+      "detect"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/devops/docker-compose-v1-v2-auto-detect",
@@ -8900,7 +11037,13 @@
     "slug": "dual-jre-docker-oz-report",
     "category": "devops",
     "description": "Package a Java 21 Spring Boot app that bundles a legacy JRE 8 + sidecar Tomcat (OZ Report engine) in one Alpine container",
-    "tags": [],
+    "tags": [
+      "devops",
+      "dual",
+      "jre",
+      "docker",
+      "report"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/devops/dual-jre-docker-oz-report",
@@ -8912,7 +11055,14 @@
     "slug": "font-cache-alpine-locale-docker",
     "category": "devops",
     "description": "Make CJK/custom fonts usable inside an Alpine container by copying TTF/OTF and rebuilding the fontconfig cache",
-    "tags": [],
+    "tags": [
+      "devops",
+      "font",
+      "cache",
+      "alpine",
+      "locale",
+      "docker"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/devops/font-cache-alpine-locale-docker",
@@ -8924,7 +11074,14 @@
     "slug": "gradle-bootrun-local-dev-env",
     "category": "devops",
     "description": "Gradle bootRun task recipe that wires local MongoDB/Kafka/Redis/MQTT/Eureka/Quartz via environment variables — no docker-compose needed",
-    "tags": [],
+    "tags": [
+      "devops",
+      "gradle",
+      "bootrun",
+      "local",
+      "dev",
+      "env"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/devops/gradle-bootrun-local-dev-env",
@@ -8936,7 +11093,13 @@
     "slug": "gradle-jacoco-exclusion-strategy",
     "category": "devops",
     "description": "Curated Jacoco/Sonar exclusion patterns for Spring Boot projects — skips config/DAO/entity/generated layers and Querydsl Q-classes",
-    "tags": [],
+    "tags": [
+      "devops",
+      "gradle",
+      "jacoco",
+      "exclusion",
+      "strategy"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/devops/gradle-jacoco-exclusion-strategy",
@@ -8948,12 +11111,15 @@
     "slug": "gradle-shared-exclusions-jacoco-sonar",
     "category": "devops",
     "description": "Keep Jacoco report, Jacoco coverage verification, and SonarQube exclusions in sync by defining one `exclusionPatterns` list in Gradle ext",
-    "tags": [],
-    "triggers": [
-      "jacoco and sonarqube exclusion lists drift apart",
-      "adding a new package to coverage exclusions requires editing multiple blocks",
-      "querydsl Q-classes / generated code leaking into coverage reports"
+    "tags": [
+      "devops",
+      "gradle",
+      "shared",
+      "exclusions",
+      "jacoco",
+      "sonar"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/devops/gradle-shared-exclusions-jacoco-sonar",
     "has_content": true
@@ -8964,7 +11130,14 @@
     "slug": "jenkins-dual-registry-docker-push",
     "category": "devops",
     "description": "Jenkins pipeline that builds one image and tags+pushes it to two registries (SaaS + on-prem) with both build-specific and rolling-latest tags",
-    "tags": [],
+    "tags": [
+      "devops",
+      "jenkins",
+      "dual",
+      "registry",
+      "docker",
+      "push"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/devops/jenkins-dual-registry-docker-push",
@@ -8976,7 +11149,13 @@
     "slug": "mongodb-volume-copy-backup",
     "category": "devops",
     "description": "Back up and restore MongoDB Docker volumes via rsync volume-copy instead of mongodump/tar.gz",
-    "tags": [],
+    "tags": [
+      "devops",
+      "mongodb",
+      "volume",
+      "copy",
+      "backup"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/devops/mongodb-volume-copy-backup",
@@ -9010,7 +11189,13 @@
     "slug": "querydsl-q-class-exclusion-pattern",
     "category": "devops",
     "description": "One `exclusionPatterns` list drives Jacoco report + verification + Sonar exclusions; catches generated Querydsl Q-classes via `('A'..'Z').collect { \"**/**/Q${it}*\" }`.",
-    "tags": [],
+    "tags": [
+      "devops",
+      "querydsl",
+      "class",
+      "exclusion",
+      "pattern"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/devops/querydsl-q-class-exclusion-pattern",
@@ -9021,8 +11206,12 @@
     "name": "skill-md-validator",
     "slug": "skill-md-validator",
     "category": "devops",
-    "description": "[Tooling] SKILL.md frontmatter + 필수 섹션을 CRITICAL/WARNING 등급으로 검증하는 품질 게이트.",
-    "tags": [],
+    "description": "\"[Tooling] SKILL.md frontmatter + 필수 섹션을 CRITICAL/WARNING 등급으로 검증하는 품질 게이트.\"",
+    "tags": [
+      "devops",
+      "skill",
+      "validator"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/devops/skill-md-validator",
@@ -9034,15 +11223,13 @@
     "slug": "slack-webhook-notify",
     "category": "devops",
     "description": "Slack Incoming Webhook으로 메시지를 전송한다. 빌드/테스트/배포 결과, 작업 완료 알림 등을 Slack 채널에 보낼 때 사용.",
-    "tags": [],
-    "triggers": [
+    "tags": [
+      "devops",
       "slack",
-      "슬랙",
-      "slack notify",
-      "webhook 알림",
-      "빌드 알림",
-      "작업 완료 알림"
+      "webhook",
+      "notify"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/devops/slack-webhook-notify",
     "has_content": false
@@ -9053,12 +11240,15 @@
     "slug": "spring-bootrun-local-dev-env-block",
     "category": "devops",
     "description": "Gradle `bootRun` env block that wires local Redis/Mongo/Kafka/Eureka/MQTT for zero-config `./gradlew bootRun` developer experience",
-    "tags": [],
-    "triggers": [
-      "new engineer asks \"how do I run this locally?",
-      "application-local.yaml is gitignored and no-one knows the defaults",
-      "Spring Cloud service refuses to start locally because Eureka client is enabled"
+    "tags": [
+      "devops",
+      "spring",
+      "bootrun",
+      "local",
+      "dev",
+      "env"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/devops/spring-bootrun-local-dev-env-block",
     "has_content": true
@@ -9069,7 +11259,14 @@
     "slug": "triple-env-file-split-loader",
     "category": "devops",
     "description": "Split operator-facing env into three files (.env / .version / .memory) and load them in a fixed order",
-    "tags": [],
+    "tags": [
+      "devops",
+      "triple",
+      "env",
+      "file",
+      "split",
+      "loader"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/devops/triple-env-file-split-loader",
@@ -9081,7 +11278,11 @@
     "slug": "document-release",
     "category": "docs",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "docs",
+      "document",
+      "release"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/docs/document-release",
@@ -9109,7 +11310,12 @@
     "slug": "learn",
     "category": "docs",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "docs",
+      "gstack",
+      "learn",
+      "knowledge"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/docs/learn",
@@ -9138,7 +11344,12 @@
     "slug": "retro",
     "category": "docs",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "docs",
+      "gstack",
+      "retro",
+      "retrospective"
+    ],
     "triggers": [],
     "version": "2.0.0",
     "path": "skills/docs/retro",
@@ -9167,14 +11378,14 @@
     "slug": "ag-grid-cell-renderer-pattern",
     "category": "frontend",
     "description": "Structured AG-Grid custom cell renderer catalog with typed column definitions and category-based organization",
-    "tags": [],
-    "triggers": [
-      "ag-grid",
-      "cell renderer",
-      "grid column",
-      "custom renderer",
-      "grid cell"
+    "tags": [
+      "frontend",
+      "grid",
+      "cell",
+      "renderer",
+      "pattern"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/frontend/ag-grid-cell-renderer-pattern",
     "has_content": true
@@ -9185,22 +11396,8 @@
     "slug": "axios-refresh-queue-zustand",
     "category": "frontend",
     "description": "Axios response interceptor that intercepts 401, queues concurrent failed requests, refreshes the token once, and replays queued requests with the new token. Prevents thundering-herd refresh calls.",
-    "tags": [
-      "axios",
-      "jwt",
-      "refresh-token",
-      "interceptor",
-      "zustand",
-      "auth"
-    ],
-    "triggers": [
-      "axios 401 refresh",
-      "token refresh queue",
-      "isRefreshing flag",
-      "axios interceptor zustand",
-      "refresh thundering herd",
-      "retry original request"
-    ],
+    "tags": "",
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/frontend/axios-refresh-queue-zustand",
     "has_content": true
@@ -9212,13 +11409,54 @@
     "category": "frontend",
     "description": "Composite scene from an animated `<canvas>` plus an overlaid `<svg>`, routing pointer events to the layer that owns each element class.",
     "tags": [
-      "auto-loop"
+      "frontend",
+      "canvas",
+      "svg",
+      "dual",
+      "layer",
+      "hit"
     ],
-    "triggers": [
-      "canvas svg dual layer hit dispatch"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/frontend/canvas-svg-dual-layer-hit-dispatch",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "causal-dag-layered-layout-from-happens-before",
+    "slug": "causal-dag-layered-layout-from-happens-before",
+    "category": "frontend",
+    "description": "Layout a DAG of events by longest happens-before depth per actor lane for readable causal diagrams.",
+    "tags": [
+      "frontend",
+      "causal",
+      "dag",
+      "layered",
+      "layout",
+      "happens"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/frontend/causal-dag-layered-layout-from-happens-before",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "copper-patina-gradient-shader",
+    "slug": "copper-patina-gradient-shader",
+    "category": "frontend",
+    "description": "Simulate aged copper map surfaces using layered radial gradients and noise-perturbed hue shifts on canvas.",
+    "tags": [
+      "frontend",
+      "copper",
+      "patina",
+      "gradient",
+      "shader",
+      "canvas"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/frontend/copper-patina-gradient-shader",
     "has_content": false
   },
   {
@@ -9227,13 +11465,13 @@
     "slug": "drawer-resizable-composition",
     "category": "frontend",
     "description": "Drawer-as-primary-modal pattern with preset widths, resizable handles, and parent state composition for React apps",
-    "tags": [],
-    "triggers": [
+    "tags": [
+      "frontend",
       "drawer",
-      "modal drawer",
-      "resizable drawer",
-      "side panel"
+      "resizable",
+      "composition"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/frontend/drawer-resizable-composition",
     "has_content": true
@@ -9244,7 +11482,13 @@
     "slug": "figma-code-connect-react",
     "category": "frontend",
     "description": "Map Figma component variants to React props using @figma/code-connect with co-located *.figma.tsx files",
-    "tags": [],
+    "tags": [
+      "frontend",
+      "figma",
+      "code",
+      "connect",
+      "react"
+    ],
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "skills/frontend/figma-code-connect-react",
@@ -9256,7 +11500,14 @@
     "slug": "figma-token-scss-style-dictionary-v3",
     "category": "frontend",
     "description": "Figma Tokens Studio JSON → split files → Style Dictionary v3 → SCSS variables, typography classes, and composition classes",
-    "tags": [],
+    "tags": [
+      "frontend",
+      "figma",
+      "token",
+      "scss",
+      "style",
+      "dictionary"
+    ],
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "skills/frontend/figma-token-scss-style-dictionary-v3",
@@ -9268,7 +11519,13 @@
     "slug": "folder-coloc-style-types",
     "category": "frontend",
     "description": "Keep component, style, and types files at the same depth; never split into styles/ or types/ subfolders",
-    "tags": [],
+    "tags": [
+      "frontend",
+      "folder",
+      "coloc",
+      "style",
+      "types"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/frontend/folder-coloc-style-types",
@@ -9281,11 +11538,13 @@
     "category": "frontend",
     "description": "Compose a natural-looking flicker/sway value by summing 2–3 sine waves whose frequencies are non-integer ratios so the pattern never visibly loops.",
     "tags": [
-      "auto-loop"
+      "frontend",
+      "incommensurate",
+      "sine",
+      "organic",
+      "flicker"
     ],
-    "triggers": [
-      "incommensurate sine organic flicker"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/frontend/incommensurate-sine-organic-flicker",
     "has_content": false
@@ -9296,11 +11555,37 @@
     "slug": "jest-test-file-naming-test-only",
     "category": "frontend",
     "description": "Use .test.ts naming (not .spec.ts) and explicitly import jest globals; .spec.ts is excluded from the runner",
-    "tags": [],
+    "tags": [
+      "frontend",
+      "jest",
+      "test",
+      "file",
+      "naming",
+      "only"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/frontend/jest-test-file-naming-test-only",
     "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "lag-watermark-dual-axis-timeline",
+    "slug": "lag-watermark-dual-axis-timeline",
+    "category": "frontend",
+    "description": "Overlay consumer lag and watermark progression on a shared time axis with dual-scale Y to keep both readable during bursts.",
+    "tags": [
+      "frontend",
+      "lag",
+      "watermark",
+      "dual",
+      "axis",
+      "timeline"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/frontend/lag-watermark-dual-axis-timeline",
+    "has_content": false
   },
   {
     "kind": "skill",
@@ -9334,14 +11619,14 @@
     "slug": "mfa-federated-component-loader",
     "category": "frontend",
     "description": "Three-layer dynamic component loading for Webpack 5 Module Federation with retry logic, script caching, and error boundaries",
-    "tags": [],
-    "triggers": [
-      "module federation",
-      "federated component",
-      "remote component loading",
-      "dynamic import remote",
-      "RemoteApp"
+    "tags": [
+      "frontend",
+      "mfa",
+      "federated",
+      "component",
+      "loader"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/frontend/mfa-federated-component-loader",
     "has_content": true
@@ -9411,14 +11696,7 @@
       "mfa",
       "monorepo"
     ],
-    "triggers": [
-      "expose a component across module federation remotes",
-      "share React component between MFA remotes",
-      "MFA expose pipeline",
-      "cross-remote import forbidden",
-      "RemoteApp wrapper",
-      "webpack alias collision"
-    ],
+    "triggers": "",
     "version": "1.1.0",
     "path": "skills/frontend/module-federation-expose-react-component",
     "has_content": true
@@ -9430,13 +11708,34 @@
     "category": "frontend",
     "description": "Rhythm-game timing mechanic that grades clicks by distance from a cyclic \"golden window\" center, with pity expansion after consecutive misses.",
     "tags": [
-      "auto-loop"
+      "frontend",
+      "phase",
+      "window",
+      "timing",
+      "grade",
+      "pity"
     ],
-    "triggers": [
-      "phase window timing grade with pity"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/frontend/phase-window-timing-grade-with-pity",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "rebalance-partition-ownership-swimlane",
+    "slug": "rebalance-partition-ownership-swimlane",
+    "category": "frontend",
+    "description": "Render partition-to-consumer assignment as horizontal swimlanes with animated handoff arcs during rebalance events.",
+    "tags": [
+      "frontend",
+      "rebalance",
+      "partition",
+      "ownership",
+      "swimlane"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/frontend/rebalance-partition-ownership-swimlane",
     "has_content": false
   },
   {
@@ -9445,16 +11744,36 @@
     "slug": "recoil-domain-atom-store",
     "category": "frontend",
     "description": "Domain-scoped Recoil atom organization with typed hook wrappers for large-scale React state management",
-    "tags": [],
-    "triggers": [
-      "recoil atom",
-      "state management",
-      "domain store",
-      "global state"
+    "tags": [
+      "frontend",
+      "recoil",
+      "domain",
+      "atom",
+      "store"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/frontend/recoil-domain-atom-store",
     "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "replica-timeline-swimlane-with-causal-arrows",
+    "slug": "replica-timeline-swimlane-with-causal-arrows",
+    "category": "frontend",
+    "description": "Render multi-replica event timelines as horizontal swimlanes with causal arrows drawn in a separate SVG layer above the event grid.",
+    "tags": [
+      "frontend",
+      "replica",
+      "timeline",
+      "swimlane",
+      "causal",
+      "arrows"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/frontend/replica-timeline-swimlane-with-causal-arrows",
+    "has_content": false
   },
   {
     "kind": "skill",
@@ -9470,14 +11789,7 @@
       "monorepo",
       "layering"
     ],
-    "triggers": [
-      "엔드포인트 추가",
-      "widgetEndPoint",
-      "shared/apis",
-      "commonApiService",
-      "API 레이어 추가",
-      "endpoint constant"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/frontend/shared-apis-endpoint-service-pattern",
     "has_content": false
@@ -9488,14 +11800,13 @@
     "slug": "sse-fetch-streaming",
     "category": "frontend",
     "description": "Fetch-based Server-Sent Events streaming with pause/resume/close control for real-time chat and data feeds",
-    "tags": [],
-    "triggers": [
+    "tags": [
+      "frontend",
       "sse",
-      "server-sent events",
-      "streaming",
-      "event stream",
-      "real-time chat"
+      "fetch",
+      "streaming"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/frontend/sse-fetch-streaming",
     "has_content": true
@@ -9506,11 +11817,34 @@
     "slug": "ts-type-prefix-convention",
     "category": "frontend",
     "description": "Prefix interfaces with I and type aliases with T; use type for unions/literals and interface for inheritable shapes",
-    "tags": [],
+    "tags": [
+      "frontend",
+      "type",
+      "prefix",
+      "convention"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/frontend/ts-type-prefix-convention",
     "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "vector-clock-concurrency-matrix",
+    "slug": "vector-clock-concurrency-matrix",
+    "category": "frontend",
+    "description": "Render N×N pairwise happens-before/concurrent relation grid from a set of vector-clock-stamped events for instant causal inspection.",
+    "tags": [
+      "frontend",
+      "vector",
+      "clock",
+      "concurrency",
+      "matrix"
+    ],
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/frontend/vector-clock-concurrency-matrix",
+    "has_content": false
   },
   {
     "kind": "skill",
@@ -9519,11 +11853,14 @@
     "category": "frontend",
     "description": "Play a pre-computed note list by scheduling every oscillator upfront on the AudioContext clock, while JS only drives a requestAnimationFrame playhead.",
     "tags": [
-      "auto-loop"
+      "frontend",
+      "webaudio",
+      "burst",
+      "schedule",
+      "melody",
+      "raf"
     ],
-    "triggers": [
-      "webaudio burst schedule melody with raf playhead"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/frontend/webaudio-burst-schedule-melody-with-raf-playhead",
     "has_content": false
@@ -9541,13 +11878,7 @@
       "data-fetch",
       "scope-injection"
     ],
-    "triggers": [
-      "confId 주입",
-      "selectCondition confId",
-      "위젯 필터링",
-      "widget scope injection",
-      "resource-scoped widget"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/frontend/widget-confid-injection-sweep",
     "has_content": false
@@ -9565,14 +11896,7 @@
       "grid",
       "checklist"
     ],
-    "triggers": [
-      "TableGridType",
-      "위젯 타입 추가",
-      "tableGridType",
-      "widget type registration",
-      "detectType",
-      "columns mapping"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/frontend/widget-grid-type-registration-checklist",
     "has_content": false
@@ -9583,21 +11907,8 @@
     "slug": "zustand-preset-manager",
     "category": "frontend",
     "description": "Zustand + persist middleware pattern for managing N named presets (team comps, saved filters, dashboard layouts) with active-selection, max-count guard, and auto-reselect on delete.",
-    "tags": [
-      "zustand",
-      "localstorage",
-      "preset",
-      "state-management",
-      "persist-middleware"
-    ],
-    "triggers": [
-      "zustand persist",
-      "saved presets",
-      "team presets",
-      "named configurations",
-      "localStorage preset",
-      "multi-preset selector"
-    ],
+    "tags": "",
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/frontend/zustand-preset-manager",
     "has_content": true
@@ -9608,21 +11919,8 @@
     "slug": "gacha-soft-hard-pity",
     "category": "game-dev",
     "description": "Server-authoritative gacha with soft pity (rate ramp after N pulls), hard pity (guaranteed top rarity at M pulls), and 50/50 guarantee carryover. Split rate calculation from result resolution so probability is testable.",
-    "tags": [
-      "gacha",
-      "pity",
-      "probability",
-      "securerandom",
-      "loot",
-      "rng-fairness"
-    ],
-    "triggers": [
-      "gacha pity system",
-      "soft pity hard pity",
-      "50/50 pity",
-      "banner rate up",
-      "rate calculator"
-    ],
+    "tags": "",
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/game-dev/gacha-soft-hard-pity",
     "has_content": true
@@ -9633,21 +11931,8 @@
     "slug": "stateless-turn-combat-engine",
     "category": "game-dev",
     "description": "Turn-based combat as a pure function — `(state, action) → newState + events`. Speed-based turn order, deterministic damage, no hidden mutation. Makes combat unit-testable, replayable, and server-authoritative.",
-    "tags": [
-      "combat-engine",
-      "turn-based",
-      "rpg",
-      "pure-function",
-      "deterministic",
-      "server-authoritative"
-    ],
-    "triggers": [
-      "turn based combat",
-      "combat engine design",
-      "speed based turn order",
-      "server authoritative combat",
-      "stateless combat"
-    ],
+    "tags": "",
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/game-dev/stateless-turn-combat-engine",
     "has_content": true
@@ -9658,21 +11943,8 @@
     "slug": "status-effect-enum-system",
     "category": "game-dev",
     "description": "Model status effects (burn, stun, buff, debuff) as enum-tagged records attached to units, with per-turn tick logic split between application, duration decay, and removal. Keeps damage-over-time and crowd control uniform and testable.",
-    "tags": [
-      "status-effect",
-      "buff-debuff",
-      "dot",
-      "cc",
-      "enum",
-      "turn-based"
-    ],
-    "triggers": [
-      "status effect system",
-      "buff debuff",
-      "damage over time",
-      "burn stun freeze",
-      "crowd control turn based"
-    ],
+    "tags": "",
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/game-dev/status-effect-enum-system",
     "has_content": true
@@ -9838,7 +12110,12 @@
     "slug": "careful",
     "category": "security",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "security",
+      "gstack",
+      "careful",
+      "safety"
+    ],
     "triggers": [],
     "version": "0.1.0",
     "path": "skills/security/careful",
@@ -9850,7 +12127,11 @@
     "slug": "cso",
     "category": "security",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "security",
+      "gstack",
+      "cso"
+    ],
     "triggers": [],
     "version": "2.0.0",
     "path": "skills/security/cso",
@@ -9862,7 +12143,12 @@
     "slug": "guard",
     "category": "security",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "security",
+      "gstack",
+      "guard",
+      "safety"
+    ],
     "triggers": [],
     "version": "0.1.0",
     "path": "skills/security/guard",
@@ -9874,22 +12160,8 @@
     "slug": "jwt-refresh-rotation-spring",
     "category": "security",
     "description": "Spring Boot 3 JWT with short-lived access token + long-lived refresh token, filter-chain integration, and stateless session config. Avoids common mistakes that silently break refresh flows.",
-    "tags": [
-      "jwt",
-      "spring-boot",
-      "auth",
-      "refresh-token",
-      "jjwt",
-      "security-filter"
-    ],
-    "triggers": [
-      "jwt spring boot",
-      "refresh token rotation",
-      "JwtAuthenticationFilter",
-      "jjwt 0.12",
-      "SessionCreationPolicy.STATELESS",
-      "access token refresh token"
-    ],
+    "tags": "",
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/security/jwt-refresh-rotation-spring",
     "has_content": true
@@ -9988,7 +12260,12 @@
     "slug": "benchmark",
     "category": "testing",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "testing",
+      "gstack",
+      "benchmark",
+      "performance"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/testing/benchmark",
@@ -10000,7 +12277,12 @@
     "slug": "browse",
     "category": "testing",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "testing",
+      "gstack",
+      "browse",
+      "playwright"
+    ],
     "triggers": [],
     "version": "1.1.0",
     "path": "skills/testing/browse",
@@ -10030,7 +12312,11 @@
     "slug": "devex-review",
     "category": "testing",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "testing",
+      "devex",
+      "review"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/testing/devex-review",
@@ -10060,7 +12346,11 @@
     "slug": "gstack-qa",
     "category": "testing",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "testing",
+      "gstack",
+      "qa"
+    ],
     "triggers": [],
     "version": "2.0.0",
     "path": "skills/testing/gstack-qa",
@@ -10072,7 +12362,11 @@
     "slug": "gstack-qa-only",
     "category": "testing",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "testing",
+      "gstack",
+      "only"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/testing/gstack-qa-only",
@@ -10084,7 +12378,12 @@
     "slug": "health",
     "category": "testing",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "testing",
+      "gstack",
+      "health",
+      "quality"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/testing/health",
@@ -10139,7 +12438,13 @@
     "slug": "spring-testcontainers-multitenant-base",
     "category": "testing",
     "description": "Base test class that boots Testcontainers (Mongo + Kafka), pre-sets tenant/auth context, and forces JVM halt in AfterAll to avoid leaked containers.",
-    "tags": [],
+    "tags": [
+      "testing",
+      "spring",
+      "testcontainers",
+      "multitenant",
+      "base"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/testing/spring-testcontainers-multitenant-base",
@@ -10167,11 +12472,14 @@
     "category": "workflow",
     "description": "Generate realistic actor workloads with crashes, backpressure, and supervision restarts for demos",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "actor",
+      "model",
+      "data",
+      "simulation",
+      "rest"
     ],
-    "triggers": [
-      "actor model data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/actor-model-data-simulation",
     "has_content": false
@@ -10183,11 +12491,13 @@
     "category": "workflow",
     "description": "Generate realistic gateway traffic with burst patterns, policy hits, and backend-selection skew driven by a seeded PRNG",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "api",
+      "gateway",
+      "data",
+      "simulation"
     ],
-    "triggers": [
-      "api gateway pattern data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/api-gateway-pattern-data-simulation",
     "has_content": false
@@ -10199,11 +12509,14 @@
     "category": "workflow",
     "description": "Generating realistic fixture data for API version timelines, diffs, and traffic migration curves",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "api",
+      "versioning",
+      "data",
+      "simulation",
+      "migration"
     ],
-    "triggers": [
-      "api versioning data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/api-versioning-data-simulation",
     "has_content": false
@@ -10220,10 +12533,7 @@
       "verification",
       "send-message"
     ],
-    "triggers": [
-      "agent completed but artifact missing",
-      "subagent incomplete output"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/async-subagent-resume-on-missing-artifact",
     "has_content": false
@@ -10234,7 +12544,12 @@
     "slug": "autoplan",
     "category": "workflow",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "workflow",
+      "gstack",
+      "autoplan",
+      "review"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/workflow/autoplan",
@@ -10247,11 +12562,12 @@
     "category": "workflow",
     "description": "Token-stepped discrete event loop driving producer/buffer/consumer with per-tick rate budgets",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "backpressure",
+      "data",
+      "simulation"
     ],
-    "triggers": [
-      "backpressure data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/backpressure-data-simulation",
     "has_content": false
@@ -10263,11 +12579,13 @@
     "category": "workflow",
     "description": "Generate realistic BFF traffic by simulating per-client request shapes, parallel backend fan-out with varied latency, and client-specific response trimming",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "bff",
+      "data",
+      "simulation",
+      "parallel"
     ],
-    "triggers": [
-      "bff pattern data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/bff-pattern-data-simulation",
     "has_content": false
@@ -10279,11 +12597,13 @@
     "category": "workflow",
     "description": "Generating realistic workloads (usernames, collisions, concurrent inserts) to exercise bloom filter behavior end-to-end",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "bloom",
+      "filter",
+      "data",
+      "simulation"
     ],
-    "triggers": [
-      "bloom filter data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/bloom-filter-data-simulation",
     "has_content": false
@@ -10295,11 +12615,14 @@
     "category": "workflow",
     "description": "Deterministic state-machine generator for blue-green cutover phases with realistic traffic drain and health-check dynamics",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "blue",
+      "green",
+      "deploy",
+      "data",
+      "simulation"
     ],
-    "triggers": [
-      "blue green deploy data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/blue-green-deploy-data-simulation",
     "has_content": false
@@ -10318,12 +12641,7 @@
       "swagger",
       "gradle"
     ],
-    "triggers": [
-      "bulk annotation",
-      "전수 적용",
-      "controller 전체 주석",
-      "DTO @Schema 전수"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/bucket-parallel-java-annotation-dispatch",
     "has_content": false
@@ -10335,11 +12653,12 @@
     "category": "workflow",
     "description": "Generating realistic traffic patterns that exercise bulkhead isolation and failure containment",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "bulkhead",
+      "data",
+      "simulation"
     ],
-    "triggers": [
-      "bulkhead data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/bulkhead-data-simulation",
     "has_content": false
@@ -10350,7 +12669,12 @@
     "slug": "canary",
     "category": "workflow",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "workflow",
+      "gstack",
+      "canary",
+      "deploy"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/workflow/canary",
@@ -10363,11 +12687,14 @@
     "category": "workflow",
     "description": "Deterministic synthetic generator for canary traffic, SLO metrics, and bake-time gate evaluations",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "canary",
+      "release",
+      "data",
+      "simulation",
+      "metrics"
     ],
-    "triggers": [
-      "canary release data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/canary-release-data-simulation",
     "has_content": false
@@ -10379,11 +12706,14 @@
     "category": "workflow",
     "description": "Generating realistic synthetic CDC event streams with proper transaction grouping, LSN monotonicity, and schema evolution",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "cdc",
+      "data",
+      "simulation",
+      "schema",
+      "transaction"
     ],
-    "triggers": [
-      "cdc data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/cdc-data-simulation",
     "has_content": false
@@ -10395,11 +12725,13 @@
     "category": "workflow",
     "description": "Generating realistic fault-injection scenarios, blast radii, and recovery curves without a real cluster",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "chaos",
+      "engineering",
+      "data",
+      "simulation"
     ],
-    "triggers": [
-      "chaos engineering data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/chaos-engineering-data-simulation",
     "has_content": false
@@ -10410,7 +12742,12 @@
     "slug": "checkpoint",
     "category": "workflow",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "workflow",
+      "gstack",
+      "checkpoint",
+      "state"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/workflow/checkpoint",
@@ -10423,13 +12760,44 @@
     "category": "workflow",
     "description": "Deterministic synthetic call stream generator for circuit breaker state machine demonstrations",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "circuit",
+      "breaker",
+      "data",
+      "simulation",
+      "synthetic"
     ],
-    "triggers": [
-      "circuit breaker data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/circuit-breaker-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "command-consolidation-via-dispatcher-alias",
+    "slug": "command-consolidation-via-dispatcher-alias",
+    "category": "workflow",
+    "description": "When you have 35+ slash commands and cognitive load is the bottleneck, consolidate via dispatcher commands (one canonical command + --kind or --only flags) and leave the originals as aliases with a deprecation note. Zero breaking changes, \"Core N\" mental model for new users.",
+    "tags": [
+      "slash-command",
+      "claude-code",
+      "command-design",
+      "consolidation",
+      "deprecation",
+      "ux",
+      "mental-model"
+    ],
+    "triggers": [
+      "too many commands",
+      "cognitive-load",
+      "deprecation",
+      "alias",
+      "/hub-list",
+      "/hub-publish",
+      "Core 8"
+    ],
+    "version": "0.1.0",
+    "path": "skills/workflow/command-consolidation-via-dispatcher-alias",
     "has_content": false
   },
   {
@@ -10439,11 +12807,14 @@
     "category": "workflow",
     "description": "Generate realistic command/query/event streams with controllable lag and conflict patterns for CQRS demos",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "command",
+      "query",
+      "data",
+      "simulation",
+      "cqrs"
     ],
-    "triggers": [
-      "command query data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/command-query-data-simulation",
     "has_content": false
@@ -10455,11 +12826,13 @@
     "category": "workflow",
     "description": "Deterministic simulation model for generating realistic connection pool workloads across acquisition, validation, and eviction events",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "connection",
+      "pool",
+      "data",
+      "simulation"
     ],
-    "triggers": [
-      "connection pool data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/connection-pool-data-simulation",
     "has_content": false
@@ -10471,11 +12844,14 @@
     "category": "workflow",
     "description": "Workflow for generating reproducible node/key datasets and rebalance event streams for consistent-hashing demos",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "consistent",
+      "hashing",
+      "data",
+      "simulation",
+      "node"
     ],
-    "triggers": [
-      "consistent hashing data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/consistent-hashing-data-simulation",
     "has_content": false
@@ -10487,11 +12863,12 @@
     "category": "workflow",
     "description": "Generate correlated command/event/projection streams with tunable skew so read-model lag and replay behavior are observable.",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "cqrs",
+      "data",
+      "simulation"
     ],
-    "triggers": [
-      "cqrs data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/cqrs-data-simulation",
     "has_content": false
@@ -10503,11 +12880,12 @@
     "category": "workflow",
     "description": "Simulating network partitions, concurrent edits, and message reordering to exercise CRDT merge logic",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "crdt",
+      "data",
+      "simulation"
     ],
-    "triggers": [
-      "crdt data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/crdt-data-simulation",
     "has_content": false
@@ -10519,11 +12897,13 @@
     "category": "workflow",
     "description": "Generating realistic synthetic pipeline telemetry with backpressure, lag, failure modes, and cascading effects",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "data",
+      "pipeline",
+      "simulation",
+      "synthetic"
     ],
-    "triggers": [
-      "data pipeline data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/data-pipeline-data-simulation",
     "has_content": false
@@ -10535,11 +12915,14 @@
     "category": "workflow",
     "description": "Synthetic workload generator for sharding scenarios using skewed key distributions and configurable hash strategies",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "database",
+      "sharding",
+      "data",
+      "simulation",
+      "synthetic"
     ],
-    "triggers": [
-      "database sharding data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/database-sharding-data-simulation",
     "has_content": false
@@ -10551,13 +12934,45 @@
     "category": "workflow",
     "description": "Generating realistic DLQ fixtures with clustered failure signatures, retry metadata, and replay outcomes",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "dead",
+      "letter",
+      "queue",
+      "data",
+      "simulation"
     ],
-    "triggers": [
-      "dead letter queue data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/dead-letter-queue-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "delegate-bulk-scans-to-explore-subagent",
+    "slug": "delegate-bulk-scans-to-explore-subagent",
+    "category": "workflow",
+    "description": "Scan-heavy slash commands (repo imports, full-project extracts, corpus-wide refactors) must delegate bulk file/web scanning to an Agent(subagent_type=Explore) in a single call, then synthesize drafts in the main thread. Prevents the 50-70 tool call thrashing that fragments conversation history.",
+    "tags": [
+      "slash-command",
+      "claude-code",
+      "subagent",
+      "explore",
+      "performance",
+      "token-budget",
+      "scan"
+    ],
+    "triggers": [
+      "hub-import",
+      "hub-extract",
+      "hub-refactor",
+      "scan repo",
+      "extract patterns",
+      "too many tool calls",
+      "73",
+      "back and forth"
+    ],
+    "version": "0.1.0",
+    "path": "skills/workflow/delegate-bulk-scans-to-explore-subagent",
     "has_content": false
   },
   {
@@ -10567,11 +12982,14 @@
     "category": "workflow",
     "description": "Generating realistic synthetic trace data with parent-child causality, latency distributions, and injected faults",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "distributed",
+      "tracing",
+      "data",
+      "simulation",
+      "synthetic"
     ],
-    "triggers": [
-      "distributed tracing data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/distributed-tracing-data-simulation",
     "has_content": false
@@ -10583,11 +13001,14 @@
     "category": "workflow",
     "description": "Generating synthetic bounded contexts, aggregates, and corpus text for DDD tooling demos",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "domain",
+      "driven",
+      "data",
+      "simulation",
+      "synthetic"
     ],
-    "triggers": [
-      "domain driven data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/domain-driven-data-simulation",
     "has_content": false
@@ -10599,11 +13020,13 @@
     "category": "workflow",
     "description": "Deterministic mock ETL data generation with realistic row counts, schemas, and job run histories",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "etl",
+      "data",
+      "simulation",
+      "schema"
     ],
-    "triggers": [
-      "etl data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/etl-data-simulation",
     "has_content": false
@@ -10615,11 +13038,13 @@
     "category": "workflow",
     "description": "Generate realistic causally-ordered event streams with aggregate lifecycles for replay demos",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "event",
+      "sourcing",
+      "data",
+      "simulation"
     ],
-    "triggers": [
-      "event sourcing data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/event-sourcing-data-simulation",
     "has_content": false
@@ -10631,11 +13056,14 @@
     "category": "workflow",
     "description": "Synthetic data generation for feature-flag rollouts, dependencies, and experiments",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "feature",
+      "flags",
+      "data",
+      "simulation",
+      "synthetic"
     ],
-    "triggers": [
-      "feature flags data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/feature-flags-data-simulation",
     "has_content": false
@@ -10647,11 +13075,14 @@
     "category": "workflow",
     "description": "Drive FSM demos with a deterministic event queue plus auto-play timer so users can step, reset, and replay transitions reproducibly.",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "finite",
+      "state",
+      "machine",
+      "data",
+      "simulation"
     ],
-    "triggers": [
-      "finite state machine data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/finite-state-machine-data-simulation",
     "has_content": false
@@ -10662,7 +13093,12 @@
     "slug": "freeze",
     "category": "workflow",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "workflow",
+      "gstack",
+      "freeze",
+      "safety"
+    ],
     "triggers": [],
     "version": "0.1.0",
     "path": "skills/workflow/freeze",
@@ -10674,18 +13110,8 @@
     "slug": "full-inventory-over-sampling-prompt",
     "category": "workflow",
     "description": "When a reference corpus fits comfortably in the LLM context window, pass the full inventory and let the model filter — don't sample arbitrarily",
-    "tags": [
-      "llm",
-      "prompt-engineering",
-      "claude-api",
-      "rag"
-    ],
-    "triggers": [
-      "llm prompt design",
-      "rag vs full context",
-      "skill sampling",
-      "reference corpus prompt"
-    ],
+    "tags": "",
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/full-inventory-over-sampling-prompt",
     "has_content": false
@@ -10715,11 +13141,13 @@
     "category": "workflow",
     "description": "Faking GraphQL responses, schemas, and subscription streams for offline demos without a live server",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "graphql",
+      "data",
+      "simulation",
+      "schema"
     ],
-    "triggers": [
-      "graphql data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/graphql-data-simulation",
     "has_content": false
@@ -10748,11 +13176,14 @@
     "category": "workflow",
     "description": "Generate realistic health-check sample streams with correlated failures, flapping, and recovery curves for demos and tests",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "health",
+      "check",
+      "data",
+      "simulation",
+      "test"
     ],
-    "triggers": [
-      "health check data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/health-check-data-simulation",
     "has_content": false
@@ -10763,14 +13194,14 @@
     "slug": "heuristic-scan-iterative-tuning",
     "category": "workflow",
     "description": "When writing a new heuristic scanner over a corpus (dedup, archive, compress, lint), expect the first run to be wrong in predictable ways. Run → inspect false positives → add one guard → re-run. Tighten the spec and the scan script in lockstep so the shipped version reflects real-world calibration, not guessed thresholds.",
-    "tags": [],
-    "triggers": [
-      "writing a corpus-level heuristic scanner",
-      "false positive triage on a scan",
-      "detector over-fires or under-fires",
-      "calibrating dedup/archive/compression thresholds",
-      "heuristic scan tuning"
+    "tags": [
+      "workflow",
+      "heuristic",
+      "scan",
+      "iterative",
+      "tuning"
     ],
+    "triggers": "",
     "version": "0.1.0",
     "path": "skills/workflow/heuristic-scan-iterative-tuning",
     "has_content": false
@@ -10782,11 +13213,13 @@
     "category": "workflow",
     "description": "Seed realistic port traffic with paired driving/driven adapter pairs and domain invariants that make violations visible",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "hexagonal",
+      "architecture",
+      "data",
+      "simulation"
     ],
-    "triggers": [
-      "hexagonal architecture data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/hexagonal-architecture-data-simulation",
     "has_content": false
@@ -10796,7 +13229,7 @@
     "name": "hub-make-parallel-build",
     "slug": "hub-make-parallel-build",
     "category": "workflow",
-    "description": "Build multiple zero-dep single-file HTML apps in parallel from installed skills/knowledge data, verify, and publish via PR branch",
+    "description": "\"Build multiple zero-dep single-file HTML apps in parallel from installed skills/knowledge data, verify, and publish via PR branch\"",
     "tags": [
       "hub-make",
       "parallel",
@@ -10805,11 +13238,7 @@
       "examples",
       "publish"
     ],
-    "triggers": [
-      "hub-make",
-      "build examples",
-      "parallel html build"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/hub-make-parallel-build",
     "has_content": true
@@ -10821,11 +13250,13 @@
     "category": "workflow",
     "description": "Generating realistic duplicate-request streams, key-collision scenarios, and retry storms to stress-test idempotency implementations.",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "idempotency",
+      "data",
+      "simulation",
+      "test"
     ],
-    "triggers": [
-      "idempotency data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/idempotency-data-simulation",
     "has_content": false
@@ -10836,7 +13267,12 @@
     "slug": "land-and-deploy",
     "category": "workflow",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "workflow",
+      "land",
+      "and",
+      "deploy"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/workflow/land-and-deploy",
@@ -10849,11 +13285,14 @@
     "category": "workflow",
     "description": "Generating plausible synthetic lantern fleet state (position, fuel, wick health, release events) for demo and test scenarios",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "lantern",
+      "data",
+      "simulation",
+      "test",
+      "release"
     ],
-    "triggers": [
-      "lantern data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/lantern-data-simulation",
     "has_content": false
@@ -10865,11 +13304,13 @@
     "category": "workflow",
     "description": "Deterministic seeded traffic generator for exercising load balancer algorithms with reproducible scenarios",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "load",
+      "balancer",
+      "data",
+      "simulation"
     ],
-    "triggers": [
-      "load balancer data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/load-balancer-data-simulation",
     "has_content": false
@@ -10881,11 +13322,14 @@
     "category": "workflow",
     "description": "Generating realistic synthetic log streams with bursts, level distributions, and source correlation for demo UIs",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "log",
+      "aggregation",
+      "data",
+      "simulation",
+      "synthetic"
     ],
-    "triggers": [
-      "log aggregation data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/log-aggregation-data-simulation",
     "has_content": false
@@ -10897,11 +13341,14 @@
     "category": "workflow",
     "description": "Generating synthetic base-table writes and refresh cycles to exercise materialized-view behaviors without a real warehouse",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "materialized",
+      "view",
+      "data",
+      "simulation",
+      "synthetic"
     ],
-    "triggers": [
-      "materialized view data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/materialized-view-data-simulation",
     "has_content": false
@@ -10930,7 +13377,7 @@
     ],
     "version": "0.1.0",
     "path": "skills/workflow/md-corpus-l1-l2-index-with-auto-regen",
-    "has_content": true
+    "has_content": false
   },
   {
     "kind": "skill",
@@ -10938,7 +13385,13 @@
     "slug": "mermaid-gitlab-mr-size-rules",
     "category": "workflow",
     "description": "Keep Mermaid diagrams in GitLab MRs readable — cap nodes, avoid nested subgraphs, quote IDs with special chars, connect all subgraphs",
-    "tags": [],
+    "tags": [
+      "workflow",
+      "mermaid",
+      "gitlab",
+      "size",
+      "rules"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/workflow/mermaid-gitlab-mr-size-rules",
@@ -10951,11 +13404,13 @@
     "category": "workflow",
     "description": "Deterministic producer-consumer event generation for reproducible queue behavior demos",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "message",
+      "queue",
+      "data",
+      "simulation"
     ],
-    "triggers": [
-      "message queue data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/message-queue-data-simulation",
     "has_content": false
@@ -10967,11 +13422,13 @@
     "category": "workflow",
     "description": "Generating realistic OAuth tokens, flow states, and scope sets for client-side simulators without a real auth server",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "oauth",
+      "data",
+      "simulation",
+      "auth"
     ],
-    "triggers": [
-      "oauth data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/oauth-data-simulation",
     "has_content": false
@@ -10983,11 +13440,14 @@
     "category": "workflow",
     "description": "Generating realistic synthetic object storage datasets with proper size/access distributions",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "object",
+      "storage",
+      "data",
+      "simulation",
+      "rag"
     ],
-    "triggers": [
-      "object storage data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/object-storage-data-simulation",
     "has_content": false
@@ -10998,7 +13458,11 @@
     "slug": "office-hours",
     "category": "workflow",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "workflow",
+      "office",
+      "hours"
+    ],
     "triggers": [],
     "version": "2.0.0",
     "path": "skills/workflow/office-hours",
@@ -11011,11 +13475,12 @@
     "category": "workflow",
     "description": "Generate deterministic outbox event streams with configurable failure and duplicate scenarios for demos",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "outbox",
+      "data",
+      "simulation"
     ],
-    "triggers": [
-      "outbox pattern data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/outbox-pattern-data-simulation",
     "has_content": false
@@ -11026,19 +13491,8 @@
     "slug": "parallel-build-sequential-publish",
     "category": "workflow",
     "description": "Build multiple independent projects in parallel via executor agents, then publish to a shared git repo sequentially",
-    "tags": [
-      "parallel",
-      "agents",
-      "git",
-      "publishing",
-      "workflow"
-    ],
-    "triggers": [
-      "build multiple projects",
-      "parallel agent build",
-      "batch publish examples",
-      "hub-make all"
-    ],
+    "tags": "",
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/parallel-build-sequential-publish",
     "has_content": false
@@ -11049,14 +13503,13 @@
     "slug": "parallel-bulk-annotation",
     "category": "workflow",
     "description": "수십~수백 개 Java 파일에 어노테이션(@Schema, @Operation, @ApiResponse 등)을 대량 추가할 때 병렬 에이전트로 분산 실행하는 패턴",
-    "tags": [],
-    "triggers": [
-      "대량 어노테이션 추가",
-      "@Schema 전수 부여",
-      "operationId 전수 부여",
-      "200개 메서드 어노테이션",
-      "bulk annotation"
+    "tags": [
+      "workflow",
+      "parallel",
+      "bulk",
+      "annotation"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/parallel-bulk-annotation",
     "has_content": false
@@ -11067,7 +13520,12 @@
     "slug": "plan-ceo-review",
     "category": "workflow",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "workflow",
+      "plan",
+      "ceo",
+      "review"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/workflow/plan-ceo-review",
@@ -11079,7 +13537,12 @@
     "slug": "plan-devex-review",
     "category": "workflow",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "workflow",
+      "plan",
+      "devex",
+      "review"
+    ],
     "triggers": [],
     "version": "2.0.0",
     "path": "skills/workflow/plan-devex-review",
@@ -11091,7 +13554,12 @@
     "slug": "plan-eng-review",
     "category": "workflow",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "workflow",
+      "plan",
+      "eng",
+      "review"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/workflow/plan-eng-review",
@@ -11103,13 +13571,14 @@
     "slug": "plan-to-screen-spec-conversion",
     "category": "workflow",
     "description": "PLAN 작업지시서를 rules/fe/02-screen-spec-template.md 형식의 화면 스펙 문서로 변환",
-    "tags": [],
-    "triggers": [
-      "PLAN을 스펙으로",
-      "작업지시서를 화면 스펙으로",
-      "screen spec 변환",
-      "기획서를 스펙 템플릿으로"
+    "tags": [
+      "design",
+      "plan",
+      "screen",
+      "spec",
+      "conversion"
     ],
+    "triggers": "",
     "version": "0.1.0-draft",
     "path": "skills/design/plan-to-screen-spec-conversion",
     "has_content": false
@@ -11156,11 +13625,14 @@
     "category": "workflow",
     "description": "Generate realistic pub-sub traffic with topic hierarchies, bursty publishers, and heterogeneous subscriber latencies",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "pub",
+      "sub",
+      "data",
+      "simulation",
+      "pub-sub"
     ],
-    "triggers": [
-      "pub sub data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/pub-sub-data-simulation",
     "has_content": false
@@ -11172,11 +13644,14 @@
     "category": "workflow",
     "description": "Deterministic event stream generation for Raft scenarios covering elections, replication, and term changes",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "raft",
+      "consensus",
+      "data",
+      "simulation",
+      "replication"
     ],
-    "triggers": [
-      "raft consensus data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/raft-consensus-data-simulation",
     "has_content": false
@@ -11188,11 +13663,14 @@
     "category": "workflow",
     "description": "Generating realistic request arrival patterns to stress-test rate limiter algorithms in demo apps",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "rate",
+      "limiter",
+      "data",
+      "simulation",
+      "test"
     ],
-    "triggers": [
-      "rate limiter data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/rate-limiter-data-simulation",
     "has_content": false
@@ -11204,11 +13682,14 @@
     "category": "workflow",
     "description": "Synthetic replication-log generator with configurable lag distributions and consistency violation injection",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "read",
+      "replica",
+      "data",
+      "simulation",
+      "replication"
     ],
-    "triggers": [
-      "read replica data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/read-replica-data-simulation",
     "has_content": false
@@ -11220,11 +13701,14 @@
     "category": "workflow",
     "description": "Generate synthetic failure streams and retry attempts to stress-test backoff, jitter, and budget policies",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "retry",
+      "strategy",
+      "data",
+      "simulation",
+      "test"
     ],
-    "triggers": [
-      "retry strategy data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/retry-strategy-data-simulation",
     "has_content": false
@@ -11235,7 +13719,12 @@
     "slug": "review",
     "category": "workflow",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "workflow",
+      "gstack",
+      "review",
+      "pr"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/workflow/review",
@@ -11266,7 +13755,7 @@
     ],
     "version": "0.1.0",
     "path": "skills/workflow/rollback-anchor-tag-before-destructive-op",
-    "has_content": true
+    "has_content": false
   },
   {
     "kind": "skill",
@@ -11275,11 +13764,13 @@
     "category": "workflow",
     "description": "Generate realistic saga transaction data with failure injection, compensation chains, and participant latency",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "saga",
+      "data",
+      "simulation",
+      "transaction"
     ],
-    "triggers": [
-      "saga pattern data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/saga-pattern-data-simulation",
     "has_content": false
@@ -11291,11 +13782,14 @@
     "category": "workflow",
     "description": "Generating realistic synthetic schema evolution histories for registry demos and tests",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "schema",
+      "registry",
+      "data",
+      "simulation",
+      "test"
     ],
-    "triggers": [
-      "schema registry data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/schema-registry-data-simulation",
     "has_content": false
@@ -11307,11 +13801,14 @@
     "category": "workflow",
     "description": "Generating realistic synthetic traffic, policy, and telemetry data for service mesh demos without a live cluster",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "service",
+      "mesh",
+      "data",
+      "simulation",
+      "synthetic"
     ],
-    "triggers": [
-      "service mesh data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/service-mesh-data-simulation",
     "has_content": false
@@ -11322,7 +13819,11 @@
     "slug": "setup-deploy",
     "category": "workflow",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "workflow",
+      "setup",
+      "deploy"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/workflow/setup-deploy",
@@ -11334,7 +13835,12 @@
     "slug": "ship",
     "category": "workflow",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "workflow",
+      "gstack",
+      "ship",
+      "deploy"
+    ],
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/workflow/ship",
@@ -11347,11 +13853,14 @@
     "category": "workflow",
     "description": "Generate synthetic sidecar proxy traffic with realistic latency, retry, and mTLS handshake semantics.",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "sidecar",
+      "proxy",
+      "data",
+      "simulation",
+      "synthetic"
     ],
-    "triggers": [
-      "sidecar proxy data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/sidecar-proxy-data-simulation",
     "has_content": false
@@ -11412,6 +13921,18 @@
   },
   {
     "kind": "skill",
+    "name": "split-llm-codegen-into-idea-plus-per-item",
+    "slug": "split-llm-codegen-into-idea-plus-per-item",
+    "category": "workflow",
+    "description": "Split large LLM code generation into lightweight idea call + per-item full code calls to maximize output per artifact",
+    "tags": "",
+    "triggers": "",
+    "version": "0.1.0-draft",
+    "path": "skills/workflow/split-llm-codegen-into-idea-plus-per-item",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "stale-persistent-context-detection",
     "slug": "stale-persistent-context-detection",
     "category": "workflow",
@@ -11449,20 +13970,8 @@
     "slug": "stdin-redirect-cli-large-prompts",
     "category": "workflow",
     "description": "Pipe large prompts to CLI tools via temp file + shell redirect to bypass argv length limits and stdin propagation issues",
-    "tags": [
-      "cli",
-      "ipc",
-      "workflow",
-      "shell",
-      "cross-platform"
-    ],
-    "triggers": [
-      "ENAMETOOLONG spawn",
-      "large prompt cli",
-      "claude -p long input",
-      "argv too long",
-      "stdin propagation"
-    ],
+    "tags": "",
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/stdin-redirect-cli-large-prompts",
     "has_content": false
@@ -11474,11 +13983,14 @@
     "category": "workflow",
     "description": "Synthetic endpoint/route inventory with migration-state machine and traffic-split fixtures for strangler-fig demos",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "strangler",
+      "fig",
+      "data",
+      "simulation",
+      "migration"
     ],
-    "triggers": [
-      "strangler fig data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/strangler-fig-data-simulation",
     "has_content": false
@@ -11489,14 +14001,12 @@
     "slug": "swagger-ai-optimization",
     "category": "workflow",
     "description": "Spring Boot + springdoc 프로젝트의 Swagger/OpenAPI 스펙을 AI Agent용으로 최적화 (operationId, @Schema, @ApiResponse, x-filterable-fields 전수 적용)",
-    "tags": [],
-    "triggers": [
-      "swagger ai 최적화",
-      "openapi ai optimization",
-      "MCP 연동 준비",
-      "swagger operationId 전수 부여",
-      "AI 이해도 테스트"
+    "tags": [
+      "workflow",
+      "swagger",
+      "optimization"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/swagger-ai-optimization",
     "has_content": false
@@ -11514,11 +14024,7 @@
       "baseline",
       "spring-boot"
     ],
-    "triggers": [
-      "swagger 전체 재실행",
-      "rerun swagger optimization",
-      "baseline 없이 시작"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/swagger-spec-baseline-from-git",
     "has_content": false
@@ -11530,11 +14036,14 @@
     "category": "workflow",
     "description": "Generate synthetic TSDB workloads using layered signal components (trend + seasonality + noise + anomalies) with back-dated timestamps.",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "time",
+      "series",
+      "data",
+      "simulation",
+      "synthetic"
     ],
-    "triggers": [
-      "time series db data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/time-series-db-data-simulation",
     "has_content": false
@@ -11545,7 +14054,12 @@
     "slug": "unfreeze",
     "category": "workflow",
     "description": "|",
-    "tags": [],
+    "tags": [
+      "workflow",
+      "gstack",
+      "unfreeze",
+      "safety"
+    ],
     "triggers": [],
     "version": "0.1.0",
     "path": "skills/workflow/unfreeze",
@@ -11558,11 +14072,12 @@
     "category": "workflow",
     "description": "Deterministic fake WebSocket traffic generator with opcode/frame fidelity for offline demos",
     "tags": [
-      "auto-loop"
+      "workflow",
+      "websocket",
+      "data",
+      "simulation"
     ],
-    "triggers": [
-      "websocket data simulation"
-    ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/websocket-data-simulation",
     "has_content": false
@@ -11590,15 +14105,13 @@
     "slug": "x-filterable-fields-extraction",
     "category": "workflow",
     "description": "OpenAPI 스펙에 x-filterable-fields 확장을 자동 생성하는 파이프라인. lucida-ui gridColumnDefs + lucida-meta i18n properties를 조합하여 필드명/한국어 title/operators를 추출",
-    "tags": [],
-    "triggers": [
-      "x-filterable-fields",
-      "필터 가능 필드 추출",
-      "gridFilters 메타데이터",
-      "tagFilters 메타데이터",
-      "리소스 키 추출",
-      "GridFilter 정확도 개선"
+    "tags": [
+      "workflow",
+      "filterable",
+      "fields",
+      "extraction"
     ],
+    "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/x-filterable-fields-extraction",
     "has_content": false

--- a/knowledge/pitfall/publish-pipelines-must-rebuild-derived-artifacts.md
+++ b/knowledge/pitfall/publish-pipelines-must-rebuild-derived-artifacts.md
@@ -1,0 +1,82 @@
+---
+name: publish-pipelines-must-rebuild-derived-artifacts
+type: knowledge
+category: pitfall
+tags: [publish-pipeline, index, registry, derived-artifact, stale-cache, search, silent-failure]
+summary: A publish flow that commits new source files but doesn't regenerate derived artifacts (flat catalog, search index, registry cache) leaves downstream consumers (search, suggestion, discovery) unable to see the new entries. Every publish pipeline needs an explicit reindex step.
+source: { kind: session, ref: hub-publish-all-pr-1027 }
+confidence: high
+linked_skills: []
+supersedes: null
+extracted_at: 2026-04-18
+---
+
+## Fact
+
+If your publish pipeline:
+1. Copies new source files to the repo ✓
+2. Commits them ✓
+3. Creates tags ✓
+4. Opens a PR ✓
+
+…but does NOT regenerate any derived artifact (flat catalog like `index.json`, a registry cache, a pre-computed search index), then:
+
+- `git log` shows the new files landed.
+- `git show` returns them correctly.
+- But the **search tool that reads the derived artifact sees nothing**. New entries are invisible.
+
+Worst-case: users type what should be a perfect query, get zero results, conclude "the publish didn't work," re-publish, still broken. Root cause is upstream of the user.
+
+## Context / Why
+
+Observed on `/hub-publish-all` (PR #1027): 6 new entries landed cleanly on `main` with proper commits, proper tags, proper PR. `/hub-find "rollback anchor"` returned `git-tag-registry-versioning` (a similar but different entry) and not the new `rollback-anchor-tag-before-destructive-op`. Why? `index.json` wasn't updated. The publish spec included commit-each-entry + push + tag + PR, but no "rebuild flat catalog" step.
+
+The fix was a follow-up PR #1028 just to reindex. This is a pipeline smell — derived-artifact refresh should be baked into the pipeline, never a manual afterthought.
+
+## Evidence
+
+Before the fix:
+
+```bash
+$ grep -c "rollback-anchor-tag-before-destructive-op" ~/.claude/skills-hub/remote/index.json
+0  ← missing
+$ git -C ~/.claude/skills-hub/remote log main -1 --stat | grep rollback
+  skills/workflow/rollback-anchor-tag-before-destructive-op/SKILL.md | 55 +++
+  ← file IS on main, but index.json was never updated
+```
+
+After rebuilding `index.json` from the filesystem:
+
+```bash
+$ hub-search "rollback anchor tag destructive" -n 1
+[ 64] skill/workflow  rollback-anchor-tag-before-destructive-op  ← now findable
+```
+
+## Applies when
+
+- You have a publish pipeline that adds content to a corpus.
+- Any downstream tool (search, suggestion, discovery, dashboard) reads a **derived artifact** (cache, flat catalog, embedding index, sitemap, etc.) instead of walking the source tree on every query.
+- The derived artifact and the source tree can drift.
+
+## Counter / Caveats
+
+**Mitigation pattern**:
+
+1. **Build a deterministic rebuilder**. A single command that reads source tree → writes derived artifact. E.g. `py tools/_rebuild_index_json.py`.
+2. **Wire it into the pipeline** as an explicit step just before push. If the rebuild produces no diff, the step is a no-op; if there is a diff, it's committed as `chore: rebuild <artifact>`.
+3. **Preserve manually-added fields** during rebuild. If the artifact has non-schema fields (`source_project`, `installed_at`, usage counters), keep them when regenerating.
+4. **Surface delta in the PR body**. "Rebuilt index.json: +6 entries, -0 removed." Reviewers can double-check.
+
+**Alternatives that don't work well**:
+- ❌ "Ask users to run `/hub-cleanup --reindex` after pulling" → forgotten, drifts.
+- ❌ "Regenerate on every query" → slow for large corpora, moves the cost to readers.
+- ❌ "Trust the git hook to rebuild" → hooks don't fire on squash-merge via GitHub UI, only on local commit/merge/checkout (see pitfall `git-reset-hard-bypasses-all-hooks`).
+
+**Generalises to**:
+- npm/pypi `package.json` `exports` field.
+- Docker image manifests.
+- Kubernetes CRD registries.
+- Sitemap XML for SEO.
+- OpenAPI spec aggregations across microservices.
+
+Any system where **new source code + cached summary** must stay in sync needs a publish-time rebuild, not post-publish repair.

--- a/knowledge/pitfall/subagent-scan-results-need-sanity-check.md
+++ b/knowledge/pitfall/subagent-scan-results-need-sanity-check.md
@@ -1,0 +1,74 @@
+---
+name: subagent-scan-results-need-sanity-check
+type: knowledge
+category: pitfall
+tags: [claude-code, subagent, explore, scan, verification, silent-failure, heuristic]
+summary: Explore subagent scans can silently return garbage — duplicated metrics, zero-line false positives, empty arrays — while reporting "success." Always embed a self-verification step in the brief and gate on its output before acting.
+source: { kind: session, ref: hub-refactor-scan-retry }
+confidence: high
+linked_skills: [delegate-bulk-scans-to-explore-subagent]
+supersedes: null
+extracted_at: 2026-04-18
+---
+
+## Fact
+
+When you delegate a bulk file scan to an `Explore` subagent, the result can be wrong in ways that **look normal** at first glance:
+
+1. **Duplicated metric values** — 5 different entries all reporting `body_lines: 894`, or 5 entries all `body_lines: 0`. This means the subagent measured one file five times (glob error) or failed to open the file.
+2. **Zero-line false positives** — a skill whose `SKILL.md` is frontmatter-only but whose real body lives in `content.md` gets measured at 0 lines. Misclassified as a "stub."
+3. **Empty high-level results** — `merge_candidates: []` for a corpus of 754 entries. Could be correct, but at 0.6 Jaccard threshold some cluster should exist.
+4. **Confident but hallucinated paths** — the subagent returns `skills/cli/gstack/subcommand` when the actual structure is different.
+
+The subagent does not flag these. It returns a tidy JSON and the main thread proceeds as if it's ground truth.
+
+## Context / Why
+
+Observed during a `/hub-refactor` run on the skills-hub corpus:
+
+- First scan: all 5 split candidates reported `body_lines: 894` (identical, impossible). All 5 archive candidates reported `body_lines: 0` despite having real content.
+- Root cause: subagent only read `SKILL.md`, didn't combine with `content.md`. No warning, no partial-failure signal.
+
+Silent failure is the worst failure mode. If the main thread had applied the archive patches, 5 legitimate skills would have been hidden from `/hub-find`.
+
+## Evidence
+
+Reproduction (from live session):
+
+```json
+{
+  "archive_candidates": [
+    {"selector": "skill:ai/ai-call-with-mock-fallback", "body_lines": 0, "condition": "A"},
+    {"selector": "skill:ai/character-sheet-multi-panel-consistency", "body_lines": 0, "condition": "A"},
+    {"selector": "skill:ai/claude-cli-from-jvm-via-node-wrapper", "body_lines": 0, "condition": "A"},
+    {"selector": "skill:ai/llm-json-extraction", "body_lines": 0, "condition": "A"},
+    {"selector": "skill:ai/mcp-runtime-prompt-refresh", "body_lines": 0, "condition": "A"}
+  ]
+}
+```
+
+Every value is 0. In reality these entries have 100-300 line `content.md` files. A second pass with an explicit "sum SKILL.md + content.md" brief produced correct, distinct values (e.g. 1057, 809, 869).
+
+## Applies when
+
+- You invoke `Agent(subagent_type="Explore", ...)` for file/corpus scans.
+- Your main-thread flow acts on the subagent's numeric/categorical output.
+- The cost of acting on wrong output is higher than re-running the scan.
+
+## Counter / Caveats
+
+**Mitigation — build self-verification into the brief**:
+
+1. Require the subagent to include a `scan_quality: "OK" | "SCAN_INVALID (reason)"` field in its return JSON.
+2. Require it to compute and report sanity metrics the main thread can check, e.g.:
+   - `distinct_body_line_values`: count of unique body_lines across candidates. Should equal candidate count.
+   - `distinct_archive_body_line_values`: same for archive list.
+3. Require file-level counting to be explicit, e.g. "For skills, body_lines = wc -l of SKILL.md body + wc -l of content.md body (if exists)."
+4. Main thread refuses to proceed if `scan_quality != "OK"` or the distinct counts don't match.
+
+**Don't do**:
+- Don't trust terse "success" messages without numeric self-checks.
+- Don't let one failed scan discourage delegation — just tighten the brief and retry.
+- Don't ask the subagent to "verify its own work semantically" — it'll just agree with itself. Require deterministic counts.
+
+**Meta-lesson**: a subagent is a black box that returns JSON. Treat it like an external API — schema validate, sanity check, fail loud.

--- a/skills/workflow/command-consolidation-via-dispatcher-alias/SKILL.md
+++ b/skills/workflow/command-consolidation-via-dispatcher-alias/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: command-consolidation-via-dispatcher-alias
+description: When you have 35+ slash commands and cognitive load is the bottleneck, consolidate via dispatcher commands (one canonical command + --kind or --only flags) and leave the originals as aliases with a deprecation note. Zero breaking changes, "Core N" mental model for new users.
+category: workflow
+tags: [slash-command, claude-code, command-design, consolidation, deprecation, ux, mental-model]
+triggers: ["too many commands", cognitive-load, deprecation, alias, "/hub-list", "/hub-publish", "Core 8"]
+source_project: skills-hub-bootstrap-v2.6.0
+version: 0.1.0
+---
+
+# command-consolidation-via-dispatcher-alias
+
+## Problem
+
+Over time, a tool family grows: `/hub-list-skills`, `/hub-list-knowledge`, `/hub-list-examples`, `/hub-publish-skills`, `/hub-publish-knowledge`, `/hub-publish-all`, `/hub-publish-example`, `/hub-install-all`, `/hub-install-example`, `/hub-extract`, `/hub-extract-session`, … 35 commands, 90% of which the user never touches. New users can't build a mental model. Existing users suffer cognitive load ("was it `/hub-list-skills` or `/hub-skills-list`?").
+
+Deleting commands breaks workflows and muscle memory. Renaming breaks every doc and tutorial that linked to them.
+
+## Pattern
+
+Two-phase consolidation that preserves full backwards compatibility.
+
+### Phase 1 — add canonical dispatchers
+
+For each cluster of related commands, introduce ONE canonical command with a selector flag:
+
+| Cluster | Canonical | Selector flag |
+|---|---|---|
+| `/hub-list-{skills,knowledge,examples}` | `/hub-list` | `--kind {skills|knowledge|examples|all}` (default: all) |
+| `/hub-publish-{skills,knowledge,all,example}` | `/hub-publish` | `--only {skills|knowledge|all|example}` (default: all) |
+| `/hub-install-{all,example}` | `/hub-install` | `--all` / `--example` flags |
+| `/hub-extract-session` | `/hub-extract` | `--session` flag |
+
+The canonical command's body explicitly defers to the specialised command for its flow ("Dispatch" section at the top). The AI reads this and delegates.
+
+### Phase 2 — annotate legacy commands
+
+Inject a one-line deprecation note right after the YAML frontmatter closing delimiter:
+
+```markdown
+---
+description: <original>
+argument-hint: <original>
+---
+
+> **Note (since v2.6.0):** `/hub-list --kind skills` is the canonical entry.
+> This command remains as a compatibility alias — same behaviour, same flags.
+
+# /hub-list-skills $ARGUMENTS
+...
+```
+
+Everything else stays. Same behaviour, same body, just a deprecation banner. Legacy scripts/docs keep working.
+
+### Phase 3 (deferred, optional) — remove aliases
+
+Only after telemetry shows the legacy command is no longer invoked. Without telemetry, don't remove — the cost of breakage outweighs the benefit of a shorter command list.
+
+## Documentation update
+
+README gains a "Core N" section at the top of the command reference that lists only canonical commands. Legacy commands are folded into a separate "Aliases" block with `→` arrows showing the canonical mapping:
+
+```
+--- Core 8 (v2.6.0+) ---
+/hub-find, /hub-suggest, /hub-install, /hub-list,
+/hub-extract, /hub-publish, /hub-sync, /hub-doctor
+
+--- Legacy aliases (still work) ---
+hub-install-all.md        → /hub-install --all
+hub-list-skills.md        → /hub-list --kind skills
+hub-extract-session.md    → /hub-extract --session
+...
+```
+
+## When to use
+
+- You have 20+ commands in a family and new users struggle to pick.
+- Frequent support questions about "which one for X?".
+- Existing user base you cannot break.
+
+## When NOT to use
+
+- Small command count (< 10). Consolidation overhead isn't worth it.
+- Commands with genuinely different semantics that happen to share a noun. Don't force `--only` onto commands that aren't parallel.
+
+## Pitfalls
+
+- **Don't consolidate too aggressively**. `/hub-merge`, `/hub-split`, `/hub-refactor`, `/hub-condense`, `/hub-cleanup` all touch the corpus but have distinct verbs and risks — leave them separate.
+- **Dispatch block must be obvious**. Put it at the top of the canonical command's body so the AI sees it before getting into flow details.
+- **Argument-hint matters**. Include the new flags (`--kind`, `--only`, `--session`) in the canonical command's `argument-hint` so tab-completion surfaces them.
+- **Avoid silent renames**. Even if an alias is never called, its file should stay; tooling (`/hub-commands-publish`) may iterate the directory and break if files disappear.

--- a/skills/workflow/delegate-bulk-scans-to-explore-subagent/SKILL.md
+++ b/skills/workflow/delegate-bulk-scans-to-explore-subagent/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: delegate-bulk-scans-to-explore-subagent
+description: Scan-heavy slash commands (repo imports, full-project extracts, corpus-wide refactors) must delegate bulk file/web scanning to an Agent(subagent_type=Explore) in a single call, then synthesize drafts in the main thread. Prevents the 50-70 tool call thrashing that fragments conversation history.
+category: workflow
+tags: [slash-command, claude-code, subagent, explore, performance, token-budget, scan]
+triggers: [hub-import, hub-extract, hub-refactor, "scan repo", "extract patterns", "too many tool calls", 73, "back and forth"]
+source_project: skills-hub-bootstrap-v2.6.1
+version: 0.1.0
+---
+
+# delegate-bulk-scans-to-explore-subagent
+
+## Problem
+
+Claude Code slash commands that scan many files (`/hub-import`, `/hub-extract`, `/hub-refactor`, `/hub-condense`, `/hub-cleanup`, `/hub-research`) produced ~70 tool calls per run when the main-thread AI iterated `Read` across files. Side effects:
+
+- **Token budget**: each `Read` eats a slice of context that persists for the rest of the session.
+- **History fragmentation**: the user sees a 10-minute log of back-and-forth instead of one task.
+- **No quality gain**: the AI rarely needed the full content of 70 files — it needed a ranked list of candidates.
+
+Observed live during a `/hub-import` run: 73 tool calls, ~10 min, ~400KB of tool output, for a result that could have been a 10-line candidate table.
+
+## Pattern
+
+In the slash command body, inject a MUST-level directive that pins the scan to an `Explore` subagent:
+
+```markdown
+## Execution strategy
+
+Bulk scanning MUST be delegated to an `Explore` subagent. The main thread
+only synthesises drafts from the returned candidate list.
+
+```
+Agent(
+  subagent_type="Explore",
+  description="<short task name>",
+  prompt="""
+<command-specific brief: what to scan, criteria, ranking rule>
+
+Return a ranked list (top N) with: name, kind, category,
+1-line description, source path(s), confidence.
+""",
+)
+```
+
+After the subagent returns, read ONLY the few MDs needed to write final
+drafts. Do NOT iterate `Read` across dozens of files in the main thread.
+```
+
+The brief must be **specific and verifiable**. Include:
+- Exact paths or URLs to scan
+- Criteria for what counts as a candidate
+- Ranking rule (so "top N" is reproducible)
+- Expected output schema (JSON is easiest to parse)
+- A self-check — e.g. "if two candidates have the same body_lines, mark SCAN_INVALID"
+
+## Why
+
+- **Isolation**: the subagent's context is separate. Its ~70 reads don't pollute the main thread's token budget.
+- **Summary at return**: you get the ranked result, not raw file contents.
+- **Verifiability**: the JSON schema makes it trivial to sanity-check before acting.
+
+## Example
+
+Before (main-thread scan):
+```
+/hub-import <url>
+→ Read repo README, Read each SKILL.md in external repo,
+  Read ../knowledge/**/*.md, ... × 70 calls ...
+→ Write draft × 6
+Total: 73 tool calls, 10 min
+```
+
+After (delegated):
+```
+/hub-import <url>
+→ Agent(Explore, "scan <url>, rank candidates, return JSON")
+→ Read specific 3 MDs for final citations
+→ Write draft × 6
+Total: ~5-8 tool calls, 2-3 min
+```
+
+## When to use
+
+- Any slash command that scans more than ~10 files.
+- Any repo-import, full-project extract, corpus-wide refactor/cleanup.
+- Any web research task that reads multiple URLs.
+
+## When NOT to use
+
+- Single-file operations (Read, Edit, small-fix workflows).
+- Cases where you actually need the full content in-context (writing a detailed comparison, summarising a specific long document).
+
+## Pitfalls
+
+- **Subagent output can silently fail**. Duplicated metric values, all-zero counts, empty result lists. Always require a self-check in the brief. See paired knowledge entry `subagent-scan-results-need-sanity-check`.
+- **Don't inline code with `Agent(...)`** — the subagent is a tool the AI invokes, not a programmatic API. The command body only tells the AI what brief to pass.
+- **Keep the brief self-contained**. The subagent has no conversation history.


### PR DESCRIPTION
## Source
Second-half extraction from the skills-hub bootstrap v2.5.4 → v2.6.1 release cycle (PRs #1029–#1033 + `/hub-refactor` scan retry). Captures meta-patterns that emerged from fixing the first-half patterns shipped in PR #1027.

## Skills (2)

| Category | Name | Version | Summary |
|---|---|---|---|
| workflow | `delegate-bulk-scans-to-explore-subagent` | v0.1.0 | Scan-heavy slash commands must delegate bulk file/web scans to `Agent(Explore)` in one call. ~70 tool-call runs drop to ~5. |
| workflow | `command-consolidation-via-dispatcher-alias` | v0.1.0 | Consolidate 20+ commands into a Core-N canonical set using dispatcher flags (`--kind`, `--only`). Legacy commands stay as annotated aliases — zero breakage. |

## Knowledge (2)

| Category | Name | Confidence | Summary |
|---|---|---|---|
| pitfall | `subagent-scan-results-need-sanity-check` | high | Explore subagent can silently return duplicated or zero-valued metrics. Always embed a self-verification step in the brief and gate on its output. Demonstrated live in this session. |
| pitfall | `publish-pipelines-must-rebuild-derived-artifacts` | high | Publish flows that commit source files but skip reindex leave derived catalogs (search index, flat JSON) stale. `/hub-find` missed 6 entries after PR #1027 — fix was PR #1028 and `tools/_rebuild_index_json.py` in v2.5.4. |

## Cross-links
- `subagent-scan-results-need-sanity-check` → links to skill `delegate-bulk-scans-to-explore-subagent` (the subagent usage pattern it warns about).

## Pipeline hygiene (v2.5.4 rules applied)
- Per-skill commit SHA captured via `git rev-parse HEAD` into a `{name: sha}` map — tags reference captured SHAs, not `HEAD~N`.
- `index.json` rebuilt via `tools/_rebuild_index_json.py` and committed on this branch; `/hub-find` will surface the new entries immediately after merge.
- Commit order: knowledge first (2) → skills (2) → `chore: rebuild index.json`.

## Tags created
- `skills/delegate-bulk-scans-to-explore-subagent/v0.1.0` @ `7b918d1`
- `skills/command-consolidation-via-dispatcher-alias/v0.1.0` @ `7b60501`

## Post-merge

Squash merge orphans the original tags — after you squash-merge this PR, run:

```bash
git -C ~/.claude/skills-hub/remote fetch origin
MERGE=$(gh pr view 1034 --repo kjuhwa/skills-hub --json mergeCommit --jq '.mergeCommit.oid')
for tag in skills/delegate-bulk-scans-to-explore-subagent/v0.1.0            skills/command-consolidation-via-dispatcher-alias/v0.1.0; do
  git tag -d "$tag"
  git tag -a "$tag" "$MERGE" -m "$(git tag -l --format='%(contents)' "$tag" | head -1)"
  git push --force origin "$tag"
done
```

(The PR number in that command is a placeholder — substitute the actual number.)

## Test plan
- [x] Each entry represents a real issue encountered or pattern validated in this session.
- [x] Sanitisation: no project-specific names, credentials, internal URLs.
- [x] `index.json` rebuild captured +4 new entries (verify delta in the chore commit diff).
- [ ] Reviewer spot-checks one skill body + one knowledge body for clarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)