### PR TITLE
bootstrap: add 5 technique-layer commands

### DIFF
--- a/bootstrap/commands/hub-find-techniques.md
+++ b/bootstrap/commands/hub-find-techniques.md
@@ -1,0 +1,37 @@
+---
+description: Search remote hub for techniques (middle-layer composition recipes). Additive to /hub-find — does not modify it.
+argument-hint: <keyword> [--category <cat>] [--tag <tag>]
+---
+
+# /hub-find-techniques $ARGUMENTS
+
+Keyword search across techniques in `~/.claude/skills-hub/remote/technique/` (when present) and the local drafts at `.technique-draft/` (project scope).
+
+**Why this is separate from `/hub-find`**: the canonical `/hub-find` has not yet been extended with a `technique` kind (see RFC `technique-rfc.md` §5). This command fills the gap **additively** so users can find techniques without waiting on the upstream extension. Once `/hub-find --kind technique` ships, this command can be removed.
+
+## Steps
+
+1. Parse `<keyword>` (required) and optional `--category`/`--tag`.
+2. Gather candidate files:
+   - `~/.claude/skills-hub/remote/technique/**/TECHNIQUE.md` (remote cache, if the directory exists)
+   - `./.technique-draft/**/TECHNIQUE.md` (project scope)
+3. For each candidate, parse frontmatter: `name`, `description`, `category`, `tags`, `composes[]`.
+4. Match keyword (case-insensitive) against: name, description, tags, and each `composes[].ref`. A hit on an atom's ref means "this technique uses something that matches your keyword" — include with an `[atom-hit]` annotation.
+5. Apply `--category`/`--tag` filters.
+6. Render top results:
+   ```
+   STATE    | CATEGORY | NAME                     | ATOMS            | WHY
+   draft    | workflow | safe-bulk-pr-publishing  | 2 skill + 2 know | keyword in description
+   draft    | debug    | root-cause-to-tdd-plan   | 3 skill + 1 know | [atom-hit] debug/investigate
+   ```
+7. If no technique directory exists remotely AND no drafts locally, print: "no techniques on this machine — see /hub-sync or author one with /hub-technique-compose".
+
+## Rules
+
+- Read-only. No mutation, no remote fetch.
+- If the remote cache lacks a `technique/` directory (current state pre-RFC merge), silently skip that root — do not error.
+- Hit ranking: exact name match > tag hit > description hit > atom-ref hit. Stable ordering within ties (alphabetical).
+
+## Relationship to /hub-find
+
+This is a **temporary additive bridge**. Do not duplicate `/hub-find`'s broader search behavior (skills, knowledge, examples). When upstream `/hub-find` learns `--kind technique`, deprecate and remove this command.

--- a/bootstrap/commands/hub-technique-compose.md
+++ b/bootstrap/commands/hub-technique-compose.md
@@ -1,0 +1,95 @@
+---
+description: Interactively compose a new technique draft from installed skills/knowledge, then verify it against the v0.1 schema
+argument-hint: <slug> [--category <cat>] [--from <existing-slug>]
+---
+
+# /hub-technique-compose $ARGUMENTS
+
+Authoring workflow for the `technique/` middle layer. Produces a `.technique-draft/<category>/<slug>/TECHNIQUE.md` scaffolded from user-selected atoms, then runs `/hub-technique-verify` to confirm the draft passes v0.1 schema rules before handing control back.
+
+## Input
+
+- **`<slug>`** (required): technique folder name. Must be kebab-case, unique within the draft root (`.technique-draft/`) AND the installed root (`~/.claude/techniques/`).
+- `--category <cat>`: one of `CATEGORIES.md` values. If omitted, ask.
+- `--from <existing-slug>`: clone frontmatter + composes of an existing technique as starting point. User still confirms each field.
+
+## Steps
+
+1. **Validate slug**:
+   - Fail if `.technique-draft/**/<slug>/` or `~/.claude/techniques/**/<slug>/` already exists.
+   - Fail if slug is not kebab-case (`^[a-z][a-z0-9-]*$`).
+
+2. **Collect frontmatter** (AskUserQuestion per field, defaulting sensibly):
+   - `description` — remind user ≤120 chars. If exceeded, warn and let them revise or accept warning.
+   - `category` — offer picker from `CATEGORIES.md` if not provided via flag.
+   - `tags` — comma-separated; dedupe.
+   - `binding` — default `loose`. Explain tradeoff before asking.
+
+3. **Pick composes[]** (iterative loop, minimum 2 atoms required):
+   - Ask user: "search for atom to add? (or `done` to finish)".
+   - On keyword: delegate to `/hub-find` flow, show top N results with `kind` badge.
+   - User picks a row; prompt for:
+     - `role`: free-text label for this atom's job in the composition (e.g. `orchestrator`, `failure-recovery`).
+     - `version`: default `^<major>.<minor>.0` for stable atoms, `"*"` for `*-draft` atoms. Let user override.
+   - Record the ref as **kind-root-relative physical path** (verify the real file exists on disk before accepting).
+   - After each add, show running list.
+   - Reject: atom whose `kind` is `technique` (v0 nesting ban).
+   - Stop condition: user says `done` AND `composes[].length >= 2`. If `< 2`, warn: "a technique with fewer than 2 atoms is just a skill — continue anyway?".
+
+4. **Optional verify hook**:
+   - Ask: "scaffold `verify.sh`? (yes/no)".
+   - If yes, write a bash check that re-asserts each `composes[].ref` file exists. Same template as §11 of `technique-schema-draft.md`.
+
+5. **Write the file**:
+   - Target: `.technique-draft/<category>/<slug>/TECHNIQUE.md`.
+   - Frontmatter: version `0.1.0-draft`, name = slug, all collected fields.
+   - Body template:
+     ```
+     # <Title Case of slug>
+
+     > Short positioning paragraph. Fill in purpose.
+
+     ## When to use
+     - ...
+
+     ## When NOT to use
+     - ...
+
+     ## Phase sequence
+     (describe how the composes[] are invoked in order)
+
+     ## Glue summary
+     | 추가 요소 | 위치 |
+     | --- | --- |
+
+     ## Known limitations
+     - ...
+     ```
+   - If `--from <existing-slug>` was passed, seed body from that file and mark sections TODO.
+
+6. **Immediate verification**:
+   - Run `/hub-technique-verify <slug>`.
+   - If FAIL, print the verifier output and offer: re-open for edit, revert (delete the draft folder), or leave as-is.
+   - If PASS/WARN, print location and next-step hint:
+     ```
+     DRAFT CREATED: .technique-draft/<category>/<slug>/TECHNIQUE.md
+     Next: /hub-technique-show <slug>
+     Or:   iterate on the body, then re-run /hub-technique-verify <slug>
+     ```
+
+## Rules
+
+- **Never write to** `~/.claude/techniques/` — that's the installed root, reserved for publish flow (not in v0.1 scope).
+- **Never call remote**. Authoring uses only the already-synced `~/.claude/skills-hub/remote/`. Stale cache → warn and suggest `/hub-sync`.
+- **Never silently reject draft atoms**. If an atom is `*-draft`, prompt: "this atom is still in draft — compose anyway? (y/n)" — don't assume.
+- Authoring is a **write pass**; verification is a **separate pass** (step 6). Do not collapse them — keep the separation so the user sees the draft before it gets validated.
+
+## Out of scope (v0.1)
+
+- Publishing to remote hub (`/hub-technique-publish` — later).
+- Nested technique composition (v0 forbids).
+- Multi-file techniques beyond TECHNIQUE.md + optional verify.sh + resources/.
+
+## Why exists
+
+`/hub-technique-verify` is a gatekeeper but you need a thing to gate. Without compose, every draft is hand-crafted from memory of the schema — high friction, easy to get ref paths wrong (see pilot's discovery that category ≠ path). Compose enforces path correctness at write time instead of at verify time.

--- a/bootstrap/commands/hub-technique-list.md
+++ b/bootstrap/commands/hub-technique-list.md
@@ -1,0 +1,43 @@
+---
+description: List locally installed and drafted techniques (skills-hub middle layer)
+argument-hint: [--drafts-only | --installed-only] [--category <cat>]
+---
+
+# /hub-technique-list $ARGUMENTS
+
+Report techniques (composition recipes) present on disk. Techniques live at:
+
+- **Installed**: `~/.claude/techniques/<category>/<slug>/TECHNIQUE.md`
+- **Drafts**: `.technique-draft/<category>/<slug>/TECHNIQUE.md` (project-local)
+
+## Steps
+
+1. Parse args. Default: list both drafts and installed.
+2. Scan the two roots:
+   - `~/.claude/techniques/**/TECHNIQUE.md`
+   - `./.technique-draft/**/TECHNIQUE.md`
+3. For each file, read the frontmatter and extract:
+   `name`, `version`, `category`, `binding`, `composes[]` (count + kinds), `description`.
+4. Cross-reference `~/.claude/skills-hub/registry.json` → `techniques` section (if the key exists in schema v3):
+   - Present on disk + tracked → normal row.
+   - Present + untracked → `[UNTRACKED]`.
+   - Tracked + missing on disk → `[ORPHAN REGISTRY]` (offer removal).
+5. Apply filters (`--category`, `--drafts-only`, `--installed-only`).
+6. Render as a stable text table:
+   ```
+   STATE    | CATEGORY | NAME                       | VERSION       | BIND   | COMPOSES
+   draft    | workflow | safe-bulk-pr-publishing    | 0.1.0-draft   | loose  | 2 skill + 2 knowledge
+   install  | workflow | other-technique            | 1.0.0         | pinned | 3 skill + 1 knowledge
+   ```
+7. Trailing summary: `<N> drafts, <M> installed`.
+
+## Rules
+
+- Read-only. No registry mutation without explicit user approval.
+- If neither root exists, print "no techniques found" — **not** an error.
+- When registry lacks the `techniques` key, treat as empty (schema pre-v3 compatibility).
+- This is a schema-draft pilot command. When the hub formalizes technique support, this file gets superseded by the canonical one.
+
+## Why exists
+
+The `technique/` layer is the middle tier between atomic skills/knowledge and complete examples. Without a list command, drafts accumulate invisibly.

--- a/bootstrap/commands/hub-technique-show.md
+++ b/bootstrap/commands/hub-technique-show.md
@@ -1,0 +1,44 @@
+---
+description: Show a technique's frontmatter, body, and expanded composition (inline descriptions of referenced skills/knowledge)
+argument-hint: <slug> [--raw]
+---
+
+# /hub-technique-show $ARGUMENTS
+
+Display one technique with its composition expanded in-place — so the reader can judge the recipe without jumping across 4+ files.
+
+## Input resolution
+
+Same as `/hub-technique-verify`: first match in `./.technique-draft/**/<slug>/TECHNIQUE.md`, then `~/.claude/techniques/**/<slug>/TECHNIQUE.md`.
+
+## Steps
+
+1. Read the technique file.
+2. Print the frontmatter block verbatim.
+3. For each `composes[]` entry:
+   - Resolve the path:
+     - `kind: skill` → `~/.claude/skills-hub/remote/skills/<ref>/SKILL.md`
+     - `kind: knowledge` → `~/.claude/skills-hub/remote/knowledge/<ref>.md`
+   - Read the referenced file's frontmatter → extract `name`, `version`, `description` (or `summary` for knowledge).
+   - Print one-line annotated entry:
+     ```
+     [skill] parallel-build-sequential-publish v1.0.0  (role: orchestrator)
+             → Build multiple independent projects in parallel... then publish ... sequentially
+     ```
+   - If the ref resolves to a missing file, mark `[MISSING]` in red equivalent and continue.
+4. Print the technique body verbatim (everything after frontmatter).
+5. Trailing status line: `<N> atoms resolved, <M> missing`.
+
+## Flags
+
+- `--raw`: skip composition expansion; print the file as-is. Use when you want the exact authoring content without enrichment.
+
+## Rules
+
+- Read-only.
+- Never modify the technique. For edits, open the file directly.
+- Never fetch remote. If atom files are missing, the show command surfaces that fact — does not try to `/hub-sync`.
+
+## Why exists
+
+A technique's value is in its **composition** — but the composition is references, not content. Reading the technique alone tells you "uses X and Y"; this command also tells you what X and Y *are*, so you can evaluate the recipe in one screen.

--- a/bootstrap/commands/hub-technique-verify.md
+++ b/bootstrap/commands/hub-technique-verify.md
@@ -1,0 +1,63 @@
+---
+description: Validate a technique against the v0.1 schema — composes exist, versions intersect, no nesting, frontmatter well-formed
+argument-hint: <slug> | --all [--strict]
+---
+
+# /hub-technique-verify $ARGUMENTS
+
+Run the schema-draft §9 verification rules against one technique (or all). This is the **canonical gatekeeper** for the `technique/` layer — if this passes, the technique is consistent with the v0.1 schema.
+
+## Input resolution
+
+- `<slug>`: locate first match in `./.technique-draft/**/<slug>/TECHNIQUE.md`, then `~/.claude/techniques/**/<slug>/TECHNIQUE.md`. Ambiguity → list matches and abort.
+- `--all`: verify every technique in both locations.
+
+## Checks (from schema-draft §9)
+
+For each technique:
+
+1. **Frontmatter well-formed**: YAML parses; required keys present: `version`, `name`, `description`, `category`, `composes`.
+2. **Name matches folder**: `name` == containing directory name.
+3. **Description length**: ≤ 120 chars. (Warning only unless `--strict`.)
+4. **`composes[]` references exist on disk**:
+   - `kind: skill` → `~/.claude/skills-hub/remote/skills/<ref>/SKILL.md`
+   - `kind: knowledge` → `~/.claude/skills-hub/remote/knowledge/<ref>.md`
+   - `ref` is **kind-root-relative physical path** (not `{category}/{slug}` semantic form). A ref may or may not include a category segment — verify the actual file.
+5. **Version range intersection**: parse each atom's frontmatter `version`; confirm the technique's `composes[i].version` (semver range) intersects. When the atom is `*-draft`, skip range check and emit a `DRAFT` note.
+6. **No technique-to-technique references**: `kind` must be `skill` or `knowledge` only. `kind: technique` is rejected in v0.
+7. **`verify.sh` hook**: if the technique folder has an executable `verify.sh`, run it and require exit 0. On non-POSIX shells, fall back to `bash verify.sh`.
+8. **Binding consistency**: if `binding: pinned`, every `composes[].version` must be an exact version (not a range, no `*`).
+
+## Output format
+
+Per technique:
+```
+TECHNIQUE: <category>/<slug>  (v<version>, binding=<binding>)
+  [PASS]  name matches folder
+  [PASS]  frontmatter well-formed
+  [WARN]  description 137 chars (>120)
+  [PASS]  composes[0] parallel-build-sequential-publish → skills/parallel-build-sequential-publish/SKILL.md
+  [FAIL]  composes[1] missing: skills/workflow/<slug>/SKILL.md
+  [NOTE]  composes[2] skipped version range (atom is 0.1.0-draft)
+  [PASS]  no technique nesting
+  [PASS]  verify.sh exit 0
+RESULT: FAIL (1 error, 1 warning)
+```
+
+With `--all`, end with an aggregate: `<K> techniques verified: <pass> pass, <warn> warn, <fail> fail`.
+
+## Exit behavior
+
+- Any `FAIL` → command reports overall failure (exit-equivalent in agent output).
+- `WARN` only → pass with advisory.
+- `--strict` upgrades `WARN` to `FAIL`.
+
+## Rules
+
+- Read-only. No mutation.
+- Does **not** fetch from remote — assumes `~/.claude/skills-hub/remote/` is current. If stale, user should run `/hub-sync` first. Warn when `remote/` is older than 7 days.
+- Never auto-fix. This is the gatekeeper; authoring is separate (`/hub-technique-compose`, not yet implemented).
+
+## Why exists
+
+The technique schema is useless without a tool that enforces it. Every rule in schema-draft §9 is exercised here. If a rule cannot be checked by this command, the rule is not real.


### PR DESCRIPTION
## Summary

Ships the 5 slash commands for the `technique/` middle layer merged in #1058.

- `/hub-technique-compose` — interactive authoring
- `/hub-technique-verify` — schema §9 gate
- `/hub-technique-list` — local readout
- `/hub-technique-show` — body + composition expansion
- `/hub-find-techniques` — additive bridge (deprecates once `/hub-find --kind technique` lands)

All 5 files are **new** under `bootstrap/commands/`. No existing commands touched.

## Validation

Already running locally under `~/.claude/commands/` against both pilots:

- `technique/workflow/safe-bulk-pr-publishing` (linear pipeline)
- `technique/debug/root-cause-to-tdd-plan` (decision tree)

`/hub-technique-verify` correctly triggers §9 rules — emits WARN on pilot #1's 143-char description, PASS on pilot #2's 110-char description.

## Test plan

- [ ] Reviewer: skim each command file for clarity
- [ ] Reviewer: confirm `/hub-technique-verify` rules match RFC §9
- [ ] After merge: users get all 5 via `/hub-commands-update`

## Follow-ups (in order)

- Extend `/hub-find` with `--kind technique` (then remove `/hub-find-techniques`)
- Bump `registry.json` to schema v3, extend `/hub-list`/`/hub-status`/`/hub-precheck`
- Cleanup: move `skills/parallel-build-sequential-publish/` under `workflow/` (RFC §4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)