### PR TITLE
Bootstrap v2.6.7: installer seeds missing hub state

### DIFF
--- a/bootstrap/install.ps1
+++ b/bootstrap/install.ps1
@@ -7,12 +7,18 @@ $ClaudeDir = if ($env:CLAUDE_DIR) { $env:CLAUDE_DIR } else { "$HOME\.claude" }
 $RepoDir = Split-Path -Parent $PSScriptRoot
 $HubDir = Join-Path $ClaudeDir "skills-hub"
 
-New-Item -ItemType Directory -Force -Path "$ClaudeDir\commands"      | Out-Null
+New-Item -ItemType Directory -Force -Path "$ClaudeDir\commands"        | Out-Null
 New-Item -ItemType Directory -Force -Path "$ClaudeDir\skills\skills-hub" | Out-Null
-New-Item -ItemType Directory -Force -Path "$HubDir"                  | Out-Null
-New-Item -ItemType Directory -Force -Path "$HubDir\tools"            | Out-Null
-New-Item -ItemType Directory -Force -Path "$HubDir\bin"              | Out-Null
-New-Item -ItemType Directory -Force -Path "$HubDir\indexes"          | Out-Null
+New-Item -ItemType Directory -Force -Path "$HubDir"                    | Out-Null
+New-Item -ItemType Directory -Force -Path "$HubDir\tools"              | Out-Null
+New-Item -ItemType Directory -Force -Path "$HubDir\bin"                | Out-Null
+New-Item -ItemType Directory -Force -Path "$HubDir\indexes"            | Out-Null
+New-Item -ItemType Directory -Force -Path "$HubDir\knowledge\api"      | Out-Null
+New-Item -ItemType Directory -Force -Path "$HubDir\knowledge\arch"     | Out-Null
+New-Item -ItemType Directory -Force -Path "$HubDir\knowledge\pitfall"  | Out-Null
+New-Item -ItemType Directory -Force -Path "$HubDir\knowledge\decision" | Out-Null
+New-Item -ItemType Directory -Force -Path "$HubDir\knowledge\domain"   | Out-Null
+New-Item -ItemType Directory -Force -Path "$HubDir\external"           | Out-Null
 
 Write-Host "Installing slash commands -> $ClaudeDir\commands\"
 Copy-Item "$RepoDir\bootstrap\commands\*.md" "$ClaudeDir\commands\" -Force
@@ -51,9 +57,49 @@ if (-not (Test-Path "$HubDir\remote\.git")) {
     Write-Host "      Either clone the repo there, or a /skills_* command will clone on first run."
 }
 
+# Initialize / upgrade registry (v2 schema). Strip a possible UTF-8 BOM
+# written by earlier installs before deciding whether to re-seed.
+$needSeed = $false
 if (-not (Test-Path "$HubDir\registry.json")) {
-    "{}" | Out-File -FilePath "$HubDir\registry.json" -Encoding utf8 -NoNewline
+    $needSeed = $true
+} else {
+    $existing = Get-Content "$HubDir\registry.json" -Raw -ErrorAction SilentlyContinue
+    if ($null -eq $existing) { $existing = '' }
+    $existing = $existing.TrimStart([char]0xFEFF)
+    $existing = ($existing -replace '\s','')
+    if ([string]::IsNullOrEmpty($existing) -or $existing -eq '{}') { $needSeed = $true }
 }
+if ($needSeed) {
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText("$HubDir\registry.json", @'
+{
+  "version": 2,
+  "skills": {},
+  "knowledge": {}
+}
+'@, $utf8NoBom)
+}
+
+# Record installed bootstrap version (strip the "bootstrap/" tag prefix).
+$installedVersion = $null
+try {
+    $installedVersion = (& git -C "$RepoDir" describe --tags --exact-match --match 'bootstrap/v*' 2>$null).Trim()
+} catch {}
+if (-not $installedVersion) {
+    try {
+        $installedVersion = ((& git -C "$RepoDir" tag --list 'bootstrap/v*' --sort=-v:refname 2>$null) | Select-Object -First 1).Trim()
+    } catch {}
+}
+if (-not $installedVersion) { $installedVersion = "unknown" }
+$installedVersion = $installedVersion -replace '^bootstrap/',''
+$installedAt = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText("$HubDir\bootstrap.json", @"
+{
+  "installed_version": "$installedVersion",
+  "installed_at": "$installedAt"
+}
+"@, $utf8NoBom)
 
 # Install git hooks if remote is ready and a POSIX bash exists.
 if ((Test-Path "$HubDir\remote\.git") -and (Test-Path "$HubDir\tools\install-hooks.sh")) {
@@ -63,6 +109,24 @@ if ((Test-Path "$HubDir\remote\.git") -and (Test-Path "$HubDir\tools\install-hoo
         & bash "$HubDir\tools\install-hooks.sh"
     } else {
         Write-Host "Note: bash not found; run 'bash $HubDir/tools/install-hooks.sh' manually to enable hooks."
+    }
+}
+
+# Build initial indexes so they exist before the first git hook fires
+if (Test-Path "$HubDir\tools\precheck.py") {
+    $pyBin = $null
+    if (Get-Command py -ErrorAction SilentlyContinue)      { $pyBin = @("py","-3") }
+    elseif (Get-Command python3 -ErrorAction SilentlyContinue) { $pyBin = @("python3") }
+    elseif (Get-Command python  -ErrorAction SilentlyContinue) { $pyBin = @("python") }
+    if ($pyBin) {
+        Write-Host "Building initial indexes"
+        $env:PYTHONIOENCODING = "utf-8"
+        & $pyBin[0] @($pyBin[1..($pyBin.Length-1)] + @("$HubDir\tools\precheck.py","--skip-lint")) *> $null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  warn: initial index build failed; run '$($pyBin -join ' ') $HubDir\tools\precheck.py --skip-lint' manually"
+        }
+    } else {
+        Write-Host "Note: no python found on PATH; skipping initial index build."
     }
 }
 

--- a/bootstrap/install.sh
+++ b/bootstrap/install.sh
@@ -8,7 +8,10 @@ REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 HUB_DIR="$CLAUDE_DIR/skills-hub"
 
 mkdir -p "$CLAUDE_DIR/commands" "$CLAUDE_DIR/skills/skills-hub" \
-         "$HUB_DIR" "$HUB_DIR/tools" "$HUB_DIR/bin" "$HUB_DIR/indexes"
+         "$HUB_DIR" "$HUB_DIR/tools" "$HUB_DIR/bin" "$HUB_DIR/indexes" \
+         "$HUB_DIR/knowledge/api" "$HUB_DIR/knowledge/arch" \
+         "$HUB_DIR/knowledge/pitfall" "$HUB_DIR/knowledge/decision" \
+         "$HUB_DIR/knowledge/domain" "$HUB_DIR/external"
 
 echo "Installing slash commands → $CLAUDE_DIR/commands/"
 cp "$REPO_DIR/bootstrap/commands/"*.md "$CLAUDE_DIR/commands/"
@@ -48,15 +51,62 @@ if [ ! -d "$HUB_DIR/remote/.git" ]; then
   echo "      Either clone the repo there, or a /skills_* command will clone on first run."
 fi
 
-# Initialize empty registry if missing
+# Initialize / upgrade registry (v2 schema). Handle pre-existing files that
+# may carry a UTF-8 BOM from earlier PowerShell installs.
+NEED_SEED=0
 if [ ! -f "$HUB_DIR/registry.json" ]; then
-  echo "{}" > "$HUB_DIR/registry.json"
+  NEED_SEED=1
+else
+  RAW="$(cat "$HUB_DIR/registry.json")"
+  RAW="${RAW#$'\xEF\xBB\xBF'}"
+  STRIPPED="$(printf '%s' "$RAW" | tr -d '[:space:]')"
+  if [ -z "$STRIPPED" ] || [ "$STRIPPED" = "{}" ]; then
+    NEED_SEED=1
+  fi
 fi
+if [ "$NEED_SEED" = 1 ]; then
+  cat > "$HUB_DIR/registry.json" <<'JSON'
+{
+  "version": 2,
+  "skills": {},
+  "knowledge": {}
+}
+JSON
+fi
+
+# Record installed bootstrap version (strip the "bootstrap/" tag prefix).
+INSTALLED_VERSION="$(git -C "$REPO_DIR" describe --tags --exact-match --match 'bootstrap/v*' 2>/dev/null \
+  || git -C "$REPO_DIR" tag --list 'bootstrap/v*' --sort=-v:refname 2>/dev/null | head -1 \
+  || echo 'unknown')"
+INSTALLED_VERSION="${INSTALLED_VERSION#bootstrap/}"
+INSTALLED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+cat > "$HUB_DIR/bootstrap.json" <<JSON
+{
+  "installed_version": "${INSTALLED_VERSION:-unknown}",
+  "installed_at": "$INSTALLED_AT"
+}
+JSON
 
 # Install git hooks if remote is ready
 if [ -d "$HUB_DIR/remote/.git" ] && [ -f "$HUB_DIR/tools/install-hooks.sh" ]; then
   echo "Installing git hooks (auto re-index on merge / commit / checkout)"
   bash "$HUB_DIR/tools/install-hooks.sh" || echo "  warn: hook install failed; run manually later"
+fi
+
+# Build initial indexes so they exist before the first git hook fires
+if [ -f "$HUB_DIR/tools/precheck.py" ]; then
+  PYBIN=""
+  if command -v py >/dev/null 2>&1; then PYBIN="py -3"
+  elif command -v python3 >/dev/null 2>&1; then PYBIN="python3"
+  elif command -v python >/dev/null 2>&1; then PYBIN="python"
+  fi
+  if [ -n "$PYBIN" ]; then
+    echo "Building initial indexes"
+    PYTHONIOENCODING=utf-8 $PYBIN "$HUB_DIR/tools/precheck.py" --skip-lint >/dev/null 2>&1 \
+      || echo "  warn: initial index build failed; run '$PYBIN $HUB_DIR/tools/precheck.py --skip-lint' manually"
+  else
+    echo "Note: no python found on PATH; skipping initial index build."
+  fi
 fi
 
 # PATH hint


### PR DESCRIPTION
## Summary
- Fix four installer gaps that caused a clean uninstall + install + `/hub-doctor` cycle to report bogus FAIL/WARN results.
- Installer now seeds the v2 `registry.json` schema, writes `bootstrap.json`, creates `knowledge/{api,arch,pitfall,decision,domain}/` + `external/`, and builds the initial master/category indexes via `tools/precheck.py --skip-lint`.
- `install.sh` and `install.ps1` kept in sync; both write registry/bootstrap JSON as UTF-8 without BOM, and `install.sh` now handles the BOM that earlier PowerShell installs left behind when deciding whether to re-seed.

## Why
Before this patch `/hub-doctor` flagged 3 FAIL + 1 WARN on a fresh install even though the install itself was fine — the doctor's v2.5.0+ expectations had drifted ahead of what the installer writes. The gaps were:

| Doctor check | Gap |
|---|---|
| 2 registry consistency | `registry.json` seeded as `{}`, missing `version: 2` |
| 4 directory structure | `knowledge/*/` subcategories and `external/` never created |
| 5 bootstrap version | `bootstrap.json` never written (`installed_version` unknown) |
| 9 indexes freshness | `indexes/` created empty; git hooks only regenerate on later merge/commit/checkout |

## Test plan
- [x] Clean uninstall → `bash install.sh` → verify `registry.json`, `bootstrap.json`, `knowledge/*/`, `external/`, and `indexes/00_MASTER_INDEX*.md` all exist.
- [x] Re-run `install.sh` against an existing `{}`-only `registry.json` (with BOM) → verify it gets re-seeded to the v2 schema.
- [x] Run `/hub-doctor` — previously-failing checks 2, 4, 5, 9 now PASS.
- [ ] Verify on Windows PowerShell (`install.ps1`) — needs a second pair of eyes / CI.
- [ ] Decide on a new `bootstrap/v2.6.7` tag once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)