### PR TITLE
fix: backfill required frontmatter fields across 13 corpus files

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,10 +1,10 @@
 [
   {
     "kind": "knowledge",
-    "name": "",
-    "slug": "",
+    "name": "grep-existing-annotations-before-parallel-subagent-dispatch",
+    "slug": "grep-existing-annotations-before-parallel-subagent-dispatch",
     "category": "agent-orchestration / workflow",
-    "description": "",
+    "description": "\"Before parallel-subagent dispatch for bulk annotation work, grep for existing markers so agents don't waste cycles re-verifying already-applied annotations\"",
     "tags": [
       "claude-code",
       "subagent",
@@ -14,7 +14,7 @@
       "efficiency"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch.md",
     "has_content": true
   },
@@ -2866,7 +2866,7 @@
       "bootstrap"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/decision/squash-merge-orphans-release-branch-tags.md",
     "has_content": true
   },
@@ -3230,18 +3230,6 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/domain/topresource-immediate-generation-invariant.md",
-    "has_content": true
-  },
-  {
-    "kind": "knowledge",
-    "name": "",
-    "slug": "",
-    "category": "pitfall",
-    "description": "ResourceMaintenanceJob flattens targetGroupIds / targetTagFilters / targetResourceIds into confInfoIds at only two moments — create/modify and trigger start — so resources joining a targeted group during a RUNNING window get no maintenance flag, no alarm auto-delete, and no end-of-window recovery.",
-    "tags": "",
-    "triggers": [],
-    "version": "",
-    "path": "knowledge/pitfall/cm-maintenance-job-target-snapshot.md",
     "has_content": true
   },
   {
@@ -3677,7 +3665,7 @@
       "silent-failure"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/claude-code-slash-command-crlf-breaks-yaml-parser.md",
     "has_content": true
   },
@@ -3710,6 +3698,18 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/pitfall/claude-plugin-marketplace-owner-required.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "cm-maintenance-job-target-snapshot",
+    "slug": "cm-maintenance-job-target-snapshot",
+    "category": "pitfall",
+    "description": "ResourceMaintenanceJob flattens targetGroupIds / targetTagFilters / targetResourceIds into confInfoIds at only two moments — create/modify and trigger start — so resources joining a targeted group during a RUNNING window get no maintenance flag, no alarm auto-delete, and no end-of-window recovery.",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/pitfall/cm-maintenance-job-target-snapshot.md",
     "has_content": true
   },
   {
@@ -4135,7 +4135,7 @@
       "invariant"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/git-reset-hard-bypasses-all-hooks.md",
     "has_content": true
   },
@@ -4884,7 +4884,7 @@
       "silent-failure"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/publish-pipelines-must-rebuild-derived-artifacts.md",
     "has_content": true
   },
@@ -5415,7 +5415,7 @@
       "heuristic"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/subagent-scan-results-need-sanity-check.md",
     "has_content": true
   },
@@ -5739,7 +5739,7 @@
       "claude-code"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/pitfall/windows-rm-rf-device-busy-retry-pattern.md",
     "has_content": true
   },
@@ -5775,10 +5775,10 @@
   },
   {
     "kind": "knowledge",
-    "name": "",
-    "slug": "",
+    "name": "identifier-regex-loose-when-legacy-coexists",
+    "slug": "identifier-regex-loose-when-legacy-coexists",
     "category": "schema-design / validation / openapi",
-    "description": "",
+    "description": "\"When legacy and new identifier formats coexist in production data, use loose regex (^MA_.+$) over tight (^MA_.+_\\\\d{14}$) so OpenAPI spec and runtime reality don't diverge\"",
     "tags": [
       "regex",
       "identifier-pattern",
@@ -5788,7 +5788,7 @@
       "pitfall"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "knowledge/schema-design/identifier-regex-loose-when-legacy-coexists.md",
     "has_content": true
   },
@@ -11038,7 +11038,7 @@
       "design-doc"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "skills/design/selfcontained-nds-design-doc-html",
     "has_content": false
   },
@@ -13569,7 +13569,7 @@
       "polestar"
     ],
     "triggers": [],
-    "version": "",
+    "version": "0.1.0-draft",
     "path": "skills/workflow/lucida-work-order-to-paired-spec",
     "has_content": false
   },

--- a/knowledge/agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch.md
+++ b/knowledge/agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch.md
@@ -1,4 +1,7 @@
 ---
+name: grep-existing-annotations-before-parallel-subagent-dispatch
+version: 0.1.0-draft
+description: "Before parallel-subagent dispatch for bulk annotation work, grep for existing markers so agents don't waste cycles re-verifying already-applied annotations"
 title: "병렬 subagent 디스패치 전에 grep 으로 선행 작업 흔적을 확인하라 — 이미 적용된 annotation 을 다시 '검증'하느라 시간 낭비"
 category: agent-orchestration / workflow
 tags: [claude-code, subagent, parallel-dispatch, pre-check, pitfall, efficiency]

--- a/knowledge/decision/squash-merge-orphans-release-branch-tags.md
+++ b/knowledge/decision/squash-merge-orphans-release-branch-tags.md
@@ -1,4 +1,5 @@
 ---
+version: 0.1.0-draft
 name: squash-merge-orphans-release-branch-tags
 type: knowledge
 category: decision

--- a/knowledge/pitfall/claude-code-slash-command-crlf-breaks-yaml-parser.md
+++ b/knowledge/pitfall/claude-code-slash-command-crlf-breaks-yaml-parser.md
@@ -1,4 +1,5 @@
 ---
+version: 0.1.0-draft
 name: claude-code-slash-command-crlf-breaks-yaml-parser
 type: knowledge
 category: pitfall

--- a/knowledge/pitfall/cm-maintenance-job-target-snapshot.md
+++ b/knowledge/pitfall/cm-maintenance-job-target-snapshot.md
@@ -1,4 +1,6 @@
 ---
+name: cm-maintenance-job-target-snapshot
+version: 0.1.0-draft
 title: Maintenance job target set is a snapshot — resources added to the group mid-run are NOT covered
 category: pitfall
 summary: ResourceMaintenanceJob flattens targetGroupIds / targetTagFilters / targetResourceIds into confInfoIds at only two moments — create/modify and trigger start — so resources joining a targeted group during a RUNNING window get no maintenance flag, no alarm auto-delete, and no end-of-window recovery.

--- a/knowledge/pitfall/git-reset-hard-bypasses-all-hooks.md
+++ b/knowledge/pitfall/git-reset-hard-bypasses-all-hooks.md
@@ -1,4 +1,5 @@
 ---
+version: 0.1.0-draft
 name: git-reset-hard-bypasses-all-hooks
 type: knowledge
 category: pitfall

--- a/knowledge/pitfall/publish-pipelines-must-rebuild-derived-artifacts.md
+++ b/knowledge/pitfall/publish-pipelines-must-rebuild-derived-artifacts.md
@@ -1,4 +1,5 @@
 ---
+version: 0.1.0-draft
 name: publish-pipelines-must-rebuild-derived-artifacts
 type: knowledge
 category: pitfall

--- a/knowledge/pitfall/subagent-scan-results-need-sanity-check.md
+++ b/knowledge/pitfall/subagent-scan-results-need-sanity-check.md
@@ -1,4 +1,5 @@
 ---
+version: 0.1.0-draft
 name: subagent-scan-results-need-sanity-check
 type: knowledge
 category: pitfall

--- a/knowledge/pitfall/windows-rm-rf-device-busy-retry-pattern.md
+++ b/knowledge/pitfall/windows-rm-rf-device-busy-retry-pattern.md
@@ -1,4 +1,5 @@
 ---
+version: 0.1.0-draft
 name: windows-rm-rf-device-busy-retry-pattern
 type: knowledge
 category: pitfall

--- a/knowledge/schema-design/identifier-regex-loose-when-legacy-coexists.md
+++ b/knowledge/schema-design/identifier-regex-loose-when-legacy-coexists.md
@@ -1,4 +1,7 @@
 ---
+name: identifier-regex-loose-when-legacy-coexists
+version: 0.1.0-draft
+description: "When legacy and new identifier formats coexist in production data, use loose regex (^MA_.+$) over tight (^MA_.+_\\d{14}$) so OpenAPI spec and runtime reality don't diverge"
 title: "식별자 regex 는 legacy + 신규 포맷이 공존하면 tight 패턴(^MA_.+_\\d{14}$) 대신 loose 패턴(^MA_.+$) 을 써라"
 category: schema-design / validation / openapi
 tags: [regex, identifier-pattern, schema-validation, openapi, legacy-data, pitfall]

--- a/skills/design/selfcontained-nds-design-doc-html/SKILL.md
+++ b/skills/design/selfcontained-nds-design-doc-html/SKILL.md
@@ -1,4 +1,5 @@
 ---
+version: 0.1.0-draft
 name: selfcontained-nds-design-doc-html
 description: 외부 CSS/JS 의존 없이 단일 .html로 완성되는 Lucida/NDS 톤 디자인 문서 템플릿. As-Is/To-Be, 페이지 맥락 목업, 다이얼로그, 인터랙션, API 테이블, MoSCoW Phase 카드 등 10개 섹션 카드로 구성. 메일/Slack/PR에 첨부해도 깨지지 않는 self-contained 아티팩트가 필요할 때 사용.
 category: design

--- a/skills/workflow/lucida-work-order-to-paired-spec/SKILL.md
+++ b/skills/workflow/lucida-work-order-to-paired-spec/SKILL.md
@@ -1,4 +1,5 @@
 ---
+version: 0.1.0-draft
 name: lucida-work-order-to-paired-spec
 description: 한 개의 작업지시서(.md)에서 specs/{domain}/planning/*.md 기획서와 specs/{domain}/design/*.html 디자인 목업을 함께 생성하는 워크플로우. 기존 specs/kcm/planning 등의 헤더·메타 관례를 먼저 스캔해 일관성을 맞춘다.
 category: workflow


### PR DESCRIPTION
## Summary

Clears the `_lint_frontmatter.py` failures that have been accumulating in the corpus. Unblocks `/hub-precheck` end-to-end (was aborting at lint step before regenerating user-side master/lite/category indexes).

## Scope

**11 files auto-fixed** via `_fix_frontmatter.py --apply --only-missing=name,version`:
- `name` added (inferred from filename) for 3 files
- `version: 0.1.0-draft` stamped on 11 files

**2 files manually patched** with English `description:` (the auto-fixer intentionally does not touch description to avoid meaning loss):
- `knowledge/agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch.md`
- `knowledge/schema-design/identifier-regex-loose-when-legacy-coexists.md`

Existing Korean `title:` fields preserved on the two files — only adding English `description:`, not replacing anything.

**`index.json` regenerated** (+/- some metadata-only diffs).

## Verification

```
$ python3 bootstrap/tools/_lint_frontmatter.py
...
PASS — 모든 파일이 스키마를 만족합니다.
```

## Test plan

- [ ] Reviewer: run `/hub-precheck` post-merge and confirm it reaches the index-build phase without aborting
- [ ] Reviewer: spot-check the 2 manual description additions for accuracy

## Out of scope

- Translating Korean bodies of the 2 edited knowledge files (only their `description:` is English)
- Tag inference suggestion for `swagger-ai-optimization` (low-value, excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)