### PR TITLE
fix(install.ps1): add UTF-8 BOM for Windows PowerShell 5.1

### DIFF
--- a/bootstrap/install.ps1
+++ b/bootstrap/install.ps1
@@ -1,4 +1,4 @@
-# Install skills-hub bootstrap into $HOME\.claude
+﻿# Install skills-hub bootstrap into $HOME\.claude
 # Usage: powershell -ExecutionPolicy Bypass -File install.ps1
 
 $ErrorActionPreference = "Stop"


### PR DESCRIPTION
## Summary
- Prepend UTF-8 BOM (`EF BB BF`) to `bootstrap/install.ps1` so Windows PowerShell 5.1 parses the script as UTF-8 instead of the system ANSI code page.

## Problem
On Windows PowerShell 5.1 with a non-UTF-8 ANSI code page (e.g. CP949 on Korean Windows), BOM-less `.ps1` files are decoded using the legacy code page. The em-dash characters in the `<skills_hub>` here-string (UTF-8 bytes `E2 80 94`) get misinterpreted, then written back to `CLAUDE.md`, producing `??` artifacts:

```
- `/hub-find <keyword>` ??search installed + remote
- `/hub-install <slug>` ??install matching skill/knowledge
- `/hub-list` ??see what's already installed
- `/hub-publish` ??publish drafts back to the hub
```

Every fresh install on these systems corrupts the block — `/hub-doctor` flags it as a `[WARN]` immediately after install.

## Fix
Add UTF-8 BOM to `install.ps1`. This forces PS 5.1 into UTF-8 mode and is transparent to PS 7+.

## Test plan
- [x] Reproduced on Windows 10, PowerShell 5.1.19041.6456, ko-KR locale — BOM-less version produces `??`.
- [x] After BOM prepend, re-running `install.ps1` writes the `<skills_hub>` block with correct em-dashes.
- [ ] Verify on PS 7+ that BOM is still parsed correctly (no regression expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)