### PR TITLE
Bootstrap v2.6.10: auto-register UserPromptSubmit hook for /hub-suggest

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 bootstrap/commands/*.md text eol=lf
 bootstrap/tools/*.py    text eol=lf
 bootstrap/tools/*.sh    text eol=lf
+bootstrap/hooks/*.py    text eol=lf
 bootstrap/bin/*         text eol=lf
 bootstrap/install.sh    text eol=lf
 

--- a/bootstrap/commands/hub-doctor.md
+++ b/bootstrap/commands/hub-doctor.md
@@ -89,6 +89,13 @@ Local environment health check and repair. While `/hub-cleanup` maintains the **
 - If present: verify the block references the canonical names (`/hub-find`, `/hub-install`, `/hub-list`, `/hub-publish`) rather than legacy ones (`/hub-search-skills`, `/hub-publish-all`).
 - **Fix**: report only — user CLAUDE.md edits are out of scope for auto-fix.
 
+### 12. UserPromptSubmit auto-suggest hook (v2.6.10+)
+- `~/.claude/skills-hub/hooks/hub-suggest-hint.py` exists and is readable.
+- `~/.claude/settings.json` exists and contains a `UserPromptSubmit` hook entry tagged with `"_marker": "skills-hub:auto-suggest-hook"` (fallback: a hook whose `command` references `hub-suggest-hint`).
+- The registered command's script path matches the installed hook path (not a stale path from a prior install in a different `CLAUDE_DIR`).
+- If the env var `SKILLS_HUB_NO_AUTO_SUGGEST=1` was set during install: INFO (user opted out).
+- **Fix**: run `python ~/.claude/skills-hub/tools/_merge_settings.py install ~/.claude/settings.json` with the correct command on stdin, or re-run `bash ~/.claude/skills-hub/remote/bootstrap/install.sh` to re-register (`--fix` required).
+
 ## Report format
 
 ```
@@ -105,9 +112,10 @@ hub-doctor results (2026-04-18 23:55):
   [WARN]  9. Indexes freshness — 00_MASTER_INDEX.md is 2h older than HEAD
   [PASS] 10. Shell PATH (hub-search resolves)
   [INFO] 11. <skills_hub> block not present in ~/.claude/CLAUDE.md
+  [FAIL] 12. UserPromptSubmit auto-suggest hook not registered in settings.json
 
-  Summary: 6 passed, 3 warnings, 2 failures, 1 info
-  Run /hub-doctor --fix to repair 3 issues automatically (registry, hooks, indexes).
+  Summary: 6 passed, 3 warnings, 3 failures, 1 info
+  Run /hub-doctor --fix to repair 4 issues automatically (registry, hooks, indexes, auto-suggest hook).
   3 issues require manual attention (CRLF, filesystem mismatch, CLAUDE.md block).
 ```
 

--- a/bootstrap/commands/hub-uninstall.md
+++ b/bootstrap/commands/hub-uninstall.md
@@ -1,6 +1,6 @@
 ---
 description: Completely uninstall the skills-hub bootstrap layer — remote cache, tools, bin, completions, indexes, registry, slash commands, and the seed skill. Dry-run by default. Creates a backup tarball unless --no-backup.
-argument-hint: [--apply] [--keep-installed|--purge-installed] [--keep-claude-md-block] [--no-backup] [--backup-path=<path>] [--force]
+argument-hint: [--apply] [--keep-installed|--purge-installed] [--keep-claude-md-block] [--keep-settings-hook] [--no-backup] [--backup-path=<path>] [--force]
 ---
 
 # /hub-uninstall $ARGUMENTS
@@ -16,6 +16,7 @@ Complete removal of the skills-hub infrastructure from `~/.claude/`. Inverse of 
 | `~/.claude/skills-hub/remote/` | Git clone cache (skills + knowledge + bootstrap source tree) |
 | `~/.claude/skills-hub/tools/` | Python helpers (precheck, indexers, linters) |
 | `~/.claude/skills-hub/bin/` | Shell wrappers (`hub-search`, `hub-precheck`, `hub-index-diff`) |
+| `~/.claude/skills-hub/hooks/` | UserPromptSubmit hook scripts (v2.6.10+) |
 | `~/.claude/skills-hub/completions/` | bash/zsh/ps1 completion scripts (v2.6.4+) |
 | `~/.claude/skills-hub/indexes/` | Generated L1/L2 markdown indexes |
 | `~/.claude/skills-hub/knowledge/` | Globally-installed knowledge entries (v2.6.5+) |
@@ -30,6 +31,7 @@ Complete removal of the skills-hub infrastructure from `~/.claude/`. Inverse of 
 - **Individually-installed skills** at `~/.claude/skills/<slug>/` (everything other than `skills-hub/`) — use `/hub-remove` per slug to drop them first, or pass `--purge-installed` to include them in this run.
 - **Project-scoped installs** under `<any-project>/.claude/skills/` and `<any-project>/.claude/knowledge/` — this command only touches `~/.claude/**`.
 - **`~/.claude/CLAUDE.md`** — the file is never deleted. If it contains a `<skills_hub>` … `</skills_hub>` block, only the block is removed. `--keep-claude-md-block` leaves even the block intact.
+- **`~/.claude/settings.json`** — the file is never deleted. Only the skills-hub UserPromptSubmit hook entry (tagged with `"_marker": "skills-hub:auto-suggest-hook"`) is removed; all other hooks and settings are preserved. `--keep-settings-hook` leaves even the hook entry intact.
 
 ## Steps
 
@@ -38,6 +40,7 @@ Complete removal of the skills-hub infrastructure from `~/.claude/`. Inverse of 
    - List `~/.claude/commands/hub-*.md`. Count.
    - Check `~/.claude/skills/skills-hub/` — exists or not.
    - Parse `~/.claude/CLAUDE.md`; locate `<skills_hub>` and `</skills_hub>` markers. Record line range.
+   - Parse `~/.claude/settings.json` (if present); count any hook entries carrying `"_marker": "skills-hub:auto-suggest-hook"` or whose `command` contains `hub-suggest-hint`.
    - Walk `~/.claude/skills/` (excluding `skills-hub/`) and cross-reference with `registry.json → skills.<slug>` to count individually-installed skills (these are **preserved** unless `--purge-installed`).
    - Print a clean summary:
 
@@ -77,16 +80,18 @@ Complete removal of the skills-hub infrastructure from `~/.claude/`. Inverse of 
 5. **Delete (ordered for fail-safety)**
 
    a. `~/.claude/commands/hub-*.md` first — stops the slash commands from being invokable mid-uninstall (prevents partial-state reinvocation).
-   b. `~/.claude/skills/skills-hub/` — the seed skill.
-   c. `~/.claude/skills-hub/` entire tree — remote cache + tools + bin + completions + indexes + knowledge + registry + bootstrap.json.
-   d. `<skills_hub>` block from `~/.claude/CLAUDE.md` — unless `--keep-claude-md-block`. Parse the file, remove the block and any surrounding blank lines that would be left stranded. Never delete or truncate the file itself.
-   e. If `--purge-installed`: also delete `~/.claude/skills/<slug>/` for every slug in `registry.json → skills`. Skip anything not on disk.
+   b. UserPromptSubmit hook entry from `~/.claude/settings.json` — unless `--keep-settings-hook`. Run `python ~/.claude/skills-hub/tools/_merge_settings.py uninstall ~/.claude/settings.json` **before** the tools dir is removed in step (d). Only entries matching the skills-hub marker or containing `hub-suggest-hint` are stripped; everything else is preserved. Fallback: parse + rewrite the JSON directly if the helper is missing.
+   c. `~/.claude/skills/skills-hub/` — the seed skill.
+   d. `~/.claude/skills-hub/` entire tree — remote cache + tools + bin + hooks + completions + indexes + knowledge + registry + bootstrap.json.
+   e. `<skills_hub>` block from `~/.claude/CLAUDE.md` — unless `--keep-claude-md-block`. Parse the file, remove the block and any surrounding blank lines that would be left stranded. Never delete or truncate the file itself.
+   f. If `--purge-installed`: also delete `~/.claude/skills/<slug>/` for every slug in `registry.json → skills`. Skip anything not on disk.
 
 6. **Post-uninstall verification**
    - `test ! -d ~/.claude/skills-hub/` — the directory should be gone.
    - `ls ~/.claude/commands/ | grep '^hub-'` — empty.
    - `test ! -d ~/.claude/skills/skills-hub/` — gone.
    - `grep -q '<skills_hub>' ~/.claude/CLAUDE.md` — should return non-zero (no match), unless `--keep-claude-md-block`.
+   - `grep -q 'skills-hub:auto-suggest-hook' ~/.claude/settings.json` — should return non-zero, unless `--keep-settings-hook`.
    - Print a summary with bytes freed and the backup path.
 
 ## Arguments
@@ -95,6 +100,7 @@ Complete removal of the skills-hub infrastructure from `~/.claude/`. Inverse of 
 - `--no-backup` — skip the tarball. **Not recommended.** Rollback becomes impossible.
 - `--backup-path=<path>` — override backup destination (default: `~/.claude/skills-hub.backup-<timestamp>.tar.gz`).
 - `--keep-claude-md-block` — leave the `<skills_hub>` block in `~/.claude/CLAUDE.md` untouched.
+- `--keep-settings-hook` — leave the UserPromptSubmit hook entry in `~/.claude/settings.json` untouched.
 - `--keep-installed` — **(default)** preserves individually-installed skills at `~/.claude/skills/<slug>/`. Kept as an explicit flag for script clarity.
 - `--purge-installed` — also delete every `~/.claude/skills/<slug>/` that `registry.json` tracks. Does NOT touch project-scoped installs. Extra caution.
 - `--force` — skip the `UNINSTALL` literal confirmation. Automation only; prints a warning banner.

--- a/bootstrap/hooks/hub-suggest-hint.py
+++ b/bootstrap/hooks/hub-suggest-hint.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+skills-hub UserPromptSubmit hook.
+
+If the user's prompt contains implementation keywords (개발/구현/build/create/...),
+emit a <system-reminder> to nudge Claude toward running /hub-suggest first, so
+existing skills and knowledge are checked before implementation starts.
+
+Opt out at runtime: set SKILLS_HUB_NO_AUTO_SUGGEST=1 in the environment.
+"""
+import json
+import os
+import re
+import sys
+
+IMPL_PATTERNS = [
+    # Korean — substring match (no reliable word boundaries)
+    re.compile(r"개발(?:해|하|할|합|하세|해줘|해봐|해주)"),
+    re.compile(r"구현(?:해|하|할|합|하세|해줘|해봐)"),
+    re.compile(r"만들(?:어|기|자|어줘|어봐|어주|어주세요)"),
+    re.compile(r"짜(?:줘|봐|주세요)"),
+    re.compile(r"작성(?:해|하|할|해줘)"),
+    re.compile(r"구축(?:해|하|할|해줘)"),
+    re.compile(r"추가(?:해|하|할|해줘)"),
+    # English — word-boundary aware, case-insensitive
+    re.compile(r"\bimplement(?:s|ed|ing)?\b", re.IGNORECASE),
+    re.compile(r"\bbuild(?:s|ing)?\b", re.IGNORECASE),
+    re.compile(r"\bcreate(?:s|d|ing)?\b", re.IGNORECASE),
+    re.compile(r"\bdevelop(?:s|ed|ing)?\b", re.IGNORECASE),
+    re.compile(r"\bscaffold(?:s|ed|ing)?\b", re.IGNORECASE),
+    re.compile(r"\bwrite\s+(?:a|an|me|some)\b", re.IGNORECASE),
+    re.compile(r"\badd\s+(?:a|an|new|the)\b", re.IGNORECASE),
+]
+
+REMINDER = (
+    "<system-reminder>\n"
+    "skills-hub auto-check: implementation intent detected in the user prompt.\n"
+    "BEFORE writing any code, invoke /hub-suggest with a keyword derived from "
+    "the task so the hub can surface existing skills or knowledge first.\n"
+    "This hook was installed by skills-hub bootstrap. "
+    "Opt out with env var SKILLS_HUB_NO_AUTO_SUGGEST=1.\n"
+    "Matched keyword: {kw}\n"
+    "</system-reminder>"
+)
+
+
+def main() -> int:
+    if os.environ.get("SKILLS_HUB_NO_AUTO_SUGGEST") == "1":
+        return 0
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    prompt = data.get("prompt") or ""
+    if not prompt:
+        return 0
+    # Skip explicit slash-command invocations — user already picked a command.
+    if prompt.lstrip().startswith("/"):
+        return 0
+    for pat in IMPL_PATTERNS:
+        m = pat.search(prompt)
+        if m:
+            sys.stdout.write(REMINDER.format(kw=m.group(0)) + "\n")
+            return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bootstrap/install.ps1
+++ b/bootstrap/install.ps1
@@ -12,6 +12,7 @@ New-Item -ItemType Directory -Force -Path "$ClaudeDir\skills\skills-hub" | Out-N
 New-Item -ItemType Directory -Force -Path "$HubDir"                    | Out-Null
 New-Item -ItemType Directory -Force -Path "$HubDir\tools"              | Out-Null
 New-Item -ItemType Directory -Force -Path "$HubDir\bin"                | Out-Null
+New-Item -ItemType Directory -Force -Path "$HubDir\hooks"              | Out-Null
 New-Item -ItemType Directory -Force -Path "$HubDir\indexes"            | Out-Null
 New-Item -ItemType Directory -Force -Path "$HubDir\knowledge\api"      | Out-Null
 New-Item -ItemType Directory -Force -Path "$HubDir\knowledge\arch"     | Out-Null
@@ -40,6 +41,12 @@ if (Test-Path "$RepoDir\bootstrap\bin") {
     Get-ChildItem "$RepoDir\bootstrap\bin\" -File |
         Where-Object { $_.Name -like "hub-*" } |
         ForEach-Object { Copy-Item $_.FullName "$HubDir\bin\" -Force }
+}
+
+# v2.6.10+: UserPromptSubmit hook scripts
+if (Test-Path "$RepoDir\bootstrap\hooks") {
+    Write-Host "Installing hook scripts -> $HubDir\hooks\"
+    Copy-Item "$RepoDir\bootstrap\hooks\*.py" "$HubDir\hooks\" -Force -ErrorAction SilentlyContinue
 }
 
 # v2.6.4+: shell completion for hub-* bin wrappers
@@ -112,12 +119,14 @@ if ((Test-Path "$HubDir\remote\.git") -and (Test-Path "$HubDir\tools\install-hoo
     }
 }
 
+# Detect a Python interpreter once — used for index build and hook registration.
+$pyBin = $null
+if (Get-Command py -ErrorAction SilentlyContinue)          { $pyBin = @("py","-3") }
+elseif (Get-Command python3 -ErrorAction SilentlyContinue) { $pyBin = @("python3") }
+elseif (Get-Command python  -ErrorAction SilentlyContinue) { $pyBin = @("python") }
+
 # Build initial indexes so they exist before the first git hook fires
 if (Test-Path "$HubDir\tools\precheck.py") {
-    $pyBin = $null
-    if (Get-Command py -ErrorAction SilentlyContinue)      { $pyBin = @("py","-3") }
-    elseif (Get-Command python3 -ErrorAction SilentlyContinue) { $pyBin = @("python3") }
-    elseif (Get-Command python  -ErrorAction SilentlyContinue) { $pyBin = @("python") }
     if ($pyBin) {
         Write-Host "Building initial indexes"
         $env:PYTHONIOENCODING = "utf-8"
@@ -127,6 +136,33 @@ if (Test-Path "$HubDir\tools\precheck.py") {
         }
     } else {
         Write-Host "Note: no python found on PATH; skipping initial index build."
+    }
+}
+
+# v2.6.10+: register UserPromptSubmit hook in settings.json.
+# Opt out with $env:SKILLS_HUB_NO_AUTO_SUGGEST = "1".
+$settingsPath = Join-Path $ClaudeDir "settings.json"
+$hookScript = Join-Path $HubDir "hooks\hub-suggest-hint.py"
+$mergeScript = Join-Path $HubDir "tools\_merge_settings.py"
+if ($env:SKILLS_HUB_NO_AUTO_SUGGEST -eq "1") {
+    Write-Host "Skipping UserPromptSubmit hook registration (SKILLS_HUB_NO_AUTO_SUGGEST=1)."
+} elseif (-not (Test-Path $hookScript)) {
+    Write-Host "Note: hub-suggest-hint.py not present; skipping hook registration."
+} elseif (-not (Test-Path $mergeScript)) {
+    Write-Host "Note: _merge_settings.py not present; skipping hook registration."
+} elseif (-not $pyBin) {
+    Write-Host "Note: no python found on PATH; skipping UserPromptSubmit hook registration."
+    Write-Host "      Register manually: add a UserPromptSubmit hook running"
+    Write-Host "      '<python> $hookScript' in $settingsPath"
+} else {
+    $hookCmd = "$($pyBin -join ' ') `"$hookScript`""
+    Write-Host "Registering UserPromptSubmit hook in $settingsPath"
+    $env:PYTHONIOENCODING = "utf-8"
+    # Pipe the command via stdin — avoids PowerShell stripping embedded quotes
+    # from argv, which would corrupt any path containing spaces.
+    $hookCmd | & $pyBin[0] @($pyBin[1..($pyBin.Length-1)] + @($mergeScript,"install",$settingsPath))
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  warn: hook registration failed; re-run install.ps1 or register manually"
     }
 }
 

--- a/bootstrap/install.sh
+++ b/bootstrap/install.sh
@@ -8,7 +8,7 @@ REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 HUB_DIR="$CLAUDE_DIR/skills-hub"
 
 mkdir -p "$CLAUDE_DIR/commands" "$CLAUDE_DIR/skills/skills-hub" \
-         "$HUB_DIR" "$HUB_DIR/tools" "$HUB_DIR/bin" "$HUB_DIR/indexes" \
+         "$HUB_DIR" "$HUB_DIR/tools" "$HUB_DIR/bin" "$HUB_DIR/hooks" "$HUB_DIR/indexes" \
          "$HUB_DIR/knowledge/api" "$HUB_DIR/knowledge/arch" \
          "$HUB_DIR/knowledge/pitfall" "$HUB_DIR/knowledge/decision" \
          "$HUB_DIR/knowledge/domain" "$HUB_DIR/external"
@@ -33,6 +33,12 @@ if [ -d "$REPO_DIR/bootstrap/bin" ]; then
   echo "Installing CLI wrappers → $HUB_DIR/bin/"
   cp "$REPO_DIR/bootstrap/bin/"hub-* "$HUB_DIR/bin/" 2>/dev/null || true
   chmod +x "$HUB_DIR/bin/"hub-* 2>/dev/null || true
+fi
+
+# --- v2.6.10+: UserPromptSubmit hook that auto-suggests /hub-suggest ---
+if [ -d "$REPO_DIR/bootstrap/hooks" ]; then
+  echo "Installing hook scripts → $HUB_DIR/hooks/"
+  cp "$REPO_DIR/bootstrap/hooks/"*.py "$HUB_DIR/hooks/" 2>/dev/null || true
 fi
 
 # --- v2.6.4+: shell completion for hub-* bin wrappers ---
@@ -93,13 +99,15 @@ if [ -d "$HUB_DIR/remote/.git" ] && [ -f "$HUB_DIR/tools/install-hooks.sh" ]; th
   bash "$HUB_DIR/tools/install-hooks.sh" || echo "  warn: hook install failed; run manually later"
 fi
 
+# Detect a Python interpreter once — used for index build and hook registration.
+PYBIN=""
+if command -v py >/dev/null 2>&1; then PYBIN="py -3"
+elif command -v python3 >/dev/null 2>&1; then PYBIN="python3"
+elif command -v python >/dev/null 2>&1; then PYBIN="python"
+fi
+
 # Build initial indexes so they exist before the first git hook fires
 if [ -f "$HUB_DIR/tools/precheck.py" ]; then
-  PYBIN=""
-  if command -v py >/dev/null 2>&1; then PYBIN="py -3"
-  elif command -v python3 >/dev/null 2>&1; then PYBIN="python3"
-  elif command -v python >/dev/null 2>&1; then PYBIN="python"
-  fi
   if [ -n "$PYBIN" ]; then
     echo "Building initial indexes"
     PYTHONIOENCODING=utf-8 $PYBIN "$HUB_DIR/tools/precheck.py" --skip-lint >/dev/null 2>&1 \
@@ -107,6 +115,26 @@ if [ -f "$HUB_DIR/tools/precheck.py" ]; then
   else
     echo "Note: no python found on PATH; skipping initial index build."
   fi
+fi
+
+# --- v2.6.10+: register UserPromptSubmit hook in ~/.claude/settings.json ---
+# Opt out with SKILLS_HUB_NO_AUTO_SUGGEST=1.
+if [ "${SKILLS_HUB_NO_AUTO_SUGGEST:-0}" = "1" ]; then
+  echo "Skipping UserPromptSubmit hook registration (SKILLS_HUB_NO_AUTO_SUGGEST=1)."
+elif [ ! -f "$HUB_DIR/hooks/hub-suggest-hint.py" ]; then
+  echo "Note: hub-suggest-hint.py not present; skipping hook registration."
+elif [ ! -f "$HUB_DIR/tools/_merge_settings.py" ]; then
+  echo "Note: _merge_settings.py not present; skipping hook registration."
+elif [ -z "$PYBIN" ]; then
+  echo "Note: no python on PATH; skipping UserPromptSubmit hook registration."
+  echo "      Register manually: add a UserPromptSubmit hook running"
+  echo "      '<python> $HUB_DIR/hooks/hub-suggest-hint.py' in $CLAUDE_DIR/settings.json"
+else
+  HOOK_CMD="$PYBIN \"$HUB_DIR/hooks/hub-suggest-hint.py\""
+  echo "Registering UserPromptSubmit hook in $CLAUDE_DIR/settings.json"
+  printf '%s' "$HOOK_CMD" | PYTHONIOENCODING=utf-8 $PYBIN \
+    "$HUB_DIR/tools/_merge_settings.py" install "$CLAUDE_DIR/settings.json" \
+    || echo "  warn: hook registration failed; re-run install.sh or register manually"
 fi
 
 # --- v2.6.8+: pre-implementation auto-check block in ~/.claude/CLAUDE.md ---

--- a/bootstrap/tools/_merge_settings.py
+++ b/bootstrap/tools/_merge_settings.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Merge (or remove) the skills-hub UserPromptSubmit hook entry in
+~/.claude/settings.json.
+
+Idempotent: entries are tagged with {"_marker": "skills-hub:auto-suggest-hook"}.
+On install, any pre-existing entries carrying that marker are stripped before
+the fresh one is appended, so reinstalling cleanly replaces the registration.
+
+Usage:
+    python _merge_settings.py install   <settings.json> < command-on-stdin
+    python _merge_settings.py uninstall <settings.json>
+
+The install subcommand reads the hook command as a single line from stdin and
+writes it verbatim into settings.json. Passing the command through stdin
+avoids cross-shell argv quoting issues (Windows/PowerShell in particular strips
+embedded quotes from arguments).
+"""
+import json
+import os
+import sys
+
+MARKER = "skills-hub:auto-suggest-hook"
+
+
+def _load(path: str) -> dict:
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8-sig") as f:
+            data = json.load(f)
+            return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError, ValueError):
+        return {}
+
+
+def _dump(path: str, obj: dict) -> None:
+    parent = os.path.dirname(path)
+    if parent and not os.path.isdir(parent):
+        os.makedirs(parent, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(obj, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+
+def _is_skills_hub_group(group: dict) -> bool:
+    """True if any hook in the group is marked as ours, or its command
+    references the hub-suggest-hint script (fallback for pre-marker installs).
+    """
+    for h in group.get("hooks", []) or []:
+        if not isinstance(h, dict):
+            continue
+        if h.get("_marker") == MARKER:
+            return True
+        cmd = h.get("command") or ""
+        if "hub-suggest-hint" in cmd:
+            return True
+    return False
+
+
+def install(settings_path: str, command: str) -> int:
+    settings = _load(settings_path)
+    hooks = settings.setdefault("hooks", {})
+    ups = hooks.setdefault("UserPromptSubmit", [])
+    if not isinstance(ups, list):
+        ups = []
+        hooks["UserPromptSubmit"] = ups
+    ups[:] = [g for g in ups if isinstance(g, dict) and not _is_skills_hub_group(g)]
+    ups.append({
+        "matcher": "*",
+        "hooks": [{
+            "type": "command",
+            "command": command,
+            "_marker": MARKER,
+        }],
+    })
+    _dump(settings_path, settings)
+    return 0
+
+
+def uninstall(settings_path: str) -> int:
+    if not os.path.exists(settings_path):
+        return 0
+    settings = _load(settings_path)
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        return 0
+    ups = hooks.get("UserPromptSubmit")
+    if not isinstance(ups, list):
+        return 0
+    before = len(ups)
+    ups[:] = [g for g in ups if isinstance(g, dict) and not _is_skills_hub_group(g)]
+    if not ups:
+        hooks.pop("UserPromptSubmit", None)
+    if not hooks:
+        settings.pop("hooks", None)
+    if len(ups) != before:
+        _dump(settings_path, settings)
+    return 0
+
+
+def main(argv: list) -> int:
+    if len(argv) >= 3 and argv[1] == "install":
+        command = sys.stdin.read().strip()
+        if not command:
+            sys.stderr.write("install: empty command on stdin\n")
+            return 2
+        return install(argv[2], command)
+    if len(argv) >= 3 and argv[1] == "uninstall":
+        return uninstall(argv[2])
+    sys.stderr.write(
+        "usage: _merge_settings.py install <settings.json> < command-on-stdin\n"
+        "       _merge_settings.py uninstall <settings.json>\n"
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary

Installs a `UserPromptSubmit` hook by default so Claude is nudged to run `/hub-suggest` on implementation-intent prompts — catches the case where the `<skills_hub>` CLAUDE.md block alone isn't enough to stop the assistant from skipping the hub check.

- New `bootstrap/hooks/hub-suggest-hint.py`: Korean + English keyword detection (`개발해`, `구현해`, `만들어`, `짜줘`, `작성해`, `구축해`, `추가해`; `implement`, `build`, `create`, `develop`, `scaffold`, `write a`, `add a`), emits `<system-reminder>` pointing Claude at `/hub-suggest`. Skips slash commands and non-impl prompts.
- New `bootstrap/tools/_merge_settings.py`: idempotent `settings.json` merger tagged with `"_marker": "skills-hub:auto-suggest-hook"`. Reads the command from stdin so PowerShell can't strip quotes from paths containing spaces. Preserves every other hook and setting.
- `install.sh` / `install.ps1`: copy hooks, detect Python once, register the hook. Opt out with `SKILLS_HUB_NO_AUTO_SUGGEST=1`.
- `hub-uninstall`: new `--keep-settings-hook` flag; removal step reordered so the settings.json entry is stripped BEFORE the tools dir is deleted.
- `hub-doctor`: new check 12 (hook registered + path matches installed script).
- `.gitattributes`: `bootstrap/hooks/*.py text eol=lf`.

## Test plan

- [x] Korean impl prompt (`apm 대시보드 개발해줘`) → hook emits reminder
- [x] English impl prompt (`build me a dashboard`) → hook emits reminder
- [x] Non-impl Korean (`설명해줘`) + slash command (`/help`) → no output (correct)
- [x] `SKILLS_HUB_NO_AUTO_SUGGEST=1` in hook env → early return
- [x] `install.sh` end-to-end in clean `CLAUDE_DIR` → hooks copied + settings.json registered
- [x] `install.ps1` end-to-end with path containing spaces (`C:/tmp/test ps with space/`) → command quoted correctly in settings.json
- [x] Reinstall is idempotent (no duplicate entries)
- [x] User's pre-existing hooks (`UserPromptSubmit` + `PreToolUse:Bash`) preserved across install and uninstall
- [ ] Review author attribution + squash-merge message

🤖 Generated with [Claude Code](https://claude.com/claude-code)