### PR TITLE
RFC: add paper/ exploration layer (v0.1 draft)

### DIFF
--- a/docs/rfc/paper-layer.md
+++ b/docs/rfc/paper-layer.md
@@ -1,0 +1,178 @@
+# RFC: `paper/` — Hypothesis-Driven Exploration Layer
+
+- **Status**: draft v0.1
+- **Target repo**: `kjuhwa/skills-hub`
+- **Author**: kjuhwa@nkia.co.kr
+- **Date**: 2026-04-24
+- **Local evidence**: 2 pilots (one meta, one domain), 4 slash commands authored + validated, schema doc with explicit retraction criteria
+
+> **Reviewer note**: this RFC follows the `technique/` layer rollout that landed in #1058–#1070 / tags v2.6.14–v2.6.17. It proposes adding **one more axis** to the hub — not another enforcement layer, but an exploration layer for "what if" hypotheses. Detailed read-before-merge: [`docs/rfc/paper-schema-draft.md`](./paper-schema-draft.md).
+
+## 1. Problem
+
+The hub's existing primitives all live on the **enforcement axis** — a reviewer or lint rule can say pass/fail:
+
+| Primitive | Pass/fail test |
+|---|---|
+| skill | Does it run? Does the frontmatter parse? |
+| knowledge | Does the frontmatter parse? |
+| technique | Do `composes[]` refs resolve? Is there no nesting? |
+| example | Does the build work? |
+
+There is no first-class place for **"what if" arguments** — essays that examine multiple entries together, apply multiple perspectives, incorporate external research, and propose new builds. Those arguments cannot be pass/fail'd: they are judgment calls. Forcing them through the technique verify gate would flatten the exploratory content they exist to hold.
+
+Today such arguments live in scattered places: RFCs (but RFCs propose changes to the hub itself), blog posts (no structure, no cite-able references to the corpus), session transcripts (ephemeral). None of those produce a durable, cite-able artifact that other hub content can reference.
+
+## 2. Proposal
+
+Add `paper/` as a first-class hub directory on a **new axis** — exploration, not enforcement:
+
+```
+atom (knowledge/skill)  →  technique (recipe, verifiable)  ←  enforcement axis
+                                   ↓
+                            paper (hypothesis + angles + external research)  ←  exploration axis
+                                   ↓
+                            example / app (concrete instantiation)
+```
+
+Key property: papers **use** the enforcement axis (they cite techniques/atoms by path) but are **not reducible** to it. Their value is in what they propose, not in whether the proposal runs today.
+
+### Directory
+
+```
+paper/
+  <category>/
+    <slug>/
+      PAPER.md           # required
+      resources/         # optional
+      notes/             # optional
+```
+
+Categories reuse `CATEGORIES.md`.
+
+### Frontmatter (core fields)
+
+```yaml
+---
+version: 0.1.0
+name: <slug>
+description: <≤120 chars>
+category: <CATEGORIES.md>
+tags: [...]
+
+premise:                # REQUIRED — what makes this a paper
+  if: <condition>
+  then: <predicted outcome>
+
+examines:               # hub refs being analyzed
+  - kind: skill | knowledge | technique
+    ref: <kind-root-relative path>
+    role: <free-text>
+
+perspectives:           # ≥2 required — multi-angle analysis
+  - name: <short label>
+    summary: <1-2 lines>
+
+external_refs: []       # URLs from hub-research (may be empty)
+proposed_builds: []     # downstream apps/experiments (may be empty)
+status: draft           # draft | reviewed | implemented | retracted
+---
+```
+
+### Verification scope — structure only
+
+The `/hub-paper-verify` command checks:
+
+1. `premise.if/then` non-empty
+2. `examines[]` non-empty + every `ref` resolves on disk
+3. `perspectives[]` length ≥ 2
+4. `description` ≤ 120 chars
+5. `name` == folder
+6. `status` in enum
+
+It **deliberately does not check**:
+
+- Claim correctness
+- Perspective accuracy
+- External-ref URL reachability or quality
+- Whether `proposed_builds[]` actually exist
+
+A paper either asserts correct things or it doesn't. That is a reviewer job, not a lint job. This is the single most important design choice in this RFC — see §11.
+
+## 3. Pilot Evidence (n=2)
+
+Two pilots authored locally, both pass the proposed `/hub-paper-verify` rules. Subjects deliberately chosen to stress-test:
+
+| | Paper 1 (meta) | Paper 2 (domain) |
+|---|---|---|
+| Subject | The `technique/` layer itself | Parallel subagent dispatch economics |
+| Self-reference | Strong (cites work shipped this session) | None (cites pre-existing corpus) |
+| Examines | technique × 2 + skill × 1 + knowledge × 1 | skill × 3 + knowledge × 1 |
+| Premise type | "Does the layer produce durable value?" — meta | "Does the pattern have a break-even point?" — cost model |
+| Perspectives | 4 (maintainability / cognition / research integration / rollout cost) | 4 (cost model / instrumentation / cognition / failure modes) |
+| Proposed builds | 3 | 3 |
+| Verify | PASS (all 6 rules) | PASS (all 6 rules) |
+
+**Finding**: the same frontmatter schema absorbs both paper shapes without modification. The `premise.if/then` pattern works for both "does the layer yield X?" (existential claim) and "does the pattern break at Y?" (threshold claim). The `perspectives[]` free-text `name` field carries the angle labels — `Maintainability` / `Rollout Cost` in paper 1 vs `Cost Model` / `Failure Modes` in paper 2. No DSL needed in v0.
+
+**Self-reference risk discharged**: paper 2 cites only atoms that existed in the hub before this session (`workflow/parallel-bulk-annotation`, `ai/ai-subagent-scope-narrowing`, etc.). If the paper layer only worked for self-referential meta-content, that would be a red flag; paper 2 shows it works on external subject matter.
+
+## 4. Observations (not required changes)
+
+- **External refs empty at draft is common, not a bug**. Both pilots ship with `external_refs[]` empty. §6 rule 7 makes this explicit — reachability and quality of external sources is not a lint concern. `hub-research` can populate them later without changing the paper's structural validity.
+- **Proposed builds length is a useful meta-signal**. Paper 1 proposes 3 builds; paper 2 proposes 3. A paper with zero proposed builds is likely a `pure-analysis` paper (tagged as such). A paper with many is likely implementable. Both are valid.
+- **Retraction has real force**. §11 of the schema draft says the layer retracts if the first pilot looks like a blog post or an RFC. Paper 1 deliberately examines this in its `Limitations` section — it asserts it passes the test but admits a neutral reviewer is needed. Paper 2 adds counter-evidence: its subject (parallel dispatch threshold) genuinely could not live inside the existing pitfall knowledge entry because the pitfall is one-session observation whereas the paper generalizes to a cost curve + a gate-skill proposal.
+
+## 5. Migration Plan
+
+Zero-disruption, mirrors the `technique/` rollout:
+
+1. **This PR**: merge the directory + schema + 2 pilots only. No tooling yet.
+2. Follow-up PR: `bootstrap/commands/hub-paper-*.md` — four slash commands (compose, verify, list, show). Already authored, validated against both pilots offline.
+3. Follow-up PR: `/hub-find --kind paper` integration + `_rebuild_index_json.py` walker for `paper/**/PAPER.md`. Same pattern as technique support in #1060.
+4. Follow-up PR: `_lint_frontmatter.py` recognizes `PAPER.md` for standard frontmatter lint.
+5. Follow-up PR: `README.md` refresh + bootstrap version bump (likely `bootstrap/v2.7.0` given this is a new layer, or `v2.6.18+` if staying in patch track).
+
+Rollback at any step: removing `paper/` directory leaves everything else untouched. Absence of the optional `papers` key in `registry.json` is handled by existing readers.
+
+## 6. Slash Commands (follow-up PR)
+
+Authored and locally validated:
+
+| Command | Role |
+|---|---|
+| `/hub-paper-compose <slug>` | Premise-first authoring (if/then required before anything else) |
+| `/hub-paper-verify <slug>\|--all` | Structure-only validation per §6 |
+| `/hub-paper-list [--status ...]` | Local state, grouped by status |
+| `/hub-paper-show <slug>` | Body + expanded examines |
+
+**Not in v0**: `/hub-paper-publish`, `/hub-make-from-paper` (scaffolds `example/` from `proposed_builds[]`).
+
+## 7. Open Questions for Reviewers
+
+1. **Nesting**: v0 forbids `examines[].kind: paper`. Academic papers cite papers — the rule is uncomfortable but mirrors the technique v0 nesting ban. Proposed revisit after ≥5 real papers exist.
+2. **`kind: doc`** in `examines[]` — should papers be able to cite `docs/rfc/*` or other repo docs directly? Currently they cite them in prose. Small scope to add, low urgency.
+3. **Retraction workflow** — `status: retracted` is in the enum, but the transition has no automated guardrails. Should a retracted paper's references get auto-unlinked from papers that cite it? Proposed: no in v0, revisit if cycles matter.
+4. **Language policy** — both pilots are English (same convention as the technique rollout). Formally declared in schema §12 Q5.
+5. **First substantive reviewer** — paper 1 explicitly acknowledges it cannot self-certify its own retraction criteria. This RFC is the request.
+
+## 8. Local Artifacts
+
+Placed alongside this RFC in the PR:
+
+- `docs/rfc/paper-layer.md` (this file)
+- `docs/rfc/paper-schema-draft.md` — full schema spec
+- `paper/workflow/technique-layer-composition-value/PAPER.md` — pilot 1 (meta)
+- `paper/workflow/parallel-dispatch-breakeven-point/PAPER.md` — pilot 2 (domain)
+
+## 9. What This RFC Does NOT Do
+
+- Not publishing the `/hub-paper-*` command set (deferred one PR).
+- Not modifying `/hub-find`, `/hub-status`, or any existing tooling (deferred two PRs).
+- Not bumping `registry.json` schema (backward-compatible additive key).
+- Not enforcing anything. Directory + schema + two pilots only.
+- Not making the case that all future `paper/` entries will be worth merging. The pilot-driven retraction mechanism (§11 of the schema) is the check, not this RFC's assertion.
+
+---
+
+**Request**: approve the directory, schema, and v0 rules. If a reviewer decides the pilots look like RFCs or blog posts rather than papers, the correct response is **retract the layer** per schema §11 — not merge anyway and hope it matures. The honest failure mode is part of the proposal.

--- a/docs/rfc/paper-schema-draft.md
+++ b/docs/rfc/paper-schema-draft.md
@@ -1,0 +1,286 @@
+---
+doc: paper-schema-draft
+status: draft-v0.1
+author: kjuhwa@nkia.co.kr
+date: 2026-04-24
+---
+
+# `paper/` — Hypothesis-Driven Exploration Layer (v0.1)
+
+## 1. Why
+
+The hub already has three primitives:
+- **atom** — `skill`, `knowledge` (verifiable: does it resolve, does it run?)
+- **recipe** — `technique` (verifiable: do the composed refs exist?)
+- **artifact** — `example` (verifiable: does it visibly work?)
+
+All three live on the **enforcement axis**. You can pass/fail them.
+
+What the hub does *not* have is a first-class place for **"what if" statements** — essays that treat the existing corpus as evidence and propose new directions. Those arguments cannot be pass/fail'd: they are judgment calls. Forcing them through a verify gate would flatten the exploratory content they exist to hold.
+
+`paper/` is the **exploration axis**:
+
+```
+atom (knowledge/skill)  →  technique (recipe, verifiable)  ←  enforcement axis
+                                   ↓
+                            paper (hypothesis + angles + external research)  ←  exploration axis
+                                   ↓
+                            example / app (concrete instantiation of a paper's proposal)
+```
+
+A paper **uses** the enforcement axis (it cites techniques/atoms by path) but is **not reducible** to it. Its value is in what it proposes, not in whether the proposal runs today.
+
+## 2. Boundary with existing concepts
+
+| Concept | Mode | Unit | Verifiable? | References |
+|---|---|---|---|---|
+| skill | atom | procedure | yes (frontmatter + runnable) | — |
+| knowledge | atom | fact/lesson | yes (frontmatter) | — |
+| technique | recipe | composition | yes (refs resolve, no nesting, etc.) | skills + knowledge |
+| **paper** | **claim** | **hypothesis** | **structure only** | **techniques + skills + knowledge + external** |
+| example | artifact | finished build | visual/runtime | often produced by a paper's proposal |
+
+**Technique vs paper**:
+- Technique answers *"how do we do X safely?"*
+- Paper answers *"what if we tried X in context Y, and what should we build to test that?"*
+
+**Paper vs RFC/design-doc**:
+- An RFC proposes a *change to the hub itself* and wants to be merged.
+- A paper stays in `paper/` as a reusable artifact. It may spawn RFCs, but it is not an RFC.
+- If a pilot paper turns out to be indistinguishable from an RFC in practice, this layer retracts — see §13.
+
+## 3. Directory and file layout
+
+```
+paper/
+  <category>/
+    <slug>/
+      PAPER.md           ← frontmatter + body (required)
+      resources/         ← optional: figures, data exports, pdf excerpts
+      notes/             ← optional: author notes, discarded drafts, rebuttals
+```
+
+Categories reuse `CATEGORIES.md`. No new enum values.
+
+## 4. Frontmatter schema
+
+```yaml
+---
+version: 0.1.0
+name: <slug>
+description: <single line, ≤120 chars — the hypothesis summarized>
+category: <one of CATEGORIES.md>
+tags: [<string>, ...]
+
+premise:                    # REQUIRED — what makes this a paper
+  if: <condition statement>
+  then: <predicted outcome>
+
+examines:                   # what this paper analyzes (hub refs)
+  - kind: technique | skill | knowledge
+    ref: <kind-root-relative path>
+    role: <free-text, e.g. "subject of analysis", "supporting evidence", "counter-example">
+
+perspectives:               # angles/lenses applied to the subject — at least 2 required
+  - name: <short label>
+    summary: <1-2 line description of what this angle examines>
+
+external_refs:              # citations found via hub-research or manual
+  - title: <string>
+    url: <string>
+    kind: paper | article | book | video | tool | repo
+    relevance: <1 line — why it matters to this paper>
+
+proposed_builds:            # concrete downstream proposals (optional but expected)
+  - slug: <kebab-case app/experiment name>
+    summary: <what it does, in 1-2 lines>
+    scope: poc | demo | production
+
+status: draft               # draft | reviewed | implemented | retracted
+---
+```
+
+### Field rationale
+
+- **`premise.if/then`** is the gate that distinguishes a paper from a wiki entry. No `if/then`, no paper.
+- **`examines[]`** makes the paper **cite-able as structured data**, so future tooling can show "which papers reference this technique/skill?"
+- **`perspectives[]`** forces multi-angle analysis — a single-angle paper is really just a note.
+- **`external_refs[]`** — `hub-research` feeds into this. An empty list is allowed but flagged as "internal-only" in `hub-paper-list`.
+- **`proposed_builds[]`** closes the loop to `example/` and new apps. Papers with no proposed builds are allowed but carry a `pure-analysis` tag.
+- **`status`** — retracted papers stay in the tree (historical record) but are ranked last in search.
+
+## 5. Body structure (recommended, not enforced)
+
+```
+# <Title>
+
+## Premise
+... expand the if/then from frontmatter with supporting intuition.
+
+## Background
+... what corpus pieces are we examining (cite examines[]).
+
+## Perspectives
+### <perspective 1 name>
+...
+### <perspective 2 name>
+...
+
+## External Context
+... cite external_refs[]; synthesize.
+
+## Proposed Builds
+### <build slug>
+... what to build, why this paper's claims require it.
+
+## Open Questions
+## Limitations
+```
+
+Body format is free markdown. The frontmatter is the structured surface.
+
+## 6. Verification rules (structure-only, v0.1)
+
+Unlike technique which verifies **refs + role + binding consistency**, paper verification is deliberately narrow — it guards **structure**, never **substance**.
+
+1. `premise.if` and `premise.then` both non-empty strings.
+2. `examines[]` non-empty, every `ref` resolves to an actual file (same path convention as technique: kind-root-relative).
+3. `perspectives[]` length ≥ 2 (a single-angle paper is not a paper).
+4. `description` ≤ 120 chars.
+5. `name` equals the containing directory name.
+6. `status` ∈ {draft, reviewed, implemented, retracted}.
+7. No check on `external_refs` URL reachability (too flaky, too online-dependent).
+8. No check on whether `proposed_builds` actually exist under `example/` (that's what the `implemented` status is for).
+
+**What is NOT verified** (intentionally):
+- The claims in `premise`.
+- The accuracy of `perspectives[].summary`.
+- The quality or real existence of `external_refs[]`.
+- Whether the paper is "good".
+
+A paper either asserts correct things or it doesn't. That is a reviewer job, not a lint job.
+
+## 7. v0 scope limits (revisitable in v0.2)
+
+- **No paper-to-paper references** in `examines[]`. Academic papers cite papers, so this is uncomfortable — but in v0 the same cycle/coupling risk applies as with technique nesting. Revisit once we have ≥5 papers.
+- **No rich citation format** (BibTeX, DOI, etc.). External refs stay free-form URL + title.
+- **No schema for `perspectives[]` names** (like "theoretical", "economic", "ethical"). Free text. We'll propose a controlled vocabulary only if we see 10+ papers converge on the same labels.
+
+## 8. Lifecycle
+
+```
+draft (.paper-draft/)   ──►  reviewed   ──►  implemented    ──►  retracted (if disproven)
+                                   ↓              ↓                        ↑
+                            (peer review)   (a proposed_build landed    (author withdraws,
+                                            in example/ and the         reviewer rejects,
+                                            paper's claim was tested)   or later evidence
+                                                                         overturns it)
+```
+
+Transition criteria are social (reviewer, author, time). Not enforced by tooling.
+
+## 9. Registry and index integration
+
+Additive (same pattern as technique):
+
+```json
+{
+  "version": 3,
+  "skills": { ... },
+  "knowledge": { ... },
+  "techniques": { ... },
+  "papers": {
+    "<cat>/<slug>": {
+      "category": "workflow",
+      "scope": "global",
+      "path": "~/.claude/papers/<cat>/<slug>/",
+      "installed_at": "2026-04-24",
+      "version": "0.1.0",
+      "status": "draft",
+      "examines_snapshot": [
+        {"kind":"technique","ref":"workflow/safe-bulk-pr-publishing","resolved_version":"0.1.0-draft"}
+      ]
+    }
+  }
+}
+```
+
+`index.json` adds `kind: "paper"` entries with `status`, `examines_count`, and `proposed_builds_count` alongside the standard fields.
+
+## 10. Slash commands (v0 minimum)
+
+- `/hub-paper-compose <slug>` — interactive authoring. Premise is first prompt ("what if"). Then examines (with hub-find integration). Then perspectives (≥2 required). Optional external_refs (suggests `/hub-research` if empty). Optional proposed_builds.
+- `/hub-paper-verify <slug>|--all` — structural lint per §6.
+- `/hub-paper-list [--status ...]` — list local papers.
+- `/hub-paper-show <slug>` — body + expanded examines (inline atom descriptions).
+- `/hub-find --kind paper <query>` — unified search integration.
+
+Deferred to v0.2: `/hub-paper-publish`, `/hub-paper-spawn-build` (auto-scaffold example/ from proposed_builds entry).
+
+## 11. Failure mode (explicit)
+
+If the first pilot paper reads like any of the following, **retract the `paper/` layer**:
+
+- A blog post with extra YAML ceremony.
+- An RFC that should have been an RFC.
+- A README section that should have been on the technique it references.
+- A skill description stretched across multiple files.
+
+The layer earns its keep only if it produces **something a technique or knowledge entry could not have held**. The pilot test this.
+
+## 12. Open issues
+
+- **Q1.** `examines[]` allowing `kind: paper`? → NO in v0. Revisit after ≥5 real papers. Citation graphs matter but cycle risks + premature complexity outweigh the benefit today.
+- **Q2.** `proposed_builds[]` should link to `example/` when implemented? → YES, proposed. Add optional `example_ref: <ref>` to each proposed_build once status→implemented.
+- **Q3.** External refs reachability check? → NO in v0 lint. Maybe a weekly CI job, separate scope.
+- **Q4.** Reviewer field in frontmatter for transition `draft → reviewed`? → Deferred. Social workflow first, metadata later.
+- **Q5.** Language policy? → Same as hub-wide convention: English for `PAPER.md` body that ships in the hub. (Per feedback from the technique rollout.)
+
+## 13. Pilot candidate
+
+**Paper 1 (meta)**: *"Does a technique/ middle layer in a skill hub produce durable composition value beyond hub-merge?"*
+
+- Premise:
+  - **IF** a skills-hub adds a `technique/` layer that composes atoms by reference (not by copy),
+  - **THEN** the layer produces distinct downstream value — reusable recipes that survive atom updates, cross-domain stress-test (n=2+), and a path for papers/apps to cite recipes as a unit — that cannot be reproduced by `hub-merge` alone.
+- Examines:
+  - `technique/workflow/safe-bulk-pr-publishing` (pilot #1, linear shape)
+  - `technique/debug/root-cause-to-tdd-plan` (pilot #2, branching shape)
+  - `docs/rfc/technique-layer.md` (RFC §4 path-category finding as evidence)
+  - `docs/rfc/technique-schema-draft.md` (schema as subject)
+- Perspectives (≥2 required):
+  - **Maintainability** — how does technique fare when a composed atom is renamed/moved? (See §4 finding.)
+  - **Cognitive load** — does a user searching `/hub-find "safe pr publish"` benefit from a technique hit vs 4 separate atom hits?
+  - **Research integration** — how does a paper cite a technique? (This very paper, recursively.)
+  - **Rollout cost** — the 13-PR chain that shipped this layer; is the pattern replicable?
+- External refs (to gather via `/hub-research`):
+  - Any prior work on "composition layers between primitive and application" in developer tool ecosystems.
+  - UNIX philosophy on stdin/stdout vs libraries.
+  - Functional composition literature.
+- Proposed builds:
+  - `/hub-paper-*` commands themselves (the paper's output is also its own tooling — self-referential pilot).
+  - A 3rd technique in a domain untouched by the first two (e.g. `security/...`) to further stress the schema's generality.
+  - A `/hub-make` variant that accepts a paper's `proposed_builds[]` list and scaffolds each one.
+
+**Why this pilot**: it uses the hub's actual, shipped-this-session evidence as subject matter. If even a self-referential paper about a shipped feature can't articulate value beyond what the RFC already says, the `paper/` layer should be retracted — which is itself a useful finding (§11).
+
+## 14. Relationship to current rollout-stage work
+
+- `hub-research` (existing skill) feeds `external_refs[]`.
+- `hub-make` (existing skill) can consume `proposed_builds[]`.
+- `hub-find --kind paper` extension required.
+- No new indexes or lint infra beyond mirror-of-technique.
+
+The paper layer rides on existing plumbing. It introduces **one new concept** (premise-driven structure) and **one new verification behavior** (≥2 perspectives, refs resolve, but nothing more).
+
+---
+
+## Request to confirm before step 2
+
+Before authoring pilot 1, confirm:
+
+1. **Verify scope**: structure-only (premise present, examines resolve, ≥2 perspectives). No substance checks. ← proposed
+2. **No paper-nesting in v0**: `examines[].kind` ∈ {skill, knowledge, technique} only. ← proposed
+3. **Pilot target**: the meta-paper above (technique layer as subject). ← proposed, but open to an outside-the-session topic if you'd rather start with something that isn't self-referential.
+
+If all three are acceptable, step 2 (author pilot 1) proceeds. Any single "no" redirects the schema.

--- a/paper/workflow/parallel-dispatch-breakeven-point/PAPER.md
+++ b/paper/workflow/parallel-dispatch-breakeven-point/PAPER.md
@@ -1,0 +1,225 @@
+---
+version: 0.1.0-draft
+name: parallel-dispatch-breakeven-point
+description: When does parallel subagent dispatch stop paying off, and what pre-flight probe catches it before tokens are wasted?
+category: workflow
+tags:
+  - parallel
+  - subagent
+  - dispatch
+  - cost-model
+  - pre-check
+
+premise:
+  if: A bulk-modification task is dispatched to N parallel subagents without a pre-flight coverage check
+  then: Beyond a prior-work coverage threshold of roughly 70 percent, the parallel pattern becomes a net negative — serial single-agent scan with targeted dispatch is cheaper, yet existing skills describe HOW to parallelize uniformly without surfacing WHEN NOT to
+
+examines:
+  - kind: skill
+    ref: workflow/parallel-bulk-annotation
+    role: the canonical HOW-TO for parallel bulk annotation dispatch
+  - kind: skill
+    ref: workflow/bucket-parallel-java-annotation-dispatch
+    role: a specific variant (Java + bucket partitioning) — same HOW-TO assumption
+  - kind: knowledge
+    ref: agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch
+    role: counter-evidence — a real session where 3 of 4 parallel agents did zero useful work because prior coverage was ~90 percent
+  - kind: skill
+    ref: ai/ai-subagent-scope-narrowing
+    role: adjacent pattern for narrowing scope before dispatch; the "decide what to parallelize" side of the problem
+
+perspectives:
+  - name: Cost Model
+    summary: Parallel dispatch cost is not just wall-clock. It is (N agents × per-agent startup overhead) + (N × verification rounds) + token cost across N agents. Break-even depends on prior-work coverage and per-file verification time.
+  - name: Instrumentation
+    summary: The pre-flight probe that catches this is a 1-second grep. The question is why the existing parallel skills do not include it as step 0 — is it because coverage is a variable the skill cannot predict, or because the skill writers were optimizing for the high-work case and never saw the low-work case dominate?
+  - name: User Cognition
+    summary: Skills describing "how to parallelize" are teachable; skills describing "when NOT to parallelize" require a judgment call the author has to encode. The missing meta-step is the paper's real contribution — a separate skill whose job is the GATE, not the DISPATCH.
+  - name: Failure Modes
+    summary: A parallel dispatch that wastes tokens on already-done work fails SILENTLY — all agents return success, total time looks normal. Silent waste is worse than loud failure because it accumulates across sessions. A gate that FAILS the dispatch with a clear message ("coverage 92 percent, switch to sampling") converts silent waste into visible decision.
+
+external_refs: []
+
+proposed_builds:
+  - slug: parallel-dispatch-coverage-gate
+    summary: Pre-flight skill that scans the target corpus for existing-work markers (grep, git log, sample-read) and refuses to dispatch when coverage exceeds a configurable threshold; delegates to sampling mode above threshold
+    scope: poc
+  - slug: coverage-threshold-decision-table
+    summary: Knowledge entry with a decision table - work-type × prior-coverage × recommended-strategy (parallel-dispatch, single-agent-scan, sampling-only) backed by session data from real runs
+    scope: poc
+  - slug: parallel-bulk-annotation-preflight-section
+    summary: Extension to the existing parallel-bulk-annotation skill adding a "Phase 0 - Pre-flight" section that calls the coverage gate and routes to serial or sampling mode when appropriate
+    scope: demo
+
+status: draft
+---
+
+# When does parallel subagent dispatch stop paying off?
+
+## Premise
+
+**If** a bulk-modification task is dispatched to N parallel subagents without a pre-flight coverage check, **then** beyond a prior-work coverage threshold of roughly 70 percent, the parallel pattern becomes a net negative — serial single-agent scan with targeted dispatch is cheaper. Yet the existing skills in the hub describe *how* to parallelize uniformly without surfacing *when not to*.
+
+This is a cost-model claim, and a tooling claim. The cost model says there is a break-even point. The tooling claim says the hub has the HOW-TO but not the GATE — the decision that must happen *before* the HOW-TO fires.
+
+## Background
+
+The hub already carries multiple skills on parallel subagent dispatch for bulk work:
+
+- `workflow/parallel-bulk-annotation` — the canonical how-to for annotating many files across parallel agents
+- `workflow/bucket-parallel-java-annotation-dispatch` — a Java-specific variant using bucket partitioning
+- `ai/ai-subagent-scope-narrowing` — the adjacent concept of narrowing what gets dispatched
+
+And one pitfall, authored mid-session when the pattern broke under it:
+
+- `agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch` — a real session where 4 parallel agents were dispatched to annotate DTO files, 3 returned "zero changes — already annotated," and the user paid for 3 wasted agent rounds because prior coverage was not checked first.
+
+The pitfall is the counter-evidence for this paper. The skills tell you *how* to parallelize; the pitfall tells you *when it stops paying off*. The two pieces of information are split across kinds and across files, and nothing in the hub enforces that a user reading the skill also encounters the pitfall.
+
+## Perspectives
+
+### 1. Cost Model
+
+Naïve intuition: parallel dispatch is faster, so parallel dispatch is cheaper. This is wall-clock reasoning.
+
+The actual cost is roughly:
+
+```
+total_cost = (N agents × startup_overhead)
+           + (N × per_agent_verification_time)
+           + (sum of per-agent token spend)
+```
+
+If prior coverage is `c` (fraction of files already done):
+
+- `N × startup_overhead` is paid regardless of `c`. Fixed.
+- `N × verification_time` grows with `c` because agents still Read → analyze → conclude "nothing to change."
+- Token spend scales with `(1 - c) × real_work` plus `c × verification_noise`.
+
+At `c = 0`, parallel wins by a large margin (all agents do real work).
+At `c = 1`, parallel pays the fixed cost for zero output — pure waste.
+Somewhere between, the line crosses. The pitfall observed `c ≈ 0.9` in practice and the crossover hit hard.
+
+The threshold is not universal — it depends on the ratio of verification time to real-work time per file. Java DTOs with heavy compile-check verification push the break-even down (closer to `c = 0.5`). Simple text edits push it up (closer to `c = 0.8`).
+
+### 2. Instrumentation
+
+The probe that catches the bad case is cheap:
+
+```bash
+# What fraction of target files already carry the marker?
+total=$(find <scope> -name "*.java" | wc -l)
+hit=$(grep -rln "@Schema" <scope> | wc -l)
+coverage=$((hit * 100 / total))
+```
+
+This is one second of shell, run before any subagent starts. It is not in any of the parallel skills currently in the hub.
+
+Two possible reasons:
+
+1. **Coverage is a variable the skill cannot predict ahead of time**, so it was omitted as out of scope.
+2. **The skill was authored for the common case** (a fresh codebase with little prior coverage), and the tail case (high prior coverage) was never observed by the author — until the session that produced the pitfall.
+
+Both are reasonable. Neither is an argument against adding the probe; they are reasons the probe was not there yet.
+
+### 3. User Cognition
+
+"How to parallelize" is a teachable procedure — N agents, split the input, collect results. It composes well as a skill because it is a procedure.
+
+"When NOT to parallelize" is a judgment call. To encode it, the skill author has to carry a mental model of the cost curve and express the threshold as a rule. That is harder to write, and easier to get wrong.
+
+The result: the hub has many skills saying *how*, and one pitfall saying *don't always*. These are not symmetric. The how-to skills get triggered by keyword matching ("bulk annotation"); the pitfall gets found only if the user happens to search `/hub-find "wasted agent parallel"`. The pitfall's discoverability is much lower than the risk it documents.
+
+This paper's third proposed build addresses the asymmetry directly: a dedicated **gate skill** whose entire job is the decision. A gate is a first-class skill with its own triggers and `description`, not a paragraph buried inside a how-to. Its purpose is to be found first.
+
+### 4. Failure Modes
+
+A parallel dispatch that wastes tokens fails **silently**:
+
+- All N agents return success.
+- Wall-clock time looks similar to the productive case.
+- The only signal is a token bill at month-end, or an observant user noticing `Agent 2 modified 0 files, Agent 3 modified 0 files` in the logs.
+
+Silent failure accumulates across sessions. A user who has been bitten once learns to probe — but only for this one domain. They don't generalize.
+
+Loud failure is rarer and more useful. A gate that rejects the dispatch with
+
+```
+Coverage 92% — parallel dispatch not justified. Switch to:
+  sampling (find untreated files → single agent)
+  or serial scan (1 agent reads all, reports untreated)
+```
+
+converts silent waste into a visible decision point. The user can override ("run anyway") but the override is explicit and auditable.
+
+## External Context
+
+`external_refs[]` empty at draft. Relevant `hub-research` topics:
+
+- Parallel algorithm amortization literature — when does fork-join pay off at small N?
+- Queueing theory cost models for server-side workload dispatch, adapted for agent-as-worker.
+- LLM token cost vs developer tooling cost-benefit analysis.
+- Whether any other agent frameworks (LangGraph, AutoGen, Crew) ship pre-flight gates for parallel dispatch.
+
+Filling these in would let the paper ground its threshold claim in prior art rather than treating it as intuition.
+
+## Proposed Builds
+
+### `parallel-dispatch-coverage-gate` (POC)
+
+A skill whose job is **the decision, not the work**. Inputs:
+
+- `scope` — target corpus (glob or path)
+- `marker` — grep pattern that identifies already-done files
+- `threshold` — decision boundary (default 0.7)
+
+Output: one of `dispatch-parallel | switch-to-sampling | switch-to-serial`, with numeric justification (`hit=X / total=Y = c`).
+
+The skill is deliberately narrow. It does not dispatch, it does not annotate, it does not recover. It answers one question.
+
+### `coverage-threshold-decision-table` (POC)
+
+Knowledge entry in the `decision` category. A table of the form:
+
+| Work type | Verify cost | Threshold |
+|---|---|---|
+| Java DTO annotation | High (compile) | 0.5 |
+| Text content edits | Low (regex) | 0.8 |
+| Schema migration | Very high (integration test) | 0.3 |
+| ... | ... | ... |
+
+Populated from real session data, augmented as new domains report their own numbers. A living document, version-bumped on every row addition.
+
+### `parallel-bulk-annotation-preflight-section` (DEMO)
+
+An edit to the existing `workflow/parallel-bulk-annotation` skill that adds a `Phase 0 — Pre-flight` section at the top:
+
+```
+Before any agent spawn, run:
+  /hub-suggest "coverage-gate" — or follow the gate skill inline.
+
+Threshold: see knowledge/decision/coverage-threshold-decision-table for
+your work type. When coverage ≥ threshold, switch mode (sampling or serial)
+and return; do not proceed to Phase 1.
+```
+
+This is the least-invasive way to make the gate discoverable — it lives where the how-to already lives.
+
+## Open Questions
+
+1. Is the threshold really ~0.7, or is it highly domain-specific? The paper asserts "roughly 70 percent" based on one pitfall observation. The decision table in the second proposed build exists partly to answer this question with more data.
+2. Can the coverage probe be made automatic — a hook that runs on any `/hub-make --parallel` invocation? Or does it have to be opt-in via the gate skill? Automatic risks false positives; opt-in risks being forgotten.
+3. Should the existing parallel skills be **retracted** and replaced with gate-mediated variants, or just annotated? The preflight-section proposal is annotation; retraction would force the decision. The former is pragmatic, the latter is honest.
+
+## Limitations
+
+- **n=1 evidence**: the 70% threshold claim rests on one observed session (the pitfall). Without additional data points across domains the number is illustrative, not authoritative.
+- **No actual implementation**: this paper proposes but does not ship. The proposed builds are scoped as POC specifically so the paper is a call for work, not a claim of completed work.
+- **Counter-argument not fully explored**: perhaps parallel dispatch is CHEAP ENOUGH in absolute terms that the break-even doesn't matter at typical token prices. The paper assumes tokens cost enough to make the gate worth building. That assumption may not hold in all deployment contexts (e.g., local models).
+
+## Provenance
+
+- Authored: 2026-04-24
+- Status: pilot #2 for the `paper/` layer schema v0.1 — non-self-referential (subject outside this session's work, unlike paper #1)
+- Schema doc: `paper-schema-draft.md`
+- Sibling paper: `.paper-draft/workflow/technique-layer-composition-value/PAPER.md`

--- a/paper/workflow/technique-layer-composition-value/PAPER.md
+++ b/paper/workflow/technique-layer-composition-value/PAPER.md
@@ -1,0 +1,224 @@
+---
+version: 0.1.0-draft
+name: technique-layer-composition-value
+description: Does a technique/ middle layer in a skills hub produce composition value beyond what hub-merge already provides?
+category: workflow
+tags:
+  - meta
+  - composition
+  - hub-architecture
+  - technique-layer
+
+premise:
+  if: A skills-hub adds a technique/ layer composing atoms by reference (not copy)
+  then: Durable composition value emerges — recipes that survive atom updates, generalize across shapes (linear and branching), and act as cite-able units for papers and apps — value not reproducible by hub-merge alone
+
+examines:
+  - kind: technique
+    ref: workflow/safe-bulk-pr-publishing
+    role: pilot #1 (linear pipeline, 4 composes)
+  - kind: technique
+    ref: debug/root-cause-to-tdd-plan
+    role: pilot #2 (decision tree, 4 composes)
+  - kind: skill
+    ref: workflow/parallel-build-sequential-publish
+    role: atom whose relocation surfaced the layout mismatch (RFC §4 evidence)
+  - kind: knowledge
+    ref: workflow/batch-pr-conflict-recovery
+    role: atom demonstrating failure-mode role in pilot #1
+
+perspectives:
+  - name: Maintainability
+    summary: How does a technique behave when a composed atom is renamed or moved? Tested against the parallel-build-sequential-publish relocation mid-rollout.
+  - name: Cognitive Load
+    summary: Does a user searching "safe bulk PR" gain more from a single technique hit than from four scattered atom hits?
+  - name: Research Integration
+    summary: Can papers cite techniques as first-class subjects? This paper is itself the first test of that capability — if the citation isn't structurally useful, the layer is suspect.
+  - name: Rollout Cost
+    summary: The 13-PR chain that shipped this layer — is the pattern replicable, and what does it suggest about adding future layers (papers included)?
+
+external_refs: []
+
+proposed_builds:
+  - slug: hub-paper-commands
+    summary: Four /hub-paper-{compose,verify,list,show} commands mirroring /hub-technique-* with verify scoped to structure only (premise presence, examines resolution, perspectives ≥2)
+    scope: poc
+  - slug: security-domain-technique-3
+    summary: A third pilot technique in a domain untouched by the first two (e.g. security/secret-rotation-safe-handover) to further stress schema generality past n=2
+    scope: poc
+  - slug: hub-make-from-paper
+    summary: Extension of /hub-make that reads a paper's proposed_builds[] and scaffolds each as an example/ draft, closing the paper → app loop
+    scope: demo
+
+status: draft
+---
+
+# Does the `technique/` middle layer produce durable composition value?
+
+## Premise
+
+**If** a skills-hub adds a `technique/` layer that composes atoms by reference (not by copy), **then** durable composition value emerges — recipes that survive atom updates, generalize across shapes (linear pipelines and branching decision trees), and serve as cite-able units for papers and apps — value that `hub-merge` alone cannot reproduce.
+
+This is a proposal, not a proof. The evidence below is from one rollout across roughly thirty hours and fifteen PRs; the claim is that the value is **durable**, which is a longer-horizon bet. What the rollout can show is whether the **shape** of the value is the shape the claim predicts.
+
+## Background
+
+Before this rollout the hub had two tiers with a gap:
+
+```
+knowledge ──┐
+skill     ──┼──► [user hand-assembles every time] ──► example
+```
+
+`hub-merge` existed as a composition tool but it **absorbs and destroys** the source atoms — a merged skill loses its standalone identity, and no other technique can reuse the same atoms afterward. It is a composition that eats its own inputs.
+
+The rollout introduced `technique/` as a third tier where composition is **by reference**: a technique names its atoms and leaves them in place. Atoms remain independent and reusable across multiple techniques.
+
+Two pilots shipped on purpose different shapes:
+
+- **Pilot #1** — linear pipeline, four composes: anchor → build → publish → recover
+- **Pilot #2** — decision tree, four composes: investigate → hypothesize → (build-error-triage | triage-issue)
+
+Schema supported both without modification.
+
+## Perspectives
+
+### 1. Maintainability
+
+The rollout exposed a real atom relocation event. `parallel-build-sequential-publish` was declared `category: workflow` in its frontmatter but lived at the root of `skills/`. PR #1063 moved it under `skills/workflow/`. Pilot #1's `composes[0].ref` had to update from `parallel-build-sequential-publish` to `workflow/parallel-build-sequential-publish`.
+
+What this tells us:
+
+- The technique's `ref` field is a **hard coupling** to a path. Rename the atom → break the technique.
+- The schema response was to define `ref` as kind-root-relative physical path (RFC §4), not as semantic `{category}/{slug}`. This made breakage **catch-able** by `/hub-technique-verify` rather than silent.
+- Follow-on: PR #1068 added a lint rule at publish time that fails if `composes[].ref` doesn't resolve on disk. A future rename therefore fails at the hub level before users see a broken technique.
+
+The claim this supports: techniques **survive atom changes via catch-and-fail, not via auto-migration**. That is a weaker form of durability than "atoms can change freely and techniques still work," but it is stronger than nothing: silent rot becomes noisy failure.
+
+### 2. Cognitive Load
+
+Under the old two-tier model, a user wanting "safe bulk PR publishing" had to know and assemble:
+
+1. `skills/workflow/parallel-build-sequential-publish` (orchestrator)
+2. `skills/workflow/rollback-anchor-tag-before-destructive-op` (pre-flight safety)
+3. `knowledge/workflow/batch-pr-conflict-recovery` (failure recovery)
+4. `knowledge/pitfall/gh-pr-create-race-with-auto-merge` (race-condition pitfall)
+
+Four separate lookups, four contexts, and the mental work of deciding in what order and at what trigger points they apply.
+
+Under the technique model, the same flow surfaces as **one** `/hub-find` hit: `technique/workflow/safe-bulk-pr-publishing`. The atoms are still there for people who want to read them — the technique's `composes[]` is an index, not a hiding layer. What the technique removes is the **assembly step**, not the primary material.
+
+That assembly step is where errors happen. The pilot's glue section lists four items the atoms alone do not tell a user:
+
+| Added element | Where |
+|---|---|
+| Anchor tag-slug convention (`pre-bulk-pr-<date>`) | Phase 0 |
+| Executor prohibitions on shared-catalog edits | Phase 1 |
+| Race-vs-failure branching for `gh pr create` | Phase 2 |
+| Recovery-mode trigger rule (N ≥ 3 CONFLICTING) | Phase 3 |
+
+None of the four are reproducible from reading the atoms. They live in the technique's body, not in the composed pieces. This is where the layer adds net value — it stores the connective tissue.
+
+### 3. Research Integration
+
+This paper examines two techniques as first-class units (`examines[]`). The question is whether that citation is **structurally useful** or just decorative.
+
+Useful tests:
+
+- A reader of this paper can follow `examines[0].ref` → `technique/workflow/safe-bulk-pr-publishing` and reach the exact pilot. No dereferencing by name or guesswork.
+- A future tool (`/hub-find --papers-citing workflow/safe-bulk-pr-publishing`) could list every paper that `examines` a given technique. The data is already structured for that.
+- If the technique is renamed, lint catches the broken citation in the paper just as it does in another technique.
+
+Decorative would look like: "In this paper we discuss pilot #1 and pilot #2." No navigable link, no broken-citation detection, no reverse-index.
+
+The test passes only weakly at `n=1` — this paper is the only example. If no second paper ever cites `technique/workflow/safe-bulk-pr-publishing`, the citation infrastructure is unused overhead. §13 of the schema draft acknowledges this risk: the `paper/` layer retracts if papers don't produce something a technique or knowledge entry could not hold.
+
+### 4. Rollout Cost
+
+The 13-PR chain that shipped this layer:
+
+- #1058 RFC + 2 pilots
+- #1059 5 slash commands
+- #1060 /hub-find extension + index builder awareness
+- #1061 English translation (user-flagged consistency breach)
+- #1062 technique-aware lint / index / status / list / precheck
+- #1063 parallel-build skill relocation (the §4 finding in action)
+- #1064 index.json regeneration (uncovered two nested bugs: flat parser for composes list, and preserve_extras overriding recomputed fields)
+- #1065 corpus frontmatter backfill (17 files)
+- #1066 normalize compound categories
+- #1067 lint category format (prevent regression of #1066)
+- #1068 lint technique composes refs (structure-only verification)
+- #1069 /hub-tools-update command
+- #1070 README refresh
+
+And four bootstrap tags: v2.6.14 → v2.6.17.
+
+The pattern: design → 2 pilots → commands → tooling → release tag, with corpus hygiene forced by the lint passes along the way. Replicable for the `paper/` layer under this paper's first proposed build.
+
+What the rollout was *not*:
+
+- Not a smooth one-shot landing. Every tooling PR surfaced at least one bug or data issue from the existing corpus.
+- Not free of user feedback. #1061 (language consistency) would not have been caught by any automated check — it took the user noticing.
+- Not obvious in size. The 13 PRs were not budgeted in advance. If the pattern is replicable, the estimate for a paper-layer rollout is ~8–12 PRs, with similar open-ended tail.
+
+## External Context
+
+`external_refs[]` is deliberately empty at first draft. Relevant searches for `/hub-research`:
+
+- "Composition layers between primitive and application" in developer-tool ecosystems (build tools, package managers, agent frameworks).
+- UNIX pipes and small-tools philosophy as a reference model for by-reference composition.
+- "Behavior trees" and "state machines" literature for decision-tree shape validation (relevant to pilot #2).
+- Prior work on documentation-as-code where structured prose cites structured artifacts (literate programming, Jupyter, MDX).
+
+A reviewer filling these in would strengthen the paper materially. Absence is flagged but not fatal.
+
+## Proposed Builds
+
+### `hub-paper-commands` (POC)
+
+Mirror of the four `/hub-technique-*` commands, with these deltas:
+
+- `/hub-paper-compose` prompts premise **first** (the `if/then`) before anything else. An author who cannot state the premise in two lines is not ready to compose the paper.
+- `/hub-paper-verify` checks only structure per schema §6: premise presence, examines resolution, perspectives ≥ 2, description ≤ 120, `status` enum. **No substance checks.**
+- `/hub-paper-list` shows `status` column and filters on `--status draft|reviewed|implemented|retracted`.
+- `/hub-paper-show` expands `examines[]` inline (like technique-show) and renders perspectives as numbered sections.
+
+Replicates the technique rollout shape. Estimated 1–2 PRs.
+
+### `security-domain-technique-3` (POC)
+
+The third technique pilot — in a domain deliberately chosen outside workflow/ and debug/. Proposal: `security/secret-rotation-safe-handover`.
+
+Composes (sketch, atoms to verify exist in hub):
+
+- skill: `security/<existing-rotation-skill>` — the rotation procedure
+- skill: `workflow/rollback-anchor-tag-before-destructive-op` — reused cross-domain atom
+- knowledge: `pitfall/<secret-exposure-class>` — failure-mode atom
+
+If the atoms do not already exist in sufficient quality, the pilot either authors missing ones first or picks a different third domain. The purpose is n=3 generality, not that specific topic.
+
+### `hub-make-from-paper` (DEMO)
+
+Extension of `/hub-make` that takes a paper slug, reads its `proposed_builds[]`, and scaffolds each as a draft under `example/<category>/<build-slug>/` with a README referencing the parent paper. Closes the paper → app loop that otherwise sits as prose.
+
+Carries a specific risk: if the paper's `proposed_builds[]` are too abstract, the scaffolds are empty folders. `/hub-make-from-paper` should refuse to scaffold a build whose `summary` is under ~60 characters, forcing the paper author to write a concrete-enough stub.
+
+## Open Questions
+
+1. When a `proposed_builds[]` item becomes a real `example/` entry, how is the back-link recorded? (§12 Q2 of the schema draft.) Proposal: add optional `example_ref` to each proposed_build; transition `status` to `implemented` when any proposed_build has a resolved `example_ref`.
+2. Is `examines[].kind: doc` (for citing `docs/rfc/...`) worth adding? Avoided in v0 for scope, but documents in the repo are legitimately cite-able subjects. Probably yes in v0.1.x or v0.2.
+3. Does the `no paper-to-paper citation` rule (§7) survive first contact with real writing? Academic papers cite papers. Watch for authors routing around it via `external_refs` (citing the paper by URL to its GitHub blob) — if that happens, v0.2 should lift the restriction.
+
+## Limitations
+
+- **n=1** paper. Generalization claims rest on one test. A second paper on an unrelated topic is needed before the layer's generality is anything more than asserted.
+- **Self-referential pilot.** This paper's subject is the layer immediately above it in the hub and its proposed builds include the tooling for its own layer. That is not a neutral test. A paper on something the author did not recently ship would be a stronger check.
+- **Durability is asserted, not measured.** The premise claims value "survives atom updates" and "generalizes across shapes." The evidence is one rename event (#1063) and two shapes (n=2). A longer window and more pilots are required before that claim is anything more than plausible.
+- **Retraction criteria not exercised.** §11 of the schema says the layer retracts if the first pilot looks like an RFC or blog post. This paper does enough differently (structured citations, multi-angle, concrete proposed builds) to not obviously trigger retraction, but the determination requires a reviewer who did not author it.
+
+## Provenance
+
+- Authored: 2026-04-24
+- Status: pilot #1 for the `paper/` layer schema v0.1
+- Schema doc: `paper-schema-draft.md`
+- Subject material: shipped in PRs #1058 through #1070 on `kjuhwa/skills-hub`, tags `bootstrap/v2.6.14` through `bootstrap/v2.6.17`


### PR DESCRIPTION
## Summary

Adds `paper/` as a hypothesis-driven exploration layer on a **new axis**. Existing primitives (skill/knowledge/technique/example) all live on the enforcement axis — pass/fail'able. Papers cannot be pass/fail'd; they are judgment calls, and forcing them through a verify gate flattens the content they exist to hold.

- v0.1 schema: `premise.if/then` required, `examines[]` cites hub refs, `perspectives[]` ≥ 2, verification deliberately **structure only**
- Two pilots — one meta (examines the technique layer), one domain (parallel-dispatch economics) — validate schema generality without self-reference crutch
- Explicit retraction criteria in schema §11 — layer retracts if pilots read like RFCs or blog posts

See [`docs/rfc/paper-layer.md`](docs/rfc/paper-layer.md) for the full proposal and [`docs/rfc/paper-schema-draft.md`](docs/rfc/paper-schema-draft.md) for the schema.

## Included

- `docs/rfc/paper-layer.md` — RFC body
- `docs/rfc/paper-schema-draft.md` — full schema v0.1
- `paper/workflow/technique-layer-composition-value/PAPER.md` — pilot #1 (meta)
- `paper/workflow/parallel-dispatch-breakeven-point/PAPER.md` — pilot #2 (domain)

## Verification

Structure-only checks per schema §6 — both pilots PASS:

| | Paper 1 | Paper 2 |
|---|---|---|
| premise.if/then non-empty | ✓ | ✓ |
| examines[] resolves on disk | 4/4 | 4/4 |
| perspectives[] count | 4 | 4 |
| description length | 112 / 120 | 116 / 120 |
| name == folder | ✓ | ✓ |
| status enum | draft | draft |

Paper 2's `examines[]` cites only atoms that existed before this session (`workflow/parallel-bulk-annotation`, `ai/ai-subagent-scope-narrowing`, `knowledge/agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch`, etc.) — discharging the self-reference risk that paper 1 could not.

## Test plan

- [ ] Reviewer: read `docs/rfc/paper-layer.md`
- [ ] Reviewer: spot-check pilot 1's `examines[]` refs (should all resolve to files in `technique/` and `skills/` and `knowledge/` on main)
- [ ] Reviewer: spot-check pilot 2's `examines[]` refs (same)
- [ ] Reviewer: apply the §11 retraction test — if either pilot reads like a blog post or an RFC, reject
- [ ] §7 open-question decisions: paper-nesting ban, `kind: doc` citations, retraction workflow, language policy, first substantive reviewer

## Follow-up PRs (after merge)

- `bootstrap/commands/hub-paper-{compose,verify,list,show}.md` — already authored and validated against both pilots
- `/hub-find --kind paper` + `_rebuild_index_json.py` walker for `paper/**/PAPER.md`
- `_lint_frontmatter.py` recognizes `PAPER.md` for standard frontmatter lint
- `README.md` refresh + `bootstrap/v2.6.18+` or `v2.7.0` tag

## What this PR does NOT do

- No commands, tooling, index regeneration, or README changes.
- No registry schema bump (optional `papers` key is backward-compatible).
- No assertion that all future `paper/` entries will be worth merging. The retraction mechanism is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)