### PR TITLE
Publish 1 skill + 2 knowledge entries (session 2026-04-24, Lucida AI Swagger 요구사항 반영)

### DIFF
--- a/index.json
+++ b/index.json
@@ -14192,5 +14192,26 @@
     "version": "1.0.0",
     "path": "skills/workflow/x-filterable-fields-extraction",
     "has_content": false
+  },
+  {
+    "category": "workflow",
+    "description": "Spring Boot springdoc 에서 DTO 코드를 수정하지 않고, OpenApiCustomizer 로 components.schemas 를 walk 하면서 property name 이 특정 패턴(resourceId, agentId 등)인 필드에 pattern + example + x-discovery-* 확장을 후처리 주입한다.",
+    "has_content": false,
+    "kind": "skill",
+    "name": "openapi-customizer-property-name-enricher",
+    "path": "skills/workflow/openapi-customizer-property-name-enricher",
+    "slug": "openapi-customizer-property-name-enricher",
+    "tags": [
+      "cross-cutting",
+      "customizer",
+      "dto-zero-touch",
+      "identifier",
+      "openapi",
+      "spring-boot",
+      "springdoc",
+      "workflow"
+    ],
+    "triggers": "identifier field pattern 전수 부여, resourceId agentId 공통 확장, @Schema 없이 property enrichment, openapi customizer post-process",
+    "version": "1.0.0"
   }
 ]

--- a/knowledge/agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch.md
+++ b/knowledge/agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch.md
@@ -1,0 +1,76 @@
+---
+title: "병렬 subagent 디스패치 전에 grep 으로 선행 작업 흔적을 확인하라 — 이미 적용된 annotation 을 다시 '검증'하느라 시간 낭비"
+category: agent-orchestration / workflow
+tags: [claude-code, subagent, parallel-dispatch, pre-check, pitfall, efficiency]
+kind: pitfall
+confidence: high
+source_session: 2026-04-24
+---
+
+# 증상
+
+Lucida `lucida-domain-sms` 에서 "SMS DTO 전수에 `@Schema(title, description, requiredMode)` 적용" 작업을 4개 executor subagent 로 병렬 위임:
+
+- Agent 1 담당: dto 루트 24 파일
+- Agent 2 담당: dto/configuration 7 파일
+- Agent 3 담당: dto/custommonitor + custommonitortemplate 20 파일
+- Agent 4 담당: dto/customscript 12 파일
+
+총 63 파일, 수백 property. 각 agent 가 Read → 분석 → Edit → build 검증을 반복하며 **평균 100초 × 4 병렬** 소요.
+
+**결과 (4개 agent 보고 집계)**:
+- Agent 1: "수정 0파일 — 이미 모두 @Schema 적용됨"
+- Agent 2: "수정 0파일 — 이미 모두 @Schema 적용됨"
+- Agent 3: "수정 0파일 — 이미 모두 @Schema 적용됨"
+- Agent 4: "수정 12파일 — title 보강 + example 추가"
+
+= 3/4 agent 는 아무 것도 안 하고 끝. **수십초 × 3 = 1~2분 + token 낭비**.
+
+# 원인
+
+선행 issue #118871 "Swagger 최적화 sms V3" 에서 이미 대부분 DTO 에 `@Schema` 를 적용한 상태였다. 이 사실을 놓치고 "전수 적용" 이라는 문구만 보고 병렬 위임.
+
+# 해결
+
+병렬 dispatch **전에** 1초짜리 grep 한 번으로 선행 작업 여부 확인:
+
+```bash
+# 이미 적용된 @Schema 가 얼마나 있는지
+grep -rln "@Schema" src/main/java/.../dto/ | wc -l
+
+# DTO 파일 총수 대비 비율 계산
+total=$(find src/main/java/.../dto/ -name "*.java" | wc -l)
+hit=$(grep -rln "@Schema" src/main/java/.../dto/ | wc -l)
+echo "coverage: $hit / $total = $((hit * 100 / total))%"
+
+# git log 로 관련 작업 이력
+git log --oneline --all | grep -iE "swagger|schema|annotation" | head
+```
+
+90%+ coverage 가 나오면 병렬 dispatch 대신:
+- **sampling 검증만 delegate**: 1개 agent 로 미적용 파일만 찾아 report → 실제 edit 필요한 것만 후속 처리
+- 또는 **단일 agent** 로 빠르게 스캔 + 보강
+
+# 판단 기준
+
+| grep 결과 | 전략 |
+|---|---|
+| coverage 0~20% | 원래대로 병렬 dispatch (작업량 큼) |
+| 20~70% | 단일 agent 로 diff 파악 후 target dispatch |
+| 70%+ | **sampling 만 / 병렬 금지** — race condition 과 무용한 compile 비용 |
+
+# 관련 교훈
+
+- **agent 작업 시작 전 전제 검증**: "이 파일이 현재 어떤 상태지?" 를 1초에 확인할 수 있으면 1분의 낭비 방지.
+- **git log 활용**: 최근 commit 메시지에 "Swagger 최적화", "annotation", "@Schema" 같은 키워드가 있으면 선행 작업 존재 신호.
+- **DTO 샘플 1개 직접 Read**: 대표 DTO 하나만 열어봐도 annotation 수준 즉시 판단 가능.
+
+# 반례 (grep 으로 못 잡는 경우)
+
+- Annotation 은 있으나 quality 가 낮음(`title` 만 있고 `description` 없음 등) → 이때는 병렬 dispatch 가 정당
+- Lombok `@FieldNameConstants` 같이 compile-time 생성된 것 → grep 결과가 실제 annotation 밀도와 다를 수 있음
+
+# 연결
+
+- Parallel dispatch 패턴 자체는 skill `parallel-bulk-annotation` / `bucket-parallel-java-annotation-dispatch` 참조.
+- 본 knowledge 는 **그 전에 pre-check 하라** 는 메타 규칙.

--- a/knowledge/schema-design/identifier-regex-loose-when-legacy-coexists.md
+++ b/knowledge/schema-design/identifier-regex-loose-when-legacy-coexists.md
@@ -1,0 +1,66 @@
+---
+title: "식별자 regex 는 legacy + 신규 포맷이 공존하면 tight 패턴(^MA_.+_\\d{14}$) 대신 loose 패턴(^MA_.+$) 을 써라"
+category: schema-design / validation / openapi
+tags: [regex, identifier-pattern, schema-validation, openapi, legacy-data, pitfall]
+kind: pitfall
+confidence: high
+source_session: 2026-04-24
+---
+
+# 증상
+
+OpenAPI spec 에 `AgentId`/`ResourceId` schema 를 정의할 때, PDF 요구사항 예시(`MA_ADServer_20250108202624`)만 보고 tight pattern 을 썼다:
+
+```
+pattern: "^MA_.+_\\d{14}$"
+example: "MA_ADServer_20250108202624"
+```
+
+실제 운영 DB 에는 다음과 같은 legacy 식별자도 존재:
+- `MA_LINUX_TEST_SERVER_01` — 번호 2자리 suffix
+- `MA_LINUX_ADServer_01` — 14자리 timestamp 없음
+- `MA_WINDOWS_TEST_01` — 조직 단위 suffix
+
+Tight pattern 을 적용하면:
+- LLM agent 가 `MA_LINUX_TEST_SERVER_01` 을 payload 에 넣었을 때 서버 validation fail
+- 프런트엔드가 식별자를 스펙대로 검증하면 기존 자원 UI 가 표시 안 됨
+- "스펙과 실제 데이터 괴리" 로 AI Agent 가 올바른 다음 API 를 못 찾음
+
+# 원인
+
+식별자 생성 규칙이 **역사적으로 여러 번 바뀜**. 초기 버전은 조직/OS 기반 suffix, 중간 버전은 순차번호, 최신 버전은 14자리 timestamp. 마이그레이션 없이 다 누적 → 한 컬럼에 다양한 포맷이 공존.
+
+# 해결
+
+**Loose pattern** 으로 prefix 만 강제, suffix 는 free-form:
+
+```
+pattern: "^MA_.+$"
+example: "MA_ADServer_20250108202624"   # 최신 예시는 남겨 LLM 참고용
+```
+
+# 판단 기준
+
+- **Tight 가능**: 식별자 생성 규칙이 단일 버전, 마이그레이션 시 모든 레거시 재생성 완료. 예: 새로 만드는 서비스.
+- **Loose 권장**: 운영 중인 레거시 시스템, 마이그레이션 이력 다수, 실제 DB 에 다양한 포맷 존재 확인.
+
+빠른 검증:
+```bash
+# MongoDB
+db.agents.distinct("agentId").sort().map(id => id.length).reduce((a,b) => Math.max(a,b), 0)
+db.agents.find({agentId: {$not: /^MA_.+_\d{14}$/}}).count()
+
+# SQL
+SELECT LENGTH(agent_id), COUNT(*) FROM agent GROUP BY 1 ORDER BY 1;
+SELECT COUNT(*) FROM agent WHERE agent_id NOT REGEXP '^MA_.+_[0-9]{14}$';
+```
+
+# 교훈
+
+스펙 설계 시 **예시 하나로 pattern 을 고정하지 말 것**. 반드시 운영 데이터 분포를 확인하고, 의심되면 loose 부터 시작. Tight 가 필요해지면 언제든 좁힐 수 있지만, loose → tight 전환은 legacy data 마이그레이션 동반이라 비용 큼.
+
+# 관련
+
+- Lucida `lucida_ask_condensed.ko.pdf` 4.2.1 x-discovery-endpoint 섹션
+- Skill `swagger-ai-optimization` Part D Phase 21
+- Skill `openapi-customizer-property-name-enricher` (식별자 후처리 주입 패턴)

--- a/registry.json
+++ b/registry.json
@@ -2184,6 +2184,15 @@
       "version": "0.1.0-draft",
       "source_commit": "a974d4aa7f23782bece6afca241e90813a2c7c5c",
       "pinned": false
+    },
+    "openapi-customizer-property-name-enricher": {
+      "category": "workflow",
+      "scope": "user",
+      "installed_at": "2026-04-24",
+      "version": "1.0.0",
+      "source_commit": "74ba6bf",
+      "pinned": false,
+      "linked_knowledge": []
     }
   },
   "knowledge": {
@@ -3935,6 +3944,26 @@
       "installed_at": "2026-04-16T00:40:04Z",
       "source_commit": "a974d4aa7f23782bece6afca241e90813a2c7c5c",
       "linked_skills": []
+    },
+    "identifier-regex-loose-when-legacy-coexists": {
+      "category": "schema-design",
+      "scope": "user",
+      "installed_at": "2026-04-24",
+      "source_commit": "138f0cc",
+      "linked_skills": [
+        "openapi-customizer-property-name-enricher",
+        "swagger-ai-optimization"
+      ]
+    },
+    "grep-existing-annotations-before-parallel-subagent-dispatch": {
+      "category": "agent-orchestration",
+      "scope": "user",
+      "installed_at": "2026-04-24",
+      "source_commit": "f969aaf",
+      "linked_skills": [
+        "parallel-bulk-annotation",
+        "bucket-parallel-java-annotation-dispatch"
+      ]
     }
   }
 }

--- a/skills/workflow/openapi-customizer-property-name-enricher/SKILL.md
+++ b/skills/workflow/openapi-customizer-property-name-enricher/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: openapi-customizer-property-name-enricher
+description: Spring Boot springdoc 에서 DTO 코드를 수정하지 않고, OpenApiCustomizer 로 components.schemas 를 walk 하면서 property name 이 특정 패턴(resourceId, agentId 등)인 필드에 pattern + example + x-discovery-* 확장을 후처리 주입한다.
+category: workflow
+tags: [spring-boot, springdoc, openapi, customizer, cross-cutting, identifier, dto-zero-touch]
+triggers:
+  - "identifier field pattern 전수 부여"
+  - "resourceId agentId 공통 확장"
+  - "@Schema 없이 property enrichment"
+  - "openapi customizer post-process"
+source_project: lucida-domain-sms
+version: 0.1.0-draft
+---
+
+# 언제 쓰는가
+
+Swagger/OpenAPI 스펙의 **여러 DTO 에 반복 등장하는 property(예: `resourceId`, `agentId`, `confId`)** 에 공통 metadata(pattern, example, x-discovery-endpoint 등)를 부여해야 할 때. 일반적 방식은 DTO 마다 `@Schema(pattern=..., extensions=...)` 를 붙이는 것인데, 수백 개 DTO 를 일일이 건드리면 유지보수 지옥.
+
+**대안**: `OpenApiCustomizer` 후처리 단계에서 `components.schemas` 를 순회하며 property name 매칭으로 일괄 주입한다. **DTO 코드 zero touch**.
+
+# 언제 쓰지 말아야 하는가
+
+- Property 별로 metadata 가 다른 경우 (예: 각 DTO 의 `resourceId` 가 서로 다른 discovery endpoint 를 가리켜야 함) → 이때는 DTO 각각에 `@Schema` 명시.
+- Enum closing / complex schema transformation → 이건 Jackson mixin 이나 `@JsonTypeInfo` 영역.
+
+# 핵심 구조
+
+```java
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.media.Schema;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+
+@Configuration
+public class SchemaEnrichmentConfig {
+
+  private static final Map<String, Map<String, String>> IDENTIFIER_META = Map.of(
+      "resourceId", Map.of(
+          "pattern", "^MA_.+$",
+          "example", "MA_LINUX_TEST_SERVER_01",
+          "x-discovery-endpoint", "/api/sms/hosts-filter",
+          "x-discovery-field", "resourceId"),
+      "agentId", Map.of(
+          "pattern", "^MA_.+$",
+          "example", "MA_ADServer_20250108202624",
+          "x-discovery-endpoint", "/api/sms/agent/list-filter",
+          "x-discovery-field", "agentId")
+      // ... confId, customMonitorId 등
+  );
+
+  @Bean
+  public OpenApiCustomizer enrichIdentifierFields() {
+    return openApi -> {
+      Components components = openApi.getComponents();
+      if (components == null || components.getSchemas() == null) return;
+
+      for (Schema<?> schema : components.getSchemas().values()) {
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        Map<String, Schema> props = schema.getProperties();
+        if (props == null) continue;
+
+        for (Map.Entry<String, Schema> entry : props.entrySet()) {
+          Map<String, String> meta = IDENTIFIER_META.get(entry.getKey());
+          if (meta == null) continue;
+
+          Schema<?> property = entry.getValue();
+          if (property == null || !"string".equals(property.getType())) continue;
+
+          if (property.getPattern() == null && meta.containsKey("pattern")) {
+            property.setPattern(meta.get("pattern"));
+          }
+          if (property.getExample() == null && meta.containsKey("example")) {
+            property.setExample(meta.get("example"));
+          }
+          property.addExtension("x-discovery-endpoint", meta.get("x-discovery-endpoint"));
+          property.addExtension("x-discovery-field", meta.get("x-discovery-field"));
+        }
+      }
+    };
+  }
+}
+```
+
+# 동작 원리
+
+1. `springdoc` 이 컨트롤러/DTO 를 스캔하여 `components.schemas` 를 생성
+2. 모든 `OpenApiCustomizer` Bean 이 **생성 후** 순차 실행
+3. 본 Customizer 가 schemas 전체를 순회하며 property name 매칭 → metadata 주입
+4. 최종 `/v3/api-docs` 에 enriched spec 노출
+
+# 주의사항
+
+1. **실행 순서 엄수**: 같은 Customizer 내에서 `addCanonicalEnums` 같은 schema 등록 메소드를 먼저, `enrichIdentifierFields` 류 walker 는 마지막. 등록된 schema 만 순회할 수 있기 때문.
+2. **기존 값 보존**: `getPattern() == null` 체크 후에만 설정. DTO 에 이미 명시된 `@Schema(pattern=...)` 을 덮어쓰지 않기.
+3. **type 체크**: `"string".equals(property.getType())` — 같은 이름이라도 string 이 아닌 필드(객체/배열)는 skip.
+4. **확장은 덮어쓰기**: `addExtension` 은 기존 값 덮어쓰므로 필요 시 먼저 체크. discovery endpoint 는 덮어쓰는 게 의도적일 수 있음.
+5. **성능**: schema 수백 개 × property 수십 개 = 수천 순회. Spring 기동 시 1회만 실행되므로 영향 없음.
+
+# 검증 명령어
+
+```bash
+# bootRun 후 /v3/api-docs 덤프
+curl -s http://localhost:59595/v3/api-docs > spec.json
+
+# resourceId property 에 x-discovery-endpoint 가 주입됐는지
+python -c "
+import json
+s = json.load(open('spec.json'))
+hits = 0
+for n, sc in s.get('components', {}).get('schemas', {}).items():
+    for p, pd in (sc.get('properties') or {}).items():
+        if p in ('resourceId','agentId','confId') and 'x-discovery-endpoint' in pd:
+            hits += 1
+print('enriched identifier fields:', hits)
+"
+```
+
+# 확장 포인트
+
+- **ID 이외 분야**: 같은 pattern 으로 `createdAt`/`updatedAt` 시간 필드 포맷 명시, `email`/`phone` 형식 주입, `color` 팔레트 enum 닫기 등에 응용 가능.
+- **복잡 조건**: `entry.getKey()` 매칭 외에 schema name + property name 조합으로 더 정교한 룰 가능 (예: `HostDto.resourceId` 만 특정 discovery endpoint).
+- **조건부 주입**: DTO 의 다른 property 값/타입에 따라 분기하는 경우 `schema.getProperties().get("confType")` 식으로 동일 schema 내 다른 property 참조 가능.
+
+# 실제 사용 맥락
+
+`lucida-domain-sms` 에서 #118871 "Swagger 최적화 sms V3" 작업으로 513 property 중 대부분에 `@Schema(title, description, requiredMode)` 가 이미 적용돼 있었다. 이 위에 `resourceId`/`agentId`/`confId`/`customMonitorId` 공통 discovery metadata 를 부여해야 했으나, 각 DTO 에 `@Schema(extensions=@Extension(name="x-discovery-endpoint", ...))` 를 추가하는 건 수백 파일 변경 → 본 Customizer 방식으로 **SwaggerExtensionConfig.java 한 파일만 추가**하여 해결. 관련 상위 스킬: `swagger-ai-optimization` Part D Phase 24.


### PR DESCRIPTION
## Skills

### skills/workflow/openapi-customizer-property-name-enricher  v1.0.0 (NEW)
Spring Boot springdoc 에서 DTO 코드 수정 없이 `OpenApiCustomizer` 로 `components.schemas` 를 walk 하면서 property name 이 특정 패턴(resourceId / agentId / confId 등)인 필드에 `pattern` + `example` + `x-discovery-endpoint` + `x-discovery-field` 확장을 후처리 일괄 주입하는 패턴. `swagger-ai-optimization` Part D Phase 24 에 포함된 핵심 기법을 **독립 재사용 가능한 skill 로 분리**.

## Knowledge

### knowledge/schema-design/identifier-regex-loose-when-legacy-coexists (pitfall, high)
Legacy(`MA_LINUX_TEST_SERVER_01`) + 신규(`MA_ADServer_20250108202624`) 식별자 포맷이 공존하는 시스템에서 tight regex (`^MA_.+_\d{14}$`) 를 쓰면 legacy 데이터가 validation fail 하는 실측 pitfall. loose (`^MA_.+$`) 사용 권장 + 운영 DB 분포 확인 명령어 포함.

### knowledge/agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch (pitfall, high)
병렬 subagent dispatch 전에 1초 grep 으로 선행 작업 흔적을 확인하지 않아 4개 agent 중 3개가 "수정 0파일" 로 종료된 실측 pitfall. coverage 별 전략 판단표 포함.

## Cross-links

- `openapi-customizer-property-name-enricher` ↔ `swagger-ai-optimization` (상위 워크플로우), `identifier-regex-loose-when-legacy-coexists` (정확한 pattern 선택)
- `identifier-regex-loose-when-legacy-coexists` ↔ `openapi-customizer-property-name-enricher`, `swagger-ai-optimization`
- `grep-existing-annotations-before-parallel-subagent-dispatch` ↔ `parallel-bulk-annotation`, `bucket-parallel-java-annotation-dispatch` (그 전에 반드시 pre-check 하라는 메타 규칙)

## Source

- **Project**: `lucida-domain-sms`  (develop-10.2.4_3)
- **Session**: 2026-04-24 (PDF `docs/lucida_ask_condensed.ko.pdf` 반영 작업)
- **Commit refs**:
  - `138f0cc` knowledge/schema-design/identifier-regex-loose-when-legacy-coexists
  - `f969aaf` knowledge/agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch
  - `74ba6bf` skills/workflow/openapi-customizer-property-name-enricher v1.0.0
  - `6712fc9` registry.json + index.json rebuild

## Tag

- `skills/openapi-customizer-property-name-enricher/v1.0.0` (annotated, pushed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)