### PR TITLE
feat: lint category format (prevent compound category regressions)

### DIFF
--- a/bootstrap/tools/_lint_frontmatter.py
+++ b/bootstrap/tools/_lint_frontmatter.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from collections import Counter, defaultdict
 from pathlib import Path
@@ -28,6 +29,10 @@ TECHNIQUE_DIR = HUB_ROOT / "technique"
 REQUIRED = ["name", "description", "category", "tags", "version"]
 # knowledge files often use `summary` instead of `description`.
 ALIASES = {"description": ("description", "summary")}
+# category must be a single kebab-case token (matching CATEGORIES.md entries).
+# Prevents compound values like "agent-orchestration / workflow" that break
+# downstream index builders that use category as a path segment.
+CATEGORY_RE = re.compile(r"^[a-z][a-z0-9-]*$")
 
 
 def extract_frontmatter(text: str) -> tuple[str | None, str | None]:
@@ -88,7 +93,14 @@ def scan_file(path: Path) -> dict:
         candidates = ALIASES.get(required, (required,))
         if not any(c in fields and not value_is_empty(fields[c]) for c in candidates):
             missing.append(required)
-    return {"path": str(path), "errors": [], "missing": missing, "fields": list(fields)}
+    errors: list[str] = []
+    category_val = fields.get("category", "").strip()
+    if category_val and not CATEGORY_RE.match(category_val):
+        errors.append(
+            f"invalid category format: {category_val!r} (must be single "
+            f"kebab-case token — no '/', '\\\\', or spaces)"
+        )
+    return {"path": str(path), "errors": errors, "missing": missing, "fields": list(fields)}
 
 
 def iter_md_files() -> list[Path]:


### PR DESCRIPTION
## Summary

Adds a category-format rule to `_lint_frontmatter.py` so future authors can't silently reintroduce the compound-category bug that #1066 just cleaned up.

## Rule

`category` must match `^[a-z][a-z0-9-]*$` (single kebab-case token — no `/`, `\`, or whitespace). The check runs only when `category` is present; the separate REQUIRED rule still catches missing categories.

## Why at lint, not index-build

The prior failure mode was: bad data slipped through lint → master/lite indexes succeeded → category-indexes aborted on invalid mkdir path. Moving detection upstream means:

- Clear, file-pinned error message at lint time
- Every downstream consumer (the 3 index builders and any future tool) inherits the guarantee for free

## Verification

```
Clean corpus:
  PASS — 모든 파일이 스키마를 만족합니다.

Synthetic negative test (category: pitfall / bad injected):
  [구조 에러] 1건
    - knowledge/pitfall/git-reset-hard-bypasses-all-hooks.md ::
      invalid category format: 'pitfall / bad' (must be single
      kebab-case token — no '/', '\', or spaces)
```

## Test plan

- [ ] Reviewer: run lint on current corpus post-merge, confirm PASS
- [ ] Reviewer: (optional) temporarily introduce a bad category in a test branch, confirm the rule fires with the expected message

## Bootstrap version note

This change touches `bootstrap/tools/_lint_frontmatter.py`. A follow-up `bootstrap/v2.6.15` tag would capture this + any other bootstrap changes since v2.6.14. Tagging is deferred to when there's a bigger delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)