### PR TITLE
Bootstrap v2.6.8: insert <skills_hub> block into CLAUDE.md on install

### DIFF
--- a/bootstrap/install.ps1
+++ b/bootstrap/install.ps1
@@ -130,6 +130,39 @@ if (Test-Path "$HubDir\tools\precheck.py") {
     }
 }
 
+# v2.6.8+: pre-implementation auto-check block in CLAUDE.md
+# Idempotent: inserts on first install, refreshes on re-install.
+# Removal is handled by /hub-uninstall.
+$claudeMd = Join-Path $ClaudeDir "CLAUDE.md"
+$canonicalBlock = @'
+<skills_hub>
+Before implementing, check the hub for existing skills/knowledge:
+- `/hub-find <keyword>` — search installed + remote
+- `/hub-install <slug>` — install matching skill/knowledge
+- `/hub-list` — see what's already installed
+- `/hub-publish` — publish drafts back to the hub
+</skills_hub>
+'@
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+if (-not (Test-Path $claudeMd)) {
+    Write-Host "Creating $claudeMd with <skills_hub> block"
+    [System.IO.File]::WriteAllText($claudeMd, $canonicalBlock + "`n", $utf8NoBom)
+} else {
+    $existing = [System.IO.File]::ReadAllText($claudeMd)
+    if ($existing -match '(?s)<skills_hub>.*?</skills_hub>') {
+        Write-Host "Refreshing <skills_hub> block in $claudeMd"
+        $regex = [regex]'(?s)<skills_hub>.*?</skills_hub>'
+        $new = $regex.Replace($existing, { param($m) $canonicalBlock }, 1)
+        [System.IO.File]::WriteAllText($claudeMd, $new, $utf8NoBom)
+    } else {
+        Write-Host "Adding <skills_hub> block to $claudeMd"
+        $sep = if ($existing.Length -eq 0) { "" }
+               elseif ($existing.EndsWith("`n")) { "`n" }
+               else { "`n`n" }
+        [System.IO.File]::AppendAllText($claudeMd, $sep + $canonicalBlock + "`n", $utf8NoBom)
+    }
+}
+
 Write-Host ""
 Write-Host "To use 'hub-search', 'hub-precheck', 'hub-index-diff' from any shell, add to your PowerShell profile:"
 Write-Host "  `$env:Path = `"`$HOME\.claude\skills-hub\bin;`" + `$env:Path"

--- a/bootstrap/install.sh
+++ b/bootstrap/install.sh
@@ -109,6 +109,49 @@ if [ -f "$HUB_DIR/tools/precheck.py" ]; then
   fi
 fi
 
+# --- v2.6.8+: pre-implementation auto-check block in ~/.claude/CLAUDE.md ---
+# Idempotent: inserts on first install, refreshes content on re-install.
+# Removal is handled by /hub-uninstall.
+CLAUDE_MD="$CLAUDE_DIR/CLAUDE.md"
+TMPBLOCK="$(mktemp)"
+cat > "$TMPBLOCK" <<'BLOCK'
+<skills_hub>
+Before implementing, check the hub for existing skills/knowledge:
+- `/hub-find <keyword>` — search installed + remote
+- `/hub-install <slug>` — install matching skill/knowledge
+- `/hub-list` — see what's already installed
+- `/hub-publish` — publish drafts back to the hub
+</skills_hub>
+BLOCK
+
+touch "$CLAUDE_MD"
+if grep -q '<skills_hub>' "$CLAUDE_MD" 2>/dev/null; then
+  echo "Refreshing <skills_hub> block in $CLAUDE_MD"
+  TMPMD="$(mktemp)"
+  awk -v blockfile="$TMPBLOCK" '
+    BEGIN {
+      while ((getline line < blockfile) > 0) {
+        block = block (block ? "\n" : "") line
+      }
+      close(blockfile)
+    }
+    /<skills_hub>/ && !done { print block; skipping=1; done=1; next }
+    skipping && /<\/skills_hub>/ { skipping=0; next }
+    !skipping { print }
+  ' "$CLAUDE_MD" > "$TMPMD"
+  mv "$TMPMD" "$CLAUDE_MD"
+else
+  echo "Adding <skills_hub> block to $CLAUDE_MD"
+  if [ -s "$CLAUDE_MD" ]; then
+    if [ "$(tail -c1 "$CLAUDE_MD" | wc -l)" -eq 0 ]; then
+      printf '\n' >> "$CLAUDE_MD"
+    fi
+    printf '\n' >> "$CLAUDE_MD"
+  fi
+  cat "$TMPBLOCK" >> "$CLAUDE_MD"
+fi
+rm -f "$TMPBLOCK"
+
 # PATH hint
 echo ""
 echo "To use 'hub-search', 'hub-precheck', 'hub-index-diff' from any shell, add to ~/.bashrc:"


### PR DESCRIPTION
## Summary
- `install.sh` and `install.ps1` now idempotently create / refresh / append the `<skills_hub>` auto-check block in `~/.claude/CLAUDE.md`.
- Closes the gap where `/hub-uninstall` (per spec) removes a block that `install` never wrote, and where `/hub-doctor` check #11 always reported INFO on fresh installs.

## Behavior
- CLAUDE.md missing → create with block.
- Block already present → replace in place (no duplicate blocks, stays at 1).
- Existing content without the block → append with a blank-line separator, handles no-trailing-newline files correctly.
- Canonical block references `/hub-find`, `/hub-install`, `/hub-list`, `/hub-publish` — matching `/hub-doctor` check #11.

## Test plan
- [x] Sandbox: no CLAUDE.md → block created.
- [x] Sandbox: re-run install → "Refreshing", block count stays 1.
- [x] Sandbox: existing content without trailing newline → proper blank-line separator before block.
- [ ] Windows PowerShell path exercised on a real Windows box (logic mirrors bash, but hasn't been run end-to-end in this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)