### PR TITLE
feat(paper): schema v0.2 — experiments + outcomes + requires (non-triviality)

### DIFF
--- a/docs/rfc/paper-schema-draft.md
+++ b/docs/rfc/paper-schema-draft.md
@@ -1,11 +1,13 @@
 ---
 doc: paper-schema-draft
-status: draft-v0.1
+status: draft-v0.2
 author: kjuhwa@nkia.co.kr
 date: 2026-04-24
 ---
 
-# `paper/` — Hypothesis-Driven Exploration Layer (v0.1)
+# `paper/` — Hypothesis-Driven Exploration Layer (v0.2)
+
+> **v0.2 change summary**: v0.1 was forward-only (premise + proposed_builds). v0.2 closes the loop — papers now have `experiments[]` (backward-looking: what was actually tested) and `outcomes[]` (what the corpus learned). `proposed_builds[]` gains a `requires[]` field to enforce **non-triviality** — a build that doesn't depend on any corpus atom is a signal the paper isn't needed for it. Papers also get a `type` enum so survey/position papers without experiments remain valid.
 
 ## 1. Why
 
@@ -66,11 +68,18 @@ Categories reuse `CATEGORIES.md`. No new enum values.
 
 ```yaml
 ---
-version: 0.1.0
+version: 0.2.0
 name: <slug>
 description: <single line, ≤120 chars — the hypothesis summarized>
 category: <one of CATEGORIES.md>
 tags: [<string>, ...]
+
+type: hypothesis            # NEW in v0.2: hypothesis | survey | position
+                            #   hypothesis: claims something is true and proposes
+                            #     experiments; experiments[] required for implemented
+                            #   survey:     reviews existing corpus patterns; experiments
+                            #     optional; outcomes still expected
+                            #   position:   argues for a stance; experiments not required
 
 premise:                    # REQUIRED — what makes this a paper
   if: <condition statement>
@@ -95,19 +104,44 @@ proposed_builds:            # concrete downstream proposals (optional but expect
   - slug: <kebab-case app/experiment name>
     summary: <what it does, in 1-2 lines>
     scope: poc | demo | production
+    requires:               # NEW in v0.2: corpus refs this build depends on
+      - kind: skill | knowledge | technique
+        ref: <kind-root-relative path>
+        role: <free-text — why this dependency matters>
+
+experiments:                # NEW in v0.2: backward-looking — what was actually tested
+  - name: <kebab-case label>
+    hypothesis: <sub-claim being tested — can be narrower than premise>
+    method: <how it was tested — build X, measure Y, N samples>
+    status: planned | running | completed | abandoned
+    built_as: <optional: ref to example/<slug> if a build was shipped>
+    result: <short observation — only when status=completed>
+    supports_premise: yes | no | partial | null   # null until completed
+    observed_at: <YYYY-MM-DD, when completed>
+
+outcomes:                   # NEW in v0.2: what the corpus learned from this paper
+  - kind: produced_skill | produced_knowledge | produced_technique
+         | updated_skill  | updated_knowledge  | updated_technique
+         | produced_pitfall
+    ref: <kind-root-relative path>
+    note: <1 line — how this paper caused the corpus change>
 
 status: draft               # draft | reviewed | implemented | retracted
+retraction_reason: null     # REQUIRED when status=retracted, else null
 ---
 ```
 
 ### Field rationale
 
+- **`type`** (v0.2) — `hypothesis` papers claim something and must run experiments to earn `status=implemented`. `survey` papers review existing corpus without mandatory experiments but must still produce `outcomes[]`. `position` papers argue a stance without data obligation (but have the lowest trust weight). Default and most common: `hypothesis`.
 - **`premise.if/then`** is the gate that distinguishes a paper from a wiki entry. No `if/then`, no paper.
 - **`examines[]`** makes the paper **cite-able as structured data**, so future tooling can show "which papers reference this technique/skill?"
 - **`perspectives[]`** forces multi-angle analysis — a single-angle paper is really just a note.
 - **`external_refs[]`** — `hub-research` feeds into this. An empty list is allowed but flagged as "internal-only" in `hub-paper-list`.
-- **`proposed_builds[]`** closes the loop to `example/` and new apps. Papers with no proposed builds are allowed but carry a `pure-analysis` tag.
-- **`status`** — retracted papers stay in the tree (historical record) but are ranked last in search.
+- **`proposed_builds[].requires[]`** (v0.2) — **non-triviality gate**. A build whose `requires[]` is empty or trivial is a signal the paper isn't needed for that build. If a proposed build could be made without referencing any corpus atom, the paper adds no justification. Lint emits WARN; author must explicitly confirm or rewrite.
+- **`experiments[]`** (v0.2) — closes the loop. `hypothesis` papers move from `draft` → `implemented` only when at least one experiment completes with a non-null `result` and `supports_premise`. This is what distinguishes a paper from a structured blog post: the paper gets tested.
+- **`outcomes[]`** (v0.2) — the paper's ROI. An outcome is a corpus change the paper caused — new skill/knowledge/technique produced, or existing one updated. A paper with zero outcomes after N weeks is a candidate for retraction: it made no difference to the corpus.
+- **`status`** + **`retraction_reason`** — retracted papers stay in the tree (historical record) but are ranked last in search. `retraction_reason` is required when `status=retracted` so future readers understand what went wrong.
 
 ## 5. Body structure (recommended, not enforced)
 
@@ -150,7 +184,25 @@ Unlike technique which verifies **refs + role + binding consistency**, paper ver
 5. `name` equals the containing directory name.
 6. `status` ∈ {draft, reviewed, implemented, retracted}.
 7. No check on `external_refs` URL reachability (too flaky, too online-dependent).
-8. No check on whether `proposed_builds` actually exist under `example/` (that's what the `implemented` status is for).
+8. No check on whether `proposed_builds` actually exist under `example/` (that's what the `implemented` status is for — see rule 11).
+
+**v0.2 additions:**
+
+9. `type` ∈ {hypothesis, survey, position}. Missing `type` defaults to `hypothesis` in the linter (backward-compat with v0.1 papers).
+10. For `type=hypothesis` only — `status=implemented` requires at least one `experiments[]` entry with `status=completed`, non-null `result`, and `supports_premise` set to one of yes/no/partial. `type=survey` and `type=position` are exempt.
+11. `status=retracted` requires non-null `retraction_reason`.
+12. Every `proposed_builds[i].requires[j].ref` resolves on disk (kind-root-relative path), same check as `examines[]`. Kind restricted to skill/knowledge/technique (no paper nesting in requires, mirrors examines rule).
+13. **Non-triviality WARN (not FAIL)** — emitted when any `proposed_builds[i].requires[]` is empty or contains a single reference that also appears in `examines[]` unchanged (i.e. the build just uses one of the things the paper already points at, no composition). WARN includes the build slug and the guidance "explicitly justify or add more dependencies".
+14. `experiments[i].built_as` if present must resolve to `example/<ref>/` on disk. Missing build while `status=completed` is a WARN (result recorded without artifact evidence — possible but weaker).
+15. `experiments[i].status=completed` requires `result`, `supports_premise`, and `observed_at` all non-null.
+
+**What is still NOT verified** (intentionally, carried from v0.1):
+
+- The claims in `premise`.
+- The accuracy of `perspectives[].summary`.
+- The quality or real existence of `external_refs[]`.
+- Whether an experiment's `result` actually supports the claim it makes (that's a reviewer job).
+- Whether an `outcomes[]` entry was genuinely caused by the paper (authors can overclaim; reviewer judges).
 
 **What is NOT verified** (intentionally):
 - The claims in `premise`.
@@ -227,6 +279,10 @@ If the first pilot paper reads like any of the following, **retract the `paper/`
 - A skill description stretched across multiple files.
 
 The layer earns its keep only if it produces **something a technique or knowledge entry could not have held**. The pilot test this.
+
+**v0.2 addition — empty-loop retraction criterion**: after the layer has accumulated ≥ 5 `type=hypothesis` papers over ≥ 3 months, measure the proportion with non-empty `experiments[]` and non-empty `outcomes[]`. If **both** are below 40 %, the layer has become a forward-only claim-accumulator — exactly the "structured blog post" failure the v0.2 fields were supposed to prevent. Retract the layer, migrate the useful paper bodies to `knowledge/` entries, and close out.
+
+This criterion is ROI-based, not structural. The lint can't catch it because each paper individually passes structure checks; the pattern emerges only across the full paper set. A periodic `/hub-paper-health` report (deferred to v0.3) would surface it.
 
 ## 12. Open issues
 

--- a/paper/workflow/parallel-dispatch-breakeven-point/PAPER.md
+++ b/paper/workflow/parallel-dispatch-breakeven-point/PAPER.md
@@ -1,5 +1,5 @@
 ---
-version: 0.1.0-draft
+version: 0.2.0-draft
 name: parallel-dispatch-breakeven-point
 description: When does parallel subagent dispatch stop paying off, and what pre-flight probe catches it before tokens are wasted?
 category: workflow
@@ -9,6 +9,8 @@ tags:
   - dispatch
   - cost-model
   - pre-check
+
+type: hypothesis
 
 premise:
   if: A bulk-modification task is dispatched to N parallel subagents without a pre-flight coverage check
@@ -44,14 +46,52 @@ proposed_builds:
   - slug: parallel-dispatch-coverage-gate
     summary: Pre-flight skill that scans the target corpus for existing-work markers (grep, git log, sample-read) and refuses to dispatch when coverage exceeds a configurable threshold; delegates to sampling mode above threshold
     scope: poc
+    requires:
+      - kind: skill
+        ref: workflow/parallel-bulk-annotation
+        role: the baseline HOW-TO the gate sits in front of
+      - kind: knowledge
+        ref: agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch
+        role: the counter-evidence session that motivates the gate
+      - kind: skill
+        ref: ai/ai-subagent-scope-narrowing
+        role: adjacent pattern for narrowing scope; the gate complements it
   - slug: coverage-threshold-decision-table
     summary: Knowledge entry with a decision table - work-type × prior-coverage × recommended-strategy (parallel-dispatch, single-agent-scan, sampling-only) backed by session data from real runs
     scope: poc
+    requires:
+      - kind: knowledge
+        ref: agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch
+        role: seed data point for the decision table's first row
   - slug: parallel-bulk-annotation-preflight-section
     summary: Extension to the existing parallel-bulk-annotation skill adding a "Phase 0 - Pre-flight" section that calls the coverage gate and routes to serial or sampling mode when appropriate
     scope: demo
+    requires:
+      - kind: skill
+        ref: workflow/parallel-bulk-annotation
+        role: the skill being edited — direct dependency
+
+experiments:
+  - name: coverage-threshold-measurement
+    hypothesis: The 70 percent break-even threshold is approximately correct across ≥3 corpus domains, within ±15 percentage points
+    method: |
+      For N target corpus directories with diverse "marker" patterns (e.g. @Schema,
+      @Deprecated, JSDoc tags, i18n keys), compute coverage ratios and simulate
+      parallel vs serial cost using a small JS harness. Compare measured crossover
+      against the 70 % claim.
+    status: planned
+    built_as: example/workflow/coverage-gate-benchmark
+    result: null
+    supports_premise: null
+    observed_at: null
+
+outcomes: []
+# Nothing produced yet. Outcomes section will populate as proposed_builds
+# ship — e.g. when parallel-dispatch-coverage-gate skill is authored,
+# add { kind: produced_skill, ref: workflow/parallel-dispatch-coverage-gate }.
 
 status: draft
+retraction_reason: null
 ---
 
 # When does parallel subagent dispatch stop paying off?

--- a/paper/workflow/technique-layer-composition-value/PAPER.md
+++ b/paper/workflow/technique-layer-composition-value/PAPER.md
@@ -1,5 +1,5 @@
 ---
-version: 0.1.0-draft
+version: 0.2.0-draft
 name: technique-layer-composition-value
 description: Does a technique/ middle layer in a skills hub produce composition value beyond what hub-merge already provides?
 category: workflow
@@ -8,6 +8,8 @@ tags:
   - composition
   - hub-architecture
   - technique-layer
+
+type: hypothesis
 
 premise:
   if: A skills-hub adds a technique/ layer composing atoms by reference (not copy)
@@ -43,14 +45,49 @@ proposed_builds:
   - slug: hub-paper-commands
     summary: Four /hub-paper-{compose,verify,list,show} commands mirroring /hub-technique-* with verify scoped to structure only (premise presence, examines resolution, perspectives ≥2)
     scope: poc
+    requires:
+      - kind: technique
+        ref: workflow/safe-bulk-pr-publishing
+        role: shape template for composition-by-reference commands
+      - kind: technique
+        ref: debug/root-cause-to-tdd-plan
+        role: second shape template — tests command generality across paper shapes
   - slug: security-domain-technique-3
     summary: A third pilot technique in a domain untouched by the first two (e.g. security/secret-rotation-safe-handover) to further stress schema generality past n=2
     scope: poc
+    requires:
+      - kind: technique
+        ref: workflow/safe-bulk-pr-publishing
+        role: reference shape (linear pipeline)
+      - kind: technique
+        ref: debug/root-cause-to-tdd-plan
+        role: reference shape (decision tree)
   - slug: hub-make-from-paper
     summary: Extension of /hub-make that reads a paper's proposed_builds[] and scaffolds each as an example/ draft, closing the paper → app loop
     scope: demo
+    requires: []
+    # NOTE: empty requires triggers v0.2 non-triviality WARN. Accepted because this
+    # build's dependency is the paper SCHEMA itself, not any specific corpus atom.
+    # A future v0.2.1 may extend requires to allow kind:schema refs.
+
+experiments: []
+# No experiments yet. This paper's premise ("durable composition value") is a
+# long-horizon claim that needs months of usage data. Experiments will be filed
+# against specific sub-claims (e.g. "rename resilience via the lint rule in #1068")
+# once observation windows close.
+
+outcomes:
+  - kind: produced_technique
+    ref: workflow/safe-bulk-pr-publishing
+    note: This paper's examines[0]; the paper framework was drafted alongside this pilot's authoring.
+  - kind: produced_technique
+    ref: debug/root-cause-to-tdd-plan
+    note: This paper's examines[1]; second pilot established shape generality.
+# outcomes[] here is weak — the paper did not CAUSE these techniques; it observes
+# them as pre-existing. A stronger outcomes[] appears once proposed_builds ship.
 
 status: draft
+retraction_reason: null
 ---
 
 # Does the `technique/` middle layer produce durable composition value?


### PR DESCRIPTION
## Summary

Closes the forward-only loop in paper schema v0.1. Without v0.2, papers stop at "propose" and never "test" — which is exactly the structured-blog-post failure mode `schema §11` was supposed to prevent.

## Three frontmatter additions

### 1. `type` enum
`hypothesis | survey | position`. Most papers are `hypothesis` and now must produce at least one completed experiment to reach `status=implemented`. `survey` and `position` are exempt (they review/argue, they don't claim empirical truth). Backward-compatible — missing `type` defaults to `hypothesis`.

### 2. `experiments[]` — backward-looking
Each entry records a sub-hypothesis test:
```yaml
- name: coverage-threshold-measurement
  hypothesis: ...
  method: ...
  status: planned | running | completed | abandoned
  built_as: example/workflow/coverage-gate-benchmark   # optional
  result: ...        # required when status=completed
  supports_premise: yes | no | partial | null
  observed_at: YYYY-MM-DD
```

Distinguishes a paper from a blog post: blogs don't have experiments with completion states.

### 3. `proposed_builds[].requires[]` — non-triviality gate
Each build lists the corpus atoms it depends on. Empty `requires[]` triggers a WARN — "could this build have been made without the paper and the corpus?" Forces authors to either justify or add dependencies.

Pilot 1's `hub-make-from-paper` build intentionally has `requires: []` with an inline comment explaining the paper-schema dependency isn't yet expressible as a corpus ref — this is a real v0.2 edge case preserved for transparency.

## Plus

- `outcomes[]` — corpus changes the paper caused (produced/updated skill/knowledge/technique refs). A paper with no outcomes after N weeks is retractable.
- `retraction_reason` — required when `status=retracted`.

## New verification rules (§6 rules 9-15)

- 9: `type` enum check
- 10: `status=implemented` requires ≥1 completed experiment (`hypothesis` type only)
- 11: `status=retracted` requires `retraction_reason`
- 12: `requires[].ref` resolves on disk
- 13: WARN (not FAIL) when `requires[]` is empty — non-triviality signal
- 14: `experiments[i].built_as` if present must resolve to `example/<ref>/`
- 15: `experiments[i]` completeness consistency (completed → result + supports_premise + observed_at all set)

Still NOT verified (by design): claim correctness, perspective accuracy, outcome causation. Those remain reviewer judgment.

## Pilot backfill

All 5 `requires[].ref` values verified to resolve on disk:

```
paper 1: technique/workflow/safe-bulk-pr-publishing        PASS
paper 1: technique/debug/root-cause-to-tdd-plan            PASS
paper 2: skill/workflow/parallel-bulk-annotation           PASS
paper 2: knowledge/agent-orchestration/grep-existing-annotations...  PASS
paper 2: skill/ai/ai-subagent-scope-narrowing              PASS
```

Pilot 2 carries one `experiments[]` entry with `status: planned` pointing at `example/workflow/coverage-gate-benchmark` — the NEXT PR actually ships that example and updates the experiment to `status: completed` with real measured coverage data across corpus domains. That PR will be the first real test of the v0.2 loop.

## v0.2 retraction criterion (§11 addition)

Empty-loop retraction: after ≥5 hypothesis papers accumulate, if ≥60% have both empty `experiments[]` AND empty `outcomes[]`, retract the layer. Lint can't catch this per-paper; it's a corpus-wide ROI check deferred to v0.3's `/hub-paper-health`.

## Test plan

- [ ] Reviewer: confirm both pilot papers still pass `/hub-paper-verify` (once command ships — schema structure is internally consistent)
- [ ] Reviewer: §6 rule 13 (non-triviality WARN) — is the WARN threshold aggressive enough? Too aggressive?
- [ ] Reviewer: v0.2 `type` field positioned correctly? Should `position` papers even be allowed, or is that a slippery slope back to blog posts?

## Follow-up PRs (unchanged from #1071's plan, now updated for v0.2)

- Commands: `/hub-paper-{compose,verify,list,show}` need v0.2 prompt flows (experiments, outcomes, requires, type)
- `/hub-find --kind paper` + index builder walker
- `_lint_frontmatter.py` recognition (needs v0.2 rule additions too)
- README + bootstrap version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)