### PR TITLE
feat: add 4 bootstrap commands for the paper/ layer (v0.2-aware)

### DIFF
--- a/bootstrap/commands/hub-paper-compose.md
+++ b/bootstrap/commands/hub-paper-compose.md
@@ -1,0 +1,118 @@
+---
+description: Interactively compose a new paper draft (premise + examines + perspectives + v0.2 experiments/outcomes/requires), then verify structure against the schema
+argument-hint: <slug> [--category <cat>] [--type hypothesis|survey|position] [--from <existing-slug>]
+---
+
+# /hub-paper-compose $ARGUMENTS
+
+Authoring workflow for the `paper/` exploration layer. Produces `.paper-draft/<category>/<slug>/PAPER.md` with a premise-first scaffold covering all v0.2 frontmatter fields, then runs `/hub-paper-verify` to confirm structural rules pass.
+
+## Input
+
+- **`<slug>`** (required): kebab-case, unique within `.paper-draft/` AND `~/.claude/papers/`.
+- `--category <cat>`: one of `CATEGORIES.md` values. Ask if omitted.
+- `--type hypothesis|survey|position`: default `hypothesis`. `survey` and `position` are exempt from the v0.2 rule that `status=implemented` requires at least one completed experiment.
+- `--from <existing-slug>`: clone frontmatter + examines of an existing paper as starting point.
+
+## Steps
+
+1. **Validate slug**
+   - Fail if `.paper-draft/**/<slug>/` or `~/.claude/papers/**/<slug>/` exists.
+   - Fail if slug doesn't match `^[a-z][a-z0-9-]*$`.
+
+2. **Premise first** (before anything else — premise IS the paper)
+   - AskUserQuestion: `premise.if` — "IF condition, single sentence: ..."
+   - AskUserQuestion: `premise.then` — "THEN predicted outcome, single sentence: ..."
+   - Warn if either is empty or < 20 chars; confirm continue.
+
+3. **Paper type**
+   - If `--type` not provided, ask:
+     - `hypothesis` — claims something; must run experiments to reach `status=implemented` (default, most papers)
+     - `survey`     — reviews corpus patterns; experiments optional but `outcomes[]` still expected
+     - `position`   — argues a stance; lowest trust weight, no data obligation
+
+4. **Frontmatter metadata**
+   - `description` (≤120 chars — remind user)
+   - `category` from CATEGORIES.md picker
+   - `tags` comma-separated; dedupe
+
+5. **Pick examines[]** (at least one required)
+   - Loop: "search for atom/technique to cite, or `done`"
+   - Delegate to `/hub-find --kind skill|knowledge|technique <query>`
+   - Capture `ref` as kind-root-relative physical path; verify file exists
+   - Reject `kind: paper` (v0 nesting ban)
+   - Prompt for `role` (free-text)
+
+6. **Write perspectives[]** (≥2 required)
+   - Loop: `name` + `summary` (1-2 lines)
+   - Warn at 1; require at 0
+
+7. **Optional external_refs[]**
+   - Ask: "run `/hub-research` to pull external citations?"
+   - If yes, the research skill populates; if no, leave empty (tagged `internal-only` in list view)
+
+8. **proposed_builds[] with requires[]** (v0.2 non-triviality gate)
+   - Loop: `slug`, `summary` (≥60 chars), `scope` (poc/demo/production)
+   - For each build, **require** `requires[]` entries — ≥1 recommended:
+     - For each entry: `kind` (skill/knowledge/technique), `ref` (verified on disk), `role`
+     - If `requires` is empty, WARN: "this build doesn't depend on any corpus atom — is the paper really needed for it?"
+   - Justification prompt if author insists on empty `requires`
+
+9. **experiments[]** (optional but encouraged for `type=hypothesis`)
+   - For each planned experiment:
+     - `name` (kebab-case label)
+     - `hypothesis` (sub-claim being tested, narrower than premise)
+     - `method` (how to test — build X, measure Y, N samples)
+     - `status: planned` (initial value)
+     - Optional: `built_as` (example/<ref> if shipping will be paired)
+     - `result: null`, `supports_premise: null`, `observed_at: null` (filled when completed)
+   - A `type=hypothesis` paper with no planned experiments gets a WARN: "this paper cannot reach status=implemented without a completed experiment"
+
+10. **outcomes[]** (usually empty at compose time)
+    - Typically empty at draft. Populated later when proposed_builds ship or experiments complete.
+    - Allowed values: `produced_skill | produced_knowledge | produced_technique | produced_pitfall | produced_example | updated_skill | updated_knowledge | updated_technique`
+
+11. **status** — default `draft`. `retraction_reason` stays null.
+
+12. **Write the file** to `.paper-draft/<category>/<slug>/PAPER.md` with v0.2 frontmatter + body scaffold:
+    ```
+    # <Title>
+
+    ## Premise
+    Expand if/then from frontmatter.
+
+    ## Background
+    Cite examines[].
+
+    ## Perspectives
+    ### <perspective 1>
+    ### <perspective 2>
+
+    ## External Context
+    ## Proposed Builds
+    ## Open Questions
+    ## Limitations
+    ```
+
+13. **Immediate verification**
+    - Run `/hub-paper-verify <slug>`
+    - If FAIL, show errors and offer: edit, revert, leave as-is
+    - If PASS, print location + next-step hints
+
+## Rules
+
+- **Premise is not optional**. No if/then → no paper.
+- `examines[].kind: paper` rejected (v0 nesting ban).
+- **Never call remote** during compose.
+- **Never write to** `~/.claude/papers/` — that's the installed root.
+- Authoring and verification are separate passes (step 13).
+
+## v0.2 vs v0.1
+
+- NEW required prompts: `type`, per-build `requires[]`, `experiments[]` planned list
+- NEW optional: `outcomes[]` (usually stays empty until experiments complete)
+- NEW behavior: `type=hypothesis` paper with no experiments gets a WARN that it cannot reach `status=implemented`
+
+## Why exists
+
+Without compose, every paper is hand-authored from schema memory. Premise-first authoring enforces the main distinction between a paper and other entries — if the author can't state if/then, the content is not paper-shaped. The v0.2 additions (`requires[]`, `experiments[]`) enforce non-triviality and loop-closability at authoring time rather than at verify time.

--- a/bootstrap/commands/hub-paper-list.md
+++ b/bootstrap/commands/hub-paper-list.md
@@ -1,0 +1,62 @@
+---
+description: List locally drafted and installed papers, grouped by status (v0.2 adds type column)
+argument-hint: [--status draft|reviewed|implemented|retracted] [--type hypothesis|survey|position] [--category <cat>] [--drafts-only | --installed-only]
+---
+
+# /hub-paper-list $ARGUMENTS
+
+Report papers (hypothesis-driven analyses) present on disk:
+
+- **Installed**: `~/.claude/papers/<category>/<slug>/PAPER.md`
+- **Drafts**: `./.paper-draft/<category>/<slug>/PAPER.md` (project-local)
+
+## Steps
+
+1. Parse args. Default: list both drafts and installed, all statuses, all types.
+2. Scan the two roots for `**/PAPER.md`.
+3. For each file, read frontmatter: `name`, `version`, `category`, `type`, `status`, `description`, `examines[]` count, `perspectives[]` count, `experiments[]` count (with sub-status breakdown), `outcomes[]` count, `proposed_builds[]` count.
+4. Cross-reference `~/.claude/skills-hub/registry.json` → `papers` section:
+   - Present + tracked → normal row
+   - Present + untracked → `[UNTRACKED]`
+   - Tracked + missing → `[ORPHAN REGISTRY]` (offer removal)
+5. Apply filters (`--status`, `--type`, `--category`, `--drafts-only`, `--installed-only`).
+6. Render stable text table, grouped by status (retracted last):
+   ```
+   STATE    | STATUS       | TYPE       | CATEGORY | NAME                          | EXAMINES | EXP(c/p) | OUT | BUILDS
+   draft    | draft        | hypothesis | workflow | technique-layer-composition-value | 4     | 0/0      | 2   | 3
+   install  | implemented  | hypothesis | workflow | parallel-dispatch-breakeven-point | 4     | 1/0      | 2   | 3
+   install  | retracted    | position   | ai       | agent-chain-composability     | 1        | 0/0      | 0   | 0
+   ```
+   Legend: `EXP(c/p)` = experiments completed / planned; `OUT` = outcomes count; `BUILDS` = proposed_builds count.
+7. Annotations:
+   - Empty `external_refs[]` → append `(internal-only)` in NAME column
+   - Empty `proposed_builds[]` → append `(pure-analysis)`
+   - `type=position` with empty `experiments[]` and empty `outcomes[]` → append `(opinion-only)` — elevated flag under v0.2 retraction criterion
+8. Trailing summary: `<N> drafts, <M> installed (<d> draft, <r> reviewed, <i> implemented, <ret> retracted; <h> hypothesis, <s> survey, <p> position)`.
+
+## v0.2 retraction-criterion signal
+
+At the end of list output, if total papers ≥ 5 AND ≥ 60% have both `experiments[]` empty AND `outcomes[]` empty, emit a warning:
+
+```
+⚠  Paper-layer empty-loop signal: <X>/<Y> papers have empty experiments AND outcomes.
+   Schema §11 retraction threshold is 60% at N≥5 papers. Currently at <pct>%.
+```
+
+This is the canonical spot for the schema §11 check — `/hub-paper-list` sees all papers at once.
+
+## Rules
+
+- Read-only.
+- If neither root exists, print "no papers found" — not an error.
+- When registry lacks the `papers` key, treat as empty.
+
+## Related
+
+- `/hub-paper-show <slug>` — full view of one paper
+- `/hub-paper-verify --all` — structural lint across all
+- `/hub-find --kind paper <query>` — remote search
+
+## Why exists
+
+The paper layer is meant to drive new builds and produce corpus outcomes. Without a list view the backlog is unreachable and the retraction signal from schema §11 cannot be observed. This command is where both live.

--- a/bootstrap/commands/hub-paper-show.md
+++ b/bootstrap/commands/hub-paper-show.md
@@ -1,0 +1,67 @@
+---
+description: Show a paper's frontmatter, body, and expanded examines[]/requires[] (inline descriptions of cited atoms/techniques). v0.2-aware — renders experiments and outcomes explicitly.
+argument-hint: <slug> [--raw]
+---
+
+# /hub-paper-show $ARGUMENTS
+
+Display one paper with its cited refs expanded in-place so the reader can evaluate the argument without jumping across multiple files.
+
+## Input resolution
+
+Same as `/hub-paper-verify`: first match in `./.paper-draft/**/<slug>/PAPER.md`, then `~/.claude/papers/**/<slug>/PAPER.md`.
+
+## Steps
+
+1. Read the paper file.
+2. Print the frontmatter block verbatim.
+3. **Expand examines[]** — for each entry:
+   - Resolve path per kind (skill/knowledge/technique); reject paper kind
+   - Read the resolved file's frontmatter; extract `name`, `version`, `description`/`summary`
+   - Print an annotated line:
+     ```
+     [technique] workflow/safe-bulk-pr-publishing v0.1.0-draft  (role: pilot #1)
+                 → Build N projects in parallel ... batch conflict recovery
+     ```
+   - If ref resolves to missing file, mark `[MISSING]` and continue
+4. **Render perspectives[]** — numbered sections with `name` and `summary`
+5. **Render experiments[]** (v0.2) — table showing:
+   ```
+   EXPERIMENTS
+     [1] coverage-threshold-measurement
+         hypothesis: ...
+         status: completed  supports_premise: partial  observed: 2026-04-24
+         built_as: example/workflow/coverage-gate-benchmark → Interactive cost-model benchmark
+         result: ...
+   ```
+   If `experiments[]` is empty AND `type=hypothesis`, print a WARN banner: `paper cannot reach status=implemented without a completed experiment`.
+6. **Render proposed_builds[]** with `requires[]` expanded — for each build, show its `requires` refs inline with one-line descriptions (same pattern as examines expansion).
+7. **Render outcomes[]** (v0.2) — for each outcome, resolve the `ref` to its current description if possible; show the `note`.
+8. Print the paper body verbatim (the markdown after the frontmatter).
+9. **Trailing status line**:
+   `<N> examines resolved (<M> missing); <P> perspectives; <E_c>/<E_p> experiments completed/planned; <O> outcomes; <B> proposed builds; type=<type>; status=<status>`
+
+## Flags
+
+- `--raw`: skip all expansion, print file as-is.
+
+## Rules
+
+- Read-only.
+- Never modify the paper.
+- Never fetch remote. Missing refs are surfaced, not auto-repaired.
+- **Retracted banner**: if `status=retracted`, prepend the output with a warning block showing `retraction_reason`. The body is still rendered (retracted papers are historical record, not deleted).
+
+## v0.2 behaviors worth flagging
+
+- If `outcomes[].kind == produced_example`, resolve against `example/<ref>/README.md` (or `manifest.json`) and print the one-line description. This works because paper #2's `built_as` + `outcomes` pattern expects this resolution.
+- If a paper has `experiments[]` with mixed statuses (some `completed`, some `planned`), show both so readers see the in-progress work.
+
+## Related
+
+- `/hub-paper-list` — all papers, one row each
+- `/hub-paper-verify <slug>` — structural check
+
+## Why exists
+
+A paper's frontmatter carries compact refs (`workflow/safe-bulk-pr-publishing`). Reading the names alone tells a reviewer *what is cited*; expanding them inline tells the reviewer *what each reference actually is*. Same logic extends to `experiments[].built_as`, `proposed_builds[].requires[]`, and `outcomes[].ref` — all of them are useful only when expanded alongside the narrative. That work belongs in the show command, not pushed onto the reader.

--- a/bootstrap/commands/hub-paper-verify.md
+++ b/bootstrap/commands/hub-paper-verify.md
@@ -1,0 +1,87 @@
+---
+description: Validate a paper against schema v0.2 — structure only (premise, examines, perspectives, description, name, status, type, experiments, requires). No substance checks.
+argument-hint: <slug> | --all [--strict]
+---
+
+# /hub-paper-verify $ARGUMENTS
+
+Run schema v0.2 §6 rules against one paper (or all). **Structure-only by design** — this command does NOT evaluate the correctness of the premise, the accuracy of the perspectives, or the truth of the external_refs.
+
+## Input resolution
+
+- `<slug>`: locate first match in `./.paper-draft/**/<slug>/PAPER.md`, then `~/.claude/papers/**/<slug>/PAPER.md`
+- `--all`: verify every paper in both locations
+
+## Checks
+
+### v0.1 rules (rules 1-8)
+
+1. **Frontmatter well-formed**: YAML parses; required keys: `version`, `name`, `description`, `category`, `premise`, `examines`, `perspectives`, `status`.
+2. **Premise non-empty**: both `premise.if` and `premise.then` present, ≥1 char after strip.
+3. **Examines non-empty + resolve**: `examines[]` length ≥1; every `ref` resolves:
+   - `kind: skill` → `skills/<ref>/SKILL.md`
+   - `kind: knowledge` → `knowledge/<ref>.md`
+   - `kind: technique` → `technique/<ref>/TECHNIQUE.md`
+   - `kind: paper` → **rejected** (v0 nesting ban)
+4. **Perspectives ≥ 2**: WARN at 1 (upgraded to FAIL under `--strict`)
+5. **Description length**: ≤120 chars (WARN if exceeded unless `--strict`)
+6. **Name matches folder**: `name` == containing directory name
+7. **Status enum**: `status` ∈ {`draft`, `reviewed`, `implemented`, `retracted`}
+8. (No check on `external_refs` URL reachability — too flaky)
+
+### v0.2 additions (rules 9-15)
+
+9. **Type enum**: `type` ∈ {`hypothesis`, `survey`, `position`}. Missing `type` defaults to `hypothesis` (backward-compat).
+10. **Implemented-status proof**: for `type=hypothesis`, `status=implemented` requires at least one `experiments[]` entry with `status=completed`, non-null `result`, and `supports_premise` set to yes/no/partial. `type=survey` and `type=position` are exempt.
+11. **Retraction requires reason**: `status=retracted` requires non-null `retraction_reason`.
+12. **Requires refs resolve**: every `proposed_builds[i].requires[j].ref` resolves on disk (kind restricted to skill/knowledge/technique — no paper nesting).
+13. **Non-triviality WARN**: emitted when any `proposed_builds[i].requires[]` is empty or contains a single ref that also appears in `examines[]` unchanged. Includes the build slug.
+14. **Built-as resolves**: `experiments[i].built_as` if present must resolve to `example/<ref>/`. Missing build with `status=completed` is a WARN.
+15. **Completed experiment completeness**: `experiments[i].status=completed` requires `result`, `supports_premise`, and `observed_at` all non-null.
+
+### v0.2.1 (opportunistic)
+
+- `outcomes[].kind` accepts `produced_example` alongside the core enum (formalized via schema update; older consumers just ignore unknown kinds).
+- Duplicate top-level frontmatter keys FAIL (global rule inherited from `_lint_frontmatter.py`).
+
+### What is NOT verified (intentionally)
+
+- `premise` content correctness
+- `perspectives[].summary` accuracy
+- `external_refs[]` URL reachability, quality, or relevance
+- Whether an experiment's `result` supports its claim (reviewer job)
+- Whether `outcomes[]` were genuinely caused by the paper (authors can overclaim)
+
+## Output format
+
+Per paper:
+```
+PAPER: <category>/<slug>  (v<version>, type=<type>, status=<status>)
+  [PASS]  frontmatter well-formed
+  [PASS]  premise.if/then non-empty
+  [PASS]  examines[0] workflow/safe-bulk-pr-publishing → technique/workflow/...
+  [PASS]  perspectives: 4 (≥2 required)
+  [PASS]  type=hypothesis
+  [WARN]  proposed_builds[2].requires is empty — non-triviality guard
+  [PASS]  experiments[0].status=completed, result non-null, supports_premise=partial, observed_at=2026-04-24
+  [PASS]  status=implemented (hypothesis type + 1 completed experiment)
+RESULT: PASS (1 warning)
+```
+
+With `--all`, end with aggregate: `<K> papers verified: <pass> pass, <warn> warn, <fail> fail`.
+
+## Exit behavior
+
+- Any `FAIL` → overall failure
+- `WARN` only → pass with advisory
+- `--strict` upgrades all `WARN` to `FAIL`
+
+## Rules
+
+- Read-only. No mutation.
+- Does NOT fetch remote. Assumes `~/.claude/skills-hub/remote/` is current.
+- Never auto-fix. Gatekeeper only.
+
+## Why exists
+
+The paper schema deliberately avoids substance verification so exploratory content survives. But structure still matters — a paper with no premise, one perspective, or unresolved citations doesn't meet the definition. This command enforces that floor without rising above it.


### PR DESCRIPTION
## Summary

Ships the `/hub-paper-{compose,verify,list,show}` command set to `bootstrap/commands/`. Mirror of the technique commands rollout in #1059, now installable via `/hub-commands-update`.

## Key v0.2 coverage (built in from day one)

| Command | v0.2 awareness |
|---|---|
| `/hub-paper-compose` | Prompts for `type`, per-build `requires[]` (non-triviality WARN), `experiments[]` planned list (WARN if hypothesis type and empty), `outcomes[]` |
| `/hub-paper-verify` | §6 rules 1-8 (v0.1) + 9-15 (v0.2): type enum, implemented requires completed experiment, retraction_reason, requires resolution, non-triviality WARN, built_as resolution, completed-experiment completeness |
| `/hub-paper-list` | Shows type + experiments (completed/planned) + outcomes count + proposed_builds count; emits the schema §11 empty-loop retraction signal when ≥5 papers with ≥60% empty experiments AND outcomes |
| `/hub-paper-show` | Expands examines, requires, outcomes inline; renders experiments as a status table; retracted-banner |

## Rationale for v0.2-first

The technique commands in #1059 were v0.1 only, then updated over follow-up PRs. The paper schema shipped with v0.2 baked in (experiments/outcomes/requires are the loop-closure mechanism), so the commands must speak v0.2 from the start — else compose produces drafts that fail verify.

## Test plan

- [ ] Reviewer: skim each command file for clarity
- [ ] Reviewer: confirm compose's prompt order (premise first, type second) and non-triviality WARN placement match schema expectations
- [ ] After merge: `/hub-commands-update` picks them up; users can author new papers via `/hub-paper-compose <slug>`

## Follow-ups

- Sync `~/.claude/skills-hub/tools/` installed copies (same pattern as technique-tools sync post-#1062)
- README refresh (add paper layer section + paper badge + Paper Layer command reference)
- `bootstrap/v2.7.0` tag (paper layer is a new major subsystem)

🤖 Generated with [Claude Code](https://claude.com/claude-code)