### PR TITLE
Bootstrap v2.6.12: block Write/Edit until hub search runs on implementation intent

### DIFF
--- a/bootstrap/hooks/hub-search-clear.py
+++ b/bootstrap/hooks/hub-search-clear.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+skills-hub PostToolUse flag-clearer.
+
+Runs after Bash / Skill / ToolSearch tool calls. If the executed tool was a
+hub search (Bash invoking hub-search/hub_search.py/hub-find/hub-install, or
+the Skill tool invoking a hub-* skill), the PENDING flag created by
+`hub-suggest-hint.py` is deleted so `hub-write-gate.py` stops blocking
+subsequent Write/Edit calls.
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+STATE_DIR = Path.home() / ".claude" / "skills-hub" / "state"
+PENDING = STATE_DIR / "hub_first_pending.flag"
+
+BASH_RE = re.compile(r"hub[_-]search|/hub-find|/hub-install|/hub-list|hub-find\b", re.IGNORECASE)
+
+
+def matches_hub_search(data: dict) -> bool:
+    tool = (data.get("tool_name") or "").strip()
+    inp = data.get("tool_input") or {}
+    if tool == "Bash":
+        cmd = inp.get("command") or ""
+        return bool(BASH_RE.search(cmd))
+    if tool == "Skill":
+        skill = (inp.get("skill") or "").strip()
+        args = (inp.get("args") or "").strip()
+        if skill.startswith("hub-") or skill in {
+            "hub-find",
+            "hub-install",
+            "hub-list",
+            "hub-search-skills",
+            "hub-search-knowledge",
+        }:
+            return True
+        if args and BASH_RE.search(args):
+            return True
+    if tool == "ToolSearch":
+        q = (inp.get("query") or "").strip()
+        if BASH_RE.search(q):
+            return True
+    return False
+
+
+def main() -> int:
+    if not PENDING.exists():
+        return 0
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    if matches_hub_search(data):
+        try:
+            PENDING.unlink()
+        except FileNotFoundError:
+            pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bootstrap/hooks/hub-suggest-hint.py
+++ b/bootstrap/hooks/hub-suggest-hint.py
@@ -3,8 +3,11 @@
 skills-hub UserPromptSubmit hook.
 
 If the user's prompt contains implementation keywords (개발/구현/build/create/...),
-emit a <system-reminder> to nudge Claude toward running /hub-suggest first, so
-existing skills and knowledge are checked before implementation starts.
+emit a blocking <system-reminder> and drop a PENDING flag file at
+~/.claude/skills-hub/state/hub_first_pending.flag. The companion PreToolUse
+hook (`hub-write-gate.py`) refuses Write/Edit/MultiEdit/NotebookEdit while the
+flag exists; the PostToolUse hook (`hub-search-clear.py`) clears it the moment
+a hub search tool runs.
 
 Opt out at runtime: set SKILLS_HUB_NO_AUTO_SUGGEST=1 in the environment.
 """
@@ -12,6 +15,10 @@ import json
 import os
 import re
 import sys
+from pathlib import Path
+
+STATE_DIR = Path.home() / ".claude" / "skills-hub" / "state"
+PENDING = STATE_DIR / "hub_first_pending.flag"
 
 IMPL_PATTERNS = [
     # Korean — substring match (no reliable word boundaries)
@@ -34,14 +41,28 @@ IMPL_PATTERNS = [
 
 REMINDER = (
     "<system-reminder>\n"
-    "skills-hub auto-check: implementation intent detected in the user prompt.\n"
-    "BEFORE writing any code, invoke /hub-suggest with a keyword derived from "
-    "the task so the hub can surface existing skills or knowledge first.\n"
-    "This hook was installed by skills-hub bootstrap. "
-    "Opt out with env var SKILLS_HUB_NO_AUTO_SUGGEST=1.\n"
-    "Matched keyword: {kw}\n"
+    "STOP — skills-hub gate engaged (matched: '{kw}').\n"
+    "Implementation intent was detected in the user prompt. BEFORE any Write, "
+    "Edit, MultiEdit, or NotebookEdit call, you MUST run a hub search:\n"
+    "  - `hub-search <keyword>`  (preferred, if on PATH)\n"
+    "  - `py -3 ~/.claude/skills-hub/tools/hub_search.py <keyword>`  (fallback)\n"
+    "  - or invoke the `hub-find` skill / `/hub-find <keyword>` slash command\n"
+    "Then report the top matches briefly and let the user steer. A follow-up "
+    "confirmation phrase like 'ok' or 'proceed' does NOT waive this gate — it "
+    "only confirms a plan the user has already seen.\n"
+    "A PreToolUse gate (`hub-write-gate.py`) will block Write/Edit until the "
+    "PostToolUse clearer observes a hub search running. Opt out only if the "
+    "user explicitly said to skip the hub: env var SKILLS_HUB_NO_AUTO_SUGGEST=1.\n"
     "</system-reminder>"
 )
+
+
+def set_pending_flag() -> None:
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        PENDING.write_text("pending\n", encoding="utf-8")
+    except OSError:
+        pass
 
 
 def main() -> int:
@@ -60,6 +81,7 @@ def main() -> int:
     for pat in IMPL_PATTERNS:
         m = pat.search(prompt)
         if m:
+            set_pending_flag()
             sys.stdout.write(REMINDER.format(kw=m.group(0)) + "\n")
             return 0
     return 0

--- a/bootstrap/hooks/hub-write-gate.py
+++ b/bootstrap/hooks/hub-write-gate.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+skills-hub PreToolUse gate for Write/Edit/MultiEdit/NotebookEdit.
+
+If `hub-suggest-hint.py` detected implementation intent earlier this turn and
+created the PENDING flag at ~/.claude/skills-hub/state/hub_first_pending.flag,
+this hook emits a blocking <system-reminder> before the first code-writing
+tool call. The flag is cleared by `hub-search-clear.py` (PostToolUse) once a
+hub search command actually runs.
+
+Opt out at runtime: set SKILLS_HUB_NO_AUTO_SUGGEST=1 in the environment.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+STATE_DIR = Path.home() / ".claude" / "skills-hub" / "state"
+PENDING = STATE_DIR / "hub_first_pending.flag"
+
+GATE = (
+    "<system-reminder>\n"
+    "STOP — skills-hub gate is engaged.\n"
+    "Implementation intent was detected in the user's prompt, but no hub search "
+    "(`hub-search`, `hub_search.py`, `/hub-find`, `/hub-install`) has been executed "
+    "yet in this turn. DO NOT proceed with this Write/Edit/MultiEdit/NotebookEdit.\n"
+    "Required action: run `hub-search <keyword>` (or `py -3 "
+    "~/.claude/skills-hub/tools/hub_search.py <keyword>`) first, surface the top "
+    "matches to the user, and THEN continue. Confirmation phrases like 'ok' or "
+    "'proceed' do NOT waive this gate.\n"
+    "Opt out with env var SKILLS_HUB_NO_AUTO_SUGGEST=1 only if the user explicitly "
+    "asked to skip the hub.\n"
+    "</system-reminder>"
+)
+
+
+def main() -> int:
+    if os.environ.get("SKILLS_HUB_NO_AUTO_SUGGEST") == "1":
+        return 0
+    if not PENDING.exists():
+        return 0
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    tool = data.get("tool_name", "") or ""
+    if tool not in ("Write", "Edit", "MultiEdit", "NotebookEdit"):
+        return 0
+    sys.stdout.write(GATE + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bootstrap/install.sh
+++ b/bootstrap/install.sh
@@ -118,23 +118,54 @@ if [ -f "$HUB_DIR/tools/precheck.py" ]; then
 fi
 
 # --- v2.6.10+: register UserPromptSubmit hook in ~/.claude/settings.json ---
+# v2.6.12+: also register PreToolUse write-gate and PostToolUse search-clear
+# so implementation intent cannot proceed to Write/Edit until a hub search ran.
 # Opt out with SKILLS_HUB_NO_AUTO_SUGGEST=1.
 if [ "${SKILLS_HUB_NO_AUTO_SUGGEST:-0}" = "1" ]; then
-  echo "Skipping UserPromptSubmit hook registration (SKILLS_HUB_NO_AUTO_SUGGEST=1)."
+  echo "Skipping skills-hub hook registration (SKILLS_HUB_NO_AUTO_SUGGEST=1)."
 elif [ ! -f "$HUB_DIR/hooks/hub-suggest-hint.py" ]; then
   echo "Note: hub-suggest-hint.py not present; skipping hook registration."
 elif [ ! -f "$HUB_DIR/tools/_merge_settings.py" ]; then
   echo "Note: _merge_settings.py not present; skipping hook registration."
 elif [ -z "$PYBIN" ]; then
-  echo "Note: no python on PATH; skipping UserPromptSubmit hook registration."
-  echo "      Register manually: add a UserPromptSubmit hook running"
-  echo "      '<python> $HUB_DIR/hooks/hub-suggest-hint.py' in $CLAUDE_DIR/settings.json"
+  echo "Note: no python on PATH; skipping skills-hub hook registration."
+  echo "      Register manually in $CLAUDE_DIR/settings.json:"
+  echo "        UserPromptSubmit  → '<python> $HUB_DIR/hooks/hub-suggest-hint.py'"
+  echo "        PreToolUse        → '<python> $HUB_DIR/hooks/hub-write-gate.py'"
+  echo "        PostToolUse       → '<python> $HUB_DIR/hooks/hub-search-clear.py'"
 else
+  echo "Registering skills-hub hooks in $CLAUDE_DIR/settings.json"
+
   HOOK_CMD="$PYBIN \"$HUB_DIR/hooks/hub-suggest-hint.py\""
-  echo "Registering UserPromptSubmit hook in $CLAUDE_DIR/settings.json"
   printf '%s' "$HOOK_CMD" | PYTHONIOENCODING=utf-8 $PYBIN \
-    "$HUB_DIR/tools/_merge_settings.py" install "$CLAUDE_DIR/settings.json" \
-    || echo "  warn: hook registration failed; re-run install.sh or register manually"
+    "$HUB_DIR/tools/_merge_settings.py" install \
+      --type UserPromptSubmit \
+      --matcher "*" \
+      --marker "skills-hub:auto-suggest-hook" \
+      "$CLAUDE_DIR/settings.json" \
+    || echo "  warn: UserPromptSubmit hook registration failed"
+
+  if [ -f "$HUB_DIR/hooks/hub-write-gate.py" ]; then
+    HOOK_CMD="$PYBIN \"$HUB_DIR/hooks/hub-write-gate.py\""
+    printf '%s' "$HOOK_CMD" | PYTHONIOENCODING=utf-8 $PYBIN \
+      "$HUB_DIR/tools/_merge_settings.py" install \
+        --type PreToolUse \
+        --matcher "Write|Edit|MultiEdit|NotebookEdit" \
+        --marker "skills-hub:write-gate-hook" \
+        "$CLAUDE_DIR/settings.json" \
+      || echo "  warn: PreToolUse write-gate registration failed"
+  fi
+
+  if [ -f "$HUB_DIR/hooks/hub-search-clear.py" ]; then
+    HOOK_CMD="$PYBIN \"$HUB_DIR/hooks/hub-search-clear.py\""
+    printf '%s' "$HOOK_CMD" | PYTHONIOENCODING=utf-8 $PYBIN \
+      "$HUB_DIR/tools/_merge_settings.py" install \
+        --type PostToolUse \
+        --matcher "Bash|Skill|ToolSearch" \
+        --marker "skills-hub:search-clear-hook" \
+        "$CLAUDE_DIR/settings.json" \
+      || echo "  warn: PostToolUse search-clear registration failed"
+  fi
 fi
 
 # --- v2.6.8+: pre-implementation auto-check block in ~/.claude/CLAUDE.md ---

--- a/bootstrap/tools/_merge_settings.py
+++ b/bootstrap/tools/_merge_settings.py
@@ -1,26 +1,48 @@
 #!/usr/bin/env python3
 """
-Merge (or remove) the skills-hub UserPromptSubmit hook entry in
-~/.claude/settings.json.
+Merge (or remove) skills-hub hook entries in ~/.claude/settings.json.
 
-Idempotent: entries are tagged with {"_marker": "skills-hub:auto-suggest-hook"}.
-On install, any pre-existing entries carrying that marker are stripped before
-the fresh one is appended, so reinstalling cleanly replaces the registration.
+Idempotent: entries are tagged with a `_marker` field. Re-running install with
+the same (hook-type, marker) pair cleanly replaces the old entry. The legacy
+invocation (no flags) targets UserPromptSubmit with matcher "*" and marker
+"skills-hub:auto-suggest-hook" so older install.sh versions keep working.
 
 Usage:
-    python _merge_settings.py install   <settings.json> < command-on-stdin
-    python _merge_settings.py uninstall <settings.json>
+  # Legacy default — UserPromptSubmit / "*" / auto-suggest marker.
+  python _merge_settings.py install <settings.json> < command-on-stdin
+
+  # Any hook type with explicit flags.
+  python _merge_settings.py install \\
+      --type PreToolUse \\
+      --matcher "Write|Edit|MultiEdit|NotebookEdit" \\
+      --marker skills-hub:write-gate-hook \\
+      <settings.json> < command-on-stdin
+
+  # Remove every skills-hub hook entry (all markers, all types).
+  python _merge_settings.py uninstall <settings.json>
 
 The install subcommand reads the hook command as a single line from stdin and
 writes it verbatim into settings.json. Passing the command through stdin
-avoids cross-shell argv quoting issues (Windows/PowerShell in particular strips
-embedded quotes from arguments).
+avoids cross-shell argv quoting issues (Windows/PowerShell in particular
+strips embedded quotes from arguments).
 """
+import argparse
 import json
 import os
 import sys
 
-MARKER = "skills-hub:auto-suggest-hook"
+LEGACY_MARKER = "skills-hub:auto-suggest-hook"
+ALL_MARKERS = {
+    "skills-hub:auto-suggest-hook",
+    "skills-hub:write-gate-hook",
+    "skills-hub:search-clear-hook",
+}
+# Fallback substrings for pre-marker installs we still want to clean up.
+LEGACY_SCRIPT_FRAGMENTS = (
+    "hub-suggest-hint",
+    "hub-write-gate",
+    "hub-search-clear",
+)
 
 
 def _load(path: str) -> dict:
@@ -43,35 +65,52 @@ def _dump(path: str, obj: dict) -> None:
         f.write("\n")
 
 
-def _is_skills_hub_group(group: dict) -> bool:
-    """True if any hook in the group is marked as ours, or its command
-    references the hub-suggest-hint script (fallback for pre-marker installs).
+def _group_has_marker(group: dict, marker: str) -> bool:
+    """True if any hook in `group` carries the exact `_marker`, or if it is a
+    pre-marker install referencing the corresponding hub script by basename.
     """
+    script_for_marker = {
+        "skills-hub:auto-suggest-hook": "hub-suggest-hint",
+        "skills-hub:write-gate-hook": "hub-write-gate",
+        "skills-hub:search-clear-hook": "hub-search-clear",
+    }.get(marker)
     for h in group.get("hooks", []) or []:
         if not isinstance(h, dict):
             continue
-        if h.get("_marker") == MARKER:
+        if h.get("_marker") == marker:
             return True
         cmd = h.get("command") or ""
-        if "hub-suggest-hint" in cmd:
+        if script_for_marker and script_for_marker in cmd:
             return True
     return False
 
 
-def install(settings_path: str, command: str) -> int:
+def _group_is_any_skills_hub(group: dict) -> bool:
+    for h in group.get("hooks", []) or []:
+        if not isinstance(h, dict):
+            continue
+        if h.get("_marker") in ALL_MARKERS:
+            return True
+        cmd = h.get("command") or ""
+        if any(frag in cmd for frag in LEGACY_SCRIPT_FRAGMENTS):
+            return True
+    return False
+
+
+def install(settings_path: str, hook_type: str, matcher: str, marker: str, command: str) -> int:
     settings = _load(settings_path)
     hooks = settings.setdefault("hooks", {})
-    ups = hooks.setdefault("UserPromptSubmit", [])
-    if not isinstance(ups, list):
-        ups = []
-        hooks["UserPromptSubmit"] = ups
-    ups[:] = [g for g in ups if isinstance(g, dict) and not _is_skills_hub_group(g)]
-    ups.append({
-        "matcher": "*",
+    slot = hooks.setdefault(hook_type, [])
+    if not isinstance(slot, list):
+        slot = []
+        hooks[hook_type] = slot
+    slot[:] = [g for g in slot if isinstance(g, dict) and not _group_has_marker(g, marker)]
+    slot.append({
+        "matcher": matcher,
         "hooks": [{
             "type": "command",
             "command": command,
-            "_marker": MARKER,
+            "_marker": marker,
         }],
     })
     _dump(settings_path, settings)
@@ -85,31 +124,51 @@ def uninstall(settings_path: str) -> int:
     hooks = settings.get("hooks")
     if not isinstance(hooks, dict):
         return 0
-    ups = hooks.get("UserPromptSubmit")
-    if not isinstance(ups, list):
-        return 0
-    before = len(ups)
-    ups[:] = [g for g in ups if isinstance(g, dict) and not _is_skills_hub_group(g)]
-    if not ups:
-        hooks.pop("UserPromptSubmit", None)
+    changed = False
+    for hook_type in list(hooks.keys()):
+        slot = hooks.get(hook_type)
+        if not isinstance(slot, list):
+            continue
+        before = len(slot)
+        slot[:] = [g for g in slot if isinstance(g, dict) and not _group_is_any_skills_hub(g)]
+        if len(slot) != before:
+            changed = True
+        if not slot:
+            hooks.pop(hook_type, None)
+            changed = True
     if not hooks:
         settings.pop("hooks", None)
-    if len(ups) != before:
+        changed = True
+    if changed:
         _dump(settings_path, settings)
     return 0
 
 
+def _parse_install(argv: list) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="_merge_settings.py install", add_help=False)
+    parser.add_argument("--type", dest="hook_type", default="UserPromptSubmit")
+    parser.add_argument("--matcher", dest="matcher", default="*")
+    parser.add_argument("--marker", dest="marker", default=LEGACY_MARKER)
+    parser.add_argument("settings_path")
+    return parser.parse_args(argv)
+
+
 def main(argv: list) -> int:
-    if len(argv) >= 3 and argv[1] == "install":
+    if len(argv) >= 2 and argv[1] == "install":
+        try:
+            args = _parse_install(argv[2:])
+        except SystemExit:
+            return 2
         command = sys.stdin.read().strip()
         if not command:
             sys.stderr.write("install: empty command on stdin\n")
             return 2
-        return install(argv[2], command)
+        return install(args.settings_path, args.hook_type, args.matcher, args.marker, command)
     if len(argv) >= 3 and argv[1] == "uninstall":
         return uninstall(argv[2])
     sys.stderr.write(
-        "usage: _merge_settings.py install <settings.json> < command-on-stdin\n"
+        "usage: _merge_settings.py install [--type T] [--matcher M] [--marker K] "
+        "<settings.json> < command-on-stdin\n"
         "       _merge_settings.py uninstall <settings.json>\n"
     )
     return 2


### PR DESCRIPTION
## Summary

- Turn the existing `hub-suggest-hint.py` nudge into a **blocking gate**: it now writes a PENDING flag under `~/.claude/skills-hub/state/` and emits a STOP-toned `<system-reminder>`.
- Add `hub-write-gate.py` (PreToolUse: `Write|Edit|MultiEdit|NotebookEdit`) that refuses the first code-writing tool call while the flag is present.
- Add `hub-search-clear.py` (PostToolUse: `Bash|Skill|ToolSearch`) that deletes the flag the moment a real hub search runs (`hub-search`, `hub_search.py`, `/hub-find`, `/hub-install`, `/hub-list`, Skill `hub-*`), so the normal workflow unblocks itself.
- Generalize `_merge_settings.py`: new `--type / --matcher / --marker` flags, while the legacy no-flag invocation still targets `UserPromptSubmit / * / skills-hub:auto-suggest-hook`. `uninstall` now sweeps all skills-hub markers across every hook type.
- `install.sh` registers all three hooks under a single `SKILLS_HUB_NO_AUTO_SUGGEST` opt-out so anyone who already opted out of the nudge also skips the gate.

## Why

Several users (incl. me) hit cases where Claude acknowledged "check the hub first" in CLAUDE.md but jumped straight to scaffolding code anyway after a confirmation like "ok" / "그래". The existing `<system-reminder>` was phrased as a suggestion; making it a PreToolUse gate turns it into a deterministic block. Once a hub search actually runs in-session, the PostToolUse hook lifts the block automatically.

## Test plan

- [x] `hub-suggest-hint.py` emits STOP reminder and creates `hub_first_pending.flag` on `apm 대시보드 개발해줘`.
- [x] Slash-command prompts (`/hub-find ...`) still exempt — no flag, no reminder.
- [x] `hub-write-gate.py` emits blocking reminder while flag exists, silent otherwise.
- [x] `hub-search-clear.py` deletes flag on Bash `hub-search ...`, Skill `hub-find`, and ToolSearch `hub-search` queries.
- [x] `_merge_settings.py install` without flags still registers the legacy UserPromptSubmit entry (backward compat).
- [x] `_merge_settings.py install --type PreToolUse --matcher "..." --marker skills-hub:write-gate-hook` writes the new PreToolUse entry.
- [x] `_merge_settings.py uninstall` removes all three markers and preserves non-skills-hub hook entries (verified `SessionStart` check-updates hook untouched).
- [x] `bash -n bootstrap/install.sh` — syntax OK.
- [ ] End-to-end `bash bootstrap/install.sh` on a fresh `~/.claude` (maintainer to run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)