### PR TITLE
fix(paper): repair broken merge of #1073 + #1074 in paper #2 frontmatter

### DIFF
--- a/paper/workflow/parallel-dispatch-breakeven-point/PAPER.md
+++ b/paper/workflow/parallel-dispatch-breakeven-point/PAPER.md
@@ -139,23 +139,6 @@ retraction_reason: null
 #      as its own knowledge entry) is a net corpus addition. Implemented
 #      here means "the paper ran its loop and produced durable output,"
 #      not "premise was fully validated."
-    ref: agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch
-    note: |
-      Placeholder pointing at the existing pitfall that seeded this paper.
-      The REAL outcome of this experiment is a PROPOSED new knowledge entry
-      (knowledge/decision/parallel-dispatch-useful-output-gate) documenting
-      the refined criterion (useful_output absolute threshold, not coverage
-      fraction). Until that entry is authored, outcomes[] cannot truthfully
-      claim produced_knowledge; this note documents the pending follow-up.
-
-status: draft
-retraction_reason: null
-# Next transitions (follow-up PRs):
-#   1. Author knowledge/decision/parallel-dispatch-useful-output-gate with
-#      the refined useful_output threshold criterion.
-#   2. Rewrite this paper's premise.then to match the refined criterion.
-#   3. Replace the placeholder outcome with the new knowledge ref.
-#   4. Transition status: draft -> implemented.
 ---
 
 # When does parallel subagent dispatch stop paying off?


### PR DESCRIPTION
## Summary

The sequential merge of #1073 (Stage C experiment) and #1074 (v0.2 loop closure) left paper #2's frontmatter with **two `status:` keys** and an **orphan YAML fragment**. Net effect on main: `status: draft` (wrong — #1074 intended `implemented`) and malformed YAML.

## What was broken

```yaml
status: implemented         # from #1074 — CORRECT
retraction_reason: null
# [#1074 comment block]
    ref: agent-orchestration/grep-existing-annotations-...   # orphan from #1073 outcomes[]
    note: |
      Placeholder pointing at the existing pitfall ...       # orphan text

status: draft               # stale from #1073 — INCORRECT, wins YAML last-key
retraction_reason: null
# [stale "Next transitions" comment from #1073]
```

**Behavior consequence**: any lint or `/hub-paper-list` reading the frontmatter saw `status: draft`, silently undoing #1074's transition to `implemented`.

## Fix

Removes lines 142-158: the orphan fragment + the duplicate status block + stale comment. Keeps the authoritative `status: implemented` block from #1074.

## Verification

```
$ python3 -c "import yaml; ..."
status = 'implemented'
retraction_reason = None
outcomes count = 2          # produced_knowledge + produced_example
PARSE: OK
```

PyYAML parses the file cleanly. No duplicate keys, no orphan list items.

## How this happened (observation, not blame)

When a stacked PR touches the same lines as its base PR, squash-merge on the base can invalidate the stacked PR's patch context. The GitHub UI may auto-resolve by keeping both sides. The safe pattern for future stacked paper/technique PRs:

1. Merge base PR first.
2. Rebase stacked PR onto fresh main.
3. Then merge stacked PR.

This PR is the recovery. No repeat until the next stacked PR chain — pattern is rare outside layer-rollout work.

## Test plan

- [ ] Reviewer: confirm only one `status:` key exists in the frontmatter post-merge
- [ ] Reviewer: confirm `outcomes[]` has exactly 2 well-formed entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)