### PR TITLE
Bootstrap v2.6.11: auto re-run install.sh from post-merge on bootstrap/ changes

### DIFF
--- a/bootstrap/commands/hub-doctor.md
+++ b/bootstrap/commands/hub-doctor.md
@@ -66,6 +66,7 @@ Local environment health check and repair. While `/hub-cleanup` maintains the **
   - `post-merge`, `post-commit`, `post-checkout`
 - Each hook file is executable (Linux/macOS/WSL) or at least present (Windows Git Bash treats the `x` bit differently).
 - Each hook invokes `precheck.py --skip-lint` (or the current equivalent) — not the default sample hooks from git init.
+- **v2.6.11+**: `post-merge` additionally contains an auto-patch block that re-runs `bootstrap/install.sh` when `bootstrap/**` changes are pulled in. Verify the hook contains `SKILLS_HUB_NO_AUTO_PATCH` and a reference to `bootstrap/install.sh`. If absent on a v2.6.11+ install, auto-patch won't fire and users must re-run install.sh manually after `/hub-sync`.
 - **Fix**: run `bash ~/.claude/skills-hub/tools/install-hooks.sh` to reinstall (`--fix` required). If `tools/install-hooks.sh` is missing, escalate to check 7 first.
 
 ### 9. Indexes freshness (v2.5.0+)

--- a/bootstrap/tools/install-hooks.sh
+++ b/bootstrap/tools/install-hooks.sh
@@ -13,8 +13,10 @@
 
 set -euo pipefail
 
-HOOKS_DIR="$HOME/.claude/skills-hub/remote/.git/hooks"
+REMOTE_DIR="$HOME/.claude/skills-hub/remote"
+HOOKS_DIR="$REMOTE_DIR/.git/hooks"
 TOOLS_DIR="$HOME/.claude/skills-hub/tools"
+INSTALL_SH="$REMOTE_DIR/bootstrap/install.sh"
 
 if [[ ! -d "$HOOKS_DIR" ]]; then
     echo "install-hooks: $HOOKS_DIR does not exist (is the hub cloned?)" >&2
@@ -24,6 +26,7 @@ fi
 write_hook() {
     local name="$1"
     local extra_check="$2"
+    local extra_body="$3"
     local path="$HOOKS_DIR/$name"
     cat > "$path" <<EOF
 #!/usr/bin/env bash
@@ -31,18 +34,35 @@ write_hook() {
 set -e
 ${extra_check}
 PYTHONIOENCODING=utf-8 py -3 "$TOOLS_DIR/precheck.py" --skip-lint >/dev/null 2>&1 || true
+${extra_body}
 EOF
     chmod +x "$path"
     echo "  installed: $name"
 }
 
+# v2.6.11+: post-merge auto-patch.
+# After git pull / merge, if anything under bootstrap/ changed, re-run install.sh
+# so the user picks up new commands, tools, hooks, and settings entries without
+# having to remember the manual command. Opt out with SKILLS_HUB_NO_AUTO_PATCH=1.
+POST_MERGE_AUTO_PATCH='
+if [ "${SKILLS_HUB_NO_AUTO_PATCH:-0}" != "1" ] && [ -x "'"$INSTALL_SH"'" ]; then
+    if git -C "'"$REMOTE_DIR"'" diff --name-only ORIG_HEAD HEAD 2>/dev/null | grep -q "^bootstrap/"; then
+        echo "skills-hub: bootstrap/ changed — re-running install.sh to apply patch" >&2
+        bash "'"$INSTALL_SH"'" >/dev/null 2>&1 || \
+            echo "  skills-hub: auto-patch failed; run manually: bash '"$INSTALL_SH"'" >&2
+    fi
+fi
+'
+
 echo "Installing skills-hub git hooks…"
 
-write_hook "post-merge" ""
-write_hook "post-commit" ""
+write_hook "post-merge" "" "$POST_MERGE_AUTO_PATCH"
+write_hook "post-commit" "" ""
 # post-checkout: always regen — ensures deleted/stale indexes are rebuilt.
 # Skip if the checkout is a file-level checkout rather than a branch/ref.
 write_hook "post-checkout" \
-'[[ "${3:-}" == "1" ]] || exit 0'
+    '[[ "${3:-}" == "1" ]] || exit 0' \
+    ""
 
 echo "Done. Hooks will run hub-precheck (skip-lint) on merge / commit / branch-switch."
+echo "  post-merge also auto-applies bootstrap patches (opt out: SKILLS_HUB_NO_AUTO_PATCH=1)."


### PR DESCRIPTION
## Summary

Closes the gap left by v2.6.10 (#1048): `git pull` / `/hub-sync` now automatically re-runs `install.sh` when the pulled commits touch `bootstrap/**`, so users pick up new commands, tools, hooks, and `settings.json` entries without having to remember the manual command.

- `bootstrap/tools/install-hooks.sh`: post-merge hook emits `precheck.py --skip-lint` as before, then checks `git diff --name-only ORIG_HEAD HEAD` for `^bootstrap/` matches. If found, runs `bootstrap/install.sh`. Failure is non-fatal (merge still completes); a one-line fallback message is printed. Opt out: `SKILLS_HUB_NO_AUTO_PATCH=1`. `post-commit` and `post-checkout` are unchanged.
- `bootstrap/commands/hub-doctor.md`: check 8 now verifies the v2.6.11 auto-patch block is present in `post-merge` (looks for `SKILLS_HUB_NO_AUTO_PATCH` + `bootstrap/install.sh` markers).

## Test plan

- [x] `install-hooks.sh` syntax check + regenerates all three hooks cleanly
- [x] Generated `post-merge` syntax-checks with `bash -n`
- [x] Running `post-merge` with no `ORIG_HEAD` (fresh clone / no prior pull) exits 0 without side effects
- [ ] Real pull on a branch with a `bootstrap/` change → install.sh fires, one line of output, exits 0
- [ ] Pull on a branch that only touches `skills/` or `knowledge/` → install.sh does NOT fire
- [ ] Pull with `SKILLS_HUB_NO_AUTO_PATCH=1` → no install.sh invocation
- [ ] `install.sh` failure inside the hook prints the fallback message + leaves the merge green

🤖 Generated with [Claude Code](https://claude.com/claude-code)