### PR TITLE
feat(paper): ship coverage-gate-benchmark experiment (paper #2 Stage C)

### DIFF
--- a/example/workflow/coverage-gate-benchmark/README.md
+++ b/example/workflow/coverage-gate-benchmark/README.md
@@ -1,0 +1,51 @@
+# Coverage Gate Benchmark
+
+> **Experiment artifact** for paper [`workflow/parallel-dispatch-breakeven-point`](../../../paper/workflow/parallel-dispatch-breakeven-point/PAPER.md).
+
+Zero-dependency single-file HTML benchmark that tests the paper's claim — **"parallel subagent dispatch stops paying off beyond ~70% prior-work coverage"** — against five measured corpus domains with an interactive cost model.
+
+## Open
+
+`index.html` directly in any browser. No build, no server.
+
+## What it does
+
+1. **§1 — Measured corpus coverage** — five domains grep'd from `kjuhwa/skills-hub`:
+   - A. Skills with `triggers:` populated (51.1%)
+   - B. Skills with `content.md` sibling (36.8%)
+   - C. Knowledge with `description:` field (55.0%)
+   - D. Knowledge with `tags:` key (100%)
+   - E. Skills with stable version 1.x+ (80.3%)
+2. **§2 — Interactive cost parameters** — sliders for A (agents), α (startup/agent), v (verify/file), w (work/file).
+3. **§3 — Per-domain recommendations** — for each domain, the model computes wall-clock savings, cost overhead, useful output, and classifies as PARALLEL / BORDERLINE / SAMPLING / NO DISPATCH.
+4. **§4 — Cost & speedup curves** — green (wall-clock saved) and orange (cost overhead) plotted across 0–100% coverage. 70% threshold marker + domain position markers.
+5. **§5 — Finding** — dynamic verdict on whether the 70% threshold holds under current parameters.
+
+## Finding under default parameters (A=4, α=30, v=5, w=60)
+
+| Domain | Coverage | Recommendation | Matches paper's prediction? |
+|---|---|---|---|
+| B — skills with content.md | 36.8% | PARALLEL | ✓ (below 70% → parallel) |
+| A — skills with triggers | 51.1% | PARALLEL | ✓ (below 70% → parallel) |
+| C — knowledge with description | 55.0% | PARALLEL | ✓ (below 70% → parallel) |
+| E — skills with version 1.x+ | 80.3% | PARALLEL | **✗ model disagrees with "70% threshold"** |
+| D — knowledge with tags | 100.0% | NO DISPATCH | ✓ (useful output = 0) |
+
+**Paper's premise partially supported.** The 70% threshold is not a constant — it shifts with cost ratios. Under typical "tokens cheap, time expensive" weights, parallel stays profitable up to ~90%+ coverage because wall-clock savings dominate the flat startup overhead. The threshold only drops near 70% when startup overhead is comparable to per-file work cost (α ≳ N·w / A · useful-ratio).
+
+This is an honest finding: the paper's claim was directionally correct (high coverage → parallel less valuable) but the specific 70% number was an observation from one session rather than a robust cost-model outcome.
+
+## Provenance
+
+- Built: 2026-04-24
+- Subject paper: `paper/workflow/parallel-dispatch-breakeven-point`
+- Status reported back to paper's `experiments[0]`: `completed`, `supports_premise: partial`
+- Data source: live grep against `~/.claude/skills-hub/remote/` at commit snapshot
+
+## Stack
+
+`html` + vanilla JS, zero dependencies, single file.
+
+## Why this exists
+
+This is not a production tool. It is the **execution artifact** demanded by paper-schema v0.2's `experiments[]` field — the paper cannot transition to `status: implemented` without a shipped build that tests its premise. The benchmark closes that loop and records what the test actually found, which is more nuanced than the paper originally asserted.

--- a/example/workflow/coverage-gate-benchmark/index.html
+++ b/example/workflow/coverage-gate-benchmark/index.html
@@ -1,0 +1,260 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Parallel Dispatch Coverage Gate — Benchmark</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+*{box-sizing:border-box}
+body{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;margin:0;padding:24px;max-width:1100px;margin-inline:auto;background:#0f1419;color:#d6deeb;line-height:1.55}
+h1{font-size:20px;margin:0 0 4px;color:#fff}
+h2{font-size:15px;margin:28px 0 10px;color:#7fdbca;border-bottom:1px solid #1d3b53;padding-bottom:6px}
+.sub{color:#8aa;font-size:13px;margin-bottom:20px}
+.card{background:#0d1f2d;border:1px solid #1d3b53;border-radius:6px;padding:16px;margin:12px 0}
+table{width:100%;border-collapse:collapse;font-size:13px}
+th,td{text-align:left;padding:8px 10px;border-bottom:1px solid #1d3b53}
+th{color:#7fdbca;font-weight:600;background:#0a1722}
+tr:hover td{background:#0a2a40}
+.rec{font-weight:600;padding:2px 8px;border-radius:3px;font-size:12px;display:inline-block}
+.rec-parallel{background:#1e4d34;color:#80f7a5}
+.rec-borderline{background:#4d4a1e;color:#f7e580}
+.rec-sampling{background:#4d2a1e;color:#f7a580}
+.rec-nodispatch{background:#3a1a1a;color:#f78080}
+label{display:block;font-size:12px;color:#8aa;margin:10px 0 4px}
+input[type=range]{width:100%;accent-color:#7fdbca}
+.param-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:16px}
+.val{color:#fff;font-weight:600;margin-left:6px}
+.finding{background:#1a2838;border-left:3px solid #7fdbca;padding:12px 14px;margin:14px 0;font-size:13px}
+.finding strong{color:#fff}
+code{background:#1a2838;padding:1px 5px;border-radius:3px;color:#f7e580;font-size:12px}
+canvas{max-width:100%;background:#0a1722;border-radius:4px}
+footer{font-size:12px;color:#667;margin-top:30px;border-top:1px solid #1d3b53;padding-top:12px}
+.num{font-variant-numeric:tabular-nums;text-align:right}
+</style>
+</head>
+<body>
+<h1>Parallel Dispatch Coverage Gate — Benchmark</h1>
+<div class="sub">Experiment artifact for paper <code>workflow/parallel-dispatch-breakeven-point</code>. Tests whether a ~70% coverage threshold for "parallel stops paying off" holds across multiple measured corpus domains.</div>
+
+<div class="card">
+<strong>Premise being tested:</strong> IF a bulk-modification task is dispatched to N parallel subagents without a pre-flight coverage check, THEN beyond a prior-work coverage threshold of roughly 70%, the parallel pattern becomes a net negative.
+</div>
+
+<h2>§1 — Measured corpus coverage (real data)</h2>
+<div class="sub">Coverage values grep'd from <code>kjuhwa/skills-hub</code> at commit snapshot. Five domains chosen for spread from ~37% to 100%.</div>
+<table>
+<thead><tr><th>Domain</th><th class="num">Total files</th><th class="num">Hit</th><th class="num">Coverage</th><th>Measurement</th></tr></thead>
+<tbody id="dataTable"></tbody>
+</table>
+
+<h2>§2 — Cost model (adjust to your environment)</h2>
+<div class="card">
+<div class="param-grid">
+<div>
+<label>Parallel agents A <span class="val" id="Aval">4</span></label>
+<input type="range" id="A" min="2" max="10" value="4">
+</div>
+<div>
+<label>Startup overhead α (sec/agent) <span class="val" id="aval">30</span></label>
+<input type="range" id="alpha" min="5" max="120" value="30">
+</div>
+<div>
+<label>Verify cost v (sec/file, already-done) <span class="val" id="vval">5</span></label>
+<input type="range" id="v" min="1" max="30" value="5">
+</div>
+<div>
+<label>Work cost w (sec/file, real edit+verify) <span class="val" id="wval">60</span></label>
+<input type="range" id="w" min="10" max="300" value="60">
+</div>
+</div>
+</div>
+
+<h2>§3 — Per-domain recommendations</h2>
+<table>
+<thead><tr><th>Domain</th><th class="num">coverage</th><th class="num">t_serial (s)</th><th class="num">t_parallel (s)</th><th class="num">wall-clock saved</th><th class="num">cost overhead</th><th class="num">useful output</th><th>recommendation</th></tr></thead>
+<tbody id="recTable"></tbody>
+</table>
+
+<h2>§4 — Cost & speedup curves</h2>
+<div class="sub">For a representative N=300, curves across 0–100% coverage. Vertical markers show measured domain positions.</div>
+<canvas id="chart" width="1040" height="360"></canvas>
+
+<h2>§5 — Finding</h2>
+<div id="finding" class="finding"></div>
+
+<footer>
+Built 2026-04-24 · <code>example/workflow/coverage-gate-benchmark</code> · ships as experiment artifact for paper #2 (parallel-dispatch-breakeven-point).
+</footer>
+
+<script>
+// Real measurements from kjuhwa/skills-hub corpus
+const DOMAINS = [
+  {key:'A', name:'Skills with triggers: populated',          N:468, coverage:0.511, measurement:'grep -l "^triggers:" on skills/**/SKILL.md'},
+  {key:'B', name:'Skills with content.md sibling',           N:468, coverage:0.368, measurement:'find + check sibling content.md existence'},
+  {key:'C', name:'Knowledge with description: (vs summary:)',N:351, coverage:0.550, measurement:'grep -l "^description:" on knowledge/**/*.md'},
+  {key:'D', name:'Knowledge with tags: key present',         N:351, coverage:1.000, measurement:'grep -l "^tags:" on knowledge/**/*.md'},
+  {key:'E', name:'Skills with version 1.x+ (stable)',        N:468, coverage:0.803, measurement:'grep -lE "^version:\\s*[1-9]" on skills/**/SKILL.md'},
+];
+
+function recommend(coverage, A, alpha, v, w, N) {
+  const useful = (1 - coverage) * N;
+  const avg = coverage * v + (1 - coverage) * w;
+  const tS  = alpha + N * avg;
+  const tP  = alpha + (N / A) * avg;
+  const costS = alpha + N * avg;
+  const costP = A * alpha + N * avg;
+  const saved = (tS - tP) / tS;
+  const overhead = (costP - costS) / costS;
+
+  let rec, cls;
+  if (useful < 5) {
+    rec = 'NO DISPATCH — use grep/sample';
+    cls = 'rec-nodispatch';
+  } else if (overhead > 0.50) {
+    rec = 'SAMPLING MODE';
+    cls = 'rec-sampling';
+  } else if (saved >= 0.50 && overhead < 0.20) {
+    rec = 'PARALLEL';
+    cls = 'rec-parallel';
+  } else if (saved >= 0.30) {
+    rec = 'PARALLEL (borderline)';
+    cls = 'rec-borderline';
+  } else {
+    rec = 'SERIAL';
+    cls = 'rec-sampling';
+  }
+  return { useful, avg, tS, tP, costS, costP, saved, overhead, rec, cls };
+}
+
+function pct(x) { return (x * 100).toFixed(1) + '%'; }
+function fmt(x) { return x.toFixed(0); }
+
+function render() {
+  const A = +document.getElementById('A').value;
+  const alpha = +document.getElementById('alpha').value;
+  const v = +document.getElementById('v').value;
+  const w = +document.getElementById('w').value;
+
+  document.getElementById('Aval').textContent = A;
+  document.getElementById('aval').textContent = alpha;
+  document.getElementById('vval').textContent = v;
+  document.getElementById('wval').textContent = w;
+
+  // Data table
+  const dt = document.getElementById('dataTable');
+  dt.innerHTML = DOMAINS.map(d =>
+    `<tr><td><strong>${d.key}</strong> · ${d.name}</td><td class="num">${d.N}</td><td class="num">${Math.round(d.coverage * d.N)}</td><td class="num">${pct(d.coverage)}</td><td><code>${d.measurement}</code></td></tr>`
+  ).join('');
+
+  // Recommendation table
+  const rt = document.getElementById('recTable');
+  rt.innerHTML = DOMAINS.map(d => {
+    const r = recommend(d.coverage, A, alpha, v, w, d.N);
+    return `<tr>
+      <td><strong>${d.key}</strong> · ${d.name}</td>
+      <td class="num">${pct(d.coverage)}</td>
+      <td class="num">${fmt(r.tS)}</td>
+      <td class="num">${fmt(r.tP)}</td>
+      <td class="num">${pct(r.saved)}</td>
+      <td class="num">${pct(r.overhead)}</td>
+      <td class="num">${Math.round(r.useful)}</td>
+      <td><span class="rec ${r.cls}">${r.rec}</span></td>
+    </tr>`;
+  }).join('');
+
+  // Chart
+  drawChart(A, alpha, v, w, 300);
+
+  // Finding
+  const findings = DOMAINS.map(d => ({ ...d, ...recommend(d.coverage, A, alpha, v, w, d.N) }));
+  const above70 = findings.filter(x => x.coverage >= 0.70);
+  const below70 = findings.filter(x => x.coverage < 0.70);
+  const above70_notParallel = above70.filter(x => !x.rec.startsWith('PARALLEL')).length;
+  const below70_parallel = below70.filter(x => x.rec.startsWith('PARALLEL')).length;
+
+  const f = document.getElementById('finding');
+  let verdict;
+  if (above70.length === 0) {
+    verdict = `<strong>Insufficient data above 70% threshold</strong> — current params happen to push all above-70% domains into PARALLEL. Try reducing work cost (w) to stress the model.`;
+  } else if (above70_notParallel === above70.length && below70_parallel === below70.length) {
+    verdict = `<strong>Premise SUPPORTED by current parameters.</strong> All ${above70.length} domain(s) ≥70% coverage recommend NON-parallel (${above70.map(x=>x.key).join(',')}); all ${below70.length} domain(s) &lt;70% recommend parallel (${below70.map(x=>x.key).join(',')}). The 70% threshold aligns with model output.`;
+  } else {
+    verdict = `<strong>Premise PARTIALLY SUPPORTED.</strong> Threshold depends on cost weights. With current params (A=${A}, α=${alpha}, v=${v}, w=${w}): `
+      + `${above70_notParallel}/${above70.length} above-70% domains correctly flagged NOT-parallel; `
+      + `${below70_parallel}/${below70.length} below-70% domains correctly recommend parallel. `
+      + `The "70%" number is a useful heuristic but not a universal constant — it shifts with the ratio of startup cost α to work cost w.`;
+  }
+  f.innerHTML = verdict;
+}
+
+function drawChart(A, alpha, v, w, N) {
+  const ctx = document.getElementById('chart').getContext('2d');
+  const W = 1040, H = 360, padL = 60, padR = 20, padT = 30, padB = 40;
+  ctx.fillStyle = '#0a1722'; ctx.fillRect(0, 0, W, H);
+
+  // Grid
+  ctx.strokeStyle = '#1d3b53'; ctx.lineWidth = 1; ctx.font = '11px monospace'; ctx.fillStyle = '#667';
+  for (let i = 0; i <= 10; i++) {
+    const x = padL + (i/10) * (W - padL - padR);
+    ctx.beginPath(); ctx.moveTo(x, padT); ctx.lineTo(x, H - padB); ctx.stroke();
+    ctx.fillText((i*10) + '%', x - 10, H - padB + 14);
+  }
+  for (let i = 0; i <= 4; i++) {
+    const y = padT + (i/4) * (H - padT - padB);
+    ctx.beginPath(); ctx.moveTo(padL, y); ctx.lineTo(W - padR, y); ctx.stroke();
+    ctx.fillText(((1 - i/4) * 100).toFixed(0) + '%', 10, y + 4);
+  }
+
+  // Axes labels
+  ctx.fillStyle = '#7fdbca'; ctx.fillText('coverage →', W - 100, H - 6);
+  ctx.save(); ctx.translate(14, 20); ctx.fillText('% saved / overhead', 0, 0); ctx.restore();
+
+  // Wall-clock savings curve (green)
+  const xAt = c => padL + c * (W - padL - padR);
+  const yAt = p => padT + (1 - p) * (H - padT - padB);
+  const pts = [];
+  for (let c = 0; c <= 1.001; c += 0.01) {
+    const avg = c * v + (1 - c) * w;
+    const tS = alpha + N * avg;
+    const tP = alpha + (N / A) * avg;
+    const saved = (tS - tP) / tS;
+    pts.push({ c, saved });
+  }
+  ctx.strokeStyle = '#80f7a5'; ctx.lineWidth = 2; ctx.beginPath();
+  pts.forEach((p, i) => (i ? ctx.lineTo(xAt(p.c), yAt(p.saved)) : ctx.moveTo(xAt(p.c), yAt(p.saved))));
+  ctx.stroke();
+  ctx.fillStyle = '#80f7a5'; ctx.fillText('wall-clock saved (parallel vs serial)', padL + 10, padT + 14);
+
+  // Cost overhead curve (orange)
+  ctx.strokeStyle = '#f7a580'; ctx.lineWidth = 2; ctx.beginPath();
+  for (let c = 0; c <= 1.001; c += 0.01) {
+    const avg = c * v + (1 - c) * w;
+    const costS = alpha + N * avg;
+    const costP = A * alpha + N * avg;
+    const over = Math.min(1, (costP - costS) / costS);
+    if (c === 0) ctx.moveTo(xAt(c), yAt(over));
+    else ctx.lineTo(xAt(c), yAt(over));
+  }
+  ctx.stroke();
+  ctx.fillStyle = '#f7a580'; ctx.fillText('cost overhead (capped 100%)', padL + 10, padT + 30);
+
+  // 70% threshold marker
+  ctx.strokeStyle = '#f7e580'; ctx.setLineDash([4, 4]);
+  ctx.beginPath(); ctx.moveTo(xAt(0.70), padT); ctx.lineTo(xAt(0.70), H - padB); ctx.stroke();
+  ctx.setLineDash([]); ctx.fillStyle = '#f7e580'; ctx.fillText('70% threshold', xAt(0.70) + 4, padT + 48);
+
+  // Domain markers
+  DOMAINS.forEach(d => {
+    const x = xAt(d.coverage);
+    ctx.strokeStyle = '#7fdbca'; ctx.lineWidth = 1;
+    ctx.beginPath(); ctx.moveTo(x, H - padB); ctx.lineTo(x, H - padB - 8); ctx.stroke();
+    ctx.fillStyle = '#7fdbca'; ctx.fillText(d.key, x - 3, H - padB - 12);
+  });
+}
+
+['A','alpha','v','w'].forEach(id =>
+  document.getElementById(id).addEventListener('input', render));
+render();
+</script>
+</body>
+</html>

--- a/example/workflow/coverage-gate-benchmark/manifest.json
+++ b/example/workflow/coverage-gate-benchmark/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "coverage-gate-benchmark",
+  "category": "workflow",
+  "description": "Parallel dispatch break-even cost model — tests paper workflow/parallel-dispatch-breakeven-point's 70% threshold claim against measured corpus coverage across 5 domains",
+  "stack": ["html", "vanilla-js"],
+  "entry": "index.html",
+  "produced_by_paper": "workflow/parallel-dispatch-breakeven-point",
+  "experiment_name": "coverage-threshold-measurement",
+  "created_at": "2026-04-24"
+}

--- a/paper/workflow/parallel-dispatch-breakeven-point/PAPER.md
+++ b/paper/workflow/parallel-dispatch-breakeven-point/PAPER.md
@@ -75,23 +75,59 @@ experiments:
   - name: coverage-threshold-measurement
     hypothesis: The 70 percent break-even threshold is approximately correct across ≥3 corpus domains, within ±15 percentage points
     method: |
-      For N target corpus directories with diverse "marker" patterns (e.g. @Schema,
-      @Deprecated, JSDoc tags, i18n keys), compute coverage ratios and simulate
-      parallel vs serial cost using a small JS harness. Compare measured crossover
-      against the 70 % claim.
-    status: planned
+      Measured prior-work coverage for 5 domains in kjuhwa/skills-hub via grep
+      against the remote cache:
+        (A) skills with triggers populated:    51.1% (239/468)
+        (B) skills with content.md sibling:    36.8% (172/468)
+        (C) knowledge with description field:  55.0% (193/351)
+        (D) knowledge with tags key:          100.0% (351/351)
+        (E) skills with stable version 1.x+:   80.3% (376/468)
+      Built an interactive cost model (example/workflow/coverage-gate-benchmark)
+      that takes (agents, startup cost, verify cost, work cost) and classifies
+      each domain as PARALLEL / BORDERLINE / SAMPLING / NO DISPATCH. Compared
+      classifier output against the paper's 70 percent threshold claim.
+    status: completed
     built_as: example/workflow/coverage-gate-benchmark
-    result: null
-    supports_premise: null
-    observed_at: null
+    result: |
+      The 70 percent threshold as a UNIVERSAL constant is NOT supported by the
+      cost model. Under typical weights (alpha=30s startup, v=5s verify,
+      w=60s work, A=4 agents), parallel wall-clock savings dominate up to
+      ~90%+ coverage for any domain with non-zero useful output. The crossover
+      shifts with the alpha/w ratio; it is not a robust constant.
 
-outcomes: []
-# Nothing produced yet. Outcomes section will populate as proposed_builds
-# ship — e.g. when parallel-dispatch-coverage-gate skill is authored,
-# add { kind: produced_skill, ref: workflow/parallel-dispatch-coverage-gate }.
+      The MEANINGFUL gate discovered is not coverage percentage but
+      "useful_output < absolute threshold" (e.g. fewer than 5 files that
+      actually need work). Domain D (100% coverage, zero useful output)
+      correctly triggers NO DISPATCH; Domain E (80.3% coverage, 92 useful
+      files) still recommends PARALLEL because 92 * work_cost dwarfs
+      A * startup_cost.
+
+      The paper's directional claim holds (very high coverage trends toward
+      non-parallel), but the specific 70 percent number was a single-session
+      observation, not a robust threshold. The premise should be restated in
+      terms of useful_output absolute count rather than coverage fraction.
+    supports_premise: partial
+    observed_at: 2026-04-24
+
+outcomes:
+  - kind: produced_knowledge
+    ref: agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch
+    note: |
+      Placeholder pointing at the existing pitfall that seeded this paper.
+      The REAL outcome of this experiment is a PROPOSED new knowledge entry
+      (knowledge/decision/parallel-dispatch-useful-output-gate) documenting
+      the refined criterion (useful_output absolute threshold, not coverage
+      fraction). Until that entry is authored, outcomes[] cannot truthfully
+      claim produced_knowledge; this note documents the pending follow-up.
 
 status: draft
 retraction_reason: null
+# Next transitions (follow-up PRs):
+#   1. Author knowledge/decision/parallel-dispatch-useful-output-gate with
+#      the refined useful_output threshold criterion.
+#   2. Rewrite this paper's premise.then to match the refined criterion.
+#   3. Replace the placeholder outcome with the new knowledge ref.
+#   4. Transition status: draft -> implemented.
 ---
 
 # When does parallel subagent dispatch stop paying off?


### PR DESCRIPTION
## Summary

First real experiment run through the paper-schema v0.2 loop. Paper [`workflow/parallel-dispatch-breakeven-point`](../../../paper/workflow/parallel-dispatch-breakeven-point/PAPER.md)'s `experiments[0]` was planned in #1072, pointing at `example/workflow/coverage-gate-benchmark`. This PR **builds the benchmark and records the experiment result**.

## What's in this PR

### 1. New `example/` entry — `example/workflow/coverage-gate-benchmark/`

- `index.html` — zero-dep single-file interactive cost model
- `README.md` — context + finding summary + manual recommendations table
- `manifest.json` — `produced_by_paper: workflow/parallel-dispatch-breakeven-point`

Five corpus domains measured via grep against `kjuhwa/skills-hub`:

| Domain | N | Coverage |
|---|---|---|
| A · Skills with `triggers:` populated | 468 | 51.1% |
| B · Skills with `content.md` sibling | 468 | 36.8% |
| C · Knowledge with `description:` field | 351 | 55.0% |
| D · Knowledge with `tags:` key | 351 | 100.0% |
| E · Skills with stable version 1.x+ | 468 | 80.3% |

The benchmark's interactive model takes (agents, α, v, w) sliders and computes per-domain recommendations (PARALLEL / BORDERLINE / SAMPLING / NO DISPATCH).

### 2. Paper update — `experiments[0]` transition `planned → completed`

- `result`: **70% threshold NOT a robust constant.** Under typical weights (α=30s, v=5s, w=60s, A=4), parallel wall-clock savings dominate up to ~90%+ coverage for any domain with non-zero useful output. The threshold shifts with the α/w ratio; it is not a universal number.
- **Refined gate discovered**: the meaningful criterion is `useful_output < absolute threshold` (e.g. < 5 files needing real work), NOT coverage fraction. Domain D (100% coverage, 0 useful) correctly triggers NO DISPATCH; Domain E (80.3%, 92 useful) still favors parallel.
- `supports_premise: partial` — paper's directional claim (higher coverage → less parallel value) holds; the specific 70% number does not.

### 3. Paper `outcomes[]` — honest placeholder

The experiment surfaces a **new** criterion that belongs in its own `knowledge/decision/` entry. Until that's authored, `outcomes[]` carries a placeholder entry pointing at the existing pitfall that seeded the paper, with an explicit note that the real `produced_knowledge` outcome is **pending**, not absent. Avoiding overclaim.

## Why this PR matters for the schema

This is the v0.2 loop's first end-to-end exercise:

- ✓ `experiments[].status` transitioned `planned → completed` with real data
- ✓ `result` non-null, `supports_premise` set (non-trivially `partial`)
- ✓ `built_as` points at a real `example/` artifact that ships in this PR
- ✓ `outcomes[]` honestly marks pending vs claimed

The schema §11 empty-loop retraction criterion is validated operationally: this paper's experiment produced a **refinement to its own premise**. Papers that can't produce such refinements would accumulate empty `outcomes[]` and eventually trigger retraction.

## Follow-up PR queue (pending)

- Author `knowledge/decision/parallel-dispatch-useful-output-gate` capturing the refined criterion
- Rewrite paper 2's `premise.then` to match the refined criterion (minor v0.2.1 if breaking)
- Replace outcomes[] placeholder with the new knowledge ref
- Transition paper 2's `status: draft → implemented`

## Test plan

- [ ] Reviewer: open `example/workflow/coverage-gate-benchmark/index.html` in a browser; interact with sliders; confirm recommendations update coherently
- [ ] Reviewer: read paper 2's updated `experiments[0].result` — does the finding match what the benchmark shows?
- [ ] Reviewer: decide whether the refined criterion ("absolute useful_output threshold") is publishable as a standalone knowledge entry or should stay folded into the paper

🤖 Generated with [Claude Code](https://claude.com/claude-code)