### PR TITLE
RFC: add technique/ middle layer (v0.1 draft)

### DIFF
--- a/docs/rfc/technique-layer.md
+++ b/docs/rfc/technique-layer.md
@@ -1,0 +1,161 @@
+# RFC: `technique/` — Middle Layer Between Skills and Examples
+
+- **Status**: draft v0.1
+- **Target repo**: `kjuhwa/skills-hub`
+- **Author**: kjuhwa@nkia.co.kr
+- **Date**: 2026-04-24
+- **Local evidence**: 2 pilots, 4 slash commands, schema doc — all validated offline before this RFC
+
+> **Reviewer note**: this RFC exists because the skills-hub currently has atomic units (`skills/`, `knowledge/`) and complete artifacts (`example/`) but no **reusable composition layer**. Users repeatedly compose the same 2-5 atoms into recipes by hand. This proposes formalizing that recipe as a first-class hub concept.
+
+## 1. Problem
+
+Today:
+
+```
+knowledge ──┐
+skill     ──┤──► [user assembles by hand, every time] ──► example
+research  ──┘
+```
+
+Every time you want "build many projects in parallel, publish to a shared repo safely" you mentally reassemble the same set:
+
+- `skills/parallel-build-sequential-publish`
+- `skills/workflow/rollback-anchor-tag-before-destructive-op`
+- `knowledge/workflow/batch-pr-conflict-recovery`
+- `knowledge/pitfall/gh-pr-create-race-with-auto-merge`
+
+`hub-merge` solves half of this — but it **absorbs and destroys** the atoms. A composition that preserves atom independence (so other compositions can also use them) has no home today.
+
+## 2. Proposal
+
+Add `technique/` as a first-class hub directory:
+
+```
+knowledge ──┐
+skill     ──┤──► technique (by reference) ──► example (instance)
+research  ──┘
+```
+
+Key property: technique **references** atoms, never copies them.
+
+### Directory
+
+```
+technique/
+  <category>/
+    <slug>/
+      TECHNIQUE.md          # required
+      verify.sh             # optional
+      resources/            # optional
+```
+
+Categories reuse the existing `CATEGORIES.md` (no new enum values).
+
+### Frontmatter
+
+```yaml
+---
+version: 0.1.0
+name: <slug>
+description: <≤120 chars>
+category: <CATEGORIES.md>
+tags: [...]
+
+composes:
+  - kind: skill            # skill | knowledge (technique is banned in v0 to prevent nesting)
+    ref: <kind-root-relative path>    # see §4 finding below
+    version: "^1.0.0"
+    role: <free-text label for the atom's job>
+  - ...
+
+binding: loose              # loose (default, semver range) | pinned (exact)
+
+verify:
+  - <human-readable check> | { cmd: ./verify.sh }
+---
+```
+
+### Registry (schema bump v2 → v3)
+
+`registry.json` gains a `techniques` section parallel to `skills`/`knowledge`, with a `composes_snapshot` capturing resolved versions at install time — supporting `loose` binding without a separate lockfile.
+
+### Index (`index.json`)
+
+Add a `technique` kind to the master/lite/category indexes. `/hub-find` treats all three kinds (skill, knowledge, technique) uniformly with a `kind` badge on results.
+
+## 3. Pilot Evidence (n=2)
+
+Two pilots authored locally, both pass the proposed `/hub-technique-verify` rules. Shapes intentionally chosen to diverge:
+
+| | Pilot 1: `safe-bulk-pr-publishing` | Pilot 2: `root-cause-to-tdd-plan` |
+|---|---|---|
+| Category | workflow | debug |
+| Shape | Linear pipeline (phase 0→1→2→3) | Decision tree with branches |
+| Composes | 2 skills + 2 knowledge | 3 skills + 1 knowledge |
+| Novel glue | Race-aware PR creation loop, N≥3 conflict-storm trigger | build-error vs runtime-bug branching, hypothesis-guard mandate |
+
+**Finding**: the same frontmatter schema absorbs both shapes without modification. The `role` free-text field carries the structural difference ("orchestrator" vs "phase-orchestrator" / "branch-build-error" / "hypothesis-guard"). No DSL needed in v0.
+
+## 4. Unexpected Finding (affects schema, already folded in)
+
+During pilot 1 authoring, discovered that `skills/parallel-build-sequential-publish/` is at the **root of `skills/`**, not nested under its declared `category: workflow`. This caused the first verify pass to fail.
+
+**Conclusion**: `ref` must be defined as **kind-root-relative physical path**, not `{category}/{slug}` semantic form. Frontmatter category and filesystem path can legally diverge in the hub (legacy or publishing oversight). The schema specifies the physical form; verify walks the actual tree.
+
+This is a **finding that a paper-only design would have missed**. It also suggests a separate cleanup PR to realign path with category for the offending skill(s), but that's out of this RFC's scope.
+
+## 5. Migration Plan
+
+Zero-disruption rollout:
+
+1. Merge this RFC with the directory + schema only. No enforcement yet.
+2. Land `bootstrap/commands/hub-technique-*.md` in a follow-up PR (4 commands: list, verify, show, compose).
+3. Accept pilot #1 and #2 as the first two real techniques (separate PRs, normal review).
+4. After 2-3 more techniques land, extend `/hub-find`, `/hub-status`, `/hub-precheck` to recognize `technique` kind.
+5. `registry.json` stays schema v2 until step 4; existing installs unaffected.
+
+Rollback: removing the `technique/` directory at any step leaves skills/knowledge/example untouched. `registry.json` v2 readers ignore an unknown `techniques` key.
+
+## 6. Slash Commands (follow-up PR)
+
+Already authored and locally validated:
+
+| Command | Role |
+|---|---|
+| `/hub-technique-compose <slug>` | Interactive authoring (AskUserQuestion-driven) |
+| `/hub-technique-verify <slug>\|--all` | Schema §9 rules enforcement |
+| `/hub-technique-list` | Local state readout |
+| `/hub-technique-show <slug>` | Print + composition expansion |
+
+Out of v0 scope: `/hub-technique-install`, `/hub-technique-publish`, `/hub-find` kind extension.
+
+## 7. Open Questions for Reviewers
+
+1. **Nesting**: should v0 allow technique-to-technique composition? (Proposed: NO. Risk of cycles, over-coupling. Revisit v0.2.)
+2. **`role` field**: free-text now. Should a controlled vocabulary ("orchestrator", "guard", "recovery", "branch", "artifact") be proposed? (My view: NO, free-text has done the work across 2 divergent pilots. Adding taxonomy prematurely is overfit.)
+3. **example ↔ technique link**: add `produced_by_technique: <ref>` to `example/` frontmatter? (My view: yes, as a separate small PR.)
+4. **verify.sh portability**: require POSIX bash only, or allow pwsh too? (My view: POSIX only for v0. Windows users already use bash via git.)
+5. **Cleanup PR for path/category divergence** (§4): should this RFC mandate it? (My view: no. Surface it in the RFC, let maintainer decide scope.)
+
+## 8. Local Artifacts Available for Review
+
+Placed alongside this RFC in the RFC author's working directory:
+
+- `technique-schema-draft.md` — full schema spec
+- `.technique-draft/workflow/safe-bulk-pr-publishing/TECHNIQUE.md` — pilot 1
+- `.technique-draft/debug/root-cause-to-tdd-plan/TECHNIQUE.md` — pilot 2
+- `.claude/commands/hub-technique-{compose,verify,list,show}.md` — commands
+
+Willing to move any of these into this PR or split into follow-ups per reviewer preference.
+
+## 9. What This RFC Does NOT Do
+
+- Not publishing pilots into the real `technique/` directory.
+- Not modifying `/hub-find`, `/hub-status`, `/hub-precheck`.
+- Not bumping `registry.json` schema (step 4).
+- Not enforcing anything. Directory + schema + verify rules only.
+
+---
+
+**Request**: approve the directory, schema, and v0 rules. Subsequent work lands in smaller PRs per §5.

--- a/docs/rfc/technique-schema-draft.md
+++ b/docs/rfc/technique-schema-draft.md
@@ -1,0 +1,183 @@
+---
+doc: technique-schema-draft
+status: draft-v0.1
+author: kjuhwa@nkia.co.kr
+date: 2026-04-24
+---
+
+# `technique/` — 스킬 허브 중간 계층 설계 초안
+
+## 1. 왜 필요한가
+
+현재 허브는 **원자 단위(skill, knowledge)** 와 **완성 산출물(example)** 두 극단만 존재한다. 실전에서는 보통 2~N개 스킬·지식을 특정 순서·조건으로 조합해야 하나의 결과가 나온다. 이 조합 자체를 재사용 가능한 단위로 고정할 수 있는 저장소가 없어, 사용자는 매번 스킬·지식을 수동으로 골라 맞춰야 한다.
+
+`technique/`는 이 **중간 레이어**를 담당한다:
+
+```
+knowledge  ─┐
+skill      ─┼──►  technique  ──►  example (instance)
+research   ─┘
+```
+
+- technique은 skill/knowledge를 **재배치하지 않고 참조만** 한다 (중복 저장 금지).
+- 부족분은 `hub-research`로 외부 자료를 당겨 technique 본문에 녹인다.
+- example은 technique을 실행해 만든 **1회성 결과물**이며, technique은 **재현 가능한 레시피**다.
+
+## 2. 기존 개념과의 경계
+
+| 개념 | 위치 | 단위 | 재사용성 | 구성 |
+|---|---|---|---|---|
+| skill | `skills/{cat}/{slug}/SKILL.md` | 원자 절차 | 높음 | 단일 |
+| knowledge | `knowledge/{cat}/{slug}.md` | 원자 사실/교훈 | 높음 | 단일 |
+| **technique** | `technique/{cat}/{slug}/TECHNIQUE.md` | **조합 레시피** | **높음** | **복수 참조** |
+| example | `example/{cat}/{slug}/` | 완성 산출물 | 낮음 (데모) | 산출물만 |
+| hub-merge | 커맨드 | 병합 (복사·흡수) | — | 1회성 |
+
+`hub-merge`와의 차이: merge는 원본 스킬을 **흡수·소멸**시키지만, technique은 원본을 **살려둔 채 참조**한다. 원자 단위의 독립성이 유지되므로 다른 technique에서 재사용할 수 있다.
+
+## 3. 디렉토리 & 파일 레이아웃
+
+```
+technique/
+  <category>/
+    <slug>/
+      TECHNIQUE.md         ← 메타 + 본문 (필수)
+      verify.sh            ← 합성 검증 스크립트 (선택)
+      resources/           ← 보조 자산 (선택, 이미지·샘플 등)
+```
+
+카테고리는 `CATEGORIES.md`의 기존 목록을 재사용. technique 전용 신규 카테고리는 만들지 않는다 (tag로 해결).
+
+## 4. Frontmatter 스키마
+
+```yaml
+---
+version: 0.1.0                  # semver, draft-0 허용
+name: <slug>                    # 디렉토리명과 동일
+description: <한 줄, ≤120자>    # 언제 써야 하는지 1문장
+category: <CATEGORIES.md 값>
+tags: [<string>, ...]
+
+composes:                       # 핵심: 어떤 원자 단위를 묶는가
+  - kind: skill                 # skill | knowledge
+    ref: workflow/autoplan      # kind 루트 기준 실제 디스크 경로 (폴더 슬러그)
+                                # ※ frontmatter category와 불일치할 수 있으므로
+                                #   '실제 경로'를 쓴다 (파일럿에서 발견)
+    version: "^1.0.0"           # semver range (loose) 또는 정확값 (pinned)
+    role: orchestrator          # 이 조합 내 역할 (자유 문자열)
+  - kind: knowledge
+    ref: workflow/batch-pr-conflict-recovery
+    version: "*"                # 최신 허용
+    role: failure-mode
+
+requires_research:              # 외부 보강 필요 시 (선택)
+  - topic: "GitHub GraphQL rate limit"
+    rationale: "hub-research로 최신 한도 확인 필요"
+
+binding: loose                  # loose (기본) | pinned
+                                #   loose: version range 만족하면 재사용
+                                #   pinned: 정확히 그 커밋/버전만 유효
+
+verify:                         # 사용 시점 건전성 체크 (선택)
+  - "모든 composes.ref 가 현재 설치되어 있는가"
+  - "composes[].version range 가 설치본과 교차하는가"
+  - cmd: "./verify.sh"          # 커스텀 검증
+---
+```
+
+## 5. 바인딩 모드 (핵심 트레이드오프)
+
+| 모드 | 동작 | 장점 | 단점 |
+|---|---|---|---|
+| `loose` (기본) | semver range로 참조, 사용 시점에 설치본 재검증 | 하위 스킬 업데이트를 자동 흡수 | 하위 breaking 시 technique 재검증 필요 |
+| `pinned` | 특정 버전(또는 commit SHA)에 고정 | 재현성 100% | 하위 스킬 오래되면 유지비 증가 |
+
+**권장**: 초기 모든 technique은 `loose`로 시작. 프로덕션/감사 경로에만 `pinned`. `hub-precheck`이 `pinned` technique의 참조 버전이 허브에서 사라졌을 때 경고.
+
+## 6. 라이프사이클
+
+```
+draft (.technique-draft/)   ──►  publish (technique/)   ──►  outdated (자동 플래그)
+     ▲                                                              │
+     └─── hub-refactor, hub-split ────────────────────────────────┘
+```
+
+- `.technique-draft/`: `.skills-draft/`·`.knowledge-draft/`와 동일한 로컬 준비 영역.
+- publish 시 `technique/{cat}/{slug}/` 로 이동.
+- **outdated 판정**: 참조하는 skill/knowledge의 major 버전이 올라가면 `index.json`에 `outdated: true` 마킹. `hub-precheck`이 리포트.
+
+## 7. Registry 통합
+
+`~/.claude/skills-hub/registry.json` 확장:
+
+```json
+{
+  "version": 3,                 // 2 → 3 (스키마 bump)
+  "skills": { ... },
+  "knowledge": { ... },
+  "techniques": {               // 신규 섹션
+    "<cat>/<slug>": {
+      "category": "workflow",
+      "scope": "global",
+      "path": "~/.claude/techniques/<cat>/<slug>/",
+      "installed_at": "2026-04-24",
+      "version": "0.1.0",
+      "source_commit": "<sha>",
+      "pinned": false,
+      "composes_snapshot": [    // 설치 시점의 실제 해석 결과
+        {"kind":"skill","ref":"workflow/autoplan","resolved_version":"1.2.3"},
+        {"kind":"knowledge","ref":"workflow/batch-pr-conflict-recovery","resolved_version":"0.1.0"}
+      ]
+    }
+  }
+}
+```
+
+`composes_snapshot`이 있어야 설치 이후 `loose` 모드에서도 "무엇이 깨졌는지" 사후 추적 가능.
+
+## 8. index.json 통합
+
+master / lite / category 인덱스에 `technique` 섹션 추가. 검색(`hub-find`)은 skill·knowledge·technique을 **동등하게** 매칭하되 결과 행에 `kind: technique` 배지를 붙여 구분.
+
+## 9. 검증 규칙 (publish 및 precheck)
+
+1. `composes[]` 의 모든 `ref`가 허브에 **실제 파일로** 존재 (frontmatter category와 무관, 디스크 경로로 확인).
+2. 각 `version` range가 허브의 해당 항목 semver와 **공집합 아님**.
+3. 순환 참조 금지: technique은 다른 technique을 참조하지 **않는다** (v0에서는 flat 1-depth만 허용. 중첩은 v0.2 이후 검토).
+4. `description` 필수 + ≤120자.
+5. `name`과 폴더명 일치.
+6. `verify.sh`가 있으면 exit code 0.
+7. `ref`는 kind 루트 기준 실제 경로 (예: `parallel-build-sequential-publish` 또는 `workflow/autoplan`).
+
+## 10. 슬래시 커맨드 (3단계에서 구현, 지금은 목록만)
+
+- `/hub-technique-compose <slug>` — 드래프트 작성 워크플로 (skill/knowledge 선택 → frontmatter 생성)
+- `/hub-technique-list` — 설치된 technique 목록
+- `/hub-technique-show <slug>` — 본문 + 구성 해설
+- `/hub-technique-install <ref>` — 리모트에서 설치
+- `/hub-technique-verify <slug>` — composes 상태 점검
+- 기존 `/hub-find`, `/hub-status`, `/hub-precheck`는 technique 섹션만 추가로 읽도록 **확장**
+
+## 11. 오픈 이슈
+
+- **Q1.** technique이 technique을 참조 허용할 것인가? → v0 금지. 과도한 결합과 순환 위험. v0.2에서 재검토.
+- **Q2.** `loose` 모드에서 lockfile 두는가? → `composes_snapshot`으로 충분하다는 판단. 별도 lockfile 없음.
+- **Q3.** example ↔ technique 연결? → example frontmatter에 `produced_by_technique: <ref>` 선택 필드 추가 제안 (본 초안 범위 밖, 별도 PR).
+- **Q4.** 카테고리 추가? → 불필요. 기존 카테고리 + tag로 수용.
+- **Q5.** (파일럿 2에서 발견) `composes[]`는 현재 **순서 없는 집합**. 선형 파이프라인은 `role`에 "phase-0-anchor" 같은 문자열로 우회 가능, 분기 결정트리는 본문 산문으로만 표현됨. v0에서는 수용 (role 자유문자열이 충분히 흡수). v0.2에서 정형 phase/branch DSL 도입 여부 재검토.
+
+## 12. 파일럿 후보 (2단계 입력)
+
+이 초안이 승인되면 다음 조합 중 하나로 첫 technique을 시작 제안:
+
+- `workflow/autoplan` + `workflow/batch-pr-conflict-recovery` → **"대량 PR 자동 생성 안전 패턴"**
+- 기타: 현재 설치된 `swagger-ai-optimization` 단독 → technique화 여부 자체가 테스트 케이스 (단일 스킬은 technique이 아님을 확인)
+
+---
+
+**다음 단계.** 이 초안에서 다음 3가지만 먼저 확정:
+1. 바인딩 기본값 (`loose` 제안)
+2. 중첩 금지 여부 (v0에서 금지 제안)
+3. 파일럿 후보 선택
+
+확정되면 2단계(파일럿 technique 1건 작성)로 진행.

--- a/technique/debug/root-cause-to-tdd-plan/TECHNIQUE.md
+++ b/technique/debug/root-cause-to-tdd-plan/TECHNIQUE.md
@@ -1,0 +1,146 @@
+---
+version: 0.1.0-draft
+name: root-cause-to-tdd-plan
+description: Bug report → systematic root-cause investigation → classified fix path → GitHub issue with TDD test plan
+category: debug
+tags:
+  - debug
+  - root-cause
+  - triage
+  - tdd
+  - github-issue
+  - decision-tree
+
+composes:
+  - kind: skill
+    ref: debug/investigate
+    version: "^1.0.0"
+    role: phase-orchestrator
+  - kind: skill
+    ref: debug/build-error-triage
+    version: "^1.0.0"
+    role: branch-build-error
+  - kind: skill
+    ref: debug/triage-issue
+    version: "*"
+    role: artifact-producer
+  - kind: knowledge
+    ref: pitfall/ai-guess-mark-and-review-checklist
+    version: "*"
+    role: hypothesis-guard
+
+binding: loose
+
+verify:
+  - "composes[].ref 모두 허브에 설치됨"
+  - "composes[].version range 가 설치본과 교차"
+  - "decision tree의 모든 종단이 GitHub 이슈 또는 명시적 non-fix 결정으로 귀결"
+---
+
+# Root Cause → TDD Fix Plan
+
+> 에러/버그 신고에서 시작해 **체계적 근본 원인 조사 → 원인 분류에 따른 경로 분기 → GitHub 이슈 + TDD 테스트 계획** 까지 가는 결정트리. 원인이 명확하지 않은 장애를 받아 fix 계획까지 안전하게 끌고 가기 위한 레시피.
+
+## When to use
+
+- 증상은 있으나 원인이 불명확한 버그/장애 신고
+- 근본 원인 없이 패치해버리는 함정을 피해야 하는 상황
+- 결과물로 **TDD 계획이 포함된 GitHub 이슈**가 필요할 때
+
+## When NOT to use
+
+- 원인이 자명한 1줄 수정 (오버헤드만 크다)
+- 배포 중 핫픽스 — 이 technique은 조사 우선이라 느리다
+- 재현 불가능한 일회성 장애 (별도 triage 패턴)
+
+## Decision tree (파일럿 1과 달리 선형 아님)
+
+```
+[bug report]
+    │
+    ▼
+┌─────────────────────────────────────────────┐
+│ skill: debug/investigate  (phase-orchestrator) │
+│ 4-phase loop: investigate → analyze →       │
+│ hypothesize → implement                      │
+└──────────────┬──────────────────────────────┘
+               │
+       ┌───────┴───────┐
+       │ hypothesize   │  ←── knowledge: ai-guess-mark-and-review-checklist
+       │ phase         │       (hypothesis-guard: 추측을 표식하고 재검토)
+       └───────┬───────┘
+               │ root cause classified
+               │
+       ┌───────┴────────────────────┐
+       ▼                            ▼
+ [build/compile error]         [runtime/logic bug]
+       │                            │
+       ▼                            ▼
+ skill: debug/build-error-triage    skill: debug/triage-issue
+ (branch-build-error)               (artifact-producer)
+       │                            │
+       └──────────────┬─────────────┘
+                      ▼
+         [GitHub issue + TDD test plan]
+```
+
+## Glue summary (technique의 순부가가치)
+
+구성 원자는 각각 독립적으로 존재한다. 이 technique이 **유일하게 추가**하는 것:
+
+| 추가 요소 | 위치 |
+|---|---|
+| 원자 간 라우팅 규칙 (build-error vs runtime-bug) | hypothesize phase 종료 시점 |
+| `investigate` hypothesize → `triage-issue` 승격 조건 | "근본 원인이 식별됨 AND 수정 범위가 명확" |
+| `ai-guess-mark-and-review-checklist` 적용 시점 | hypothesize phase 진입 시 모든 가설에 강제 적용 |
+| 출력 계약 | decision tree의 모든 종단은 "GitHub 이슈 + TDD 계획" 또는 "명시적 non-fix 결정" 둘 중 하나 |
+
+원자 스킬들은 "어떻게"를 제공하고, technique은 "언제·왜 이 스킬에서 저 스킬로 넘어가는가"를 제공한다.
+
+## Hypothesis-guard 통합 규칙
+
+`ai-guess-mark-and-review-checklist` 지식은 체크리스트다. 이 technique이 강제하는 것:
+
+- `investigate` hypothesize 단계에서 생성되는 **모든 가설**에 체크리스트 적용
+- 체크리스트 미통과 가설은 implement 단계로 진행 금지
+- 미통과 사유는 GitHub 이슈 본문의 "Rejected Hypotheses" 섹션에 기록 (감사 추적)
+
+## Output contract
+
+`triage-issue`는 GitHub 이슈를 만들지만 형식은 자유도가 있다. 이 technique은 필수 섹션을 고정:
+
+1. Symptom (사용자 관찰)
+2. Root Cause (investigate phase 결론)
+3. Rejected Hypotheses (체크리스트 미통과분)
+4. Fix Plan (TDD 순서: 실패 테스트 → 최소 구현 → 리팩터)
+5. Rollback 조건
+
+## Verification (draft)
+
+```bash
+#!/usr/bin/env bash
+set -e
+SKILLS_HUB="${SKILLS_HUB:-$HOME/.claude/skills-hub/remote}"
+for ref in \
+  "skills/debug/investigate/SKILL.md" \
+  "skills/debug/build-error-triage/SKILL.md" \
+  "skills/debug/triage-issue/SKILL.md" \
+  "knowledge/pitfall/ai-guess-mark-and-review-checklist.md"; do
+  test -f "$SKILLS_HUB/$ref" || { echo "MISSING: $ref"; exit 1; }
+done
+echo "OK"
+```
+
+## Known limitations (v0.1 draft)
+
+- 구성 원자 중 2개가 `0.1.0-draft` → technique도 draft 고정
+- 결정트리 분기가 v0 스키마에서는 **자연어 기술**로만 표현됨 (정형 DSL 없음). Phase 순서 모델링 이상의 구조는 아직 필요 없다고 판단
+- `loose` 바인딩 — `investigate`의 4-phase 구조가 major 변경되면 전체 재검증 필요
+- Runtime 원인이라도 특수 케이스(메모리 누수, 경쟁 상태)는 `triage-issue`의 TDD 범위를 벗어날 수 있음 — 이런 경우 별도 technique 필요 (v0.2 검토)
+
+## Provenance
+
+- Authored: 2026-04-24 (kjuhwa@nkia.co.kr)
+- Status: **pilot #2** for `technique/` schema v0.1 — decision-tree shape (vs pilot #1 linear pipeline)
+- Schema doc: `../../../technique-schema-draft.md`
+- Sibling pilot: `../../workflow/safe-bulk-pr-publishing/TECHNIQUE.md`

--- a/technique/workflow/safe-bulk-pr-publishing/TECHNIQUE.md
+++ b/technique/workflow/safe-bulk-pr-publishing/TECHNIQUE.md
@@ -1,0 +1,146 @@
+---
+version: 0.1.0-draft
+name: safe-bulk-pr-publishing
+description: Build N projects in parallel then publish them as many PRs safely — with rollback anchor, race-aware PR creation, and batch conflict recovery
+category: workflow
+tags:
+  - parallel
+  - bulk
+  - pull-request
+  - automation
+  - safety
+  - pr-flow
+
+composes:
+  - kind: skill
+    ref: parallel-build-sequential-publish       # NOTE: 카테고리 폴더 밖에 있음 (허브 불일치)
+    version: "^1.0.0"
+    role: orchestrator
+  - kind: skill
+    ref: workflow/rollback-anchor-tag-before-destructive-op
+    version: "*"
+    role: pre-flight-safety
+  - kind: knowledge
+    ref: workflow/batch-pr-conflict-recovery
+    version: "*"
+    role: failure-recovery
+  - kind: knowledge
+    ref: pitfall/gh-pr-create-race-with-auto-merge
+    version: "*"
+    role: known-pitfall
+
+binding: loose
+
+verify:
+  - "composes[].ref 모두 허브에 설치됨"
+  - "composes[].version range 가 설치본 semver와 교차"
+  - cmd: "./verify.sh"
+---
+
+# Safe Bulk PR Publishing
+
+> 대량으로 독립 산출물을 만들고 하나씩 PR로 올리는 파이프라인. 개별 스킬·지식은 이미 존재하지만, **어느 순서·어느 지점에 엮어야 안전한지**를 고정한 레시피.
+
+## When to use
+
+- 한 번에 10개 이상 독립 프로젝트·예제·마이그레이션을 만들고 각자 PR로 올려야 할 때
+- auto-merge가 켜진 저장소에 연속 PR을 밀어넣을 때
+- 과거 비슷한 흐름에서 카탈로그/인덱스 파일 충돌로 수십 개 PR이 막힌 적이 있을 때
+
+## When NOT to use
+
+- 단일 PR (오버헤드만 생긴다 — 구성 스킬을 개별적으로 써라)
+- PR이 서로 의존적일 때 (순서·병합 전략이 다름, 별도 technique 필요)
+
+## Phase sequence
+
+```
+[0] Anchor      → rollback-anchor-tag-before-destructive-op
+[1] Build       → parallel-build-sequential-publish (Build Phase)
+[2] Publish     → parallel-build-sequential-publish (Publish Phase)
+                  + gh-pr-create-race-with-auto-merge (detection in retry loop)
+[3] Recover?    → batch-pr-conflict-recovery  (on catalog-file conflict storm)
+```
+
+### [0] Pre-flight anchor (필수)
+
+`rollback-anchor-tag-before-destructive-op`를 **구성 스킬 그대로** 실행해 `backup/pre-bulk-pr-YYYYMMDD` 태그를 origin에 푸시. PR 본문에 롤백 커맨드를 미리 기록해 둔다.
+
+**technique이 추가하는 것**: 태그 슬러그 컨벤션을 `pre-bulk-pr-<date>`로 고정 (다른 technique과 충돌 없이 식별 가능).
+
+### [1] Build phase (병렬)
+
+`parallel-build-sequential-publish`의 Build 절차를 따른다. 각 executor는 **git 건드리지 말 것** — 파일만 만든다.
+
+**technique이 추가하는 것**: executor 프롬프트 말미에 다음 금지 규칙 추가:
+- `example/README.md` 같은 공유 카탈로그 파일을 **수정하지 말 것** (knowledge: batch-pr-conflict-recovery §Prevention)
+- 공유 파일 재생성은 Publish phase 끝에서 **한 번만** 수행
+
+### [2] Publish phase (순차, 레이스 감지)
+
+`parallel-build-sequential-publish`의 Publish 절차를 따르되, `gh pr create` 단계를 아래 패턴으로 감싼다:
+
+```bash
+if ! gh pr create ...; then
+  # 레이스 감지 (knowledge: gh-pr-create-race-with-auto-merge)
+  if git merge-base --is-ancestor "$BRANCH" origin/main; then
+    echo "auto-merge already picked it up — treat as success"
+  else
+    echo "genuine failure"; exit 1
+  fi
+fi
+```
+
+**technique이 추가하는 것**: 실패와 "이미 머지됨"을 구분하는 retry/skip 로직. 구성 원자 단위는 이 분기 로직을 갖고 있지 않다.
+
+### [3] Recovery (선택, 사고 시)
+
+카탈로그 파일 충돌이 연쇄로 터지면 즉시 PR 발행 중단하고 `batch-pr-conflict-recovery`의 복구 절차로 전환. 조건 판정:
+
+- 연속 3개 이상 PR이 `CONFLICTING` 상태로 나온다 → 복구 모드 스위치
+- 충돌 파일이 모두 동일(`example/README.md` 등) → 조건 충족
+
+**technique이 추가하는 것**: "언제 복구 모드로 전환할지" 판정 규칙 (원자 지식은 복구 방법만 기술, 전환 트리거는 비어 있음).
+
+## Glue summary (technique의 순부가가치)
+
+구성 원자가 이미 제공하는 것은 기술하지 않고, **오직 이 레시피가 더하는 것**만:
+
+| 추가 요소 | 위치 |
+|---|---|
+| 태그 슬러그 컨벤션 `pre-bulk-pr-<date>` | Phase 0 |
+| executor 금지 규칙 (공유 카탈로그 편집 금지) | Phase 1 |
+| 레이스 vs 실패 분기 로직 | Phase 2 |
+| 복구 모드 전환 트리거 규칙 (N≥3 CONFLICTING) | Phase 3 |
+
+## Verification (draft)
+
+`verify.sh`는 v0.1에서는 아래 셸 프라그먼트 수준으로만 제공:
+
+```bash
+#!/usr/bin/env bash
+# 구성 단위가 허브 설치 상태인지 검증
+set -e
+SKILLS_HUB="${SKILLS_HUB:-$HOME/.claude/skills-hub/remote}"
+for ref in \
+  "skills/parallel-build-sequential-publish/SKILL.md" \
+  "skills/workflow/rollback-anchor-tag-before-destructive-op/SKILL.md" \
+  "knowledge/workflow/batch-pr-conflict-recovery.md" \
+  "knowledge/pitfall/gh-pr-create-race-with-auto-merge.md"; do
+  test -f "$SKILLS_HUB/$ref" || { echo "MISSING: $ref"; exit 1; }
+done
+echo "OK"
+```
+
+## Known limitations (v0.1 draft)
+
+- 구성 원자 중 2개가 `0.1.0-draft` → technique도 draft 고정
+- v0에서 technique 중첩 금지이므로, 이 technique을 다른 technique이 참조 불가
+- `loose` 바인딩 — 구성 스킬 major 업데이트 시 재검증 필요
+- **허브 불일치 발견**: `parallel-build-sequential-publish`는 frontmatter `category: workflow`지만 실제 디스크 경로는 `skills/parallel-build-sequential-publish/`(카테고리 폴더 밖). 스키마의 `ref`는 **의미(category/slug)가 아니라 kind 루트 기준 실제 경로**를 써야 함. 이 발견은 스키마 초안 §4에 반영됨
+
+## Provenance
+
+- Authored: 2026-04-24 (kjuhwa@nkia.co.kr)
+- Status: pilot for `technique/` schema draft v0.1
+- Schema doc: `technique-schema-draft.md`


### PR DESCRIPTION
## Summary

- Adds `technique/` as a first-class middle layer between atomic `skills/`·`knowledge/` and complete `example/` artifacts
- v0.1 schema: `composes[]` references (not copies), `loose` binding default, no technique-to-technique nesting
- Two pilots validate schema generality across divergent shapes (linear pipeline + decision tree)
- Zero-disruption rollout: new directory + docs only; no `registry.json`/`index.json` changes in this PR

Full proposal: [`docs/rfc/technique-layer.md`](docs/rfc/technique-layer.md)
Schema spec: [`docs/rfc/technique-schema-draft.md`](docs/rfc/technique-schema-draft.md)

## Included

- `docs/rfc/technique-layer.md` — RFC body
- `docs/rfc/technique-schema-draft.md` — full schema v0.1
- `technique/workflow/safe-bulk-pr-publishing/TECHNIQUE.md` — pilot #1 (linear pipeline)
- `technique/debug/root-cause-to-tdd-plan/TECHNIQUE.md` — pilot #2 (decision tree)

## Test plan

- [ ] Reviewer: read `docs/rfc/technique-layer.md`
- [ ] Reviewer: verify pilot #1 `composes[]` resolves against current hub (4 atoms: `skills/parallel-build-sequential-publish`, `skills/workflow/rollback-anchor-tag-before-destructive-op`, `knowledge/workflow/batch-pr-conflict-recovery`, `knowledge/pitfall/gh-pr-create-race-with-auto-merge`)
- [ ] Reviewer: verify pilot #2 `composes[]` resolves (4 atoms: `skills/debug/investigate`, `skills/debug/build-error-triage`, `skills/debug/triage-issue`, `knowledge/pitfall/ai-guess-mark-and-review-checklist`)
- [ ] Reviewer: decide on §7 open questions (nesting, `role` taxonomy, example ↔ technique link, verify.sh portability, path/category cleanup)
- [ ] Decision: accept (merges with zero enforcement) OR request follow-ups

## Follow-up PRs (after merge)

- `bootstrap/commands/hub-technique-{compose,verify,list,show}.md` — already authored locally, validated against both pilots
- Extend `/hub-find` with `--kind technique`
- Bump `registry.json` to schema v3 (once commands ship)

## Unexpected finding (already folded into spec)

Pilot #1 authoring discovered `skills/parallel-build-sequential-publish/` lives at the root of `skills/` despite `category: workflow` in frontmatter. Schema now defines `ref` as kind-root-relative physical path, not semantic `{category}/{slug}`. See RFC §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)