### PR TITLE
Bootstrap v2.6.4: scale guards + shell completion + /hub-install discovery panel

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,13 @@ bootstrap/tools/*.sh    text eol=lf
 bootstrap/bin/*         text eol=lf
 bootstrap/install.sh    text eol=lf
 
+# v2.6.4+: shell completion scripts — bash/zsh MUST be LF or they fail to source
+# on Linux/macOS with CRLF. .ps1 is left on platform-native for PowerShell
+# compatibility, README stays LF like the rest of the corpus.
+bootstrap/completions/*.bash text eol=lf
+bootstrap/completions/*.zsh  text eol=lf
+bootstrap/completions/*.md   text eol=lf
+
 # Corpus markdown: same YAML frontmatter parser applies, keep LF.
 skills/**/*.md          text eol=lf
 knowledge/**/*.md       text eol=lf

--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Tags are annotated and created automatically by `/hub-publish-skills` and `/hub-
 
 | Version | Highlights |
 |---|---|
+| [`v2.6.4`](https://github.com/kjuhwa/skills-hub/releases/tag/bootstrap/v2.6.4) | **Scale guards + shell completion** — `/hub-publish-all` auto-chunks into batched PRs past 50 drafts (refuses ≥1000 without `--force-large`), `/hub-install` shows a discovery panel (recent installs + categories + counts) when invoked with no args, and bash/zsh/PowerShell tab-completion scripts ship for the `hub-*` bin wrappers (Claude Code REPL still has no arg autocomplete — documented limitation). |
 | [`v2.6.3`](https://github.com/kjuhwa/skills-hub/releases/tag/bootstrap/v2.6.3) | **`/hub-install` optimization** — exact-name fast path skips interactive prompt, auto-fetch removed (opt-in via `--refresh`), graceful version fallback (tag → frontmatter → friendly hint / `--force-main`) replaces the old "tag or bust" behavior. |
 | [`v2.6.2`](https://github.com/kjuhwa/skills-hub/releases/tag/bootstrap/v2.6.2) | **`/hub-doctor` v2.5.x awareness** — 11 checks covering tools/bin installation, git hooks, index freshness, shell PATH, and the `<skills_hub>` CLAUDE.md block. |
 | [`v2.6.1`](https://github.com/kjuhwa/skills-hub/releases/tag/bootstrap/v2.6.1) | **Bulk-scan delegation** — `/hub-import`, `/hub-extract`, `/hub-refactor`, `/hub-condense`, `/hub-cleanup`, `/hub-research` now delegate file/web scanning to an Explore subagent. ~70 tool calls → ~5 for typical runs. |

--- a/bootstrap/commands/hub-install.md
+++ b/bootstrap/commands/hub-install.md
@@ -73,5 +73,9 @@ If none of these flags are present, run the main flow below.
 - **Always install from `main` branch.** All skill/knowledge sources must come from the `main` branch of the remote cache. Never use feature branches (`example/*`, `skill/*`, etc.) — they may contain outdated or unmerged content. Version-pinned installs use tags that point to commits on `main`.
 - Never install without explicit user selection unless `--yes` flag.
 - Never modify the remote clone cache's working tree (read-only usage).
-- If `$ARGUMENTS` is empty, list top-level categories from `CATEGORIES.md` and prompt.
+- **Discovery panel when `$ARGUMENTS` is empty (v2.6.4+)** — show a three-part panel before prompting:
+  1. **Recent installs** — up to 5 entries from `~/.claude/skills-hub/registry.json`, sorted by `installed_at` descending. Skips entries whose files are missing on disk.
+  2. **Categories** — from `CATEGORIES.md`, annotated with entry counts read from `index.json` (e.g. `security (47)`).
+  3. **Hint line** — Claude Code's REPL has no native tab-complete for slash-command args. When you don't remember a slug, run `/hub-find <keyword>` first and paste the `name` from the results. For shell wrappers outside Claude Code, source `~/.claude/skills-hub/completions/hub-completion.{bash,zsh,ps1}` from your rc.
+  Then prompt the user for a keyword, slug, or category.
 - **Archived entries** (`archived: true` in frontmatter or index) are excluded from search results and bulk installs. Install them only when the user explicitly names the entry AND passes `--include-archived`; then print the `archived_reason` before proceeding so the user has context.

--- a/bootstrap/commands/hub-publish-all.md
+++ b/bootstrap/commands/hub-publish-all.md
@@ -1,6 +1,6 @@
 ---
-description: One-shot publish of both `.skills-draft/` and `.knowledge-draft/` to kjuhwa/skills.git on a single branch with a single PR
-argument-hint: [--all] [--pr] [--branch=<name>] [--bump=major|minor|patch] [--only skills|knowledge]
+description: One-shot publish of both `.skills-draft/` and `.knowledge-draft/` to kjuhwa/skills.git on a single branch with a single PR; auto-chunks into multiple PRs at scale
+argument-hint: [--all] [--pr] [--branch=<name>] [--bump=major|minor|patch] [--only skills|knowledge] [--batch-size=<N>] [--batch-squash|--no-batch-squash] [--force-large]
 ---
 
 # /hub-publish-all $ARGUMENTS
@@ -14,6 +14,29 @@ Use when `/hub-extract` (or `/hub-extract`) produced drafts in **both** `.skills
 - Union of `/hub-publish-skills` and `/hub-publish-knowledge` preconditions.
 - At least one draft under `.skills-draft/` OR `.knowledge-draft/` (if both empty, stop).
 - `~/.claude/skills-hub/remote/` clean (no uncommitted local changes).
+
+## Modes
+
+`/hub-publish-all` runs in one of two modes based on total draft count (`K + S`):
+
+- **Single-PR mode (default)** — `K + S ≤ --batch-size` (default 50). Steps 1–6 execute once; one branch, one PR. This is the common case and keeps history tidy.
+- **Batched mode** — `K + S > --batch-size`. Steps 1–6 execute **once per batch**. Each batch gets its own branch `release/combined-<YYYYMMDD>-batch-<N>-of-<M>` and its own PR. Step 7 (post-merge retag) runs once per PR after its squash-merge.
+
+## Pre-flight scale check (runs before step 1)
+
+1. Count: `K = size of .knowledge-draft/**/*.md`, `S = size of .skills-draft/**/SKILL.md`. Total = `K + S`.
+2. **Pre-load the existing slug set once** from `~/.claude/skills-hub/remote/index.json` into an in-memory `set` so subsequent collision checks are O(1) per draft. The naive per-draft scan of the catalog is O(N²) and becomes the dominant cost past ~200 drafts.
+3. Branch on total:
+
+   | Total | Behavior |
+   |---|---|
+   | `≤ --batch-size` (default 50) | Single-PR mode. Proceed to step 1. |
+   | `51–199` | Warn: `note: <total> drafts, auto-chunking into <M> batches of ≤ <batch-size>`. Show batch plan (table: batch #, K count, S count, slug preview of first 3). Ask once for `ok` / `abort`. |
+   | `200–999` | Same warning plus a wall-time estimate (`≈ total × 0.5s` for commit+push, `+ M × 2s` for gh pr create). Re-confirm explicitly. |
+   | `≥ 1000` | **Refuse** unless `--force-large` is present. Print top 5 category counts so the user can diagnose (e.g. `knowledge/pitfall: 412 — did you mean to publish these?`). This scale almost always means a wrong-dir mistake or a duplicate import. |
+
+4. If mode = batched, build the batch list: sort drafts by slug (stable order so re-runs assign the same drafts to the same batches), knowledge-first within each chunk, chunks of ≤ `--batch-size`.
+5. **Within-batch squash**: `--batch-squash` (default ON when `--batch-size > 20`) collapses each batch's commits into at most two (`knowledge: batch N/M (K entries)`, `skills: batch N/M (S entries)`). This matters because the remote's `post-commit` git hook re-runs `precheck.py` on every commit; one-commit-per-draft at 1000 drafts = 1000 full-tree reindexes. `--no-batch-squash` restores the legacy one-commit-per-draft shape for small batches where commit granularity aids review.
 
 ## Steps
 
@@ -56,10 +79,14 @@ Use when `/hub-extract` (or `/hub-extract`) produced drafts in **both** `.skills
    - For each **skill**, create the annotated tag `skills/<name>/v<version>` at the captured SHA from the map in step 3 (not at `HEAD`, because other commits have landed since).
    - Push tags: `git push origin --tags` restricted to this run's tags.
    - If `--pr` and `gh` available:
-     - `gh pr create --title "Publish <N> skills + <M> knowledge entries" --body ...`
-     - Body sections: `## Skills`, `## Knowledge`, `## Cross-links` (skill ↔ knowledge pairs created this run), `## Source` (project/session/commit refs).
+     - Title: `Publish <N> skills + <M> knowledge entries` (single-PR mode) or `Publish batch <N>/<M>: <K> knowledge + <S> skills` (batched mode).
+     - **Body size guard**: build the body in memory first; if it exceeds ~50 KB (safe margin under GitHub's ~65 KB PR body limit and typical shell arg limits), truncate the `## Skills` / `## Knowledge` sections to the first 20 entries each and commit a full `MANIFEST.md` to the branch root. The PR body links to it: `_... and N more — see [MANIFEST.md](../blob/<branch>/MANIFEST.md)_`.
+     - **Always invoke via `--body-file`** (write body to a temp file, `gh pr create --body-file /tmp/pr-body-<N>.md`). Never pass body inline — `--body "..."` hits shell arg length limits around 32 KB on Windows and breaks silently in the middle of a run.
+     - **Use explicit `--repo <owner>/<name> --head <branch> --base main`** flags rather than relying on the shell's cwd being the git directory. See knowledge entry `gh-pr-create-cwd-prefix-does-not-stick`.
+     - Body sections: `## Skills`, `## Knowledge`, `## Cross-links` (skill ↔ knowledge pairs created this run), `## Source` (project/session/commit refs), `## Batch` (only in batched mode: `<N>/<M>`, total, slug range, previous/next batch PR links once available).
      - Add a `## Post-merge` block that tells the reviewer/merger to run step 7 after squash-merge.
    - Otherwise print branch name, tag list, and compare URL.
+   - In **batched mode**, each batch opens one PR. Do **not** open all PRs in parallel — serialize: open batch N, wait for `ok` (or `--yes` auto-confirm), then open batch N+1. Prevents accidental mass-PR floods from an incorrectly-counted draft dir.
 
 6. **Cleanup drafts**
    - Move published skill drafts → `.skills-draft/_published/<date>/`.
@@ -81,13 +108,22 @@ Use when `/hub-extract` (or `/hub-extract`) produced drafts in **both** `.skills
 
 ## Rules
 
-- **Never push to `main` directly.** One feature branch per run.
+- **Never push to `main` directly.** One feature branch per run (per batch, in batched mode).
 - **Never skip the dry-run step.**
-- If either pipeline aborts mid-run, the branch is kept as-is for inspection — no automatic rollback, no force-push.
-- Cross-linking is **opt-in**: only link when a skill's SKILL.md explicitly names a `linked_knowledge` slug, or a knowledge file's frontmatter names `linked_skills`. Never infer links from name similarity.
+- If either pipeline aborts mid-run, the branch is kept as-is for inspection — no automatic rollback, no force-push. In batched mode, already-merged batches are never reverted; only the batch that failed stops the sequence.
+- Cross-linking is **opt-in**: only link when a skill's SKILL.md explicitly names a `linked_knowledge` slug, or a knowledge file's frontmatter names `linked_skills`. Never infer links from name similarity. Cross-links across batches are allowed only when the referenced entry has already landed on `main` (i.e. the target batch's PR is merged).
 - Sanitization rules from both underlying commands apply.
 - On conflict between `--only` and the presence of drafts in the excluded kind, warn and proceed with the requested kind only; don't silently publish the other.
 - If `gh` is unavailable, still push the branch and print a ready-to-paste PR URL + title + body draft.
+
+### Scale rules (v2.6.4+)
+
+- `--batch-size=<N>` defaults to 50 and is clamped to the range `[5, 200]`. Values below 5 create too many tiny PRs; values above 200 risk GitHub's diff-rendering and shell-arg limits regardless of squashing.
+- `--force-large` is required to publish ≥ 1000 drafts in a single invocation. Without it, the pre-flight check refuses and prints the top 5 category counts for diagnosis. This is a guardrail against accidental mass publishes, not a performance limit.
+- **Slug collisions against the existing catalog must be resolved before any commit lands.** The pre-flight pre-loads the catalog slugs into a `set` exactly once; every draft is checked against it in O(1). If any collision is found, the whole run stops and prints the offending pairs — do not let partial batches leak through.
+- **Within-batch squash is on by default at scale.** When `--batch-size > 20`, each batch collapses to at most two commits (`knowledge: batch N/M`, `skills: batch N/M`) so the remote's `post-commit` hook runs a bounded number of reindexes. Users who want commit-per-draft granularity for review pass `--no-batch-squash` and accept the hook-fire cost.
+- **PR bodies MUST use `--body-file`** when generated at scale; inline `--body "..."` breaks silently past ~32 KB on Windows shells. At any size, explicit `--repo`/`--head`/`--base` flags are mandatory — never rely on shell cwd for `gh` invocations (see `gh-pr-create-cwd-prefix-does-not-stick`).
+- **Batched PRs open serially, not in parallel.** Opening N PRs concurrently can trip per-user rate limits on `gh` / the GitHub API, and the serial flow gives the user a chance to abort after seeing batch 1 render correctly.
 
 ## When NOT to use
 

--- a/bootstrap/completions/README.md
+++ b/bootstrap/completions/README.md
@@ -1,0 +1,67 @@
+# Shell tab-completion for `hub-*` bin wrappers
+
+Tab completion for `hub-search`, `hub-precheck`, `hub-index-diff` **outside** Claude Code's REPL. Claude Code does not support dynamic autocomplete for slash-command argument values — the `argument-hint` frontmatter field is descriptive text only, and there is no first-party completion-provider API for MCP/SDK/hooks as of v2.6.4.
+
+## Install
+
+The bootstrap installer copies these files into `~/.claude/skills-hub/completions/`. Source from your shell rc:
+
+**bash** (`~/.bashrc`)
+```bash
+[ -f "$HOME/.claude/skills-hub/completions/hub-completion.bash" ] \
+  && source "$HOME/.claude/skills-hub/completions/hub-completion.bash"
+```
+
+**zsh** (`~/.zshrc`)
+```zsh
+[ -f "$HOME/.claude/skills-hub/completions/hub-completion.zsh" ] \
+  && source "$HOME/.claude/skills-hub/completions/hub-completion.zsh"
+```
+
+**PowerShell** (`$PROFILE`)
+```powershell
+. "$HOME\.claude\skills-hub\completions\hub-completion.ps1"
+```
+
+Open a new shell. Try:
+```
+$ hub-search jwt-r<TAB>
+jwt-refresh-rotation-spring
+$ hub-index-diff HEAD~<TAB>
+HEAD~1   HEAD~5
+```
+
+## Coverage
+
+| Wrapper | Completion |
+|---|---|
+| `hub-search <slug>` | Slug list from `~/.claude/skills-hub/remote/index.json` (archived entries excluded) |
+| `hub-search --category=<cat>` | Categories from the same catalog |
+| `hub-search --flags` | `--category --cat --kind --html --json -n --help` |
+| `hub-precheck <flags>` | `--strict --skip-lint --json --help` |
+| `hub-index-diff <ref>` | Recent branches and tags from the remote cache + `HEAD~N` shortcuts |
+
+## Inside Claude Code
+
+Claude Code slash commands (`/hub-install`, `/hub-show`, `/hub-remove`, etc.) do NOT benefit from these files. When you forget a slug while inside the REPL:
+
+1. Run `/hub-find <keyword>` — ranked search over the full 800-entry catalog with Korean↔English synonym expansion.
+2. Copy the `name` column from the top result.
+3. Paste into `/hub-install <slug>`.
+
+This two-step flow is the closest equivalent to tab-complete in the current Claude Code surface area.
+
+## Refresh semantics
+
+The completion functions read `~/.claude/skills-hub/remote/index.json` on every tab press — no caching, so new skills appear as soon as a `/hub-sync` or `git pull` updates the catalog. If completion returns empty or stale results:
+
+- `ls ~/.claude/skills-hub/remote/index.json` — confirm the catalog exists.
+- `/hub-precheck` — regenerate the catalog from filesystem if it's been lost.
+- `/hub-doctor` — full environment health check.
+
+## Limitations
+
+- Archived entries are filtered out by design.
+- Completion is O(N) per tab press — fine at N ≤ 5000. Beyond that, consider caching.
+- PowerShell completion requires the command to already be on `PATH` when the profile loads. If `hub-search` isn't found at shell start, completion registers but won't fire; restart after adding to `PATH`.
+- No completion for slash commands — this is a Claude Code limitation, not fixable at the hub level.

--- a/bootstrap/completions/hub-completion.bash
+++ b/bootstrap/completions/hub-completion.bash
@@ -1,0 +1,93 @@
+# hub-* shell wrapper tab-completion (bash).
+# Outside Claude Code only — Claude Code's REPL does NOT expose a
+# completion-provider API for slash-command args.
+#
+# Install: source this file from ~/.bashrc:
+#   [ -f "$HOME/.claude/skills-hub/completions/hub-completion.bash" ] \
+#     && source "$HOME/.claude/skills-hub/completions/hub-completion.bash"
+
+_hub_catalog_path() {
+    printf '%s\n' "$HOME/.claude/skills-hub/remote/index.json"
+}
+
+_hub_py_bin() {
+    if command -v py >/dev/null 2>&1;     then printf 'py -3\n'
+    elif command -v python3 >/dev/null 2>&1; then printf 'python3\n'
+    else return 1
+    fi
+}
+
+_hub_slug_list() {
+    local catalog py
+    catalog="$(_hub_catalog_path)"
+    [ -r "$catalog" ] || return 0
+    py="$(_hub_py_bin)" || return 0
+    # shellcheck disable=SC2016
+    $py -c '
+import json, os, sys
+catalog = os.path.expanduser(sys.argv[1])
+try:
+    for e in json.load(open(catalog, encoding="utf-8")):
+        if e.get("archived"): continue
+        n = e.get("name")
+        if n: print(n)
+except Exception:
+    pass
+' "$catalog" 2>/dev/null
+}
+
+_hub_category_list() {
+    local catalog py
+    catalog="$(_hub_catalog_path)"
+    [ -r "$catalog" ] || return 0
+    py="$(_hub_py_bin)" || return 0
+    # shellcheck disable=SC2016
+    $py -c '
+import json, os, sys
+catalog = os.path.expanduser(sys.argv[1])
+try:
+    cats = {e.get("category") for e in json.load(open(catalog, encoding="utf-8")) if e.get("category")}
+    for c in sorted(cats): print(c)
+except Exception:
+    pass
+' "$catalog" 2>/dev/null
+}
+
+_hub_search_complete() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]:-}"
+    case "$prev" in
+        --category|--cat)
+            # shellcheck disable=SC2207
+            COMPREPLY=( $(compgen -W "$(_hub_category_list)" -- "$cur") )
+            return
+            ;;
+    esac
+    if [[ "$cur" == --* ]]; then
+        # shellcheck disable=SC2207
+        COMPREPLY=( $(compgen -W "--category --cat --kind --html --json -n --help" -- "$cur") )
+    else
+        # shellcheck disable=SC2207
+        COMPREPLY=( $(compgen -W "$(_hub_slug_list)" -- "$cur") )
+    fi
+}
+
+_hub_precheck_complete() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    # shellcheck disable=SC2207
+    COMPREPLY=( $(compgen -W "--strict --skip-lint --json --help" -- "$cur") )
+}
+
+_hub_index_diff_complete() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local refs
+    refs=$(git -C "$HOME/.claude/skills-hub/remote" \
+        for-each-ref --format='%(refname:short)' --sort=-committerdate \
+        refs/heads refs/tags 2>/dev/null | head -50)
+    # shellcheck disable=SC2207
+    COMPREPLY=( $(compgen -W "${refs} HEAD HEAD~1 HEAD~5 --help" -- "$cur") )
+}
+
+complete -F _hub_search_complete     hub-search
+complete -F _hub_precheck_complete   hub-precheck
+complete -F _hub_index_diff_complete hub-index-diff

--- a/bootstrap/completions/hub-completion.ps1
+++ b/bootstrap/completions/hub-completion.ps1
@@ -1,0 +1,50 @@
+# hub-* shell wrapper tab-completion (PowerShell 5.1+ / 7+).
+# Outside Claude Code only — Claude Code's REPL does NOT expose a
+# completion-provider API for slash-command args.
+#
+# Install: dot-source this file from $PROFILE:
+#   . $HOME\.claude\skills-hub\completions\hub-completion.ps1
+
+$script:HubCatalogPath = Join-Path $HOME ".claude\skills-hub\remote\index.json"
+
+function Get-HubSlugs {
+    if (-not (Test-Path $script:HubCatalogPath)) { return @() }
+    try {
+        (Get-Content $script:HubCatalogPath -Raw -Encoding UTF8 |
+            ConvertFrom-Json) |
+            Where-Object { -not $_.archived -and $_.name } |
+            ForEach-Object { $_.name }
+    } catch { @() }
+}
+
+$hubCompleter = {
+    param($wordToComplete, $commandAst, $cursorPosition)
+    Get-HubSlugs |
+        Where-Object { $_ -like "$wordToComplete*" } |
+        ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new(
+                $_, $_, 'ParameterValue', $_)
+        }
+}
+
+Register-ArgumentCompleter -CommandName 'hub-search'     -Native -ScriptBlock $hubCompleter
+Register-ArgumentCompleter -CommandName 'hub-precheck'   -Native -ScriptBlock {
+    param($wordToComplete)
+    @('--strict','--skip-lint','--json','--help') |
+        Where-Object { $_ -like "$wordToComplete*" } |
+        ForEach-Object { [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_) }
+}
+Register-ArgumentCompleter -CommandName 'hub-index-diff' -Native -ScriptBlock {
+    param($wordToComplete)
+    $remote = Join-Path $HOME ".claude\skills-hub\remote"
+    $refs = @()
+    if (Test-Path (Join-Path $remote ".git")) {
+        try {
+            $refs = & git -C $remote for-each-ref --format='%(refname:short)' --sort=-committerdate refs/heads refs/tags 2>$null |
+                    Select-Object -First 50
+        } catch {}
+    }
+    ($refs + @('HEAD','HEAD~1','HEAD~5','--help')) |
+        Where-Object { $_ -like "$wordToComplete*" } |
+        ForEach-Object { [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_) }
+}

--- a/bootstrap/completions/hub-completion.zsh
+++ b/bootstrap/completions/hub-completion.zsh
@@ -1,0 +1,13 @@
+# hub-* shell wrapper tab-completion (zsh).
+# Outside Claude Code only — see hub-completion.bash for rationale.
+#
+# Install: source this file from ~/.zshrc:
+#   [ -f "$HOME/.claude/skills-hub/completions/hub-completion.zsh" ] \
+#     && source "$HOME/.claude/skills-hub/completions/hub-completion.zsh"
+#
+# Reuses the bash completion via zsh's bashcompinit; bash 4+ syntax
+# used in hub-completion.bash is supported.
+
+autoload -Uz bashcompinit && bashcompinit
+# shellcheck disable=SC1091
+source "${0:A:h}/hub-completion.bash"

--- a/bootstrap/install.ps1
+++ b/bootstrap/install.ps1
@@ -36,6 +36,16 @@ if (Test-Path "$RepoDir\bootstrap\bin") {
         ForEach-Object { Copy-Item $_.FullName "$HubDir\bin\" -Force }
 }
 
+# v2.6.4+: shell completion for hub-* bin wrappers
+if (Test-Path "$RepoDir\bootstrap\completions") {
+    Write-Host "Installing shell completions -> $HubDir\completions\"
+    New-Item -ItemType Directory -Force -Path "$HubDir\completions" | Out-Null
+    Copy-Item "$RepoDir\bootstrap\completions\hub-completion.bash" "$HubDir\completions\" -Force -ErrorAction SilentlyContinue
+    Copy-Item "$RepoDir\bootstrap\completions\hub-completion.zsh"  "$HubDir\completions\" -Force -ErrorAction SilentlyContinue
+    Copy-Item "$RepoDir\bootstrap\completions\hub-completion.ps1"  "$HubDir\completions\" -Force -ErrorAction SilentlyContinue
+    Copy-Item "$RepoDir\bootstrap\completions\README.md"           "$HubDir\completions\README.md" -Force -ErrorAction SilentlyContinue
+}
+
 if (-not (Test-Path "$HubDir\remote\.git")) {
     Write-Host "Note: runtime remote cache not present at $HubDir\remote\"
     Write-Host "      Either clone the repo there, or a /skills_* command will clone on first run."
@@ -59,6 +69,14 @@ if ((Test-Path "$HubDir\remote\.git") -and (Test-Path "$HubDir\tools\install-hoo
 Write-Host ""
 Write-Host "To use 'hub-search', 'hub-precheck', 'hub-index-diff' from any shell, add to your PowerShell profile:"
 Write-Host "  `$env:Path = `"`$HOME\.claude\skills-hub\bin;`" + `$env:Path"
+
+# v2.6.4+: completion hint
+if (Test-Path "$HubDir\completions") {
+    Write-Host ""
+    Write-Host "Optional: tab-completion for hub-* bin wrappers (outside Claude Code)"
+    Write-Host "  PowerShell: . `$HOME\.claude\skills-hub\completions\hub-completion.ps1"
+    Write-Host "  bash/zsh:   source `$HOME/.claude/skills-hub/completions/hub-completion.{bash,zsh}"
+}
 
 Write-Host ""
 Write-Host "Done. Installed commands:"

--- a/bootstrap/install.sh
+++ b/bootstrap/install.sh
@@ -32,6 +32,16 @@ if [ -d "$REPO_DIR/bootstrap/bin" ]; then
   chmod +x "$HUB_DIR/bin/"hub-* 2>/dev/null || true
 fi
 
+# --- v2.6.4+: shell completion for hub-* bin wrappers ---
+if [ -d "$REPO_DIR/bootstrap/completions" ]; then
+  echo "Installing shell completions → $HUB_DIR/completions/"
+  mkdir -p "$HUB_DIR/completions"
+  cp "$REPO_DIR/bootstrap/completions/hub-completion.bash" "$HUB_DIR/completions/" 2>/dev/null || true
+  cp "$REPO_DIR/bootstrap/completions/hub-completion.zsh"  "$HUB_DIR/completions/" 2>/dev/null || true
+  cp "$REPO_DIR/bootstrap/completions/hub-completion.ps1"  "$HUB_DIR/completions/" 2>/dev/null || true
+  cp "$REPO_DIR/bootstrap/completions/README.md"           "$HUB_DIR/completions/README.md" 2>/dev/null || true
+fi
+
 # Ensure the remote cache symlink / copy exists for the runtime commands
 if [ ! -d "$HUB_DIR/remote/.git" ]; then
   echo "Note: runtime remote cache not present at $HUB_DIR/remote/"
@@ -53,6 +63,15 @@ fi
 echo ""
 echo "To use 'hub-search', 'hub-precheck', 'hub-index-diff' from any shell, add to ~/.bashrc:"
 echo "  export PATH=\"\$HOME/.claude/skills-hub/bin:\$PATH\""
+
+# Completion hint (v2.6.4+)
+if [ -d "$HUB_DIR/completions" ]; then
+  echo ""
+  echo "Optional: tab-completion for hub-* bin wrappers (outside Claude Code)"
+  echo "  bash: source \$HOME/.claude/skills-hub/completions/hub-completion.bash"
+  echo "  zsh:  source \$HOME/.claude/skills-hub/completions/hub-completion.zsh"
+  echo "  (PowerShell has a parallel hub-completion.ps1 — dot-source from \$PROFILE)"
+fi
 
 echo ""
 echo "Done. Installed commands:"


### PR DESCRIPTION
## Summary

Three bundled UX improvements:

### 1. `/hub-publish-all` scale guards

Current spec publishes every draft in a single PR. At 1000 drafts this breaks in predictable ways:
- Single-PR diff un-reviewable, CI timeouts
- `post-commit` git hook runs `precheck.py` per draft → 1000 full-tree reindexes
- PR body ≥65KB hits GitHub's description limit
- Slug collision check is O(N²) against the catalog

New behavior:

| Total drafts | Mode |
|---|---|
| ≤ `--batch-size` (default 50) | Single PR (current behavior) |
| 51–199 | Auto-chunk into batched PRs, warn + confirm once |
| 200–999 | Same + wall-time estimate, explicit re-confirm |
| ≥ 1000 | **Refuse** unless `--force-large` present |

Plus: `--batch-squash` (default ON at `batch-size > 20`) collapses within-batch commits, slug collision check pre-loads the catalog set once, PR body size guard auto-falls back to a `MANIFEST.md` file, PRs open serially not in parallel.

### 2. `/hub-install` discovery panel

When invoked with no args (common first-timer entry point), replaces the bare `CATEGORIES.md` listing with:
- Recent installs from `registry.json` (top 5 by `installed_at`)
- Categories with entry counts from `index.json`
- Hint line explaining Claude Code's slash-command autocomplete limitation and the `/hub-find`-first workflow

### 3. Shell tab-completion for `hub-*` bin wrappers

- `bootstrap/completions/hub-completion.bash` — bash completion via `complete -F`, reads slugs from `index.json` live
- `bootstrap/completions/hub-completion.zsh` — zsh via `bashcompinit` wrapper
- `bootstrap/completions/hub-completion.ps1` — PowerShell via `Register-ArgumentCompleter -Native`
- `bootstrap/completions/README.md` — install instructions + Claude Code limitation note
- `install.sh` / `install.ps1` copy completions to `~/.claude/skills-hub/completions/` and print source-line hints
- `.gitattributes` extended to enforce LF on `*.bash` / `*.zsh` / `*.md` under `bootstrap/completions/`

**Important**: these help only **outside** Claude Code. The REPL itself has no completion-provider API for slash-command args (confirmed via Anthropic's official slash-commands docs). The discovery panel + `/hub-find`-first workflow is the best we can offer inside.

## Test plan

- [x] `argument-hint` of `/hub-publish-all` advertises new flags (`--batch-size`, `--batch-squash`, `--force-large`)
- [x] `/hub-install` Rules section includes the discovery-panel spec
- [x] Completion scripts readable and self-contained (no external deps beyond `py`/`python3` + `git`)
- [x] `.gitattributes` covers `bootstrap/completions/*.{bash,zsh,md}` with `eol=lf`
- [x] `install.sh` / `install.ps1` ship completions and emit hints
- [x] README release history row for v2.6.4 landed

## Post-merge

Standard bootstrap release dance:
1. Squash-merge this PR
2. Retag `bootstrap/v2.6.4` at the squash commit (current tag points at the pre-squash `2d7bf6f`)
3. Sync `~/.claude/skills-hub/remote/main` locally
4. Copy updated slash commands to `~/.claude/commands/`
5. Copy completions to `~/.claude/skills-hub/completions/` (or re-run `bash install.sh`)
6. Bump `~/.claude/skills-hub/bootstrap.json` to `installed_version: 2.6.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)