### PR TITLE
Bootstrap v2.6.2: /hub-doctor — add v2.5.x infrastructure checks

### DIFF
--- a/bootstrap/commands/hub-doctor.md
+++ b/bootstrap/commands/hub-doctor.md
@@ -1,5 +1,5 @@
 ---
-description: Diagnose and repair the local skills hub environment — cache integrity, registry consistency, broken links, permission issues
+description: Diagnose and repair the local skills hub environment — cache, registry, tools, bin, indexes, git hooks, PATH, and the pre-implementation auto-check block
 argument-hint: [--fix] [--verbose]
 ---
 
@@ -12,7 +12,7 @@ Local environment health check and repair. While `/hub-cleanup` maintains the **
 ### 1. Remote cache integrity
 - `~/.claude/skills-hub/remote/` exists and is a git repo (`git -C <path> rev-parse --git-dir`).
 - Working tree is clean (`git status --porcelain` is empty).
-- Remote origin URL matches expected (`https://github.com/kjuhwa/skills.git` or SSH equivalent).
+- Remote origin URL matches expected (`https://github.com/kjuhwa/skills-hub.git` or SSH equivalent).
 - HEAD is detached or on `main` — warn if on a stale feature branch.
 - **Fix**: re-clone if corrupt (`--fix` required); checkout main if on wrong branch.
 
@@ -44,38 +44,78 @@ Local environment health check and repair. While `/hub-cleanup` maintains the **
 ### 5. Bootstrap version
 - `~/.claude/skills-hub/bootstrap.json` exists and is valid JSON.
 - `installed_version` is not `"unknown"`.
-- Compare with latest `bootstrap/v*` tag in cache.
+- Compare with latest `bootstrap/v*` tag in cache — warn if N minor versions behind.
 - **Fix**: recreate `bootstrap.json` from current command files (`--fix` required).
 
 ### 6. Permission & encoding
 - All `SKILL.md` and knowledge `*.md` files are UTF-8 readable.
 - No files with BOM markers that might cause parse issues.
 - No files > 1MB (unusually large skill/knowledge — likely a mistake).
-- **Fix**: report only — no auto-fix for encoding/size issues.
+- Slash command files under `~/.claude/commands/hub-*.md` are **LF-terminated** (not CRLF). CRLF silently breaks YAML frontmatter parsing on Windows; description falls back to H1 body and argument-hint disappears.
+- **Fix**: `sed -i 's/\r$//' ~/.claude/commands/hub-*.md` (report only; requires user to confirm).
+
+### 7. Tools & bin installation (v2.5.0+)
+- `~/.claude/skills-hub/tools/` exists and contains the expected helper scripts:
+  - `precheck.py`, `hub_search.py`, `_rebuild_index_json.py`, `_build_master_index.py`, `_build_master_index_lite.py`, `_build_category_indexes.py`, `_lint_frontmatter.py`, `_fix_frontmatter.py`, `_index_diff.py`, `install-hooks.sh`.
+- `~/.claude/skills-hub/bin/` exists and contains executable wrappers:
+  - `hub-search`, `hub-precheck`, `hub-index-diff` — each readable and with execute permission.
+- **Fix**: re-run `bash ~/.claude/skills-hub/remote/bootstrap/install.sh` to reinstall from the current bootstrap version (`--fix` required; bootstrap must be present in the remote cache).
+
+### 8. Git hooks (v2.5.0+)
+- `~/.claude/skills-hub/remote/.git/hooks/` contains:
+  - `post-merge`, `post-commit`, `post-checkout`
+- Each hook file is executable (Linux/macOS/WSL) or at least present (Windows Git Bash treats the `x` bit differently).
+- Each hook invokes `precheck.py --skip-lint` (or the current equivalent) — not the default sample hooks from git init.
+- **Fix**: run `bash ~/.claude/skills-hub/tools/install-hooks.sh` to reinstall (`--fix` required). If `tools/install-hooks.sh` is missing, escalate to check 7 first.
+
+### 9. Indexes freshness (v2.5.0+)
+- `~/.claude/skills-hub/indexes/` exists with:
+  - `00_MASTER_INDEX.md` (full L1)
+  - `00_MASTER_INDEX_LITE.md` (compact L1)
+  - `category_indexes/` (L2)
+- Each file's mtime is more recent than the remote's `HEAD` commit timestamp. If older, indexes are stale (git hooks likely didn't fire, e.g. after a `git reset --hard` or on a fresh clone before hook install).
+- **Fix**: run `py -3 ~/.claude/skills-hub/tools/precheck.py --skip-lint` to regenerate indexes (`--fix` required).
+
+### 10. Shell PATH (v2.5.0+)
+- Run `type hub-search` (or PowerShell `Get-Command hub-search`) — it should resolve to `~/.claude/skills-hub/bin/hub-search`.
+- If missing, warn the user to add to their shell profile:
+  - `bash/zsh`: `export PATH="$HOME/.claude/skills-hub/bin:$PATH"` in `~/.bashrc` / `~/.zshrc`.
+  - `PowerShell`: `$env:Path = "$HOME\.claude\skills-hub\bin;" + $env:Path` in `$PROFILE`.
+- **Fix**: report only — modifying a user's shell profile is out of scope for auto-fix.
+
+### 11. Pre-implementation auto-check block (v2.5.2+)
+- `~/.claude/CLAUDE.md` exists and contains a `<skills_hub>` block.
+- If absent: INFO (not a failure) — the user opted out of the auto-check, `/hub-suggest` still works manually.
+- If present: verify the block references the canonical names (`/hub-find`, `/hub-install`, `/hub-list`, `/hub-publish`) rather than legacy ones (`/hub-search-skills`, `/hub-publish-all`).
+- **Fix**: report only — user CLAUDE.md edits are out of scope for auto-fix.
 
 ## Report format
 
 ```
-hub-doctor results:
+hub-doctor results (2026-04-18 23:55):
 
-  [PASS]  Remote cache integrity (main @ abc1234, clean)
-  [WARN]  Registry consistency — 2 orphan entries
-  [FAIL]  Filesystem sync — 3 untracked skills, 1 path mismatch
-  [PASS]  Directory structure
-  [WARN]  Bootstrap — version unknown
-  [PASS]  Permissions & encoding
+  [PASS]  1. Remote cache integrity (main @ 56a1091, clean, origin = kjuhwa/skills-hub)
+  [WARN]  2. Registry consistency — 2 orphan entries
+  [FAIL]  3. Filesystem sync — 3 untracked skills, 1 path mismatch
+  [PASS]  4. Directory structure
+  [PASS]  5. Bootstrap (v2.6.2, latest)
+  [WARN]  6. Permissions — 4 commands have CRLF line endings
+  [PASS]  7. Tools & bin installation (v2.5.0+)
+  [FAIL]  8. Git hooks — post-merge missing; post-commit size suspicious
+  [WARN]  9. Indexes freshness — 00_MASTER_INDEX.md is 2h older than HEAD
+  [PASS] 10. Shell PATH (hub-search resolves)
+  [INFO] 11. <skills_hub> block not present in ~/.claude/CLAUDE.md
 
-  Summary: 2 passed, 2 warnings, 1 failure
-  
-  Run /hub-doctor --fix to repair 3 issues automatically.
-  1 issue requires manual attention (see details above).
+  Summary: 6 passed, 3 warnings, 2 failures, 1 info
+  Run /hub-doctor --fix to repair 3 issues automatically (registry, hooks, indexes).
+  3 issues require manual attention (CRLF, filesystem mismatch, CLAUDE.md block).
 ```
 
-With `--verbose`: expand each check to show individual items (orphan names, untracked paths, etc.).
+With `--verbose`: expand each check to show individual items (orphan names, untracked paths, hook contents diff, index mtime deltas, etc.).
 
 ## Arguments
 
-- `--fix` — automatically repair fixable issues. Prompts for confirmation before each destructive repair (re-clone, registry entry removal).
+- `--fix` — automatically repair fixable issues. Prompts for confirmation before each destructive repair (re-clone, registry entry removal, reinstalling hooks).
 - `--verbose` — show detailed per-item results for every check.
 
 ## Rules
@@ -84,5 +124,6 @@ With `--verbose`: expand each check to show individual items (orphan names, untr
 - **Never delete installed skills** — only clean up registry entries that point to missing files.
 - **Never modify the remote** — this is local-only.
 - **Never re-clone without confirmation** — even with `--fix`, prompt before destructive actions.
+- **Never edit the user's shell profile or CLAUDE.md** — report only; user confirms the change manually.
 - If the environment is completely uninitialized, suggest `/hub-init` instead of trying to fix from scratch.
-- Exit with a clear summary: pass/warn/fail counts + next steps.
+- Exit with a clear summary: pass/warn/fail/info counts + next steps.


### PR DESCRIPTION
## Problem
`/hub-doctor` was written pre-v2.5.0 and silently skipped everything we added in v2.5.x: the `tools/` + `bin/` layer, git hooks, indexes freshness, shell PATH, and the `<skills_hub>` auto-check block in CLAUDE.md. On top of that, its origin URL check expected `kjuhwa/skills.git` but the real origin is `kjuhwa/skills-hub.git`, so every run warned falsely.

## Changes
- Fix origin URL (check 1): `skills.git` → `skills-hub.git`.
- Extend encoding check (check 6) to flag CRLF line endings in `~/.claude/commands/hub-*.md` — the silent YAML parser killer fixed in v2.5.3.
- **NEW check 7** — tools/ + bin/ installation (all expected helper scripts present, wrappers executable).
- **NEW check 8** — git hooks (post-merge / post-commit / post-checkout) installed and calling `precheck.py --skip-lint`.
- **NEW check 9** — indexes freshness (`indexes/00_MASTER_INDEX*.md` mtime vs remote HEAD commit time).
- **NEW check 10** — shell PATH resolves `hub-search` (bash/zsh `type` or PowerShell `Get-Command`).
- **NEW check 11** — `<skills_hub>` block present in `~/.claude/CLAUDE.md` (info-level: absent = opt-out, not failure).
- Report format adds INFO severity + numbered check IDs for `--verbose` cross-reference.
- `--fix` never touches the user's shell profile or CLAUDE.md — those stay manual.

## Rollback
Revert single commit; `/hub-doctor` reverts to the 6-check version. Existing behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)