### PR TITLE
Bootstrap v2.6.3: optimize /hub-install (fast path + graceful version fallback + skip auto-fetch)

### DIFF
--- a/bootstrap/commands/hub-install.md
+++ b/bootstrap/commands/hub-install.md
@@ -1,6 +1,6 @@
 ---
 description: Search kjuhwa/skills.git by keyword/category and install matching skills locally, optionally pinning a version
-argument-hint: <keyword | name@version> [--all] [--example] [--global] [--category=<name>] [--version=<x.y.z>] [--include-archived]
+argument-hint: <keyword | name@version> [--all] [--example] [--global] [--category=<name>] [--version=<x.y.z>] [--include-archived] [--refresh] [--interactive] [--force-main]
 ---
 
 # /hub-install $ARGUMENTS
@@ -17,10 +17,11 @@ If none of these flags are present, run the main flow below.
 
 ## Steps
 
-1. **Ensure remote cache exists**
+1. **Ensure remote cache exists (fast path in v2.6.3+)**
    - Path: `~/.claude/skills-hub/remote/`
-   - If missing: `git clone https://github.com/kjuhwa/skills.git ~/.claude/skills-hub/remote` (full clone — shallow drops tags needed for version pinning).
-   - If present and older than 1h: `git -C ~/.claude/skills-hub/remote fetch --tags --prune origin` then `git pull --ff-only` (run in background if slow).
+   - If missing: `git clone https://github.com/kjuhwa/skills-hub.git ~/.claude/skills-hub/remote` (full clone — shallow drops tags needed for version pinning). The URL is `skills-hub.git`, not `skills.git`.
+   - **Otherwise do NOT auto-fetch.** Installing always uses the current working-tree state of the remote cache. Staleness detection is the job of `/hub-sync` (explicit) or `/hub-doctor` check 9 (reports the gap). The old "fetch if older than 1h" heuristic was the top contributor to slow installs.
+   - `--refresh` flag opts into an inline `git fetch --tags --prune origin && git pull --ff-only` before install (for users who know they want fresh).
    - If clone fails (network/auth), report clearly and stop — do NOT fabricate skills.
 
 2. **Parse version spec**
@@ -29,22 +30,27 @@ If none of these flags are present, run the main flow below.
    - Default (no version): install from `main` HEAD (latest).
 
 3. **Search**
-   - Read `~/.claude/skills-hub/remote/index.json` if present; else scan `**/SKILL.md` frontmatter.
-   - **Skip archived entries.** An entry is considered archived when its `SKILL.md` frontmatter (or `index.json` record) has `archived: true`. Archived entries remain in the repo for history but must never be surfaced to installers. If the user explicitly names an archived entry (`/hub-install <exact-name>` or `name@version` that resolves to an archived entry), show a single-line notice with the `archived_reason` and stop — do not install unless the user passes `--include-archived`.
+   - Read `~/.claude/skills-hub/remote/index.json`. It's the authoritative flat catalog (rebuilt on every publish since v2.5.4). Fall back to scanning `**/SKILL.md` only if `index.json` is missing (unusual).
+   - **Skip archived entries.** An entry is considered archived when its `SKILL.md` frontmatter (or `index.json` record) has `archived: true`. Archived entries remain in the repo for history but must never be surfaced to installers. If the user explicitly names an archived entry, show a single-line notice with the `archived_reason` and stop — do not install unless the user passes `--include-archived`.
    - Match keyword against: `name`, `description`, `tags`, `triggers`, `category` (case-insensitive).
    - If `--category=<name>` flag present, restrict to that category.
 
-4. **Present matches**
-   - Show: `category/skill-name — description (tags)` in a numbered list.
+4. **Present matches (v2.6.3+ fast-path)**
+   - **Exact-name fast path**: if the keyword equals exactly one entry's `name` field (case-insensitive exact match, after stripping `@version`), **skip the interactive prompt** and go straight to step 6. This is the common case for `/hub-install kafka-batch-consumer-partition-tuning`-style invocations and for demos. Add `--interactive` to force the prompt back on.
+   - Otherwise show: `category/skill-name — description (tags)` in a numbered list.
    - If zero matches: suggest closest categories from `CATEGORIES.md` and stop.
    - If many (>10): show top 10 by tag-match score; ask user to narrow.
 
-5. **Ask user** which to install (accept numbers, `all`, or `cancel`).
+5. **Ask user** which to install (accept numbers, `all`, or `cancel`). Skipped entirely when step 4 hit the exact-name fast path.
 
-6. **Resolve ref per skill**
-   - If a version was specified: verify tag `skills/<name>/v<version>` exists (`git -C ~/.claude/skills-hub/remote rev-parse --verify refs/tags/skills/<name>/v<version>`). If missing, list available tags for that skill via `git tag -l "skills/<name>/v*"` and stop.
-   - Checkout that skill's files from the tag into a temp staging dir: `git -C <remote> show <tag>:skills/<category>/<name>/<file>` per file (keeps main working tree untouched).
-   - No version → use current `main` checkout.
+6. **Resolve ref per skill (v2.6.3+ graceful fallback)**
+   - **If a version was specified**, resolve in this order:
+     1. **Tag match**: verify `refs/tags/skills/<name>/v<version>` exists (`git -C ~/.claude/skills-hub/remote rev-parse --verify refs/tags/skills/<name>/v<version>`). If so, use that tag.
+     2. **Frontmatter match**: if the tag is missing but the current `main` copy's SKILL.md frontmatter has `version: <same-version>`, install from `main` HEAD and print a one-line warning: `note: no tag exists for v<version>, but main declares this version in frontmatter — installing from main`. Treat as pinned=true in the registry.
+     3. **No match + no tags exist for this skill**: print a friendly line — `hint: this skill has no version tags yet. Drop "@<version>" to install from main, or use --force-main to proceed anyway.` Stop unless `--force-main`.
+     4. **No match + other tags exist**: list available tags via `git tag -l "skills/<name>/v*"` and stop. User picks one explicitly.
+   - **No version specified**: use current `main` checkout — same as before.
+   - Checkout files via `git -C <remote> show <ref>:skills/<category>/<name>/<file>` per file (keeps main working tree untouched).
 
 7. **Install selected**
    - Destination:


### PR DESCRIPTION
## Summary

Three optimizations to `/hub-install` that address the **"install is too slow and the version you gave doesn't exist"** class of feedback from v2.6.2:

1. **Exact-name fast path** (Step 4). When the keyword exactly matches one entry's `name`, skip the numbered-list prompt and go straight to resolve. Covers `/hub-install <exact-slug>` and `name@version` calls (demos, scripted installs). `--interactive` forces the prompt back on.

2. **Skip auto-fetch on every install** (Step 1). The old "fetch+pull if cache is older than 1h" heuristic was the top contributor to slow installs. Staleness is now the job of `/hub-sync` (explicit) and `/hub-doctor` check 9. Opt in with the new `--refresh` flag.

3. **Graceful version fallback** (Step 6). Version resolution now has a 4-tier order instead of "tag or bust":
   - **Tag match** → use tag (unchanged)
   - **No tag, but main's frontmatter declares the same version** → install from main HEAD with a one-line warning; mark `pinned=true`
   - **No tag, no tags ever existed** for this skill → friendly hint ("drop `@<version>` or pass `--force-main`")
   - **No tag, other tags exist** → list them for manual selection

Also fixes the `skills.git` vs `skills-hub.git` URL typo in Step 1.

## Test plan

- [x] `/hub-install kafka-batch-consumer-partition-tuning` (exact-name) skips prompt
- [x] `/hub-install "카프카"` (keyword, multi-match) still shows numbered list
- [x] `/hub-install jwt-refresh-rotation-spring@1.0.0` (no tag, frontmatter mismatch) → friendly hint + `--force-main` escape hatch
- [x] `/hub-install <name>@<version>` with valid tag → installs from tag (unchanged)
- [x] Install latency without `--refresh` — no git fetch, local-only read
- [x] `/hub-doctor` check 9 still reports index staleness
- [x] Argument hint advertises `--refresh / --interactive / --force-main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)