### PR TITLE
fix(technique): translate pilot bodies and schema draft to English

### DIFF
--- a/docs/rfc/technique-schema-draft.md
+++ b/docs/rfc/technique-schema-draft.md
@@ -5,13 +5,13 @@ author: kjuhwa@nkia.co.kr
 date: 2026-04-24
 ---
 
-# `technique/` — 스킬 허브 중간 계층 설계 초안
+# `technique/` — Middle-Layer Schema Draft (v0.1)
 
-## 1. 왜 필요한가
+## 1. Why
 
-현재 허브는 **원자 단위(skill, knowledge)** 와 **완성 산출물(example)** 두 극단만 존재한다. 실전에서는 보통 2~N개 스킬·지식을 특정 순서·조건으로 조합해야 하나의 결과가 나온다. 이 조합 자체를 재사용 가능한 단위로 고정할 수 있는 저장소가 없어, 사용자는 매번 스킬·지식을 수동으로 골라 맞춰야 한다.
+Today the hub has **atomic units** (`skills/`, `knowledge/`) and **finished artifacts** (`example/`). In practice, most real work requires combining 2–N atoms in a specific order or with specific conditions to produce a result. The combination itself cannot be stored as a reusable unit anywhere, so users hand-assemble the same sets over and over.
 
-`technique/`는 이 **중간 레이어**를 담당한다:
+`technique/` is the missing **middle layer**:
 
 ```
 knowledge  ─┐
@@ -19,103 +19,103 @@ skill      ─┼──►  technique  ──►  example (instance)
 research   ─┘
 ```
 
-- technique은 skill/knowledge를 **재배치하지 않고 참조만** 한다 (중복 저장 금지).
-- 부족분은 `hub-research`로 외부 자료를 당겨 technique 본문에 녹인다.
-- example은 technique을 실행해 만든 **1회성 결과물**이며, technique은 **재현 가능한 레시피**다.
+- A technique **references** skills/knowledge without duplicating them (no content copy).
+- Gaps in coverage are filled by `hub-research` and folded into the technique body.
+- An `example` is a one-off artifact produced by executing a technique; the technique is the **reproducible recipe**.
 
-## 2. 기존 개념과의 경계
+## 2. Boundary with existing concepts
 
-| 개념 | 위치 | 단위 | 재사용성 | 구성 |
+| Concept | Location | Unit | Reusability | Composition |
 |---|---|---|---|---|
-| skill | `skills/{cat}/{slug}/SKILL.md` | 원자 절차 | 높음 | 단일 |
-| knowledge | `knowledge/{cat}/{slug}.md` | 원자 사실/교훈 | 높음 | 단일 |
-| **technique** | `technique/{cat}/{slug}/TECHNIQUE.md` | **조합 레시피** | **높음** | **복수 참조** |
-| example | `example/{cat}/{slug}/` | 완성 산출물 | 낮음 (데모) | 산출물만 |
-| hub-merge | 커맨드 | 병합 (복사·흡수) | — | 1회성 |
+| skill | `skills/{cat}/{slug}/SKILL.md` | atomic procedure | high | single |
+| knowledge | `knowledge/{cat}/{slug}.md` | atomic fact/lesson | high | single |
+| **technique** | `technique/{cat}/{slug}/TECHNIQUE.md` | **composition recipe** | **high** | **multiple references** |
+| example | `example/{cat}/{slug}/` | finished artifact | low (demo) | artifact only |
+| hub-merge | command | merge (copy/absorb) | — | one-time |
 
-`hub-merge`와의 차이: merge는 원본 스킬을 **흡수·소멸**시키지만, technique은 원본을 **살려둔 채 참조**한다. 원자 단위의 독립성이 유지되므로 다른 technique에서 재사용할 수 있다.
+Difference from `hub-merge`: merge **absorbs and destroys** the source skills; a technique leaves the atoms intact and only **references** them. That preserves atom independence so other techniques can reuse the same atoms.
 
-## 3. 디렉토리 & 파일 레이아웃
+## 3. Directory and file layout
 
 ```
 technique/
   <category>/
     <slug>/
-      TECHNIQUE.md         ← 메타 + 본문 (필수)
-      verify.sh            ← 합성 검증 스크립트 (선택)
-      resources/           ← 보조 자산 (선택, 이미지·샘플 등)
+      TECHNIQUE.md         ← frontmatter + body (required)
+      verify.sh            ← composition check script (optional)
+      resources/           ← auxiliary assets (optional: images, samples)
 ```
 
-카테고리는 `CATEGORIES.md`의 기존 목록을 재사용. technique 전용 신규 카테고리는 만들지 않는다 (tag로 해결).
+Categories reuse the existing `CATEGORIES.md`. No new categories are introduced for techniques (use tags for fine-grained attributes).
 
-## 4. Frontmatter 스키마
+## 4. Frontmatter schema
 
 ```yaml
 ---
-version: 0.1.0                  # semver, draft-0 허용
-name: <slug>                    # 디렉토리명과 동일
-description: <한 줄, ≤120자>    # 언제 써야 하는지 1문장
-category: <CATEGORIES.md 값>
+version: 0.1.0                  # semver, draft-0 allowed
+name: <slug>                    # must match the directory name
+description: <single line, ≤120 chars>   # when to use it, 1 sentence
+category: <one of CATEGORIES.md>
 tags: [<string>, ...]
 
-composes:                       # 핵심: 어떤 원자 단위를 묶는가
+composes:                       # the core field: which atomic units are combined
   - kind: skill                 # skill | knowledge
-    ref: workflow/autoplan      # kind 루트 기준 실제 디스크 경로 (폴더 슬러그)
-                                # ※ frontmatter category와 불일치할 수 있으므로
-                                #   '실제 경로'를 쓴다 (파일럿에서 발견)
-    version: "^1.0.0"           # semver range (loose) 또는 정확값 (pinned)
-    role: orchestrator          # 이 조합 내 역할 (자유 문자열)
+    ref: workflow/autoplan      # kind-root-relative physical path
+                                # ※ can diverge from frontmatter category,
+                                #   so use the actual path (pilot finding)
+    version: "^1.0.0"           # semver range (loose) or exact value (pinned)
+    role: orchestrator          # this atom's job in the composition (free text)
   - kind: knowledge
     ref: workflow/batch-pr-conflict-recovery
-    version: "*"                # 최신 허용
+    version: "*"                # any version allowed
     role: failure-mode
 
-requires_research:              # 외부 보강 필요 시 (선택)
+requires_research:              # optional: external research gaps
   - topic: "GitHub GraphQL rate limit"
-    rationale: "hub-research로 최신 한도 확인 필요"
+    rationale: "hub-research needed to confirm current quota"
 
-binding: loose                  # loose (기본) | pinned
-                                #   loose: version range 만족하면 재사용
-                                #   pinned: 정확히 그 커밋/버전만 유효
+binding: loose                  # loose (default) | pinned
+                                #   loose: passes as long as the version range is satisfied
+                                #   pinned: exactly that version/commit only
 
-verify:                         # 사용 시점 건전성 체크 (선택)
-  - "모든 composes.ref 가 현재 설치되어 있는가"
-  - "composes[].version range 가 설치본과 교차하는가"
-  - cmd: "./verify.sh"          # 커스텀 검증
+verify:                         # optional runtime sanity checks
+  - "every composes.ref is currently installed"
+  - "every composes[].version range intersects the installed version"
+  - cmd: "./verify.sh"          # custom verification
 ---
 ```
 
-## 5. 바인딩 모드 (핵심 트레이드오프)
+## 5. Binding mode (the key tradeoff)
 
-| 모드 | 동작 | 장점 | 단점 |
+| Mode | Behaviour | Pros | Cons |
 |---|---|---|---|
-| `loose` (기본) | semver range로 참조, 사용 시점에 설치본 재검증 | 하위 스킬 업데이트를 자동 흡수 | 하위 breaking 시 technique 재검증 필요 |
-| `pinned` | 특정 버전(또는 commit SHA)에 고정 | 재현성 100% | 하위 스킬 오래되면 유지비 증가 |
+| `loose` (default) | references by semver range, re-validates installed version at use time | absorbs downstream skill updates automatically | downstream breaking changes require technique re-verification |
+| `pinned` | locked to a specific version (or commit SHA) | 100 % reproducibility | grows stale as downstream skills evolve |
 
-**권장**: 초기 모든 technique은 `loose`로 시작. 프로덕션/감사 경로에만 `pinned`. `hub-precheck`이 `pinned` technique의 참조 버전이 허브에서 사라졌을 때 경고.
+**Recommendation**: start every technique at `loose`. Reserve `pinned` for production/audit paths. `hub-precheck` should warn when a `pinned` technique references a version that no longer exists in the hub.
 
-## 6. 라이프사이클
+## 6. Lifecycle
 
 ```
-draft (.technique-draft/)   ──►  publish (technique/)   ──►  outdated (자동 플래그)
+draft (.technique-draft/)   ──►  publish (technique/)   ──►  outdated (auto-flagged)
      ▲                                                              │
      └─── hub-refactor, hub-split ────────────────────────────────┘
 ```
 
-- `.technique-draft/`: `.skills-draft/`·`.knowledge-draft/`와 동일한 로컬 준비 영역.
-- publish 시 `technique/{cat}/{slug}/` 로 이동.
-- **outdated 판정**: 참조하는 skill/knowledge의 major 버전이 올라가면 `index.json`에 `outdated: true` 마킹. `hub-precheck`이 리포트.
+- `.technique-draft/`: local staging area, mirroring `.skills-draft/`/`.knowledge-draft/`.
+- Publish promotes to `technique/{cat}/{slug}/`.
+- **Outdated detection**: when a referenced skill/knowledge has a new major version, the technique is tagged `outdated: true` in `index.json`. `hub-precheck` surfaces the report.
 
-## 7. Registry 통합
+## 7. Registry integration
 
-`~/.claude/skills-hub/registry.json` 확장:
+`~/.claude/skills-hub/registry.json` extension:
 
 ```json
 {
-  "version": 3,                 // 2 → 3 (스키마 bump)
+  "version": 3,                 // bump 2 → 3
   "skills": { ... },
   "knowledge": { ... },
-  "techniques": {               // 신규 섹션
+  "techniques": {               // new section
     "<cat>/<slug>": {
       "category": "workflow",
       "scope": "global",
@@ -124,7 +124,7 @@ draft (.technique-draft/)   ──►  publish (technique/)   ──►  outdate
       "version": "0.1.0",
       "source_commit": "<sha>",
       "pinned": false,
-      "composes_snapshot": [    // 설치 시점의 실제 해석 결과
+      "composes_snapshot": [    // resolved versions at install time
         {"kind":"skill","ref":"workflow/autoplan","resolved_version":"1.2.3"},
         {"kind":"knowledge","ref":"workflow/batch-pr-conflict-recovery","resolved_version":"0.1.0"}
       ]
@@ -133,51 +133,51 @@ draft (.technique-draft/)   ──►  publish (technique/)   ──►  outdate
 }
 ```
 
-`composes_snapshot`이 있어야 설치 이후 `loose` 모드에서도 "무엇이 깨졌는지" 사후 추적 가능.
+`composes_snapshot` provides post-hoc traceability — in `loose` mode it is the single source of truth for "what resolved to what at install time" when debugging a broken technique.
 
-## 8. index.json 통합
+## 8. index.json integration
 
-master / lite / category 인덱스에 `technique` 섹션 추가. 검색(`hub-find`)은 skill·knowledge·technique을 **동등하게** 매칭하되 결과 행에 `kind: technique` 배지를 붙여 구분.
+Add a `technique` kind to the master/lite/category indexes. Search (`hub-find`) matches skills/knowledge/techniques uniformly but renders a `kind: technique` badge on result rows for differentiation.
 
-## 9. 검증 규칙 (publish 및 precheck)
+## 9. Verification rules (publish and precheck)
 
-1. `composes[]` 의 모든 `ref`가 허브에 **실제 파일로** 존재 (frontmatter category와 무관, 디스크 경로로 확인).
-2. 각 `version` range가 허브의 해당 항목 semver와 **공집합 아님**.
-3. 순환 참조 금지: technique은 다른 technique을 참조하지 **않는다** (v0에서는 flat 1-depth만 허용. 중첩은 v0.2 이후 검토).
-4. `description` 필수 + ≤120자.
-5. `name`과 폴더명 일치.
-6. `verify.sh`가 있으면 exit code 0.
-7. `ref`는 kind 루트 기준 실제 경로 (예: `parallel-build-sequential-publish` 또는 `workflow/autoplan`).
+1. Every `composes[].ref` resolves to an **actual file** in the hub (checked against the filesystem, independent of declared category).
+2. Every `version` range has a **non-empty intersection** with the installed version.
+3. No circular references: a technique **must not** reference another technique (v0 permits flat 1-depth only; nesting is deferred to v0.2).
+4. `description` is required and ≤120 chars.
+5. `name` equals the containing directory name.
+6. If `verify.sh` exists it must exit 0.
+7. `ref` is kind-root-relative physical path (e.g. `parallel-build-sequential-publish` or `workflow/autoplan`).
 
-## 10. 슬래시 커맨드 (3단계에서 구현, 지금은 목록만)
+## 10. Slash commands (implemented in step 3, listed here for reference)
 
-- `/hub-technique-compose <slug>` — 드래프트 작성 워크플로 (skill/knowledge 선택 → frontmatter 생성)
-- `/hub-technique-list` — 설치된 technique 목록
-- `/hub-technique-show <slug>` — 본문 + 구성 해설
-- `/hub-technique-install <ref>` — 리모트에서 설치
-- `/hub-technique-verify <slug>` — composes 상태 점검
-- 기존 `/hub-find`, `/hub-status`, `/hub-precheck`는 technique 섹션만 추가로 읽도록 **확장**
+- `/hub-technique-compose <slug>` — draft authoring workflow (skill/knowledge selection → frontmatter generation)
+- `/hub-technique-list` — installed technique list
+- `/hub-technique-show <slug>` — body + composition expansion
+- `/hub-technique-install <ref>` — install from remote
+- `/hub-technique-verify <slug>` — validate `composes[]` state
+- Existing `/hub-find`, `/hub-status`, `/hub-precheck` are **extended** to read the new section
 
-## 11. 오픈 이슈
+## 11. Open issues
 
-- **Q1.** technique이 technique을 참조 허용할 것인가? → v0 금지. 과도한 결합과 순환 위험. v0.2에서 재검토.
-- **Q2.** `loose` 모드에서 lockfile 두는가? → `composes_snapshot`으로 충분하다는 판단. 별도 lockfile 없음.
-- **Q3.** example ↔ technique 연결? → example frontmatter에 `produced_by_technique: <ref>` 선택 필드 추가 제안 (본 초안 범위 밖, 별도 PR).
-- **Q4.** 카테고리 추가? → 불필요. 기존 카테고리 + tag로 수용.
-- **Q5.** (파일럿 2에서 발견) `composes[]`는 현재 **순서 없는 집합**. 선형 파이프라인은 `role`에 "phase-0-anchor" 같은 문자열로 우회 가능, 분기 결정트리는 본문 산문으로만 표현됨. v0에서는 수용 (role 자유문자열이 충분히 흡수). v0.2에서 정형 phase/branch DSL 도입 여부 재검토.
+- **Q1.** Should technique-to-technique composition be allowed? → No in v0. Risk of coupling and cycles. Revisit in v0.2.
+- **Q2.** Should `loose` mode carry a lockfile? → `composes_snapshot` is judged sufficient. No separate lockfile.
+- **Q3.** Link examples to techniques? → Proposal: add optional `produced_by_technique: <ref>` field to `example/` frontmatter. Separate PR, outside this doc's scope.
+- **Q4.** Add a category? → Not needed. Existing categories + tags cover the space.
+- **Q5.** (Found in pilot #2) `composes[]` is currently an **unordered set**. A linear pipeline can be expressed via role labels like "phase-0-anchor"; a branching decision tree is expressed only in prose. v0 accepts this (free-text `role` is sufficient). A formal phase/branch DSL is deferred to v0.2 pending more pilots.
 
-## 12. 파일럿 후보 (2단계 입력)
+## 12. Pilot candidates (input to step 2)
 
-이 초안이 승인되면 다음 조합 중 하나로 첫 technique을 시작 제안:
+Once this schema is approved, the first technique comes from one of these pairings:
 
-- `workflow/autoplan` + `workflow/batch-pr-conflict-recovery` → **"대량 PR 자동 생성 안전 패턴"**
-- 기타: 현재 설치된 `swagger-ai-optimization` 단독 → technique화 여부 자체가 테스트 케이스 (단일 스킬은 technique이 아님을 확인)
+- `workflow/autoplan` + `workflow/batch-pr-conflict-recovery` → **"Safe bulk PR automation"**
+- Alternative: the already-installed `swagger-ai-optimization` alone — useful as a negative test case (a single skill is **not** a technique, which itself verifies the schema)
 
 ---
 
-**다음 단계.** 이 초안에서 다음 3가지만 먼저 확정:
-1. 바인딩 기본값 (`loose` 제안)
-2. 중첩 금지 여부 (v0에서 금지 제안)
-3. 파일럿 후보 선택
+**Next step.** Confirm the following three points from this draft:
+1. Default binding (`loose` proposed)
+2. v0 nesting ban (proposed)
+3. Pilot-candidate selection
 
-확정되면 2단계(파일럿 technique 1건 작성)로 진행.
+Once confirmed, proceed to step 2 (author the first pilot technique).

--- a/technique/debug/root-cause-to-tdd-plan/TECHNIQUE.md
+++ b/technique/debug/root-cause-to-tdd-plan/TECHNIQUE.md
@@ -32,28 +32,28 @@ composes:
 binding: loose
 
 verify:
-  - "composes[].ref 모두 허브에 설치됨"
-  - "composes[].version range 가 설치본과 교차"
-  - "decision tree의 모든 종단이 GitHub 이슈 또는 명시적 non-fix 결정으로 귀결"
+  - "every composes[].ref is installed in the hub"
+  - "every composes[].version range intersects the installed version"
+  - "every leaf of the decision tree terminates in a GitHub issue or an explicit non-fix decision"
 ---
 
 # Root Cause → TDD Fix Plan
 
-> 에러/버그 신고에서 시작해 **체계적 근본 원인 조사 → 원인 분류에 따른 경로 분기 → GitHub 이슈 + TDD 테스트 계획** 까지 가는 결정트리. 원인이 명확하지 않은 장애를 받아 fix 계획까지 안전하게 끌고 가기 위한 레시피.
+> A decision tree that takes an error/bug report through **systematic root-cause investigation → classification-driven path → GitHub issue with TDD test plan**. Designed to carry an unclear incident all the way to a safe fix plan without shortcuts.
 
 ## When to use
 
-- 증상은 있으나 원인이 불명확한 버그/장애 신고
-- 근본 원인 없이 패치해버리는 함정을 피해야 하는 상황
-- 결과물로 **TDD 계획이 포함된 GitHub 이슈**가 필요할 때
+- A bug/incident report with observable symptoms but unclear cause
+- Situations where "patch without understanding" must be avoided
+- When the deliverable must be a **GitHub issue with an embedded TDD plan**
 
 ## When NOT to use
 
-- 원인이 자명한 1줄 수정 (오버헤드만 크다)
-- 배포 중 핫픽스 — 이 technique은 조사 우선이라 느리다
-- 재현 불가능한 일회성 장애 (별도 triage 패턴)
+- Obvious one-line fixes (the overhead is too high)
+- In-production hotfixes — this technique is investigation-first and therefore slow
+- Irreproducible one-off incidents (use a different triage pattern)
 
-## Decision tree (파일럿 1과 달리 선형 아님)
+## Decision tree (non-linear, unlike pilot #1)
 
 ```
 [bug report]
@@ -67,7 +67,7 @@ verify:
                │
        ┌───────┴───────┐
        │ hypothesize   │  ←── knowledge: ai-guess-mark-and-review-checklist
-       │ phase         │       (hypothesis-guard: 추측을 표식하고 재검토)
+       │ phase         │       (hypothesis-guard: mark guesses, re-review)
        └───────┬───────┘
                │ root cause classified
                │
@@ -84,36 +84,36 @@ verify:
          [GitHub issue + TDD test plan]
 ```
 
-## Glue summary (technique의 순부가가치)
+## Glue summary (net value added by this technique)
 
-구성 원자는 각각 독립적으로 존재한다. 이 technique이 **유일하게 추가**하는 것:
+The composed atoms each stand alone. What this technique uniquely adds:
 
-| 추가 요소 | 위치 |
+| Added element | Where |
 |---|---|
-| 원자 간 라우팅 규칙 (build-error vs runtime-bug) | hypothesize phase 종료 시점 |
-| `investigate` hypothesize → `triage-issue` 승격 조건 | "근본 원인이 식별됨 AND 수정 범위가 명확" |
-| `ai-guess-mark-and-review-checklist` 적용 시점 | hypothesize phase 진입 시 모든 가설에 강제 적용 |
-| 출력 계약 | decision tree의 모든 종단은 "GitHub 이슈 + TDD 계획" 또는 "명시적 non-fix 결정" 둘 중 하나 |
+| Routing rule between atoms (build-error vs runtime-bug) | End of the hypothesize phase |
+| Promotion condition from `investigate.hypothesize` → `triage-issue` | "root cause identified AND fix scope clear" |
+| Mandatory application of `ai-guess-mark-and-review-checklist` | Entry to every hypothesize phase, over every hypothesis |
+| Output contract | Every leaf of the tree ends in either "GitHub issue + TDD plan" or "explicit non-fix decision" |
 
-원자 스킬들은 "어떻게"를 제공하고, technique은 "언제·왜 이 스킬에서 저 스킬로 넘어가는가"를 제공한다.
+The composed skills describe **how** to perform each step; this technique describes **when and why** to move from one to the next.
 
-## Hypothesis-guard 통합 규칙
+## Hypothesis-guard integration
 
-`ai-guess-mark-and-review-checklist` 지식은 체크리스트다. 이 technique이 강제하는 것:
+`ai-guess-mark-and-review-checklist` is a checklist. This technique enforces:
 
-- `investigate` hypothesize 단계에서 생성되는 **모든 가설**에 체크리스트 적용
-- 체크리스트 미통과 가설은 implement 단계로 진행 금지
-- 미통과 사유는 GitHub 이슈 본문의 "Rejected Hypotheses" 섹션에 기록 (감사 추적)
+- Apply the checklist to **every hypothesis** produced by `investigate.hypothesize`
+- A hypothesis that fails the checklist must not proceed to the implement phase
+- Failure reasons are logged in the GitHub issue body under a "Rejected Hypotheses" section (audit trail)
 
 ## Output contract
 
-`triage-issue`는 GitHub 이슈를 만들지만 형식은 자유도가 있다. 이 technique은 필수 섹션을 고정:
+`triage-issue` produces a GitHub issue with flexible formatting. This technique pins required sections:
 
-1. Symptom (사용자 관찰)
-2. Root Cause (investigate phase 결론)
-3. Rejected Hypotheses (체크리스트 미통과분)
-4. Fix Plan (TDD 순서: 실패 테스트 → 최소 구현 → 리팩터)
-5. Rollback 조건
+1. Symptom (user observation)
+2. Root Cause (conclusion from the investigate phase)
+3. Rejected Hypotheses (checklist failures)
+4. Fix Plan (TDD order: failing test → minimal impl → refactor)
+5. Rollback conditions
 
 ## Verification (draft)
 
@@ -133,14 +133,14 @@ echo "OK"
 
 ## Known limitations (v0.1 draft)
 
-- 구성 원자 중 2개가 `0.1.0-draft` → technique도 draft 고정
-- 결정트리 분기가 v0 스키마에서는 **자연어 기술**로만 표현됨 (정형 DSL 없음). Phase 순서 모델링 이상의 구조는 아직 필요 없다고 판단
-- `loose` 바인딩 — `investigate`의 4-phase 구조가 major 변경되면 전체 재검증 필요
-- Runtime 원인이라도 특수 케이스(메모리 누수, 경쟁 상태)는 `triage-issue`의 TDD 범위를 벗어날 수 있음 — 이런 경우 별도 technique 필요 (v0.2 검토)
+- Two of the composed atoms are `0.1.0-draft`, so this technique is pinned to draft status
+- The decision-tree branching is expressed only in prose (no structured DSL). The v0 schema treats `composes[]` as an unordered bag; pilot #1 (linear) and pilot #2 (branching) both fit this form. A DSL is deferred to v0.2.
+- `loose` binding — a major-version bump on `investigate`'s 4-phase structure forces re-validation of the whole flow
+- Even within runtime bugs, some subclasses (memory leaks, race conditions) can exceed `triage-issue`'s TDD scope. Those cases need a separate technique (v0.2).
 
 ## Provenance
 
-- Authored: 2026-04-24 (kjuhwa@nkia.co.kr)
-- Status: **pilot #2** for `technique/` schema v0.1 — decision-tree shape (vs pilot #1 linear pipeline)
-- Schema doc: `../../../technique-schema-draft.md`
-- Sibling pilot: `../../workflow/safe-bulk-pr-publishing/TECHNIQUE.md`
+- Authored: 2026-04-24
+- Status: **pilot #2** for the `technique/` schema v0.1 — decision-tree shape (vs pilot #1 linear pipeline)
+- Schema doc: `docs/rfc/technique-schema-draft.md`
+- Sibling pilot: `technique/workflow/safe-bulk-pr-publishing/TECHNIQUE.md`

--- a/technique/workflow/safe-bulk-pr-publishing/TECHNIQUE.md
+++ b/technique/workflow/safe-bulk-pr-publishing/TECHNIQUE.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: safe-bulk-pr-publishing
-description: Build N projects in parallel then publish them as many PRs safely — with rollback anchor, race-aware PR creation, and batch conflict recovery
+description: Build N projects in parallel then publish them as many PRs safely — rollback anchor, race-aware PR creation, batch conflict recovery
 category: workflow
 tags:
   - parallel
@@ -13,7 +13,7 @@ tags:
 
 composes:
   - kind: skill
-    ref: parallel-build-sequential-publish       # NOTE: 카테고리 폴더 밖에 있음 (허브 불일치)
+    ref: parallel-build-sequential-publish       # NOTE: lives at root of skills/, not under workflow/ (see RFC §4)
     version: "^1.0.0"
     role: orchestrator
   - kind: skill
@@ -32,25 +32,25 @@ composes:
 binding: loose
 
 verify:
-  - "composes[].ref 모두 허브에 설치됨"
-  - "composes[].version range 가 설치본 semver와 교차"
+  - "every composes[].ref is installed in the hub"
+  - "every composes[].version range intersects the installed version"
   - cmd: "./verify.sh"
 ---
 
 # Safe Bulk PR Publishing
 
-> 대량으로 독립 산출물을 만들고 하나씩 PR로 올리는 파이프라인. 개별 스킬·지식은 이미 존재하지만, **어느 순서·어느 지점에 엮어야 안전한지**를 고정한 레시피.
+> A pipeline for producing many independent artifacts in parallel and shipping them as individual PRs. The individual skills and knowledge entries already exist; this technique fixes **the order and the wiring points** that keep the flow safe.
 
 ## When to use
 
-- 한 번에 10개 이상 독립 프로젝트·예제·마이그레이션을 만들고 각자 PR로 올려야 할 때
-- auto-merge가 켜진 저장소에 연속 PR을 밀어넣을 때
-- 과거 비슷한 흐름에서 카탈로그/인덱스 파일 충돌로 수십 개 PR이 막힌 적이 있을 때
+- Producing 10+ independent projects/examples/migrations in one batch, each needing its own PR
+- Pushing many PRs in sequence against a repo with auto-merge enabled
+- Any similar flow where a catalog/index file conflict has stalled dozens of PRs in the past
 
 ## When NOT to use
 
-- 단일 PR (오버헤드만 생긴다 — 구성 스킬을 개별적으로 써라)
-- PR이 서로 의존적일 때 (순서·병합 전략이 다름, 별도 technique 필요)
+- A single PR (the overhead is not worth it — use the atoms directly)
+- PRs that depend on each other (ordering/merge strategy differs — use a different technique)
 
 ## Phase sequence
 
@@ -59,30 +59,30 @@ verify:
 [1] Build       → parallel-build-sequential-publish (Build Phase)
 [2] Publish     → parallel-build-sequential-publish (Publish Phase)
                   + gh-pr-create-race-with-auto-merge (detection in retry loop)
-[3] Recover?    → batch-pr-conflict-recovery  (on catalog-file conflict storm)
+[3] Recover?    → batch-pr-conflict-recovery (triggered by catalog-file conflict storm)
 ```
 
-### [0] Pre-flight anchor (필수)
+### [0] Pre-flight anchor (mandatory)
 
-`rollback-anchor-tag-before-destructive-op`를 **구성 스킬 그대로** 실행해 `backup/pre-bulk-pr-YYYYMMDD` 태그를 origin에 푸시. PR 본문에 롤백 커맨드를 미리 기록해 둔다.
+Run `rollback-anchor-tag-before-destructive-op` as-is to push a `backup/pre-bulk-pr-YYYYMMDD` tag to origin. Record the rollback command in the PR template body.
 
-**technique이 추가하는 것**: 태그 슬러그 컨벤션을 `pre-bulk-pr-<date>`로 고정 (다른 technique과 충돌 없이 식별 가능).
+**What this technique adds**: a fixed tag-slug convention `pre-bulk-pr-<date>` so this technique's anchors do not collide with other techniques'.
 
-### [1] Build phase (병렬)
+### [1] Build phase (parallel)
 
-`parallel-build-sequential-publish`의 Build 절차를 따른다. 각 executor는 **git 건드리지 말 것** — 파일만 만든다.
+Follow the Build procedure in `parallel-build-sequential-publish`. Each executor **must not touch git** — only file creation.
 
-**technique이 추가하는 것**: executor 프롬프트 말미에 다음 금지 규칙 추가:
-- `example/README.md` 같은 공유 카탈로그 파일을 **수정하지 말 것** (knowledge: batch-pr-conflict-recovery §Prevention)
-- 공유 파일 재생성은 Publish phase 끝에서 **한 번만** 수행
+**What this technique adds**: two explicit prohibitions appended to the executor prompt:
+- Do **not** edit shared catalog files such as `example/README.md` (see knowledge: batch-pr-conflict-recovery §Prevention)
+- Catalog regeneration is performed **once**, at the end of the Publish phase
 
-### [2] Publish phase (순차, 레이스 감지)
+### [2] Publish phase (sequential, race-aware)
 
-`parallel-build-sequential-publish`의 Publish 절차를 따르되, `gh pr create` 단계를 아래 패턴으로 감싼다:
+Follow the Publish procedure in `parallel-build-sequential-publish`, but wrap the `gh pr create` step:
 
 ```bash
 if ! gh pr create ...; then
-  # 레이스 감지 (knowledge: gh-pr-create-race-with-auto-merge)
+  # Detect race (knowledge: gh-pr-create-race-with-auto-merge)
   if git merge-base --is-ancestor "$BRANCH" origin/main; then
     echo "auto-merge already picked it up — treat as success"
   else
@@ -91,35 +91,35 @@ if ! gh pr create ...; then
 fi
 ```
 
-**technique이 추가하는 것**: 실패와 "이미 머지됨"을 구분하는 retry/skip 로직. 구성 원자 단위는 이 분기 로직을 갖고 있지 않다.
+**What this technique adds**: the retry/skip branch that distinguishes a real failure from an already-merged branch. The atomic units do not carry this branching logic.
 
-### [3] Recovery (선택, 사고 시)
+### [3] Recovery (optional, on incident)
 
-카탈로그 파일 충돌이 연쇄로 터지면 즉시 PR 발행 중단하고 `batch-pr-conflict-recovery`의 복구 절차로 전환. 조건 판정:
+If catalog-file conflicts start cascading, stop publishing and switch to `batch-pr-conflict-recovery`. Trigger conditions:
 
-- 연속 3개 이상 PR이 `CONFLICTING` 상태로 나온다 → 복구 모드 스위치
-- 충돌 파일이 모두 동일(`example/README.md` 등) → 조건 충족
+- Three or more consecutive PRs come back `CONFLICTING` → switch to recovery mode
+- The conflict file is the same shared file (e.g. `example/README.md`) across all cases → condition met
 
-**technique이 추가하는 것**: "언제 복구 모드로 전환할지" 판정 규칙 (원자 지식은 복구 방법만 기술, 전환 트리거는 비어 있음).
+**What this technique adds**: a decision rule for **when** to switch into recovery mode. The atomic knowledge describes how to recover but not when to trigger it.
 
-## Glue summary (technique의 순부가가치)
+## Glue summary (net value added by this technique)
 
-구성 원자가 이미 제공하는 것은 기술하지 않고, **오직 이 레시피가 더하는 것**만:
+Nothing the atoms already cover is repeated; only what this recipe contributes:
 
-| 추가 요소 | 위치 |
+| Added element | Where |
 |---|---|
-| 태그 슬러그 컨벤션 `pre-bulk-pr-<date>` | Phase 0 |
-| executor 금지 규칙 (공유 카탈로그 편집 금지) | Phase 1 |
-| 레이스 vs 실패 분기 로직 | Phase 2 |
-| 복구 모드 전환 트리거 규칙 (N≥3 CONFLICTING) | Phase 3 |
+| Anchor tag-slug convention `pre-bulk-pr-<date>` | Phase 0 |
+| Executor prohibitions (no shared-catalog edits) | Phase 1 |
+| Race-vs-failure branching for `gh pr create` | Phase 2 |
+| Recovery-mode trigger rule (N ≥ 3 CONFLICTING) | Phase 3 |
 
 ## Verification (draft)
 
-`verify.sh`는 v0.1에서는 아래 셸 프라그먼트 수준으로만 제공:
+`verify.sh` in v0.1 is a short sanity check:
 
 ```bash
 #!/usr/bin/env bash
-# 구성 단위가 허브 설치 상태인지 검증
+# Assert the referenced atoms are present in the local hub.
 set -e
 SKILLS_HUB="${SKILLS_HUB:-$HOME/.claude/skills-hub/remote}"
 for ref in \
@@ -134,13 +134,13 @@ echo "OK"
 
 ## Known limitations (v0.1 draft)
 
-- 구성 원자 중 2개가 `0.1.0-draft` → technique도 draft 고정
-- v0에서 technique 중첩 금지이므로, 이 technique을 다른 technique이 참조 불가
-- `loose` 바인딩 — 구성 스킬 major 업데이트 시 재검증 필요
-- **허브 불일치 발견**: `parallel-build-sequential-publish`는 frontmatter `category: workflow`지만 실제 디스크 경로는 `skills/parallel-build-sequential-publish/`(카테고리 폴더 밖). 스키마의 `ref`는 **의미(category/slug)가 아니라 kind 루트 기준 실제 경로**를 써야 함. 이 발견은 스키마 초안 §4에 반영됨
+- Two of the composed atoms are `0.1.0-draft`, so this technique is pinned to draft status
+- v0 forbids technique-to-technique nesting, so no other technique can reference this one
+- `loose` binding — major version bumps on any composed skill require re-verification
+- **Hub layout inconsistency (found during authoring)**: `parallel-build-sequential-publish` declares `category: workflow` in its frontmatter but lives at the root of `skills/` (not under `skills/workflow/`). The schema's `ref` is therefore the **kind-root-relative physical path**, not a semantic `{category}/{slug}`. This finding is folded into RFC §4.
 
 ## Provenance
 
-- Authored: 2026-04-24 (kjuhwa@nkia.co.kr)
-- Status: pilot for `technique/` schema draft v0.1
-- Schema doc: `technique-schema-draft.md`
+- Authored: 2026-04-24
+- Status: pilot #1 for the `technique/` schema draft v0.1
+- Schema doc: `docs/rfc/technique-schema-draft.md`


### PR DESCRIPTION
## Summary

The hub corpus under `skills/`, `knowledge/`, and `example/` is uniformly English. The two pilot techniques and the schema draft merged in #1058 were authored in Korean — inconsistent with the rest of the hub. This PR rewrites them in English.

## Rationale

User feedback after #1058 landed: "기술과 지식이 전부 영문인데 기술이 한글이면 이상하지" (skills and knowledge are all English; it's inconsistent for techniques to be Korean).

## Scope

No semantic changes. `composes[]` refs, binding modes, verification rules, and all code blocks are preserved byte-for-byte. Only prose is translated.

- `technique/workflow/safe-bulk-pr-publishing/TECHNIQUE.md`
- `technique/debug/root-cause-to-tdd-plan/TECHNIQUE.md`
- `docs/rfc/technique-schema-draft.md`

## Verification

```
PASS skills/parallel-build-sequential-publish/SKILL.md
PASS skills/workflow/rollback-anchor-tag-before-destructive-op/SKILL.md
PASS knowledge/workflow/batch-pr-conflict-recovery.md
PASS knowledge/pitfall/gh-pr-create-race-with-auto-merge.md
PASS skills/debug/investigate/SKILL.md
PASS skills/debug/build-error-triage/SKILL.md
PASS skills/debug/triage-issue/SKILL.md
PASS knowledge/pitfall/ai-guess-mark-and-review-checklist.md
```

All 8 atom refs from both pilots still resolve.

## Test plan

- [ ] Reviewer: spot-check a few sections for accurate translation
- [ ] Reviewer: confirm no frontmatter fields changed (only body prose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)