### PR TITLE
fix: lint duplicate frontmatter keys + formalize produced_example in paper schema

### DIFF
--- a/bootstrap/tools/_lint_frontmatter.py
+++ b/bootstrap/tools/_lint_frontmatter.py
@@ -159,6 +159,32 @@ def lint_technique_composes(raw_fm: str) -> list[str]:
     return errors
 
 
+def find_duplicate_top_level_keys(raw_fm: str) -> list[str]:
+    """Return list of top-level keys that appear more than once in the frontmatter.
+
+    Duplicate keys cause silent last-wins overwrites in YAML consumers
+    (including the lint itself via parse_flat_keys). In the #1075 incident
+    a stacked-PR merge produced two `status:` keys — one 'implemented' and
+    one 'draft' — and the stale 'draft' value silently won on parse. This
+    check surfaces that class of merge damage at lint time.
+    """
+    seen: set[str] = set()
+    dups: set[str] = set()
+    for line in raw_fm.splitlines():
+        if not line or line[0].isspace() or line.startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        key = line.split(":", 1)[0].strip()
+        if not key:
+            continue
+        if key in seen:
+            dups.add(key)
+        else:
+            seen.add(key)
+    return sorted(dups)
+
+
 def scan_file(path: Path) -> dict:
     try:
         text = path.read_text(encoding="utf-8")
@@ -174,6 +200,12 @@ def scan_file(path: Path) -> dict:
         if not any(c in fields and not value_is_empty(fields[c]) for c in candidates):
             missing.append(required)
     errors: list[str] = []
+    dup_keys = find_duplicate_top_level_keys(raw)
+    if dup_keys:
+        errors.append(
+            f"duplicate top-level frontmatter keys: {', '.join(dup_keys)} "
+            f"(likely stacked-PR merge residue; YAML silently takes the last value)"
+        )
     category_val = fields.get("category", "").strip()
     if category_val and not CATEGORY_RE.match(category_val):
         errors.append(

--- a/docs/rfc/paper-schema-draft.md
+++ b/docs/rfc/paper-schema-draft.md
@@ -122,7 +122,11 @@ experiments:                # NEW in v0.2: backward-looking — what was actuall
 outcomes:                   # NEW in v0.2: what the corpus learned from this paper
   - kind: produced_skill | produced_knowledge | produced_technique
          | updated_skill  | updated_knowledge  | updated_technique
-         | produced_pitfall
+         | produced_pitfall | produced_example        # produced_example added
+                                                      # in v0.2.1 after paper
+                                                      # workflow/parallel-dispatch-breakeven-point
+                                                      # shipped an example/
+                                                      # artifact as an outcome.
     ref: <kind-root-relative path>
     note: <1 line — how this paper caused the corpus change>
 


### PR DESCRIPTION
## Summary

Two corrections after the paper #2 rollout post-mortem:

### 1. Duplicate top-level frontmatter keys now FAIL lint

Prevents recurrence of the #1075 class of bug — stacked-PR merge residue that leaves two copies of a key (e.g. `status: implemented` + `status: draft`). YAML last-wins silently takes the last value; individual files parse, so no existing rule caught it.

New `find_duplicate_top_level_keys()` helper in `bootstrap/tools/_lint_frontmatter.py` scans raw frontmatter for column-0 keys and reports any duplicates. Error message points explicitly at stacked-PR merge residue as the likely cause.

Verified:
```
Clean corpus:                 PASS
Inject duplicate version:     FAIL (reports 'version')
Restore:                      PASS
```

### 2. `produced_example` formalized in paper schema outcomes enum

Paper #2 (#1074) added `kind: produced_example` to its `outcomes[]`, pointing at the coverage-gate-benchmark that shipped in #1073. v0.2's formal enum did not include this kind and the paper inline-flagged it as a v0.2.1 extension candidate. This PR formalizes it.

Updated `docs/rfc/paper-schema-draft.md` §4 frontmatter YAML to include `produced_example` alongside the existing outcome kinds, with a comment citing paper #2 as the motivating case.

## Why one PR

Both fixes emerge from the same post-mortem (stacked-PR merge of #1073 + #1074). One is retrospective (lint rule prevents recurrence); the other is prospective (schema now accepts the field paper #2 already uses). Small, independent, but same context.

## Test plan

- [ ] Reviewer: confirm the lint rule catches a deliberately-duplicated key but doesn't false-positive on valid multi-line values (e.g. `method: |\n  ...`)
- [ ] Reviewer: decide whether `produced_example` should formally trigger a schema version bump from v0.2 → v0.2.1 in `version:` frontmatter, or remain additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)