### PR TITLE
feat: lint technique composes[] — ref resolution, kind whitelist, no nesting

### DIFF
--- a/bootstrap/tools/_lint_frontmatter.py
+++ b/bootstrap/tools/_lint_frontmatter.py
@@ -79,6 +79,86 @@ def value_is_empty(raw: str) -> bool:
     return False
 
 
+def parse_composes(raw_fm: str) -> list[dict[str, str]]:
+    """Extract composes[] entries from a raw frontmatter block.
+
+    parse_flat_keys cannot handle list-of-dict fields, so we scan the raw
+    text. Returns a list of dicts with at least a 'kind' key per entry
+    and whatever other sub-keys (ref, version, role) appeared on the
+    indented follow-up lines.
+    """
+    entries: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    in_composes = False
+    for line in raw_fm.splitlines():
+        if not line:
+            continue
+        # Top-level (column-0) key terminates any prior block.
+        if line[0] not in (" ", "\t"):
+            if current is not None:
+                entries.append(current)
+                current = None
+            in_composes = line.startswith("composes:")
+            continue
+        if not in_composes:
+            continue
+        stripped = line.strip()
+        if stripped.startswith("- kind:"):
+            if current is not None:
+                entries.append(current)
+            current = {"kind": stripped.split(":", 1)[1].strip()}
+        elif current is not None and ":" in stripped and not stripped.startswith("-"):
+            k, v = stripped.split(":", 1)
+            current[k.strip()] = v.strip().strip('"\'')
+    if current is not None:
+        entries.append(current)
+    return entries
+
+
+def lint_technique_composes(raw_fm: str) -> list[str]:
+    """Return technique-specific lint errors for the composes[] list.
+
+    Enforces v0.1 schema rules:
+    - composes must have at least one entry
+    - kind must be 'skill' or 'knowledge' (technique nesting forbidden)
+    - ref must resolve to an actual file on disk (kind-root-relative path)
+    """
+    errors: list[str] = []
+    entries = parse_composes(raw_fm)
+    if not entries:
+        errors.append("composes: must contain at least one entry")
+        return errors
+    for i, e in enumerate(entries):
+        kind = e.get("kind", "")
+        ref = e.get("ref", "")
+        if not kind:
+            errors.append(f"composes[{i}]: missing kind")
+            continue
+        if kind == "technique":
+            errors.append(
+                f"composes[{i}]: technique-to-technique composition forbidden in v0"
+            )
+            continue
+        if kind not in ("skill", "knowledge"):
+            errors.append(
+                f"composes[{i}]: unknown kind {kind!r} (must be skill or knowledge)"
+            )
+            continue
+        if not ref:
+            errors.append(f"composes[{i}]: missing ref")
+            continue
+        if kind == "skill":
+            target = SKILL_DIR / ref / "SKILL.md"
+        else:
+            target = KNOWLEDGE_DIR / f"{ref}.md"
+        if not target.exists():
+            errors.append(
+                f"composes[{i}]: {kind} ref not found: {ref!r} "
+                f"(expected {target.relative_to(HUB_ROOT).as_posix()})"
+            )
+    return errors
+
+
 def scan_file(path: Path) -> dict:
     try:
         text = path.read_text(encoding="utf-8")
@@ -100,6 +180,8 @@ def scan_file(path: Path) -> dict:
             f"invalid category format: {category_val!r} (must be single "
             f"kebab-case token — no '/', '\\\\', or spaces)"
         )
+    if path.name == "TECHNIQUE.md":
+        errors.extend(lint_technique_composes(raw))
     return {"path": str(path), "errors": errors, "missing": missing, "fields": list(fields)}
 
 


### PR DESCRIPTION
## Summary

Technique-specific `composes[]` validation in `_lint_frontmatter.py`. Closes RFC §9 rules 1 (ref resolution) and 3 (no technique nesting) at the lint layer, so bad techniques fail at authoring/precheck rather than at `/hub-find` or `/hub-technique-verify` runtime.

## Checks applied (TECHNIQUE.md files only)

| Rule | Behaviour |
|---|---|
| `composes` non-empty | At least one entry required |
| `kind` ∈ {skill, knowledge} | `technique` explicitly rejected (v0 nesting ban) |
| `ref` resolves | `skills/<ref>/SKILL.md` or `knowledge/<ref>.md` must exist |
| `ref` or `kind` present | Missing either produces a pinned error |

## Composes parser

`parse_flat_keys` can't handle list-of-dict shapes. Added a small walker (`parse_composes`) that tracks the `composes:` block and groups indented sub-keys under each `- kind:` entry. Same pattern the index builder uses, now reusable from the linter.

## Verification

```
Clean corpus (both pilots):
  PASS — 모든 파일이 스키마를 만족합니다.

Inject bad ref:
  composes[0]: skill ref not found: 'workflow/nonexistent-skill'
  (expected skills/workflow/nonexistent-skill/SKILL.md)

Inject technique kind:
  composes[0]: technique-to-technique composition forbidden in v0

Restore to clean:
  PASS
```

## Deferred (not in this PR)

- Version range intersection check (§9 rule 2) — requires semver range parser; tradeoff between complexity and real-world value is unclear right now
- `description` ≤120 chars check (§9 rule 4) — already implemented in `/hub-technique-verify` as a warning, not blocking; leaving as warning-only feels right
- `binding: pinned` requires exact versions check (§9 rule 8) — see above

## Bootstrap version note

Touches `bootstrap/tools/_lint_frontmatter.py`. Would fit into a future `bootstrap/v2.6.16` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)