### PR TITLE
fix: normalize compound category values in 2 knowledge files

### DIFF
--- a/index.json
+++ b/index.json
@@ -3,7 +3,7 @@
     "kind": "knowledge",
     "name": "grep-existing-annotations-before-parallel-subagent-dispatch",
     "slug": "grep-existing-annotations-before-parallel-subagent-dispatch",
-    "category": "agent-orchestration / workflow",
+    "category": "agent-orchestration",
     "description": "\"Before parallel-subagent dispatch for bulk annotation work, grep for existing markers so agents don't waste cycles re-verifying already-applied annotations\"",
     "tags": [
       "claude-code",
@@ -5777,7 +5777,7 @@
     "kind": "knowledge",
     "name": "identifier-regex-loose-when-legacy-coexists",
     "slug": "identifier-regex-loose-when-legacy-coexists",
-    "category": "schema-design / validation / openapi",
+    "category": "schema-design",
     "description": "\"When legacy and new identifier formats coexist in production data, use loose regex (^MA_.+$) over tight (^MA_.+_\\\\d{14}$) so OpenAPI spec and runtime reality don't diverge\"",
     "tags": [
       "regex",

--- a/knowledge/agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch.md
+++ b/knowledge/agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch.md
@@ -3,7 +3,7 @@ name: grep-existing-annotations-before-parallel-subagent-dispatch
 version: 0.1.0-draft
 description: "Before parallel-subagent dispatch for bulk annotation work, grep for existing markers so agents don't waste cycles re-verifying already-applied annotations"
 title: "병렬 subagent 디스패치 전에 grep 으로 선행 작업 흔적을 확인하라 — 이미 적용된 annotation 을 다시 '검증'하느라 시간 낭비"
-category: agent-orchestration / workflow
+category: agent-orchestration
 tags: [claude-code, subagent, parallel-dispatch, pre-check, pitfall, efficiency]
 kind: pitfall
 confidence: high

--- a/knowledge/schema-design/identifier-regex-loose-when-legacy-coexists.md
+++ b/knowledge/schema-design/identifier-regex-loose-when-legacy-coexists.md
@@ -3,7 +3,7 @@ name: identifier-regex-loose-when-legacy-coexists
 version: 0.1.0-draft
 description: "When legacy and new identifier formats coexist in production data, use loose regex (^MA_.+$) over tight (^MA_.+_\\d{14}$) so OpenAPI spec and runtime reality don't diverge"
 title: "식별자 regex 는 legacy + 신규 포맷이 공존하면 tight 패턴(^MA_.+_\\d{14}$) 대신 loose 패턴(^MA_.+$) 을 써라"
-category: schema-design / validation / openapi
+category: schema-design
 tags: [regex, identifier-pattern, schema-validation, openapi, legacy-data, pitfall]
 kind: pitfall
 confidence: high


### PR DESCRIPTION
## Summary

Two knowledge files declared multi-value `category:` fields with `/` separators, which `_build_category_indexes.py` treats as filesystem path separators — producing invalid directory paths (e.g. `indexes\category_indexes\knowledge\agent-orchestration \ workflow`) and aborting the index build.

Collapses each to the primary (first) category:

- `knowledge/agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch.md`
  - before: `category: agent-orchestration / workflow`
  - after:  `category: agent-orchestration`
- `knowledge/schema-design/identifier-regex-loose-when-legacy-coexists.md`
  - before: `category: schema-design / validation / openapi`
  - after:  `category: schema-design`

Secondary themes are already in the `tags:` arrays on both files — no information lost.

`index.json` regenerated.

## Why now

This surfaced as a follow-up after #1065 fixed lint for the same two files. With lint passing, `/hub-precheck` advanced to the category-index step, which then hit the compound-category bug.

## Verification

After this PR's changes:

```
--- [lint] PASS  (0.28s)
--- [master-index] PASS  (0.23s)
--- [master-index-lite] PASS  (0.14s)
--- [category-indexes] PASS  (0.17s)
[ALL PASS] 출판 가능 상태.
wrote C:\Users\Nkia\.claude\skills-hub\indexes\00_MASTER_INDEX.md (820 entries, 367482 bytes)
wrote C:\Users\Nkia\.claude\skills-hub\indexes\00_MASTER_INDEX_LITE.md (820 entries considered, 114 shown, 19.1 KB)
wrote 31 category INDEX.md files under ...indexes\category_indexes
```

`/hub-precheck` end-to-end passes for the first time in this session's chain.

## Deferred (not in this PR)

- Hardening `_build_category_indexes.py` to reject/sanitize compound categories at the tool level (would catch future occurrences) — out of scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)