### PR TITLE
feat: /hub-find --kind technique + technique/ indexing

### DIFF
--- a/bootstrap/commands/hub-find.md
+++ b/bootstrap/commands/hub-find.md
@@ -1,6 +1,6 @@
 ---
 description: 스킬 허브 전체 코퍼스에서 키워드 기반 top-N 검색 (한/영 동의어 포함)
-argument-hint: <query> [-n N] [--kind skill|knowledge] [--category CAT] [--html --out FILE]
+argument-hint: <query> [-n N] [--kind skill|knowledge|technique] [--category CAT] [--html --out FILE]
 ---
 
 # /hub-find $ARGUMENTS
@@ -24,6 +24,7 @@ PYTHONIOENCODING=utf-8 py -3 ~/.claude/skills-hub/tools/hub_search.py $ARGUMENTS
 - `/hub-find 카프카 이벤트`
 - `/hub-find websocket -n 20 --kind skill`
 - `/hub-find rate-limit --category decision`
+- `/hub-find "pr publish" --kind technique`
 - `/hub-find 보안 --json`
 - `/hub-find 인증 --html --out /tmp/auth.html`
 

--- a/bootstrap/tools/_rebuild_index_json.py
+++ b/bootstrap/tools/_rebuild_index_json.py
@@ -1,4 +1,4 @@
-"""Rebuild `index.json` from filesystem (skills/**/SKILL.md + knowledge/**/*.md).
+"""Rebuild `index.json` from filesystem (skills/**/SKILL.md + knowledge/**/*.md + technique/**/TECHNIQUE.md).
 
 Deterministic flat catalog regeneration for the corpus. Called by
 `/hub-publish-all` before push so newly added skills/knowledge become
@@ -107,6 +107,29 @@ def entry_from_knowledge(root: Path, md: Path) -> dict | None:
     }
 
 
+def entry_from_technique(root: Path, tech_md: Path) -> dict | None:
+    fm = parse_frontmatter(tech_md.read_text(encoding="utf-8", errors="replace"))
+    if _is_archived(fm):
+        return None
+    rel = tech_md.relative_to(root).as_posix()
+    path_dir = "/".join(rel.split("/")[:-1])
+    composes = fm.get("composes") or []
+    return {
+        "kind": "technique",
+        "name": fm.get("name", ""),
+        "slug": fm.get("name", ""),
+        "category": fm.get("category", ""),
+        "description": fm.get("description", ""),
+        "tags": fm.get("tags", []),
+        "triggers": fm.get("triggers", []),
+        "version": fm.get("version", ""),
+        "path": path_dir,
+        "has_content": True,
+        "composes_count": len(composes) if isinstance(composes, list) else 0,
+        "binding": fm.get("binding", "loose"),
+    }
+
+
 def preserve_extras(existing_entries: list[dict], key: str) -> dict:
     """Keep non-standard keys (like source_project, installed_at) from old index."""
     out: dict = {}
@@ -154,6 +177,18 @@ def main() -> int:
     if kn_root.exists():
         for p in sorted(kn_root.rglob("*.md")):
             e = entry_from_knowledge(root, p)
+            if e is None:  # archived
+                continue
+            key = (e["kind"], e["path"])
+            if key in extras:
+                e.update(extras[key])
+            entries.append(e)
+
+    # Techniques: one folder per technique with TECHNIQUE.md inside.
+    tech_root = root / "technique"
+    if tech_root.exists():
+        for p in sorted(tech_root.rglob("TECHNIQUE.md")):
+            e = entry_from_technique(root, p)
             if e is None:  # archived
                 continue
             key = (e["kind"], e["path"])

--- a/bootstrap/tools/hub_search.py
+++ b/bootstrap/tools/hub_search.py
@@ -23,6 +23,7 @@ v2 변경점:
     py hub_search.py "스프링 세션"                    # 한글 쿼리 OK
     py hub_search.py -n 20 "websocket"
     py hub_search.py --kind skill "lock"
+    py hub_search.py --kind technique "pr publish"
     py hub_search.py --category pitfall "mongo"
     py hub_search.py --json "rate limit"
     py hub_search.py --synonyms "카프카"              # 확장 경로 점검
@@ -390,7 +391,7 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("query", nargs="+", help="키워드 (여러 개 가능)")
     ap.add_argument("-n", "--top", type=int, default=10)
-    ap.add_argument("--kind", choices=("skill", "knowledge"), default=None)
+    ap.add_argument("--kind", choices=("skill", "knowledge", "technique"), default=None)
     ap.add_argument("--category", default=None)
     ap.add_argument("--json", dest="as_json", action="store_true")
     ap.add_argument("--html", dest="as_html", action="store_true",


### PR DESCRIPTION
## Summary

Extends `/hub-find` and the index rebuilder to recognize the `technique/` middle layer merged in #1058.

- `hub_search.py`: `--kind` now accepts `technique` alongside `skill`/`knowledge`
- `_rebuild_index_json.py`: walks `technique/**/TECHNIQUE.md`, produces index entries with the standard fields plus `composes_count` and `binding`
- `hub-find.md`: argument-hint and example list updated

## Test plan

- [ ] Reviewer: `py -3 ~/.claude/skills-hub/tools/_rebuild_index_json.py --dry-run` — confirm technique entries appear with kind=technique
- [ ] Reviewer: `py -3 ~/.claude/skills-hub/tools/hub_search.py --kind technique "pr"` — returns the two pilot techniques
- [ ] Index rebuild post-merge picks up new entries (standard flow)

## Deferred to follow-up PRs

- Deprecation note on `/hub-find-techniques` — depends on #1059 landing first
- `/hub-list`, `/hub-status`, `/hub-precheck` extension for technique kind (item 3 of the follow-up sequence)
- Cleanup of `skills/parallel-build-sequential-publish/` path/category mismatch (item 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)