### PR TITLE
docs: add v2.6.2 and v2.6.3 to release history table

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,8 @@ Tags are annotated and created automatically by `/hub-publish-skills` and `/hub-
 
 | Version | Highlights |
 |---|---|
+| [`v2.6.3`](https://github.com/kjuhwa/skills-hub/releases/tag/bootstrap/v2.6.3) | **`/hub-install` optimization** — exact-name fast path skips interactive prompt, auto-fetch removed (opt-in via `--refresh`), graceful version fallback (tag → frontmatter → friendly hint / `--force-main`) replaces the old "tag or bust" behavior. |
+| [`v2.6.2`](https://github.com/kjuhwa/skills-hub/releases/tag/bootstrap/v2.6.2) | **`/hub-doctor` v2.5.x awareness** — 11 checks covering tools/bin installation, git hooks, index freshness, shell PATH, and the `<skills_hub>` CLAUDE.md block. |
 | [`v2.6.1`](https://github.com/kjuhwa/skills-hub/releases/tag/bootstrap/v2.6.1) | **Bulk-scan delegation** — `/hub-import`, `/hub-extract`, `/hub-refactor`, `/hub-condense`, `/hub-cleanup`, `/hub-research` now delegate file/web scanning to an Explore subagent. ~70 tool calls → ~5 for typical runs. |
 | [`v2.6.0`](https://github.com/kjuhwa/skills-hub/releases/tag/bootstrap/v2.6.0) | **Command consolidation** — 35 commands → Core 8 canonical entry points. `/hub-list`, `/hub-publish` added; dispatch flags on `/hub-extract`, `/hub-install`. Legacy names still work. |
 | [`v2.5.4`](https://github.com/kjuhwa/skills-hub/releases/tag/bootstrap/v2.5.4) | `tools/_rebuild_index_json.py` + `/hub-publish-all` spec hardened (SHA-map for tagging, post-merge retag step). |


### PR DESCRIPTION
## Summary

Adds the two most recent bootstrap entries to the **Recent bootstrap releases** table in the README:

- **v2.6.3** — `/hub-install` optimization (exact-name fast path, skip auto-fetch, graceful version fallback)
- **v2.6.2** — `/hub-doctor` 11-check v2.5.x awareness

Both shipped without a README pass; this backfills them in one commit.

## Test plan

- [x] Table order matches git tag order (descending semver)
- [x] Release links follow the `bootstrap/v<x.y.z>` format used elsewhere in the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)