### PR TITLE
Publish 2 skills from polestar10 alarm personalization session

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1092,6 +1092,14 @@
       "source_commit": "a974d4aa7f23782bece6afca241e90813a2c7c5c",
       "pinned": false
     },
+    "lucida-work-order-to-paired-spec": {
+      "category": "workflow",
+      "scope": "user",
+      "installed_at": "2026-04-24T02:43:25Z",
+      "version": "1.0.0",
+      "source_commit": "b0f1c9d819df1a38441daf1a89bfe24e10390982",
+      "pinned": false
+    },
     "mcp-capability-negotiated-initialize": {
       "category": "backend",
       "scope": "user",
@@ -1647,6 +1655,14 @@
       "installed_at": "2026-04-16T00:40:04Z",
       "version": "1.0.0",
       "source_commit": "a974d4aa7f23782bece6afca241e90813a2c7c5c",
+      "pinned": false
+    },
+    "selfcontained-nds-design-doc-html": {
+      "category": "design",
+      "scope": "user",
+      "installed_at": "2026-04-24T02:43:25Z",
+      "version": "1.0.0",
+      "source_commit": "b0f1c9d819df1a38441daf1a89bfe24e10390982",
       "pinned": false
     },
     "server-plugin-scripting-and-builtin-extensibility": {

--- a/skills/design/selfcontained-nds-design-doc-html/SKILL.md
+++ b/skills/design/selfcontained-nds-design-doc-html/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: selfcontained-nds-design-doc-html
+description: 외부 CSS/JS 의존 없이 단일 .html로 완성되는 Lucida/NDS 톤 디자인 문서 템플릿. As-Is/To-Be, 페이지 맥락 목업, 다이얼로그, 인터랙션, API 테이블, MoSCoW Phase 카드 등 10개 섹션 카드로 구성. 메일/Slack/PR에 첨부해도 깨지지 않는 self-contained 아티팩트가 필요할 때 사용.
+category: design
+tags: [html, mockup, nds, lucida, self-contained, design-doc]
+---
+
+# Self-contained NDS 스타일 디자인 문서 HTML
+
+## 언제 쓰는가
+
+- 기획서(.md)와 **쌍으로 붙일 비주얼 목업**이 필요한데, Figma 링크 공유가 제한적이거나 오프라인 리뷰 상황
+- 이해관계자에게 메일/Slack/PR로 **HTML 하나만 던져도 그대로 보이는** 문서가 필요할 때
+- Lucida의 NDS 팔레트·톤(심각도 색, brand blue, line/muted 중립톤)을 대충이라도 유지하고 싶을 때
+
+Figma가 확보되면 `nds-html-mockup-from-tokens` 쪽이 상위 호환이다. 이 스킬은 **Figma 없이** 기획서만 가지고 도면을 뽑는 용도.
+
+## 핵심 원칙
+
+1. **외부 요청 금지** — Google Fonts, CDN icon, fetch 전부 금지. `<style>` 한 블록 + 인라인 SVG만.
+2. **CSS 변수로 NDS 톤 근사치**를 먼저 정의. 하드코딩된 색 값 반복 금지.
+3. **섹션 카드 패턴** — `<section class="card">` + `<h2><span class="num">{N}</span> ...</h2>` + `<div class="body">`. 번호는 기획서 섹션과 1:1.
+4. 목업은 **실제 컴포넌트를 흉내낸 div 구조**로 그린다. `<img>` placeholder 금지.
+
+## 팔레트 (복붙용)
+
+```css
+:root{
+  --bg:#f4f6fa; --panel:#ffffff; --ink:#1b1f27; --muted:#6b7380;
+  --line:#e4e7ee; --line-strong:#c9cfdb;
+  --brand:#1c6dd0; --brand-weak:#e9f1fb;
+  --sev-crit:#d23f3f; --sev-warn:#e08a1a; --sev-caut:#e0b41a; --sev-ok:#2b8a58;
+  --chip:#eef1f6; --chip-ink:#3a4453;
+  --accent:#7a3ff2;
+  --mono: ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  --shadow: 0 6px 24px rgba(18,30,55,0.08);
+  --radius: 10px;
+}
+body{font:14px/1.55 "Pretendard","Apple SD Gothic Neo","Segoe UI",system-ui,sans-serif;color:var(--ink);background:var(--bg);margin:0}
+```
+
+## 권장 섹션 구성 (10 카드)
+
+| # | 섹션 | 주 콘텐츠 |
+|---|---|---|
+| 1 | 요약 · 핵심 변경점 | 3열 그리드 카드, 한 줄 hook + 한 문장 설명 |
+| 2 | As-Is vs To-Be | `compare.col` 2열, As-Is는 빨강 태그·To-Be는 초록 태그, `<ul>` 대비 리스트 |
+| 3 | 페이지 맥락 | 탭·액션바·테이블 목업. 심각도 `.sev.crit/warn/caut/info/ok` 뱃지, `.truncate`로 말줄임 연출 |
+| 4 | 다이얼로그 목업 | `.stage`(줄무늬 배경)에 `.modal` 올리기. 상단 툴바 + `.collist`(☰ 핸들 + .checkbox + 뱃지) + 하단 좌:위험버튼 / 우:취소·저장 |
+| 5 | 핵심 인터랙션 | 드래그 재배치·너비 리사이즈·우클릭 메뉴·확인 모달. 2×2 그리드 |
+| 6 | 사용자 시나리오 | `.steps`에 번호 달린 5 스텝 카드, 각 스텝 상단 원형 번호 뱃지 |
+| 7 | API 설계 | Method 칩(GET/POST/PUT/PATCH/DELETE 색상 구분) + 경로 + 용도 테이블 + 다크 codeblock(JSON) + 에러 응답 테이블 |
+| 8 | Phase (MoSCoW) | Must/Should/Could/Won't 4열 카드, 색상 태그 구분 |
+| 9 | 수용 기준 | 체크박스 box UI로 시각적 체크리스트 |
+| 10 | Open Questions | `<ol>` 단순 나열 |
+
+각 카드 스타일(권장):
+```css
+section.card{background:#fff;border:1px solid var(--line);border-radius:10px;
+  box-shadow:var(--shadow);margin:18px 0;overflow:hidden}
+section.card > h2{margin:0;padding:16px 22px;border-bottom:1px solid var(--line);
+  font-size:15px;background:#fbfcff;display:flex;align-items:center;gap:10px}
+section.card > h2 .num{display:inline-flex;align-items:center;justify-content:center;
+  width:22px;height:22px;border-radius:6px;background:var(--brand);color:#fff;font-size:12px;font-weight:700}
+section.card > .body{padding:22px}
+```
+
+## 관용 마이크로 컴포넌트
+
+- `.btn` / `.btn.primary` / `.btn.danger` / `.btn.sm` — 9~13px 패딩, 5~6px radius, 라인 버튼 기본
+- `.sev.{crit|warn|caut|info|ok}` — `::before` 원형 점 + pill 스타일 뱃지
+- `.chip` — 선택된 컬럼 등 태그 표현. `.x`로 제거 아이콘
+- `.collist .row` — 드래그 핸들(☰) + checkbox div + name + 우측 width meta
+- `.m.{GET|POST|PUT|PATCH|DELETE}` — HTTP method 태그, 각 색상 고유
+- `.codeblock` — 다크(#0f172a) JSON/코드 블록, `.k/.s/.c` span으로 키/문자열/주석 색 구분
+
+## 검증
+
+태그 밸런스 체크는 항상 마지막에:
+```bash
+node -e "const fs=require('fs');const s=fs.readFileSync('{path}','utf8');
+['section','div','table','ul'].forEach(t=>{
+  const o=(s.match(new RegExp('<'+t+'(?:\\\\s|>)','g'))||[]).length;
+  const c=(s.match(new RegExp('</'+t+'>','g'))||[]).length;
+  console.log(t, o, '/', c);
+});"
+```
+
+브라우저에서 열었을 때:
+1. 스크롤 시 섹션 헤더가 sticky하지 않도록(기본 그대로 둘 것). 긴 스크롤 허용.
+2. 960px 미만에서 `.grid-2`·`.grid-3`·`.phase`·`.steps`가 1~2열로 접히는지.
+3. 브라우저 인쇄 시 다이얼로그 `.stage`의 줄무늬 배경이 잉크 낭비라 `@media print{.stage{background:none}}` 추가 가능.
+
+## 실패 모드
+
+| 상황 | 대처 |
+|---|---|
+| 기획서에 API 설계 없음 | 섹션 7 자체 삭제하고 남은 번호 재정렬. 빈 카드 두지 말 것. |
+| 한국어 폰트가 두꺼워 보임 | `Pretendard`가 없으면 `Apple SD Gothic Neo` fallback. Noto Sans KR CDN은 금지(외부 요청). |
+| 다크모드 요청 | CSS 변수를 `@media (prefers-color-scheme: dark)`로 재정의. 기본은 라이트 고정(리뷰 환경이 대개 라이트). |
+| 파일이 커짐(>50KB) | 인라인 SVG 반복 제거, 목업 테이블 행 수 줄이기. 30KB 내외가 이상적. |
+
+## 참고 결과물
+
+- `specs/alarm/design/알람이벤트_컬럼_개인화설정_디자인.html` (605줄, 31KB, 섹션 10 / div 153, 모두 쌍 밸런스)

--- a/skills/workflow/lucida-work-order-to-paired-spec/SKILL.md
+++ b/skills/workflow/lucida-work-order-to-paired-spec/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: lucida-work-order-to-paired-spec
+description: 한 개의 작업지시서(.md)에서 specs/{domain}/planning/*.md 기획서와 specs/{domain}/design/*.html 디자인 목업을 함께 생성하는 워크플로우. 기존 specs/kcm/planning 등의 헤더·메타 관례를 먼저 스캔해 일관성을 맞춘다.
+category: workflow
+tags: [lucida, planning, design-doc, specs, polestar]
+---
+
+# Lucida 작업지시서 → 기획서 + HTML 디자인 문서 페어 생성
+
+## 언제 쓰는가
+
+`examples/*/*.md` 또는 PIMS에서 떨어진 1차 작업지시서(기획 초안 + 요구사항)가 있을 때, 프로젝트 관례에 맞춘 **정리된 기획서**와 **비주얼 검토용 HTML 디자인 문서**를 **한 번에 페어로** 산출하고 싶을 때.
+
+`/product-planning`은 요구사항부터 새로 뽑아내는 상위 스킬이고, 이 스킬은 **이미 작성된 작업지시서**를 두 포맷으로 정돈한다.
+
+## 절차
+
+### 1. 입력 식별
+- 사용자가 지목한 파일 경로(예: `examples/alarm/*.md`)를 `Read`.
+- 파일명에서 **도메인 추정**: `알람/이벤트 → alarm`, `KCM → kcm`, `계정 → account`. 애매하면 사용자에게 한 번 확인.
+
+### 2. 관례 정찰 (필수)
+한 번의 병렬 배치로 세 가지를 동시에 확인:
+
+- `Glob("specs/**/planning/*.md")` — 기존 기획서 존재 여부
+- `Read` 가장 최근/가장 정돈된 기획서 상단 80줄 — 메타 헤더 블록 패턴
+- `Read("rules/fe/15-design-system-rules.md")` 상단 — NDS/Sirius 토큰·컴포넌트 매핑 참조
+
+레포에 기존 예시가 있으면 **이름 컨벤션·헤더 포맷·디렉터리 구조**를 그대로 따른다. 없으면 아래 §3의 템플릿 사용.
+
+### 3. 출력 경로
+```
+specs/{domain}/
+├── planning/{기능명}_기획서.md
+└── design/{기능명}_디자인.html
+```
+`design/`이 새 디렉터리여도 그대로 생성. `openapi/`는 이 스킬의 범위 밖이다(별도로 `/extract-api-spec`).
+
+### 4. 기획서(.md) 작성 규칙
+
+헤더 메타 블록은 **HTML 주석 + 블록쿼트** 2층 구조로 고정:
+
+```markdown
+<!-- source: {원본 경로 또는 PIMS URL} -->
+<!-- fetched: YYYY-MM-DD -->
+
+# {기능명} 기능 명세서
+
+> **상태**: 초안 | 확정
+> **유형**: 기존 개선 | 신규
+> **버전**: Polestar 10.x
+> **위치**: {메뉴 경로}
+> **영향 범위**: {탭/모듈}
+> **작성일**: YYYY-MM-DD
+> **원본**: {source 경로}
+```
+
+본문 섹션 순서(경험칙, 기존 `specs/kcm/planning/*` 관찰):
+1. 화면 개요 (+ 진입 경로 + 핵심 사용 흐름 테이블)
+2. 범위 (Scope — 포함/제외)
+3. As-Is 분석
+4. 요구사항 (FR / NFR 테이블, MoSCoW 컬럼 포함)
+5. 기능 상세 설계 (UI/UX · 데이터 모델 · API 설계)
+6. 사용자 시나리오
+7. 엣지 케이스
+8. 구현 우선순위 (Phase 1~4)
+9. 수용 기준 (AC)
+10. 확장 고려
+11. Open Questions
+12. 부록 (컬럼 인벤토리 등)
+
+작업지시서가 이미 이 구조를 갖고 있으면 **이름·톤만 정돈**하고 사족 문장은 줄인다. 부족한 섹션을 **창작하지 않는다**.
+
+### 5. 디자인 문서(.html) 작성 규칙
+자매 스킬 `selfcontained-nds-design-doc-html`의 템플릿을 사용. 섹션 구성은 기획서와 1:1 매핑되도록 번호를 맞춘다(요약 · As-Is/To-Be · 페이지 맥락 · 다이얼로그 · 인터랙션 · 시나리오 · API · Phase · AC · Open Q).
+
+### 6. 검증
+```bash
+# 1) 파일 생성 확인 + 라인 수
+ls specs/{domain}/planning specs/{domain}/design
+wc -l specs/{domain}/planning/*.md specs/{domain}/design/*.html
+
+# 2) HTML 태그 밸런스 (section/div 쌍 매칭)
+node -e "const fs=require('fs');const s=fs.readFileSync('<path>','utf8');
+const o=(s.match(/<section/g)||[]).length;
+const c=(s.match(/<\/section>/g)||[]).length;
+const od=(s.match(/<div(?:\s|>)/g)||[]).length;
+const cd=(s.match(/<\/div>/g)||[]).length;
+console.log('sections',o,'/',c,'  divs',od,'/',cd);"
+```
+section/div 좌우가 일치해야 한다. 어긋나면 닫힘 태그 누락.
+
+## 실패 모드
+
+| 상황 | 대처 |
+|---|---|
+| 작업지시서가 이미 `*_기획서.md`로 명명됨 | 파일명은 유지, 내용만 `specs/`의 포맷으로 재조립. `원본` 필드로 추적. |
+| 도메인 폴더가 없음 | `specs/{domain}/` 신규 생성. 이후 타 스킬이 이 구조를 그대로 사용. |
+| 작업지시서에 API/데이터 모델이 없음 | 기획서에는 해당 섹션 생략, HTML에서도 해당 섹션 카드 자체를 삭제(비우지 말고 섹션 번호를 재정렬). |
+| 사용자가 도메인 힌트를 주지 않음 | 파일명 → 메뉴 경로 → 키워드 순서로 추정 후 **한 문장으로만** 확인 질문. |
+
+## 참고 결과물 (이 스킬이 실제로 만든 페어)
+
+- `specs/alarm/planning/알람이벤트_컬럼_개인화설정_기획서.md`
+- `specs/alarm/design/알람이벤트_컬럼_개인화설정_디자인.html`


### PR DESCRIPTION
## Skills

| Category | Slug | Version | Tag |
|---|---|---|---|
| design | `selfcontained-nds-design-doc-html` | v1.0.0 | `skills/selfcontained-nds-design-doc-html/v1.0.0` |
| workflow | `lucida-work-order-to-paired-spec` | v1.0.0 | `skills/lucida-work-order-to-paired-spec/v1.0.0` |

### `design/selfcontained-nds-design-doc-html`
외부 CSS/JS 의존 없는 단일 `.html` Lucida/NDS 톤 디자인 문서 템플릿. 10개 섹션 카드(As-Is/To-Be · 페이지 맥락 목업 · 다이얼로그 · 인터랙션 · 시나리오 · API 테이블+JSON · MoSCoW · AC · Open Q)로 구성. `.sev`/`.chip`/`.collist`/`.m.{GET|POST|...}` 관용 마이크로 컴포넌트. 메일/Slack/PR 첨부해도 깨지지 않는 self-contained 아티팩트가 필요할 때.

### `workflow/lucida-work-order-to-paired-spec`
한 개의 작업지시서(`.md`)에서 `specs/{domain}/planning/*.md` + `specs/{domain}/design/*.html` 쌍을 생성하는 워크플로우. 기존 `specs/kcm/planning/*` 헤더 관례를 먼저 스캔해 일관성 유지. HTML 태그 밸런스 검증 스니펫과 실패 모드 테이블 포함.

## Knowledge
— (이 릴리스에 해당 없음)

## Cross-links
— (linked_knowledge/linked_skills 없음)

## Source
- **Project**: `polestar10-auto-pipeline`
- **Session**: `2026-04-24 11:23 KST`
- **Source commit**: `b0f1c9d819df1a38441daf1a89bfe24e10390982`
- **Originating deliverables**:
  - `specs/alarm/planning/알람이벤트_컬럼_개인화설정_기획서.md` (278줄)
  - `specs/alarm/design/알람이벤트_컬럼_개인화설정_디자인.html` (605줄, 31KB, section 10/10 · div 153/153 밸런스)

## Notes
- 초기 작업 중 동일 hub remote에서 다른 액터의 `/hub-publish-knowledge` 세션과 브랜치 체크아웃이 충돌. 스트랜디드 커밋 `473a057`을 cherry-pick으로 이 분리 브랜치에 복구 — 다른 액터의 `release/combined-20260424-final` 및 `knowledge/add-pitfall-20260424`에는 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)