### PR TITLE
Publish batch 4/24: 27 knowledge + 23 skills

### DIFF
--- a/index.json
+++ b/index.json
@@ -81,6 +81,60 @@
   },
   {
     "kind": "knowledge",
+    "name": "claude-session-resume-semantics",
+    "slug": "claude-session-resume-semantics",
+    "category": "api",
+    "description": "If claude --resume <id> doesn't find the session, Claude silently generates a fresh session and exits. Treat emitted_id != requested_id AND failed status as \"resume didn't land\".",
+    "tags": [
+      "claude-code",
+      "session",
+      "resume",
+      "pitfall",
+      "llm"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/api/claude-session-resume-semantics.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "claude-stream-json-protocol",
+    "slug": "claude-stream-json-protocol",
+    "category": "api",
+    "description": "Claude Code CLI's stream-json mode emits typed JSON events (assistant, user, system, result, log) that wrap content blocks like text/thinking/tool_use/tool_result.",
+    "tags": [
+      "claude-code",
+      "streaming",
+      "json-protocol",
+      "llm",
+      "agent"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/api/claude-stream-json-protocol.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "cli-release-via-git-tag",
+    "slug": "cli-release-via-git-tag",
+    "category": "api",
+    "description": "CLI releases are cut from semver tags on main — push a tag, GitHub Actions runs tests, GoReleaser builds multi-platform binaries and updates the Homebrew tap.",
+    "tags": [
+      "release",
+      "cli",
+      "git-tag",
+      "goreleaser",
+      "github-actions"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/api/cli-release-via-git-tag.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "confid-vs-resourceid-routing",
     "slug": "confid-vs-resourceid-routing",
     "category": "api",
@@ -424,6 +478,21 @@
   },
   {
     "kind": "knowledge",
+    "name": "cli-implemented-in-rust-for-speed",
+    "slug": "cli-implemented-in-rust-for-speed",
+    "category": "arch",
+    "description": "The Magika CLI is Rust, not Python, to eliminate interpreter startup overhead.",
+    "tags": [
+      "magika",
+      "arch"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/cli-implemented-in-rust-for-speed.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "commons-logging-exclusion-strategy",
     "slug": "commons-logging-exclusion-strategy",
     "category": "arch",
@@ -438,6 +507,36 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/arch/commons-logging-exclusion-strategy.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "config-minimization-min-json",
+    "slug": "config-minimization-min-json",
+    "category": "arch",
+    "description": "Model configs ship as config.min.json (minified) to shrink package size — especially important for browser deployment.",
+    "tags": [
+      "magika",
+      "arch"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/config-minimization-min-json.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "content-types-knowledge-base-minified",
+    "slug": "content-types-knowledge-base-minified",
+    "category": "arch",
+    "description": "The full content-types KB ships as content_types_kb.min.json so APIs can offer rich metadata without a large overhead.",
+    "tags": [
+      "magika",
+      "arch"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/content-types-knowledge-base-minified.md",
     "has_content": true
   },
   {
@@ -1945,6 +2044,80 @@
   },
   {
     "kind": "knowledge",
+    "name": "ci-gpg-signing-batch-mode-non-interactive",
+    "slug": "ci-gpg-signing-batch-mode-non-interactive",
+    "category": "ci-cd",
+    "description": "GPG signing in CI requires `--batch --yes` flags, a pre-imported key, and `git config user.signingKey` set; without a TTY, pinentry will fail and the signing step hangs or errors unless all interactive prompts are bypassed.",
+    "tags": [
+      "gpg",
+      "signing",
+      "ci-cd",
+      "github-actions",
+      "non-interactive",
+      "batch",
+      "pinentry"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/ci-cd/ci-gpg-signing-batch-mode-non-interactive.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "ci-push-race-condition-retry-rebase-loop",
+    "slug": "ci-push-race-condition-retry-rebase-loop",
+    "category": "ci-cd",
+    "description": "Parallel CI jobs pushing to the same branch (e.g., `gh-pages`) race; solve with a `git pull --rebase` + retry loop with exponential backoff, or serialize jobs with `needs:` dependencies to avoid the race entirely.",
+    "tags": [
+      "ci-cd",
+      "git-push",
+      "race-condition",
+      "gh-pages",
+      "retry",
+      "rebase",
+      "github-actions",
+      "concurrency"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/ci-cd/ci-push-race-condition-retry-rebase-loop.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "clipboard-context-lazy-initialization",
+    "slug": "clipboard-context-lazy-initialization",
+    "category": "clipboard",
+    "description": "Clipboard context is lazy-init on first check_clipboard(); one context per side.",
+    "tags": [
+      "clipboard",
+      "context",
+      "initialization",
+      "lazy"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/clipboard/clipboard-context-lazy-initialization.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "clipboard-ownership-protocol",
+    "slug": "clipboard-ownership-protocol",
+    "category": "clipboard",
+    "description": "Clipboard-ownership detection uses a custom format flag (dyn.com.rustdesk.owner) to prevent copy-paste loops between host and guest.",
+    "tags": [
+      "clipboard",
+      "ownership",
+      "protocol"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/clipboard/clipboard-ownership-protocol.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "agent-director-art-director",
     "slug": "agent-director-art-director",
     "category": "collaboration",
@@ -2233,6 +2406,42 @@
   },
   {
     "kind": "knowledge",
+    "name": "collaborative-design-principles",
+    "slug": "collaborative-design-principles",
+    "category": "collaboration",
+    "description": "Collaborative design principles for multi-agent game development workflows",
+    "tags": [
+      "game-studios",
+      "ccgs",
+      "collaboration",
+      "design-principles",
+      "multi-agent"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/collaboration/collaborative-design-principles.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "config-system-four-tiers",
+    "slug": "config-system-four-tiers",
+    "category": "configuration",
+    "description": "Four config tiers: Settings (persistent), Local (user), Display (per-display), Built-in (defaults).",
+    "tags": [
+      "config",
+      "configuration",
+      "four",
+      "system",
+      "tiers"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/configuration/config-system-four-tiers.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "actuator-endpoints-skip-auth-by-design",
     "slug": "actuator-endpoints-skip-auth-by-design",
     "category": "decision",
@@ -2434,6 +2643,24 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/decision/circular-dependency-detection-script.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "cli-release-accompanies-prod-deploy",
+    "slug": "cli-release-accompanies-prod-deploy",
+    "category": "decision",
+    "description": "Every production deployment of the server must be accompanied by a matching CLI release, so server-CLI protocol changes never ship skewed.",
+    "tags": [
+      "release",
+      "versioning",
+      "cli",
+      "server",
+      "protocol"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/cli-release-accompanies-prod-deploy.md",
     "has_content": true
   },
   {
@@ -3511,6 +3738,21 @@
   },
   {
     "kind": "knowledge",
+    "name": "content-types-knowledge-base-vs-model-outputs",
+    "slug": "content-types-knowledge-base-vs-model-outputs",
+    "category": "domain",
+    "description": "content_types_kb.min.json is a research superset — distinct from any single model's actual output space.",
+    "tags": [
+      "magika",
+      "domain"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/domain/content-types-knowledge-base-vs-model-outputs.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "encrypted-pii-decode-on-export",
     "slug": "encrypted-pii-decode-on-export",
     "category": "domain",
@@ -3658,6 +3900,21 @@
   },
   {
     "kind": "knowledge",
+    "name": "condition-based-waiting",
+    "slug": "condition-based-waiting",
+    "category": "engineering",
+    "description": "Replace arbitrary sleep/timeouts in tests with explicit condition polling to eliminate flaky timing-dependent failures",
+    "tags": [
+      "superpowers",
+      "engineering"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/engineering/condition-based-waiting.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "a2a-protocol-agent-to-agent-knowledge-exchange",
     "slug": "a2a-protocol-agent-to-agent-knowledge-exchange",
     "category": "integration",
@@ -3672,6 +3929,28 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/integration/a2a-protocol-agent-to-agent-knowledge-exchange.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "cowork-backend-auto-detection-priority",
+    "slug": "cowork-backend-auto-detection-priority",
+    "category": "linux-sandbox",
+    "description": "Sandbox backend selection should prefer the most-isolated available option (bwrap > kvm > host) using functional tests, not just binary presence; expose the active backend via a `--doctor` diagnostic command and allow override via an environment variable.",
+    "tags": [
+      "sandbox",
+      "bubblewrap",
+      "kvm",
+      "qemu",
+      "detection",
+      "backend",
+      "isolation",
+      "cowork",
+      "linux"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/linux-sandbox/cowork-backend-auto-detection-priority.md",
     "has_content": true
   },
   {
@@ -3709,6 +3988,24 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/llm-agents/agent-runner-loop-semantics.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "connection-type-enum-design",
+    "slug": "connection-type-enum-design",
+    "category": "networking",
+    "description": "ConnType enum: RDP (over relay), Direct TCP, Direct UDP, LAN discovery — drives fallback logic.",
+    "tags": [
+      "connection",
+      "design",
+      "enum",
+      "networking",
+      "type"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/networking/connection-type-enum-design.md",
     "has_content": true
   },
   {
@@ -4196,6 +4493,41 @@
   },
   {
     "kind": "knowledge",
+    "name": "claudecode-env-breaks-nested-spawn",
+    "slug": "claudecode-env-breaks-nested-spawn",
+    "category": "pitfall",
+    "description": "Claude Agent SDK's nesting guard sees CLAUDECODE=1 in a child process env and refuses to run — must strip before spawn when your CLI runs inside another Claude session.",
+    "tags": [
+      "claude-agent-sdk",
+      "env-vars",
+      "nesting",
+      "subprocess"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/claudecode-env-breaks-nested-spawn.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "claudecode-env-var-leakage",
+    "slug": "claudecode-env-var-leakage",
+    "category": "pitfall",
+    "description": "When spawning Claude Code from a parent Claude Code session, strip CLAUDECODE*, CLAUDE_CODE_* env vars so the child doesn't inherit the parent's session state.",
+    "tags": [
+      "claude-code",
+      "environment",
+      "subprocess",
+      "session",
+      "leakage"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/claudecode-env-var-leakage.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "cm-maintenance-job-target-snapshot",
     "slug": "cm-maintenance-job-target-snapshot",
     "category": "pitfall",
@@ -4204,6 +4536,42 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/pitfall/cm-maintenance-job-target-snapshot.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "codex-oauth-strips-vars-at-spawn",
+    "slug": "codex-oauth-strips-vars-at-spawn",
+    "category": "pitfall",
+    "description": "Codex (ChatGPT Plus OAuth via Pi SDK) looks at specific env vars at subprocess spawn; leaving CODEX_SESSION_ID / OPENAI_API_KEY from an earlier run can misroute the current session to the wrong account.",
+    "tags": [
+      "codex",
+      "oauth",
+      "env-pollution",
+      "pi-sdk"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/codex-oauth-strips-vars-at-spawn.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "codex-seatbelt-ignores-network-access",
+    "slug": "codex-seatbelt-ignores-network-access",
+    "category": "pitfall",
+    "description": "On macOS, Codex CLI's Seatbelt sandbox in workspace-write mode silently ignores network_access=true, causing \"no such host\" errors inside agent sessions.",
+    "tags": [
+      "codex",
+      "macos",
+      "sandbox",
+      "seatbelt",
+      "dns",
+      "network"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/codex-seatbelt-ignores-network-access.md",
     "has_content": true
   },
   {
@@ -4276,6 +4644,25 @@
   },
   {
     "kind": "knowledge",
+    "name": "compute-sanitizer-needs-temp-cublaslt-workspace",
+    "slug": "compute-sanitizer-needs-temp-cublaslt-workspace",
+    "category": "pitfall",
+    "description": "",
+    "tags": [
+      "compute-sanitizer",
+      "cublaslt",
+      "teardown",
+      "cuda-runtime",
+      "destructor",
+      "workspace"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pytorch-integration/compute-sanitizer-needs-temp-cublaslt-workspace.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "concurrent-edge-detection-without-full-clock-compare",
     "slug": "concurrent-edge-detection-without-full-clock-compare",
     "category": "pitfall",
@@ -4303,6 +4690,24 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/pitfall/conf-info-may-lack-resource-type.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "connect-via-devtools-active-port-file",
+    "slug": "connect-via-devtools-active-port-file",
+    "category": "pitfall",
+    "description": "When Chrome is launched with `--user-data-dir` and remote debugging but the port is auto-chosen, connect by reading the `DevToolsActivePort` file in the user-data-dir — line 1 is the port, line 2 is the browser-target path — to construct `ws://127.0.0.1:<port><path>`.",
+    "tags": [
+      "chrome",
+      "cdp",
+      "devtools-active-port",
+      "connection",
+      "puppeteer"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/connect-via-devtools-active-port-file.md",
     "has_content": true
   },
   {
@@ -6317,6 +6722,77 @@
   },
   {
     "kind": "knowledge",
+    "name": "claude-cli-hook-bypass-envs",
+    "slug": "claude-cli-hook-bypass-envs",
+    "category": "reference",
+    "description": "Three environment variables — `DISABLE_OMC=1`, `OMC_SKIP_HOOKS=*`, `CLAUDE_DISABLE_SESSION_HOOKS=1` — neutralize the oh-my-claudecode harness and Claude's own SessionStart/Stop hooks so a spawned `claude -p` child can run unattended without a parent-side hook printing to stdout or hijacking stdin.",
+    "tags": [
+      "claude-code",
+      "oh-my-claudecode",
+      "omc",
+      "hooks",
+      "env-vars",
+      "unattended",
+      "spawn",
+      "reference"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/reference/claude-cli-hook-bypass-envs.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "clearcut-source-and-client-type-constants",
+    "slug": "clearcut-source-and-client-type-constants",
+    "category": "reference",
+    "description": "Shipping events to Google Clearcut requires two well-known numeric constants in every LogRequest: `log_source` (assigned per project — chrome-devtools-mcp uses 2839) and `client_info.client_type` (47 for CLI-like tools), wrapped around a `source_extension_json` stringified event.",
+    "tags": [
+      "clearcut",
+      "google-telemetry",
+      "constants",
+      "batch-format"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/reference/clearcut-source-and-client-type-constants.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "config-dir-layout",
+    "slug": "config-dir-layout",
+    "category": "reference",
+    "description": "Full layout of ~/.craft-agent/ including app-level config/credentials/preferences/themes and per-workspace subdirs for sessions, sources, skills, statuses, automations.",
+    "tags": [
+      "filesystem",
+      "config",
+      "workspaces",
+      "layout"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/reference/config-dir-layout.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "craft-cli-command-surface",
+    "slug": "craft-cli-command-surface",
+    "category": "reference",
+    "description": "One-page reference for the craft-cli command taxonomy: info/health, resource listing, session ops, streaming send, power-user invoke/listen, self-contained run, and the 21-step --validate-server.",
+    "tags": [
+      "cli",
+      "rpc",
+      "reference"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/reference/craft-cli-command-surface.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "vector-clock-ui-dominance-tri-state-color",
     "slug": "vector-clock-ui-dominance-tri-state-color",
     "category": "reference",
@@ -6452,6 +6928,42 @@
   },
   {
     "kind": "skill",
+    "name": "code-review",
+    "slug": "code-review",
+    "category": "",
+    "description": "\"Performs an architectural and quality code review on a specified file or set of files. Checks for coding standard compliance, architectural pattern adherence, SOLID principles, testability, and performance concerns.\"",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/engineering/code-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "consistency-check",
+    "slug": "consistency-check",
+    "category": "",
+    "description": "\"Scan all GDDs against the entity registry to detect cross-document inconsistencies: same entity with different stats, same item with different values, same formula with different variables. Grep-first approach — reads registry then targets only conflicting GDD sections rather than full document reads.\"",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/qa/consistency-check",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "content-audit",
+    "slug": "content-audit",
+    "category": "",
+    "description": "\"Audit GDD-specified content counts against implemented content. Identifies what's planned vs built.\"",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/qa/content-audit",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "alert-time-window-with-buffer",
     "slug": "alert-time-window-with-buffer",
     "category": "agent-sdk",
@@ -6465,6 +6977,23 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/agent-sdk/alert-time-window-with-buffer",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "claude-agent-sdk-multi-provider-bridge",
+    "slug": "claude-agent-sdk-multi-provider-bridge",
+    "category": "agent-sdk",
+    "description": "Drive non-Anthropic providers (OpenRouter, Ollama, Vercel AI Gateway, any Anthropic-compatible endpoint) through the Claude Agent SDK by swapping base URL + auth env, and route Google/OpenAI/Copilot through a parallel Pi SDK backend with a shared AgentBackend interface.",
+    "tags": [
+      "claude-agent-sdk",
+      "multi-provider",
+      "pi-sdk",
+      "backend-abstraction"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/agent-sdk/claude-agent-sdk-multi-provider-bridge",
     "has_content": false
   },
   {
@@ -6517,6 +7046,42 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/agents/agent-structured-output",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "claude-code-stream-json-driver",
+    "slug": "claude-code-stream-json-driver",
+    "category": "agents",
+    "description": "Drive the Claude Code CLI non-interactively via stream-json — build input on stdin, parse typed events on stdout, handle session resume and token usage.",
+    "tags": [
+      "claude-code",
+      "stream-json",
+      "cli",
+      "llm",
+      "streaming"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/agents/claude-code-stream-json-driver",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "coding-agent-cli-backend-interface",
+    "slug": "coding-agent-cli-backend-interface",
+    "category": "agents",
+    "description": "Unified Go/TS interface for invoking any coding-agent CLI (Claude, Codex, OpenCode, Gemini, Cursor, etc.) behind one streaming Execute/Session/Result contract.",
+    "tags": [
+      "agents",
+      "cli",
+      "abstraction",
+      "streaming",
+      "llm"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/agents/coding-agent-cli-backend-interface",
     "has_content": false
   },
   {
@@ -9691,6 +10256,42 @@
   },
   {
     "kind": "skill",
+    "name": "coverage-data-file-under-pytest-cache",
+    "slug": "coverage-data-file-under-pytest-cache",
+    "category": "build",
+    "description": "Move coverage data files into .pytest_cache/.coverage so pytest-xdist worker fragments (.coverage.<host>.<pid>.<random>) end up inside the already-gitignored cache dir instead of polluting the repo root.",
+    "tags": [
+      "coverage",
+      "pytest-xdist",
+      "gitignore",
+      "dx"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/build/coverage-data-file-under-pytest-cache",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "cmake-cuda-extension-with-git-submodule-vendoring",
+    "slug": "cmake-cuda-extension-with-git-submodule-vendoring",
+    "category": "build-system",
+    "description": "Build a PyTorch CUDA extension with CMake, vendoring CUTLASS and fmt as git submodules, plus a pre-built-wheel fast path for CI via GitHub releases.",
+    "tags": [
+      "cmake",
+      "pytorch-extension",
+      "git-submodule",
+      "cuda-build",
+      "wheel",
+      "ci"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/build-system/cmake-cuda-extension-with-git-submodule-vendoring",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "autoplan",
     "slug": "autoplan",
     "category": "cli",
@@ -9807,6 +10408,39 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/cli/gstack/checkpoint",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "cli-output-format-dispatch-with-template",
+    "slug": "cli-output-format-dispatch-with-template",
+    "category": "cli",
+    "description": "CLI accepts --format=json|jsonl|text and an optional --format-str with printf-style placeholders (%p path, %l label, %s score, %i mime, %g group, %b overwrite_reason).",
+    "tags": [
+      "magika",
+      "cli"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/cli-output-format-dispatch-with-template",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "cli-serve-blocking-exit",
+    "slug": "cli-serve-blocking-exit",
+    "category": "cli",
+    "description": "In a CLI that wraps a long-running server, block on SIGINT/SIGTERM with a Promise instead of `process.exit(0)` so the underlying Bun.serve/Hono event loop keeps running.",
+    "tags": [
+      "cli",
+      "signal-handling",
+      "bun",
+      "server",
+      "lifecycle"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/cli-serve-blocking-exit",
     "has_content": false
   },
   {
@@ -10554,6 +11188,21 @@
     "version": "1.0.0",
     "path": "skills/codecs/android-mediacodec-jni-wrapper",
     "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "content-type-info-metadata-embedding",
+    "slug": "content-type-info-metadata-embedding",
+    "category": "data",
+    "description": "Embed structured metadata per content type (mime_type, group, description, extensions, is_text) at codegen time so callers can convert predictions to human output or filter by group without lookup tables.",
+    "tags": [
+      "magika",
+      "data"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/data/content-type-info-metadata-embedding",
+    "has_content": true
   },
   {
     "kind": "skill",
@@ -12945,6 +13594,53 @@
   },
   {
     "kind": "skill",
+    "name": "claude-cli-grace-kill-after-success-result",
+    "slug": "claude-cli-grace-kill-after-success-result",
+    "category": "integration",
+    "description": "When driving `claude -p --output-format stream-json`, treat a `result:success` event as completion even if the child doesn't self-exit; arm a 15s grace timer to kill, and return ok=true regardless of exit code.",
+    "tags": "",
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/integration/claude-cli-grace-kill-after-success-result",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "computer-use-agent",
+    "slug": "computer-use-agent",
+    "category": "integration",
+    "description": "Build an agent that controls a computer (screenshots, clicks, keyboard) using ComputerTool.",
+    "tags": [
+      "openai-agents",
+      "computer-use",
+      "automation",
+      "computer-tool",
+      "rpa"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/integration/computer-use-agent",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "confidence-lowering-by-source-factor",
+    "slug": "confidence-lowering-by-source-factor",
+    "category": "integration",
+    "description": "Lower external asset confidence by a configurable factor to reflect source reliability",
+    "tags": [
+      "evolver",
+      "integration",
+      "trust",
+      "confidence"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/integration/confidence-lowering-by-source-factor",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "agent-handoff-routing",
     "slug": "agent-handoff-routing",
     "category": "llm-agents",
@@ -13030,6 +13726,24 @@
   },
   {
     "kind": "skill",
+    "name": "chunked-tts-with-crossfade",
+    "slug": "chunked-tts-with-crossfade",
+    "category": "ml-ops",
+    "description": "Generate long TTS outputs by sentence-splitting the input, generating each chunk independently, and concatenating with a short crossfade.",
+    "tags": [
+      "tts",
+      "audio",
+      "chunking",
+      "crossfade",
+      "long-form"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/ml-ops/chunked-tts-with-crossfade",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "react-native-android-emulator-localhost",
     "slug": "react-native-android-emulator-localhost",
     "category": "mobile",
@@ -13055,6 +13769,24 @@
     "version": "0.1.0-draft",
     "path": "skills/mobile/react-native-android-emulator-localhost",
     "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "config-json-architecture-dispatch",
+    "slug": "config-json-architecture-dispatch",
+    "category": "model-loading",
+    "description": "Auto-detect model version from config.json architecture field and dispatch to the correct model class",
+    "tags": [
+      "model-loading",
+      "config",
+      "dispatch",
+      "versioning",
+      "pytorch"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/model-loading/config-json-architecture-dispatch",
+    "has_content": false
   },
   {
     "kind": "skill",
@@ -13090,6 +13822,27 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/observability/anonymous-posthog-telemetry",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "claude-cli-unattended-wrapper",
+    "slug": "claude-cli-unattended-wrapper",
+    "category": "operations",
+    "description": "Spawn `claude -p` non-interactively from a Node parent process so a long-running loop can drive slash commands without any human at the keyboard. Layers a prompt tempfile, a piped \"y\\n\" stream, hook-bypass env vars, and a stream-json consumer to keep the child from ever blocking.",
+    "tags": [
+      "claude-code",
+      "cli",
+      "unattended",
+      "automation",
+      "spawn",
+      "stdin",
+      "stream-json",
+      "loop"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/operations/claude-cli-unattended-wrapper",
     "has_content": false
   },
   {
@@ -13197,6 +13950,24 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/reverse-engineering/androidmanifest-to-network-call-flow-tracing",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "contextual-identifier-detectors-overlap-resolution",
+    "slug": "contextual-identifier-detectors-overlap-resolution",
+    "category": "safety",
+    "description": "Detect sensitive identifiers (pods, namespaces, IPs, emails, accounts) using context-anchored regex (e.g. preceded by \"namespace=\") and resolve overlapping matches by keeping the longest earliest one to avoid corrupting splice replacements.",
+    "tags": [
+      "regex",
+      "masking",
+      "identifiers",
+      "kubernetes",
+      "infrastructure"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/safety/contextual-identifier-detectors-overlap-resolution",
     "has_content": false
   },
   {
@@ -13366,6 +14137,24 @@
     "version": "1.0.0",
     "path": "skills/security/openssl-4-migration-checklist",
     "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "clearcut-batch-flush-with-retry",
+    "slug": "clearcut-batch-flush-with-retry",
+    "category": "telemetry",
+    "description": "Buffer telemetry events in-memory with drop-oldest overflow, flush on a timer, optimistically remove events before send, requeue on transient errors, honor server-provided `next_request_wait_millis`, and race a final flush with a shutdown deadline.",
+    "tags": [
+      "telemetry",
+      "batching",
+      "retry",
+      "clearcut",
+      "shutdown"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/telemetry/clearcut-batch-flush-with-retry",
+    "has_content": false
   },
   {
     "kind": "skill",
@@ -13576,6 +14365,62 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "skills/testing/tdd",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "comprehensive-gpu-kernel-testing-harness",
+    "slug": "comprehensive-gpu-kernel-testing-harness",
+    "category": "testing-gpu",
+    "description": "Test GPU kernels by running random-shape sweeps against a FP32 reference, using tolerance-aware diff metrics that account for quantization noise, plus TFLOPS/bandwidth bench.",
+    "tags": [
+      "testing",
+      "gpu-kernels",
+      "quantization",
+      "benchmarking",
+      "numerical-validation"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/testing-gpu/comprehensive-gpu-kernel-testing-harness",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "cosine-similarity-diff-for-fp8-numerics",
+    "slug": "cosine-similarity-diff-for-fp8-numerics",
+    "category": "testing-gpu",
+    "description": "Compare two tensors with `1 - 2*sum(x*y)/sum(x^2 + y^2)` instead of absolute max-diff — scale-insensitive, handles all-zero tensors, and gives an interpretable \"fraction of disagreement\" for FP8/FP4 reference-testing.",
+    "tags": [
+      "numeric-testing",
+      "fp8",
+      "fp4",
+      "cosine-similarity",
+      "tolerance",
+      "gpu-testing"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/testing-gpu/cosine-similarity-diff-for-fp8-numerics",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "content-disposition-filename-fallback",
+    "slug": "content-disposition-filename-fallback",
+    "category": "web",
+    "description": "Derive a best-guess filename + extension from an HTTP response by checking Content-Disposition header first, then the URL's basename, then falling back to nothing — with quote stripping and robust extraction.",
+    "tags": [
+      "web",
+      "http",
+      "content-disposition",
+      "filename",
+      "ingestion",
+      "python"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/web/content-disposition-filename-fallback",
     "has_content": false
   },
   {
@@ -13948,6 +14793,24 @@
     "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/command-query-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "completion-signal-detector",
+    "slug": "completion-signal-detector",
+    "category": "workflow",
+    "description": "Detect AI \"I'm done\" signals in loop prompts using `<promise>SIGNAL</promise>` tags as primary, with a restrictive end-of-output / own-line plain match as legacy fallback.",
+    "tags": [
+      "workflow",
+      "loop",
+      "completion",
+      "signal",
+      "regex"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/completion-signal-detector",
     "has_content": false
   },
   {

--- a/knowledge/api/claude-session-resume-semantics.md
+++ b/knowledge/api/claude-session-resume-semantics.md
@@ -1,0 +1,42 @@
+---
+name: claude-session-resume-semantics
+summary: If claude --resume <id> doesn't find the session, Claude silently generates a fresh session and exits. Treat emitted_id != requested_id AND failed status as "resume didn't land".
+category: api
+tags: [claude-code, session, resume, pitfall, llm]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: server/pkg/agent/claude.go
+imported_at: 2026-04-18T00:00:00Z
+---
+
+When you invoke `claude --resume <session_id>`:
+- If the session exists on disk → resumed normally, emitted `session_id` matches requested.
+- If the session does not exist → Claude prints `No conversation found with session ID: ...` to stderr, generates a fresh session ID, emits events with that new ID, and exits non-zero.
+
+If your orchestrator persists the emitted session ID blindly, it will record a brand-new unrelated session as though resume had succeeded. Future "resume this task" calls then keep forking fresh sessions and the task state is effectively lost.
+
+Correct handling:
+
+```go
+func resolveSessionID(requestedResume, emitted string, failed bool) string {
+    if failed && requestedResume != "" && emitted != "" && emitted != requestedResume {
+        return ""  // signal caller to retry with a fresh session
+    }
+    return emitted
+}
+```
+
+Report `""` so the daemon's retry path runs, rather than silently persisting a brand-new ID as if resume had succeeded.
+
+## Why
+
+Claude doesn't expose "did resume land?" as a first-class signal — you have to infer from the session-id-mismatch + exit-status combo. Without this inference the system drifts over time; after enough "resume missed" events the task log in your DB has no useful session continuity.
+
+## Evidence
+
+- `server/pkg/agent/claude.go:448-461` — `resolveSessionID` and its comment block.
+- `server/pkg/agent/claude.go:185-198` — call site where the result is logged.

--- a/knowledge/api/claude-stream-json-protocol.md
+++ b/knowledge/api/claude-stream-json-protocol.md
@@ -1,0 +1,45 @@
+---
+name: claude-stream-json-protocol
+summary: Claude Code CLI's stream-json mode emits typed JSON events (assistant, user, system, result, log) that wrap content blocks like text/thinking/tool_use/tool_result.
+category: api
+tags: [claude-code, streaming, json-protocol, llm, agent]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: server/pkg/agent/claude.go
+imported_at: 2026-04-18T00:00:00Z
+---
+
+Launch Claude in non-interactive stream mode with:
+
+```
+claude -p --output-format stream-json --input-format stream-json --verbose \
+  --strict-mcp-config --permission-mode bypassPermissions
+```
+
+Input is written to stdin as JSON objects: `{"type":"user","message":{"role":"user","content":[{"type":"text","text":"..."}]}}` then close stdin. Output is NDJSON on stdout; each line has a top-level `type`:
+
+- `assistant` — `message.content[]` blocks: `text`, `thinking`, `tool_use` (has `id`, `name`, `input`). `message.usage` carries token counts (input, output, cache_read, cache_creation) per model name.
+- `user` — tool_result blocks via `content[]`, referenced by `tool_use_id`.
+- `system` — carries `session_id`; use this ID for `--resume`.
+- `result` — terminal event with `result` (final text), `is_error`, `duration_ms`, `num_turns`, `session_id`.
+- `log` — passthrough for `level` + `message`.
+
+Session resume: if `--resume <id>` is passed and the session doesn't exist, Claude prints an error to stderr, generates a fresh session, and exits. If the emitted session ID differs from the requested one AND the run failed, treat the session ID as unusable (return empty) so a retry-with-fresh-session path can trigger.
+
+Flags that must be blocked from user-configured `custom_args` because they break the protocol: `-p`, `--output-format`, `--input-format`, `--permission-mode`, `--mcp-config`.
+
+Child environment leakage: strip `CLAUDECODE`, `CLAUDECODE_*`, `CLAUDE_CODE_*` from the child env so the spawned Claude doesn't inherit the parent Claude's session state.
+
+## Why
+
+Wrapping a coding-agent CLI as an RPC backend needs a stable wire format. Stream-JSON is the only one Claude supports non-interactively that exposes tool calls and thinking. Buffered stdout scanning with a 10MB max token size handles large tool outputs without breaking.
+
+## Evidence
+
+- `server/pkg/agent/claude.go:129-220` — scanner and event handlers.
+- `server/pkg/agent/claude.go:316-420` — Go types for the JSON wire format.
+- `server/pkg/agent/claude.go:383-416` — blocked-args filter and protocol flag list.

--- a/knowledge/api/cli-release-via-git-tag.md
+++ b/knowledge/api/cli-release-via-git-tag.md
@@ -1,0 +1,34 @@
+---
+name: cli-release-via-git-tag
+summary: CLI releases are cut from semver tags on main — push a tag, GitHub Actions runs tests, GoReleaser builds multi-platform binaries and updates the Homebrew tap.
+category: api
+tags: [release, cli, git-tag, goreleaser, github-actions]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: CLAUDE.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+Release flow is two commands:
+
+```bash
+git tag v0.1.13
+git push origin v0.1.13
+```
+
+The tag push triggers `release.yml`: run Go tests → GoReleaser builds multi-platform binaries → publishes to GitHub Releases + updates Homebrew tap.
+
+Bump the patch version each release by default (`v0.1.12` → `v0.1.13`) unless the user specifies a specific version. A CLI release must accompany every production deployment.
+
+## Why
+
+Tag-triggered releases keep release history auditable (one tag = one release) and make rollback obvious (just delete the tag and re-tag). GoReleaser handles the cross-platform binary production and the Homebrew formula update automatically; manual formula edits are error-prone. Coupling CLI release to production deploy means server-CLI protocol changes never ship skewed.
+
+## Evidence
+
+- CLAUDE.md, "CLI Release" section.
+- `.github/workflows/release.yml` (referenced).

--- a/knowledge/arch/cli-implemented-in-rust-for-speed.md
+++ b/knowledge/arch/cli-implemented-in-rust-for-speed.md
@@ -1,0 +1,26 @@
+---
+name: cli-implemented-in-rust-for-speed
+type: knowledge
+category: arch
+summary: The Magika CLI is Rust, not Python, to eliminate interpreter startup overhead.
+confidence: high
+tags: [magika, arch]
+linked_skills: [python-rust-client-fallback-with-warning]
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Cli Implemented In Rust For Speed
+
+## Fact
+
+The original Python CLI took several hundred ms just to start. The Rust CLI starts near-instantly, which matters for shell scripting and batch use. The Python package ships the precompiled Rust binary in platform wheels (with a pure-Python fallback for unsupported platforms).
+
+## Evidence
+
+- `python/README.md:38-39`
+- `website-ng/src/content/docs/additional-resources/faq.md:27-32`

--- a/knowledge/arch/config-minimization-min-json.md
+++ b/knowledge/arch/config-minimization-min-json.md
@@ -1,0 +1,25 @@
+---
+name: config-minimization-min-json
+type: knowledge
+category: arch
+summary: Model configs ship as config.min.json (minified) to shrink package size — especially important for browser deployment.
+confidence: medium
+tags: [magika, arch]
+linked_skills: [model-config-min-json-compact-format]
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Config Minimization Min Json
+
+## Fact
+
+Minification removes whitespace, comments, and unnecessary metadata. The .min suffix is a convention for distributable artifacts. Browser bundles in particular benefit from this — load time is dominated by transfer size.
+
+## Evidence
+
+- `python/src/magika/magika.py:95`

--- a/knowledge/arch/content-types-knowledge-base-minified.md
+++ b/knowledge/arch/content-types-knowledge-base-minified.md
@@ -1,0 +1,25 @@
+---
+name: content-types-knowledge-base-minified
+type: knowledge
+category: arch
+summary: The full content-types KB ships as content_types_kb.min.json so APIs can offer rich metadata without a large overhead.
+confidence: medium
+tags: [magika, arch]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Content Types Knowledge Base Minified
+
+## Fact
+
+Distributing the comprehensive KB as minified JSON lets the CLI/APIs surface descriptions, MIME types, and extensions cheaply. Small enough to ship with every wheel/binary.
+
+## Evidence
+
+- `python/src/magika/magika.py:118-121`

--- a/knowledge/ci-cd/ci-gpg-signing-batch-mode-non-interactive.md
+++ b/knowledge/ci-cd/ci-gpg-signing-batch-mode-non-interactive.md
@@ -1,0 +1,107 @@
+---
+name: ci-gpg-signing-batch-mode-non-interactive
+summary: GPG signing in CI requires `--batch --yes` flags, a pre-imported key, and `git config user.signingKey` set; without a TTY, pinentry will fail and the signing step hangs or errors unless all interactive prompts are bypassed.
+category: ci-cd
+tags: [gpg, signing, ci-cd, github-actions, non-interactive, batch, pinentry]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: medium
+---
+
+# CI GPG Signing Batch Mode (Non-Interactive)
+
+## Context
+
+Package signing (`.deb`, `.rpm`, APT repository metadata, RPM repository
+metadata) often requires GPG. CI environments have no interactive terminal
+(TTY), which breaks the standard GPG flow that relies on pinentry for
+passphrase input.
+
+## Observation
+
+Two distinct GPG errors occur in CI:
+
+1. **"cannot open /dev/tty"**: GPG tries to open a TTY for passphrase input
+   via pinentry-curses or pinentry-gnome3. Without a TTY, this fails.
+   Fix: `--batch` flag tells GPG to read from stdin/env and not try to open
+   a terminal.
+
+2. **"File exists"**: When exporting or writing a key file that already exists
+   from a previous run (common in cached CI runners or re-runs).
+   Fix: `--yes` flag tells GPG to overwrite without prompting.
+
+Additionally, if the signing key is not imported into the CI runner's GPG
+keyring before the signing step, GPG will fail with "secret key not available".
+Keys must be imported from a CI secret (environment variable or file secret)
+as an explicit step.
+
+## Why it happens
+
+GPG's interactive mode is designed for human users. It opens `/dev/tty`
+directly (bypassing stdin/stdout redirection) to read passphrases. CI
+environments run in containers or VMs without a controlling terminal; the
+open fails immediately.
+
+The `--batch` flag enables non-interactive mode:
+- Reads passphrase from `--passphrase-fd 0` or `--passphrase` option.
+- Does not attempt to open a terminal.
+- Fails deterministically on errors instead of prompting.
+
+`--yes` globally answers "yes" to overwrite prompts that would otherwise block.
+
+## Practical implication
+
+CI GPG signing setup checklist:
+
+```yaml
+- name: Import GPG signing key
+  run: |
+    echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
+
+- name: Configure git signing
+  run: |
+    git config user.signingKey "${{ secrets.GPG_KEY_ID }}"
+    git config commit.gpgsign true
+
+- name: Sign a file (e.g., APT repo Release file)
+  run: |
+    gpg --batch --yes \
+        --passphrase "${{ secrets.GPG_PASSPHRASE }}" \
+        --pinentry-mode loopback \
+        --armor --detach-sign \
+        --output Release.gpg \
+        Release
+```
+
+Key flags:
+- `--batch`: non-interactive mode.
+- `--yes`: overwrite existing files.
+- `--passphrase-fd 0` or `--passphrase "..."` + `--pinentry-mode loopback`:
+  reads passphrase without TTY.
+- `--pinentry-mode loopback`: modern GPG 2.1+ way to bypass pinentry entirely
+  for scripted use.
+
+Common CI pitfall table:
+
+| Error | Cause | Fix |
+|---|---|---|
+| "cannot open /dev/tty" | No TTY, interactive mode | Add `--batch` |
+| "File exists" | Output file already present | Add `--yes` |
+| "No secret key" | Key not imported | Import key from secret first |
+| "Bad passphrase" | Passphrase in env has whitespace | Quote the passphrase |
+| Push rejected after signing | Concurrent pushes | Add retry with rebase |
+
+Test signing commands locally with `--dry-run` where available, or in a
+container without a TTY, before committing the CI workflow.
+
+## Source reference
+
+- `CLAUDE.md`: "Common CI Pitfalls" table — lists "GPG 'cannot open /dev/tty'"
+  with `--batch` fix and "GPG 'File exists'" with `--yes` fix.
+- `CLAUDE.md`: "CI/CD" section — `gh workflow run` and `gh run watch` commands
+  for triggering and monitoring CI.

--- a/knowledge/ci-cd/ci-push-race-condition-retry-rebase-loop.md
+++ b/knowledge/ci-cd/ci-push-race-condition-retry-rebase-loop.md
@@ -1,0 +1,131 @@
+---
+name: ci-push-race-condition-retry-rebase-loop
+summary: Parallel CI jobs pushing to the same branch (e.g., `gh-pages`) race; solve with a `git pull --rebase` + retry loop with exponential backoff, or serialize jobs with `needs:` dependencies to avoid the race entirely.
+category: ci-cd
+tags: [ci-cd, git-push, race-condition, gh-pages, retry, rebase, github-actions, concurrency]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: medium
+---
+
+# CI Push Race Condition: Retry Rebase Loop
+
+## Context
+
+CI/CD pipelines that build multiple package formats in parallel (e.g., `.deb`
+and `.rpm`) and publish them to a shared branch (e.g., `gh-pages` for a
+package repository) face a write-write race condition: both jobs push to the
+same branch near-simultaneously. One succeeds; the other fails with
+"Updates were rejected because the remote contains work that you do not have
+locally."
+
+GitHub Pages deployment adds a third actor: the Pages deployment workflow
+runs automatically on every push to `gh-pages` and may itself modify the
+branch.
+
+## Observation
+
+The race manifests as:
+
+```
+error: failed to push some refs to 'origin'
+hint: Updates were rejected because the remote contains work that you do not
+hint: have locally. Integrate the remote changes (e.g.
+hint: 'git pull ...') before pushing again.
+```
+
+This happens even with fresh checkouts because both jobs clone the `gh-pages`
+branch at `T=0` (same state), both add their files, and then race to push at
+`T=N`.
+
+Job dependencies (`needs: [other-job]`) fully eliminate the race by
+serializing the jobs, but increase total pipeline time.
+
+A retry loop with `git pull --rebase` handles the common case where one job
+finishes just before another and the rebase is fast (no real conflict):
+
+```bash
+MAX_RETRIES=5
+ATTEMPT=0
+
+while (( ATTEMPT < MAX_RETRIES )); do
+  if git push origin gh-pages; then
+    echo "Push succeeded on attempt $((ATTEMPT + 1))"
+    break
+  fi
+
+  ATTEMPT=$(( ATTEMPT + 1 ))
+  if (( ATTEMPT >= MAX_RETRIES )); then
+    echo "Push failed after $MAX_RETRIES attempts" >&2
+    exit 1
+  fi
+
+  echo "Push failed, rebasing and retrying (attempt $ATTEMPT)..."
+  git pull --rebase origin gh-pages
+
+  # Exponential backoff: 2^attempt seconds
+  sleep $(( 2 ** ATTEMPT ))
+done
+```
+
+## Why it happens
+
+`git push` is not atomic at the application level across multiple CI runners.
+Two runners that cloned the branch at the same ref cannot both push without
+one failing — the second push will be rejected because the remote ref has
+advanced since the clone.
+
+`git pull --rebase` fast-forwards the local branch to the new remote state
+and replays any local commits on top, allowing the retry push to succeed
+unless there is a true content conflict (which should not happen if each
+job writes to different files in the branch).
+
+GitHub Pages auto-deployment also creates commits on `gh-pages` (to update
+metadata files), adding a third concurrent writer.
+
+## Practical implication
+
+Choose the approach based on the tradeoff:
+
+**Option 1: Serialize with `needs:`**
+```yaml
+jobs:
+  publish-apt:
+    steps:
+      - uses: actions/checkout@v4
+        with: { ref: gh-pages }
+      - name: Add deb package
+        run: |
+          # ... add files, commit
+          git push origin gh-pages
+
+  publish-rpm:
+    needs: [publish-apt]  # serializes the push
+    steps:
+      # ... same pattern
+```
+- Pro: simple, guaranteed no conflicts.
+- Con: increases total pipeline time.
+
+**Option 2: Retry loop** (if parallel speed is important)
+- Use the retry loop above.
+- Limit to 5-10 attempts with backoff.
+- Ensure each job writes to non-overlapping paths to avoid real rebase
+  conflicts.
+
+Either approach is better than no mitigation. The retry loop handles transient
+races well but is not a substitute for proper serialization when jobs write to
+the same file paths.
+
+## Source reference
+
+- `CLAUDE.md`: "Consider Concurrency" section — "Multiple jobs writing to the
+  same branch will race — add job dependencies or retry loops with
+  `git pull --rebase` before push."
+- `CLAUDE.md`: "Common CI Pitfalls" table — "Push rejected (ref changed):
+  Add `git pull --rebase` before push, with retry loop."

--- a/knowledge/clipboard/clipboard-context-lazy-initialization.md
+++ b/knowledge/clipboard/clipboard-context-lazy-initialization.md
@@ -1,0 +1,28 @@
+---
+name: clipboard-context-lazy-initialization
+type: knowledge
+category: clipboard
+summary: Clipboard context is lazy-init on first check_clipboard(); one context per side.
+confidence: medium
+tags: [clipboard, context, initialization, lazy]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: src/clipboard.rs
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Clipboard Context Lazy Initialization
+
+## Fact
+Clipboard context is lazy-init on first check_clipboard(); one context per side.
+
+## Why it matters
+Avoid creating the context during app startup — it grabs OS locks.
+
+## Evidence
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- `src/clipboard.rs`

--- a/knowledge/clipboard/clipboard-ownership-protocol.md
+++ b/knowledge/clipboard/clipboard-ownership-protocol.md
@@ -1,0 +1,28 @@
+---
+name: clipboard-ownership-protocol
+type: knowledge
+category: clipboard
+summary: Clipboard-ownership detection uses a custom format flag (dyn.com.rustdesk.owner) to prevent copy-paste loops between host and guest.
+confidence: high
+tags: [clipboard, ownership, protocol]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: src/clipboard.rs
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Clipboard Ownership Protocol
+
+## Fact
+Clipboard-ownership detection uses a custom format flag (dyn.com.rustdesk.owner) to prevent copy-paste loops between host and guest.
+
+## Why it matters
+Any clipboard-sync tool must own a sentinel format, or two instances will echo content forever.
+
+## Evidence
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- `src/clipboard.rs`

--- a/knowledge/collaboration/collaborative-design-principles.md
+++ b/knowledge/collaboration/collaborative-design-principles.md
@@ -1,0 +1,499 @@
+---
+name: collaborative-design-principles
+summary: Collaborative design principles for multi-agent game development workflows
+category: collaboration
+confidence: medium
+tags: [game-studios, ccgs, collaboration, design-principles, multi-agent]
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+source_path: docs/COLLABORATIVE-DESIGN-PRINCIPLE.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Collaborative Design Principle
+
+**Last Updated:** 2026-02-13
+
+---
+
+## 🎯 Core Philosophy
+
+This agent architecture is designed for **USER-DRIVEN COLLABORATION**, not autonomous AI generation.
+
+### ✅ The Right Model: Collaborative Consultant
+
+```
+Agent = Expert Consultant
+User = Creative Director (Final Decision Maker)
+
+Agents:
+- Ask clarifying questions
+- Research and present options
+- Explain trade-offs and reasoning
+- Draft proposals for review
+- Wait for user approval before writing
+
+Users:
+- Make all creative and strategic decisions
+- Approve or reject agent suggestions
+- Direct the design vision
+- Sign off before anything is written to files
+```
+
+### ❌ The Wrong Model: Autonomous Generator
+
+```
+❌ Agent creates design and writes it
+❌ Agent makes decisions without user input
+❌ Agent writes code without approval
+❌ User just says "make a game" and waits
+```
+
+---
+
+## 🔄 Collaborative Workflow Pattern
+
+Every agent interaction should follow this pattern:
+
+### Pattern: Question → Options → Decision → Draft → Approval
+
+```
+1. AGENT ASKS QUESTIONS
+   Agent: "To design the crafting system, I need to understand:
+          - Should recipes be discovered or learned from NPCs?
+          - How punishing should failed attempts be?
+          - Is there a resource cost to experimentation?"
+
+2. USER PROVIDES CONTEXT
+   User: "Recipes discovered through experimentation. Failed attempts should consume
+         materials but give partial XP. We're targeting Explorers primarily."
+
+3. AGENT PRESENTS OPTIONS WITH REASONING
+   Agent: "Based on your goals, here are three approaches:
+
+          **Option A: Full Randomized Discovery**
+          - Mechanics: Try any item combo, random success chance
+          - ✅ Maximum exploration reward
+          - ❌ Can feel arbitrary without skill expression
+          - Example games: Minecraft early, Doodle God
+          - Aligns with pillars: ✅ Emergent Stories, ⚠️ Meaningful Choices (low)
+
+          **Option B: Ingredient Hint System**
+          - Mechanics: Items show 'compatible tags' when inspected
+          - ✅ Rewards observation and deduction
+          - ✅ Skill expression through pattern recognition
+          - ❌ Less pure discovery magic
+          - Example games: Potion Craft, Opus Magnum
+          - Aligns with pillars: ✅ Meaningful Choices, ✅ Emergent Stories
+
+          **Option C: Hybrid (Discovery + Hints)**
+          - Mechanics: Start random, unlock hint system after X failures
+          - ✅ Accessible to multiple player types
+          - ✅ Rewards persistence
+          - ❌ More complex to implement
+          - Aligns with pillars: ✅✅ Both pillars strongly
+
+          Which approach aligns best with your vision?"
+
+4. USER DECIDES
+   User: "Option C feels right. Let's set X = 5 failures to unlock hints."
+
+5. AGENT DRAFTS BASED ON DECISION
+   Agent: "Great. Here's a draft of the core mechanic:
+
+          ### Core Loop
+          1. Player selects 2-4 ingredients from inventory
+          2. System checks against recipe database
+          3. If match: Success! Recipe learned, item created, full XP
+          4. If no match: Failure. Materials consumed, 25% XP gained
+          5. After 5 failures on any item combo, hint system unlocks for those items
+          6. Hints show ingredient 'tags' (e.g., 'Fire', 'Healing', 'Metal')
+
+          ### Formula Proposal
+          success_xp = base_xp * recipe_tier^1.5
+          failure_xp = success_xp * 0.25
+          hint_unlock_threshold = 5  # Failures to unlock hints
+
+          Does this match your intent?"
+
+6. USER REVIEWS AND REFINES
+   User: "The loop looks good, but 25% XP feels too generous. Make it 15%.
+         Also, let's make hint threshold scale: 5 for Tier 1 recipes, 3 for Tier 2+
+         so players aren't frustrated by complex recipes."
+
+7. AGENT UPDATES DRAFT
+   Agent: "Updated:
+          failure_xp = success_xp * 0.15
+          hint_unlock_threshold = 5 if recipe_tier == 1 else 3
+
+          Should I continue drafting the Edge Cases section, or would you like
+          to review formulas in more detail first?"
+
+8. USER APPROVES NEXT STEP
+   User: "Formulas are good. Continue with Edge Cases."
+
+9. [REPEAT CYCLE FOR EACH SECTION]
+
+10. FINAL APPROVAL BEFORE WRITING
+    Agent: "The full GDD draft is complete. I've covered:
+           ✓ Overview, ✓ Player Fantasy, ✓ Detailed Rules, ✓ Formulas,
+           ✓ Edge Cases, ✓ Dependencies, ✓ Tuning Knobs, ✓ Acceptance Criteria
+
+           May I write this to design/gdd/crafting-system.md?"
+
+    User: "Yes, write it."  ← ONLY NOW does file get created
+
+11. AGENT WRITES FILE
+    Agent: [Uses Write tool]
+           "Created design/gdd/crafting-system.md. Would you like me to run
+            /design-review to validate it against the standard?"
+```
+
+---
+
+## 📋 How This Applies to Different Tasks
+
+### 🎨 Design Tasks
+
+**Example:** "Design the combat system"
+
+```
+❌ WRONG (Autonomous):
+User: "Design the combat system"
+Agent: [Writes design/gdd/combat-system.md with full design]
+Agent: "Done! Here's your combat system."
+
+✅ RIGHT (Collaborative):
+User: "Design the combat system"
+Agent: "I'd love to help design your combat system. First, some questions:
+       1. What's the core fantasy? (precise timing? tactical positioning? resource management?)
+       2. Real-time or turn-based?
+       3. How much depth vs accessibility? (think Celeste vs Dark Souls)
+       4. Any reference games that nail the feel you want?"
+
+User: [Answers questions]
+Agent: [Presents 3 combat approaches with pros/cons]
+User: [Picks one, refines it]
+Agent: [Drafts mechanics section]
+User: [Reviews, requests changes]
+Agent: [Iterates until user approves]
+Agent: "Ready to write to design/gdd/combat-system.md?"
+User: "Yes"
+Agent: [Writes file]
+```
+
+### 💻 Coding Tasks
+
+**Example:** "Implement the damage calculation"
+
+```
+❌ WRONG:
+User: "Implement damage calculation"
+Agent: [Writes src/gameplay/combat/damage_calculator.gd]
+Agent: "Implemented!"
+
+✅ RIGHT:
+User: "Implement damage calculation per design/gdd/combat-system.md"
+Agent: [Reads design doc]
+       "I see the design calls for:
+        - Base damage * weapon multiplier * crit multiplier * resistance
+
+        Before I implement, a few architectural questions:
+        1. Should DamageCalculator be a static utility or a node in the scene tree?
+        2. Where should weapon/resistance data live? (CharacterStats? Equipment class?)
+        3. Do we need damage events for VFX/SFX hookup?
+
+        Also, I notice the design doc doesn't specify rounding behavior.
+        Should we round damage (to int) or allow decimal damage?"
+
+User: "Static utility. Stats on CharacterStats node. Yes, emit signal on damage.
+      Round damage down to int."
+
+Agent: "Got it. Here's the proposed architecture:
+
+       [Shows code structure]
+
+       Does this match your expectations? Any changes before I write the code?"
+
+User: "Looks good. Implement it."
+
+Agent: [Writes code, runs through gameplay-code rule checks, fixes issues]
+       "Implemented src/gameplay/combat/damage_calculator.gd.
+        The gameplay-code rule flagged one issue: multiplier was hardcoded.
+        I moved it to assets/data/combat_config.json.
+
+        Would you like me to write tests now, or review the code first?"
+```
+
+### 🎯 Brainstorming Tasks
+
+**Example:** `/brainstorm roguelike`
+
+```
+❌ WRONG:
+User: "/brainstorm roguelike"
+Skill: [Generates 1 concept and writes it to design/concept.md]
+
+✅ RIGHT:
+User: "/brainstorm roguelike"
+Skill: "I'll help you brainstorm roguelike concepts using professional
+       ideation frameworks. First:
+
+       1. What excites you about roguelikes? (permadeath tension? build variety?
+          skill mastery? emergent stories?)
+       2. Any sub-genre? (action, deckbuilder, puzzle, tactics?)
+       3. Any roguelikes you love/hate and why?
+       4. Solo dev or team? (Affects scope recommendations)
+
+       [User answers]
+
+       Okay! I'll generate 10 raw concepts across 3 categories:
+       - Traditional (combat-focused)
+       - Hybrid (combat + other verb)
+       - Unconventional (non-combat primary loop)
+
+       [Generates 10 concepts with MDA analysis for each]
+
+       Which 2-3 resonate most? I'll do deep MDA + SDT analysis on those."
+
+User: "Concepts 3, 7, and 9 are interesting"
+
+Skill: [Analyzes those 3 in depth]
+       "Here's the deep analysis:
+
+       Concept 3: [Full breakdown]
+       Concept 7: [Full breakdown]
+       Concept 9: [Full breakdown]
+
+       Based on MDA alignment, target audience, and scope:
+       **I recommend Concept 7** because [reasoning].
+
+       But you should pick based on what excites YOU most.
+       Which concept do you want to develop into your game?"
+
+User: "Let's go with Concept 7"
+
+Skill: "Excellent. Should I:
+       A) Create the full concept document now (design/concept.md)
+       B) First explore Concept 7 more (core verbs, unique hooks)
+       C) Prototype a tiny vertical slice to validate the feel?"
+
+User: "A, create the doc"
+
+Skill: "Writing design/concept.md..."
+```
+
+---
+
+## 🛠️ How Agents Should Ask Questions
+
+### Good Question Patterns
+
+✅ **Multiple Choice with Reasoning:**
+```
+"Should enemies telegraph attacks?
+ A) Yes, 0.5s before (accessible, rhythm-based)
+ B) Yes, 0.2s before (tight timing, skill-based)
+ C) No telegraph (pure pattern learning, high difficulty)
+ Which fits your vision?"
+```
+
+✅ **Constrained Options with Trade-offs:**
+```
+"Inventory system options:
+ 1. Grid-based (Resident Evil, Diablo): Deep space management, slower
+ 2. List-based (Skyrim, Fallout): Fast access, less strategic
+ 3. Hybrid (weight limit + limited slots): Medium complexity
+
+ Given your 'Meaningful Choices' pillar, I'd lean toward #1 or #3. Thoughts?"
+```
+
+✅ **Open-Ended with Context:**
+```
+"The design doc doesn't specify what happens when a player dies while crafting.
+ Some options:
+ - Materials lost (harsh, risk/reward)
+ - Materials returned to inventory (forgiving)
+ - Work-in-progress saved (complex to implement)
+
+ What fits your target difficulty?"
+```
+
+### Bad Question Patterns
+
+❌ **Too Open-Ended:**
+```
+"What should the combat system be like?"
+← Too broad, user doesn't know where to start
+```
+
+❌ **Leading/Assuming:**
+```
+"I'll make combat real-time since that's standard for this genre."
+← Didn't ask, just assumed
+```
+
+❌ **Binary Without Context:**
+```
+"Should we have a skill tree? Yes or no?"
+← No pros/cons, no reference to game pillars
+```
+
+---
+
+## 🎛️ Structured Decision UI (AskUserQuestion)
+
+Use the `AskUserQuestion` tool to present decisions as a **selectable UI** instead
+of plain markdown text. This gives the user a clean interface to pick from options
+(or type "Other" for a custom answer).
+
+### The Explain → Capture Pattern
+
+Detailed reasoning doesn't fit in the tool's short descriptions. So use a two-step
+pattern:
+
+1. **Explain first** — Write your full expert analysis in conversation text:
+   detailed pros/cons, theory references, example games, pillar alignment. This is
+   where the reasoning lives.
+
+2. **Capture the decision** — Call `AskUserQuestion` with concise option labels
+   and short descriptions. The user picks from the UI or types a custom answer.
+
+### When to Use AskUserQuestion
+
+✅ **Use it for:**
+- Every decision point where you'd present 2-4 options
+- Initial clarifying questions with constrained answers
+- Batching up to 4 independent questions in one call
+- Next-step choices ("Draft formulas or refine rules first?")
+- Architecture decisions ("Static utility or singleton?")
+- Strategic choices ("Simplify scope, slip deadline, or cut feature?")
+
+❌ **Don't use it for:**
+- Open-ended discovery questions ("What excites you about roguelikes?")
+- Single yes/no confirmations ("May I write to file?")
+- When running as a Task subagent (tool may not be available)
+
+### Format Guidelines
+
+- **Labels**: 1-5 words (e.g., "Hybrid Discovery", "Full Randomized")
+- **Descriptions**: 1 sentence summarizing the approach and key trade-off
+- **Recommended**: Add "(Recommended)" to your preferred option's label
+- **Previews**: Use `markdown` field for comparing code structures or formulas
+- **Multi-select**: Use `multiSelect: true` when choices aren't mutually exclusive
+
+### Example — Multi-Question Batch (Clarifying Questions)
+
+After introducing the topic in conversation, batch constrained questions:
+
+```
+AskUserQuestion:
+  questions:
+    - question: "Should crafting recipes be discovered or learned?"
+      header: "Discovery"
+      options:
+        - label: "Experimentation"
+          description: "Players discover by trying combinations — high mystery"
+        - label: "NPC/Book Learning"
+          description: "Recipes taught explicitly — accessible, lower mystery"
+        - label: "Tiered Hybrid"
+          description: "Basic recipes learned, advanced discovered — best of both"
+    - question: "How punishing should failed crafts be?"
+      header: "Failure"
+      options:
+        - label: "Materials Lost"
+          description: "All consumed on failure — high stakes, risk/reward"
+        - label: "Partial Recovery"
+          description: "50% returned — moderate risk"
+        - label: "No Loss"
+          description: "Materials returned, only time spent — forgiving"
+```
+
+### Example — Design Decision (After Full Analysis)
+
+After writing the full pros/cons analysis in conversation text:
+
+```
+AskUserQuestion:
+  questions:
+    - question: "Which crafting approach fits your vision?"
+      header: "Approach"
+      options:
+        - label: "Hybrid Discovery (Recommended)"
+          description: "Discovery base with earned hints — balances exploration and accessibility"
+        - label: "Full Discovery"
+          description: "Pure experimentation — maximum mystery, risk of frustration"
+        - label: "Hint System"
+          description: "Progressive hints reveal recipes — accessible but less surprise"
+```
+
+### Example — Strategic Decision
+
+After presenting the full strategic analysis with pillar alignment:
+
+```
+AskUserQuestion:
+  questions:
+    - question: "How should we handle crafting scope for Alpha?"
+      header: "Scope"
+      options:
+        - label: "Simplify to Core (Recommended)"
+          description: "Recipe discovery only, 10 recipes — makes deadline, pillar visible"
+        - label: "Full Implementation"
+          description: "Complete system, 30 recipes — slips Alpha by 1 week"
+        - label: "Cut Entirely"
+          description: "Drop crafting, focus on combat — deadline met, pillar missing"
+```
+
+### Team Skill Orchestration
+
+In team skills, subagents return their analysis as text. The **orchestrator**
+(main session) calls `AskUserQuestion` at each decision point between phases:
+
+```
+[game-designer returns 3 combat approaches with analysis]
+
+Orchestrator uses AskUserQuestion:
+  question: "Which combat approach should we develop?"
+  options: [concise summaries of the 3 approaches]
+
+[User picks → orchestrator passes decision to next phase]
+```
+
+---
+
+## 📄 File Writing Protocol
+
+### NEVER Write Files Without Explicit Approval
+
+Every file write must follow:
+
+```
+1. Agent: "I've completed the [design/code/doc]. Here's a summary:
+           [Key points]
+
+           May I write this to [filepath]?"
+
+2. User: "Yes" or "No, change X first" or "Show me the full draft"
+
+3. IF User says "Yes":
+   Agent: [Uses Write/Edit tool]
+          "Written to [filepath]. Next steps?"
+
+   IF User says "No":
+   Agent: [Makes requested changes]
+          [Returns to step 1]
+```
+
+### Incremental Section Writing (Design Documents)
+
+For multi-section documents (design docs, lore entries, architecture docs), write
+each section to the file as it's approved instead of building the full document
+in conversation. This prevents context overflow during long iterative sessions.
+
+```
+
+> _Truncated; see source file for full content._

--- a/knowledge/configuration/config-system-four-tiers.md
+++ b/knowledge/configuration/config-system-four-tiers.md
@@ -1,0 +1,28 @@
+---
+name: config-system-four-tiers
+type: knowledge
+category: configuration
+summary: Four config tiers: Settings (persistent), Local (user), Display (per-display), Built-in (defaults).
+confidence: medium
+tags: [config, configuration, four, system, tiers]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: CLAUDE.md
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Config System Four Tiers
+
+## Fact
+Four config tiers: Settings (persistent), Local (user), Display (per-display), Built-in (defaults).
+
+## Why it matters
+Layered config avoids 'one config.toml with 300 lines' anti-pattern.
+
+## Evidence
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- `CLAUDE.md`

--- a/knowledge/decision/cli-release-accompanies-prod-deploy.md
+++ b/knowledge/decision/cli-release-accompanies-prod-deploy.md
@@ -1,0 +1,28 @@
+---
+name: cli-release-accompanies-prod-deploy
+summary: Every production deployment of the server must be accompanied by a matching CLI release, so server-CLI protocol changes never ship skewed.
+category: decision
+tags: [release, versioning, cli, server, protocol]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: CLAUDE.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+Hard rule: a CLI release must accompany every production deployment. Default is a patch bump per release (`v0.1.12 → v0.1.13`) unless the change is larger.
+
+## Why
+
+CLI and server share a wire protocol (REST, WebSocket, task/message shapes). Deploying the server alone can break CLIs that users are already running; forcing a paired release keeps both sides in lockstep. The `multica update` command (and `brew upgrade`) lets users pull the new CLI, so the friction of staying current is low.
+
+Even when the protocol is technically unchanged, cutting a CLI release keeps `multica version` reporting a commit that matches what's on the server for easier support triage ("what commit were you running when this happened?").
+
+Automate the pairing: release pipeline refuses to deploy the server if the latest tag on main hasn't been published through the CLI release workflow.
+
+## Evidence
+
+- CLAUDE.md, "CLI Release" section — prerequisite explicitly stated.

--- a/knowledge/domain/content-types-knowledge-base-vs-model-outputs.md
+++ b/knowledge/domain/content-types-knowledge-base-vs-model-outputs.md
@@ -1,0 +1,25 @@
+---
+name: content-types-knowledge-base-vs-model-outputs
+type: knowledge
+category: domain
+summary: content_types_kb.min.json is a research superset — distinct from any single model's actual output space.
+confidence: high
+tags: [magika, domain]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Content Types Knowledge Base Vs Model Outputs
+
+## Fact
+
+The internal knowledge base lists all content types Magika research is interested in. A given model only outputs a subset (200+ for standard_v3_3). Always check the model's own README for its supported types instead of assuming the KB defines model capability. Each model has 'model outputs' (raw NN labels) and 'tool outputs' (model outputs + generic fallbacks).
+
+## Evidence
+
+- `website-ng/src/content/docs/core-concepts/models-and-content-types.md:19-21`

--- a/knowledge/engineering/condition-based-waiting.md
+++ b/knowledge/engineering/condition-based-waiting.md
@@ -1,0 +1,130 @@
+---
+name: condition-based-waiting
+summary: Replace arbitrary sleep/timeouts in tests with explicit condition polling to eliminate flaky timing-dependent failures
+category: engineering
+confidence: medium
+tags: [superpowers, engineering]
+source_type: extracted-from-git
+source_url: https://github.com/obra/superpowers.git
+source_ref: main
+source_commit: b55764852ac78870e65c6565fb585b6cd8b3c5c9
+source_project: superpowers
+source_path: skills/systematic-debugging/condition-based-waiting.md
+imported_at: 2026-04-18T06:36:49Z
+---
+
+# Condition-Based Waiting
+
+## Overview
+
+Flaky tests often guess at timing with arbitrary delays. This creates race conditions where tests pass on fast machines but fail under load or in CI.
+
+**Core principle:** Wait for the actual condition you care about, not a guess about how long it takes.
+
+## When to Use
+
+```dot
+digraph when_to_use {
+    "Test uses setTimeout/sleep?" [shape=diamond];
+    "Testing timing behavior?" [shape=diamond];
+    "Document WHY timeout needed" [shape=box];
+    "Use condition-based waiting" [shape=box];
+
+    "Test uses setTimeout/sleep?" -> "Testing timing behavior?" [label="yes"];
+    "Testing timing behavior?" -> "Document WHY timeout needed" [label="yes"];
+    "Testing timing behavior?" -> "Use condition-based waiting" [label="no"];
+}
+```
+
+**Use when:**
+- Tests have arbitrary delays (`setTimeout`, `sleep`, `time.sleep()`)
+- Tests are flaky (pass sometimes, fail under load)
+- Tests timeout when run in parallel
+- Waiting for async operations to complete
+
+**Don't use when:**
+- Testing actual timing behavior (debounce, throttle intervals)
+- Always document WHY if using arbitrary timeout
+
+## Core Pattern
+
+```typescript
+// ❌ BEFORE: Guessing at timing
+await new Promise(r => setTimeout(r, 50));
+const result = getResult();
+expect(result).toBeDefined();
+
+// ✅ AFTER: Waiting for condition
+await waitFor(() => getResult() !== undefined);
+const result = getResult();
+expect(result).toBeDefined();
+```
+
+## Quick Patterns
+
+| Scenario | Pattern |
+|----------|---------|
+| Wait for event | `waitFor(() => events.find(e => e.type === 'DONE'))` |
+| Wait for state | `waitFor(() => machine.state === 'ready')` |
+| Wait for count | `waitFor(() => items.length >= 5)` |
+| Wait for file | `waitFor(() => fs.existsSync(path))` |
+| Complex condition | `waitFor(() => obj.ready && obj.value > 10)` |
+
+## Implementation
+
+Generic polling function:
+```typescript
+async function waitFor<T>(
+  condition: () => T | undefined | null | false,
+  description: string,
+  timeoutMs = 5000
+): Promise<T> {
+  const startTime = Date.now();
+
+  while (true) {
+    const result = condition();
+    if (result) return result;
+
+    if (Date.now() - startTime > timeoutMs) {
+      throw new Error(`Timeout waiting for ${description} after ${timeoutMs}ms`);
+    }
+
+    await new Promise(r => setTimeout(r, 10)); // Poll every 10ms
+  }
+}
+```
+
+See `condition-based-waiting-example.ts` in this directory for complete implementation with domain-specific helpers (`waitForEvent`, `waitForEventCount`, `waitForEventMatch`) from actual debugging session.
+
+## Common Mistakes
+
+**❌ Polling too fast:** `setTimeout(check, 1)` - wastes CPU
+**✅ Fix:** Poll every 10ms
+
+**❌ No timeout:** Loop forever if condition never met
+**✅ Fix:** Always include timeout with clear error
+
+**❌ Stale data:** Cache state before loop
+**✅ Fix:** Call getter inside loop for fresh data
+
+## When Arbitrary Timeout IS Correct
+
+```typescript
+// Tool ticks every 100ms - need 2 ticks to verify partial output
+await waitForEvent(manager, 'TOOL_STARTED'); // First: wait for condition
+await new Promise(r => setTimeout(r, 200));   // Then: wait for timed behavior
+// 200ms = 2 ticks at 100ms intervals - documented and justified
+```
+
+**Requirements:**
+1. First wait for triggering condition
+2. Based on known timing (not guessing)
+3. Comment explaining WHY
+
+## Real-World Impact
+
+From debugging session (2025-10-03):
+- Fixed 15 flaky tests across 3 files
+- Pass rate: 60% → 100%
+- Execution time: 40% faster
+- No more race conditions

--- a/knowledge/linux-sandbox/cowork-backend-auto-detection-priority.md
+++ b/knowledge/linux-sandbox/cowork-backend-auto-detection-priority.md
@@ -1,0 +1,118 @@
+---
+name: cowork-backend-auto-detection-priority
+summary: Sandbox backend selection should prefer the most-isolated available option (bwrap > kvm > host) using functional tests, not just binary presence; expose the active backend via a `--doctor` diagnostic command and allow override via an environment variable.
+category: linux-sandbox
+tags: [sandbox, bubblewrap, kvm, qemu, detection, backend, isolation, cowork, linux]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: medium
+---
+
+# Cowork Backend Auto-Detection Priority
+
+## Context
+
+A service that needs process isolation has multiple backend options with
+different isolation levels and dependency requirements. Choosing the right
+backend automatically (without user configuration) requires more than checking
+if the relevant binary is in PATH — the binary may be present but non-functional
+due to missing kernel features, disabled privileges, or missing device nodes.
+
+## Observation
+
+A three-tier backend priority system with functional testing works as follows:
+
+| Priority | Backend | Isolation | Functional test |
+|---|---|---|---|
+| 1 (default) | bwrap (bubblewrap) | PID + mount namespace | `bwrap --ro-bind / / true` succeeds |
+| 2 (opt-in) | KVM (QEMU/KVM) | Full VM | `/dev/kvm` readable+writable, `qemu-system-x86_64` in PATH, `/dev/vhost-vsock` readable |
+| 3 (fallback) | host | None | Always available |
+
+Key design decisions:
+- **Functional test, not presence test**: `which bwrap` succeeds even when
+  user namespaces are disabled (common in some container environments). The
+  functional test `bwrap --ro-bind / / true` actually verifies the sandbox
+  can run.
+- **KVM is opt-in**: full VM isolation has higher latency and resource cost.
+  It should not be auto-selected unless explicitly requested.
+- **Host is always-available fallback**: never fails, but provides no
+  isolation. Should be documented as a security tradeoff.
+- **Environment variable override**: `BACKEND_NAME=bwrap/kvm/host` allows
+  power users and CI environments to force a specific backend.
+
+## Why it happens
+
+Binary presence alone is insufficient for two reasons:
+1. System-level features may be disabled (user namespaces, KVM acceleration,
+   vsock) even when the tool binary is installed.
+2. Permission issues (missing read/write on `/dev/kvm`, missing group
+   membership) can prevent a tool from functioning.
+
+A fast functional test (`bwrap --ro-bind / / true` exits in milliseconds)
+catches all of these cases at once.
+
+## Practical implication
+
+```js
+async function detectBackend() {
+  const override = process.env.SANDBOX_BACKEND;
+  if (override) {
+    console.log(`Backend override: ${override}`);
+    return createBackend(override);
+  }
+
+  // Test bwrap: check both presence and functionality
+  if (commandExists('bwrap')) {
+    try {
+      execFileSync('bwrap', ['--ro-bind', '/', '/', 'true'], {
+        timeout: 5000,
+        stdio: 'ignore'
+      });
+      console.log('Backend: bwrap (namespace sandbox)');
+      return new BwrapBackend();
+    } catch (_) {
+      console.log('bwrap present but non-functional, trying next backend');
+    }
+  }
+
+  // Test KVM: check device nodes and binary
+  if (
+    canReadWrite('/dev/kvm') &&
+    commandExists('qemu-system-x86_64') &&
+    canRead('/dev/vhost-vsock')
+  ) {
+    console.log('Backend: KVM (VM isolation)');
+    return new KvmBackend();
+  }
+
+  // Fallback: no isolation
+  console.log('Backend: host (no isolation — install bwrap for sandbox)');
+  return new HostBackend();
+}
+```
+
+Expose the active backend via a diagnostic command:
+
+```bash
+# Output example:
+# Cowork isolation: bubblewrap (namespace sandbox)
+# Cowork isolation: KVM (full VM isolation)
+# Cowork isolation: none (host-direct, no isolation)
+```
+
+Log the selected backend to a file at daemon startup so users can verify what
+is active without running the diagnostic command.
+
+## Source reference
+
+- `docs/cowork-linux-handover.md`: "Backend Detection" section — auto-detection
+  order, functional test for bwrap, KVM device checks, and override mechanism.
+- `docs/cowork-linux-handover.md`: target architecture diagram showing the
+  three-backend hierarchy.
+- `scripts/cowork-vm-service.js`: `detectBackend()` function and `BACKEND_OVERRIDE`
+  constant.

--- a/knowledge/networking/connection-type-enum-design.md
+++ b/knowledge/networking/connection-type-enum-design.md
@@ -1,0 +1,28 @@
+---
+name: connection-type-enum-design
+type: knowledge
+category: networking
+summary: ConnType enum: RDP (over relay), Direct TCP, Direct UDP, LAN discovery — drives fallback logic.
+confidence: medium
+tags: [connection, design, enum, networking, type]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: src/common.rs
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Connection Type Enum Design
+
+## Fact
+ConnType enum: RDP (over relay), Direct TCP, Direct UDP, LAN discovery — drives fallback logic.
+
+## Why it matters
+Explicit enum beats boolean flags for multi-mode connection logic.
+
+## Evidence
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- `src/common.rs`

--- a/knowledge/pitfall/claudecode-env-breaks-nested-spawn.md
+++ b/knowledge/pitfall/claudecode-env-breaks-nested-spawn.md
@@ -1,0 +1,56 @@
+---
+name: claudecode-env-breaks-nested-spawn
+summary: Claude Agent SDK's nesting guard sees CLAUDECODE=1 in a child process env and refuses to run — must strip before spawn when your CLI runs inside another Claude session.
+category: pitfall
+tags: [claude-agent-sdk, env-vars, nesting, subprocess]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: apps/cli/src/server-spawner.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Don't inherit CLAUDECODE when spawning an SDK subprocess
+
+### Situation
+You have a CLI (craft-cli) that spawns a headless server that uses the Claude Agent SDK. Sometimes users run your CLI from INSIDE a Claude Code session (e.g. `claude-code` terminal). Then:
+
+- Parent shell has `CLAUDECODE=1` (set by Claude Code).
+- Your CLI does `Bun.spawn(['bun', 'run', 'server.ts'], { env: process.env, ... })`.
+- Server imports `@anthropic-ai/claude-agent-sdk`.
+- SDK's "nesting guard" sees `CLAUDECODE=1` in its env, assumes it's about to cause an infinite loop, refuses to run.
+- Server process exits silently (or throws an obscure message that doesn't mention `CLAUDECODE`).
+- Your CLI hangs until `startupTimeout` (30s) then errors with "server did not start".
+
+### Fix
+Strip `CLAUDECODE` (and probably other `CLAUDE_*` / `CLAUDE_CODE_*` vars) before spawn. The craft-agents repo uses:
+
+```ts
+const { CLAUDECODE: _, ...parentEnv } = process.env;
+const proc = Bun.spawn(['bun', 'run', serverEntry], {
+  env: {
+    ...parentEnv,
+    CRAFT_SERVER_TOKEN: token,
+    CRAFT_RPC_PORT: '0',
+  },
+  stdout: 'pipe', stderr: 'pipe',
+});
+```
+
+### Why it's easy to miss
+- `process.env` inheritance is invisible; the env vars that poison the child aren't in any config file you look at.
+- The SDK's error message historically was "running inside Claude Code is not supported" which doesn't obviously mean "your env has CLAUDECODE set".
+- Only happens in the narrow case where your tooling is invoked from Claude Code; standard shell use works fine.
+
+### Generalization
+When spawning a subprocess that uses a tool-agent SDK, audit which env vars that SDK treats as "I'm running inside myself" signals. Common suspects:
+- `CLAUDECODE`
+- `CLAUDE_CODE_OAUTH_TOKEN` (auth-credential leak in addition to nesting)
+- `CLAUDE_CODE_SSE_PORT`
+- `CODEX_SESSION_ID`
+
+### Reference
+`apps/cli/src/server-spawner.ts` — the craft-agents CLI spawn helper.

--- a/knowledge/pitfall/claudecode-env-var-leakage.md
+++ b/knowledge/pitfall/claudecode-env-var-leakage.md
@@ -1,0 +1,35 @@
+---
+name: claudecode-env-var-leakage
+summary: When spawning Claude Code from a parent Claude Code session, strip CLAUDECODE*, CLAUDE_CODE_* env vars so the child doesn't inherit the parent's session state.
+category: pitfall
+tags: [claude-code, environment, subprocess, session, leakage]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: server/pkg/agent/claude.go
+imported_at: 2026-04-18T00:00:00Z
+---
+
+When Claude Code runs, it exports env vars like `CLAUDECODE`, `CLAUDECODE_*`, and `CLAUDE_CODE_*` so child processes can detect they're running inside a Claude session. If you spawn another Claude Code process from inside one (e.g. a managed-agents daemon that's itself running as a Claude session), those env vars leak to the child and the child behaves as if it's already inside a session.
+
+Fix: filter the parent environment before passing it to the child.
+
+```go
+func isFilteredChildEnvKey(key string) bool {
+    return key == "CLAUDECODE" ||
+           strings.HasPrefix(key, "CLAUDECODE_") ||
+           strings.HasPrefix(key, "CLAUDE_CODE_")
+}
+```
+
+## Why
+
+Symptoms of not doing this: the spawned Claude has strange defaults, auto-reads the parent session's permission grants, or misreports tool-use events. Reproducing is annoying because everything works fine from a plain shell — only breaks from inside a Claude-driven workflow.
+
+## Evidence
+
+- `server/pkg/agent/claude.go:480-486` — `isFilteredChildEnvKey` function.
+- `server/pkg/agent/claude.go:463-478` — `mergeEnv` call site.

--- a/knowledge/pitfall/codex-oauth-strips-vars-at-spawn.md
+++ b/knowledge/pitfall/codex-oauth-strips-vars-at-spawn.md
@@ -1,0 +1,63 @@
+---
+name: codex-oauth-strips-vars-at-spawn
+summary: Codex (ChatGPT Plus OAuth via Pi SDK) looks at specific env vars at subprocess spawn; leaving CODEX_SESSION_ID / OPENAI_API_KEY from an earlier run can misroute the current session to the wrong account.
+category: pitfall
+tags: [codex, oauth, env-pollution, pi-sdk]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: packages/pi-agent-server/src
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Codex OAuth env pollution pitfall
+
+### The issue
+The Pi SDK path for Codex (ChatGPT Plus OAuth) spawns a subprocess that reads auth config from env. Common pollution sources:
+- `OPENAI_API_KEY` in the user's shell → wrong account used if they've also connected Codex OAuth.
+- `CODEX_SESSION_ID` from an aborted earlier run → Codex attaches to a stale session.
+- `CODEX_BINARY` / `CODEX_HOME` pointing at a non-bundled install → skips the shipped Codex.
+
+### Defensive spawn env
+When spawning the Pi agent server subprocess, DO NOT blindly inherit env. Build a minimal allowlist:
+
+```ts
+const subprocessEnv = {
+  HOME: process.env.HOME,
+  USER: process.env.USER,
+  PATH: process.env.PATH,
+  TMPDIR: process.env.TMPDIR,
+  // explicit: auth vars we CONTROL, not inherited
+  PI_CONFIG_DIR: getPiConfigDir(workspaceId),
+  CODEX_SESSION_ID: newSessionId,
+};
+```
+
+Strip known pollutants: `OPENAI_API_KEY`, `CODEX_BINARY`, `CODEX_HOME`, `CODEX_SESSION_ID`, `COPILOT_TOKEN`, `GITHUB_COPILOT_*`.
+
+Also strip `CLAUDECODE` (see related pitfall) even if going the Pi path — the CLI's nesting guard doesn't care which SDK the child uses.
+
+### Auto-resolve bundled binary
+Rather than trust `PATH`, have a `binary-resolver` module check, in order:
+1. Explicit `CODEX_PATH` env.
+2. Bundled binary (`vendor/codex/<platform-arch>/codex`).
+3. Local dev fork.
+4. System PATH as last resort.
+
+Set it yourself before spawn so the child doesn't pick up a random system version:
+```ts
+subprocessEnv.CODEX_PATH = resolveCodexBinary();
+```
+
+### Symptoms if you miss it
+- User has ChatGPT Plus, connects it in the app, expects Codex to use their subscription.
+- Subprocess starts, finds `OPENAI_API_KEY` in env (user had set for another project).
+- Codex uses the API key, bills the user instead of using their subscription.
+- User is (rightly) angry.
+
+### Reference
+- `packages/pi-agent-server/src/index.ts` and `custom-endpoint-models.ts`.
+- `apps/electron/src/main/index.ts` comments on `CODEX_PATH` binary-resolver strategy.

--- a/knowledge/pitfall/codex-seatbelt-ignores-network-access.md
+++ b/knowledge/pitfall/codex-seatbelt-ignores-network-access.md
@@ -1,0 +1,31 @@
+---
+name: codex-seatbelt-ignores-network-access
+summary: On macOS, Codex CLI's Seatbelt sandbox in workspace-write mode silently ignores network_access=true, causing "no such host" errors inside agent sessions.
+category: pitfall
+tags: [codex, macos, sandbox, seatbelt, dns, network]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: docs/codex-sandbox-troubleshooting.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+On macOS, when Codex is configured with `sandbox_mode = "workspace-write"`, the Seatbelt profile hard-codes `CODEX_SANDBOX_NETWORK_DISABLED=1` and blocks DNS/UDP syscalls even if `[sandbox_workspace_write] network_access = true` is set. Code inside the sandbox sees `dial tcp: lookup HOST: no such host` while a plain shell on the same host resolves the same domain fine. Linux (Landlock) is not affected.
+
+## Why
+
+Upstream bug: `openai/codex#10390`. Until a fixed Codex release ships, the only reliable workaround on macOS is to write `sandbox_mode = "danger-full-access"` for that session, which drops the Seatbelt filesystem sandbox entirely. When emitting TOML into a user-owned `config.toml`, use top-level dotted-key assignments (`sandbox_workspace_write.network_access = true`) instead of a `[sandbox_workspace_write]` section header — otherwise a bare `sandbox_mode = ...` sitting below a preceding user table like `[permissions.multica]` is parsed as `permissions.multica.sandbox_mode` and silently ignored.
+
+Distinguishing fingerprint:
+- `no such host` inside Codex session, but host shell `curl` works → Seatbelt bug.
+- `connection refused` → server not running on that port.
+- `i/o timeout` → container-level network policy / firewall.
+- `x509: certificate signed by unknown authority` → TLS/CA issue, unrelated.
+
+## Evidence
+
+- `docs/codex-sandbox-troubleshooting.md` — full fingerprint table and mitigation.
+- `server/internal/daemon/execenv/codex_sandbox.go:13-100` — policy decision code and rationale.

--- a/knowledge/pitfall/connect-via-devtools-active-port-file.md
+++ b/knowledge/pitfall/connect-via-devtools-active-port-file.md
@@ -1,0 +1,52 @@
+---
+name: connect-via-devtools-active-port-file
+summary: When Chrome is launched with `--user-data-dir` and remote debugging but the port is auto-chosen, connect by reading the `DevToolsActivePort` file in the user-data-dir — line 1 is the port, line 2 is the browser-target path — to construct `ws://127.0.0.1:<port><path>`.
+category: pitfall
+confidence: high
+tags: [chrome, cdp, devtools-active-port, connection, puppeteer]
+source_type: extracted-from-git
+source_url: https://github.com/ChromeDevTools/chrome-devtools-mcp.git
+source_ref: main
+source_commit: 0a6aaa52ebacb2db834ffa437863e5844aa3730b
+source_project: chrome-devtools-mcp
+source_path: src/browser.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# `DevToolsActivePort` File Connection
+
+## Context
+
+Automation tools want to connect to a Chrome already started by the user — typical for the "attach to my browser" flow. If the user passed `--remote-debugging-port=9222`, connection is easy. If they passed `--remote-debugging-port=0` (pick an ephemeral port) or used `chrome://inspect/#remote-debugging` to enable debugging after launch, the port isn't predictable.
+
+## The fact / decision / pitfall
+
+Chrome writes a `DevToolsActivePort` file into the user-data-dir whenever remote debugging is active. The file has two lines:
+
+```
+<port>
+<path>
+```
+
+Line 1 is the numeric port; line 2 is the full WS path including the browser target UUID, e.g. `/devtools/browser/abc-def-...`. Concatenate for the WebSocket endpoint:
+
+```
+ws://127.0.0.1:<port><path>
+```
+
+Implementation notes:
+- Trim each line; some Chrome builds write with trailing whitespace.
+- Validate the port parses as an integer in `1..65535`. Corrupt/empty files happen, particularly if Chrome crashed mid-write.
+- On failure to read, tell the user exactly what's wrong: `"Could not connect to Chrome in <dir>. Check if Chrome is running and remote debugging is enabled by going to chrome://inspect/#remote-debugging."`
+
+## Evidence
+
+- `src/browser.ts::ensureBrowserConnected` reads `path.join(userDataDir, 'DevToolsActivePort')` and splits by `\n`.
+- The same file pattern is used by Playwright and Lighthouse for the same reason.
+
+## Implications
+
+- The user-data-dir is the discovery mechanism, not the port. A flow that "connects to port 9222" breaks when the user is running multiple Chromes; read the file from each user-data-dir.
+- You must have *read* permission on the user-data-dir. MCP servers running sandboxed (macOS Seatbelt, Linux containers) may not; document that as a known fault mode.
+- Don't cache the resolved WS endpoint across sessions. Chrome regenerates the browser-target UUID on each launch.
+- If you spawn Chrome yourself with `--remote-debugging-port=0`, you can use the same file to discover your own port after startup.

--- a/knowledge/pytorch-integration/compute-sanitizer-needs-temp-cublaslt-workspace.md
+++ b/knowledge/pytorch-integration/compute-sanitizer-needs-temp-cublaslt-workspace.md
@@ -1,0 +1,47 @@
+---
+name: compute-sanitizer-needs-temp-cublaslt-workspace
+type: knowledge
+category: pitfall
+confidence: medium
+source: DeepGEMM
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - csrc/jit/device_runtime.hpp
+tags: [compute-sanitizer, cublaslt, teardown, cuda-runtime, destructor, workspace]
+imported_at: 2026-04-18T13:30:00Z
+---
+
+# compute-sanitizer Needs Per-Call cuBLASLt Workspace (Destructor-Ordering Pitfall)
+
+## Fact / Decision
+A library that holds a persistent `torch::Tensor` cuBLASLt workspace (32 MB, allocated once at module init) hits `cudaErrorCudartUnloading` during process teardown when running under `compute-sanitizer` (or any tool that shuts down CUDA driver before user-code destructors run).
+
+The fix: conditionally allocate a temporary workspace per call instead of reusing a persistent one. Controlled by env var `DG_USE_TEMP_CUBLASLT_WORKSPACE=1`.
+
+## Why it matters
+- At normal process exit, PyTorch tears down CUDA in a specific order that's friendly to user-code destructors.
+- `compute-sanitizer` intercepts the tear-down sequence and unloads the CUDA runtime earlier than usual.
+- When your global `DeviceRuntime` destructor runs `cublaslt_workspace` falls out of scope, `~Tensor()` tries `cudaFree`, and the runtime is already gone → `cudaErrorCudartUnloading`.
+- The error is non-fatal but surfaces as `RuntimeError: CUDA error: cudart unloading` in sanitizer reports, masking real issues.
+
+Per-call workspace allocation avoids the problem because the tensor is scoped to the cuBLASLt call and destructed before the sanitizer ever sees it.
+
+## Evidence
+- `csrc/jit/device_runtime.hpp:34-49`: the env var read and the explicit comment:
+  ```cpp
+  // Whether to create workspace tensor on each call instead of holding one.
+  // Enabled by compute-sanitizer tests, which trigger `cudaErrorCudartUnloading`
+  // when the workspace tensor is destructed after CUDA driver shutdown.
+  use_temp_cublaslt_workspace = get_env<int>("DG_USE_TEMP_CUBLASLT_WORKSPACE", 0) > 0;
+  ```
+- `csrc/jit/device_runtime.hpp:66-70`: the per-call allocation branch in `get_cublaslt_workspace()`.
+
+## Caveats / When this doesn't apply
+- **Only affects compute-sanitizer and similar teardown-interceptors.** Normal `pytest` runs don't trigger this — don't enable the workaround by default, or you pay the per-call allocation cost unnecessarily.
+- **Same class of issue exists for the cuBLASLt handle**, but `cublasLtDestroy` on an already-torn-down runtime is typically reported as a return-code error, not a cuda-unload error. DeepGEMM uses `noexcept(false)` on the destructor so the error can propagate.
+- **PyTorch's own `at::cuda::getCurrentCUDABlasLtHandle`** might have a different behavior under sanitizer (since it's managed by PyTorch's tear-down order). Testing under sanitizer should cover both handle modes.
+- **Per-call allocation is ~300ns overhead** in the PyTorch caching allocator — negligible for real workloads but measurable on a microbench of 10M small GEMMs.

--- a/knowledge/reference/claude-cli-hook-bypass-envs.md
+++ b/knowledge/reference/claude-cli-hook-bypass-envs.md
@@ -1,0 +1,53 @@
+---
+name: claude-cli-hook-bypass-envs
+summary: Three environment variables — `DISABLE_OMC=1`, `OMC_SKIP_HOOKS=*`, `CLAUDE_DISABLE_SESSION_HOOKS=1` — neutralize the oh-my-claudecode harness and Claude's own SessionStart/Stop hooks so a spawned `claude -p` child can run unattended without a parent-side hook printing to stdout or hijacking stdin.
+category: reference
+confidence: medium
+tags: [claude-code, oh-my-claudecode, omc, hooks, env-vars, unattended, spawn, reference]
+source_type: extracted-from-project
+source_project: trending-hub-loop
+imported_at: 2026-04-18T00:00:00Z
+linked_skills: [claude-cli-unattended-wrapper, stream-json-assistant-event-router]
+---
+
+# Claude CLI Hook Bypass Env Vars
+
+## What the three vars do
+
+| Env var | Turns off | Why it matters for unattended runs |
+|---|---|---|
+| `DISABLE_OMC=1` | The entire oh-my-claudecode orchestration layer | OMC would otherwise inject `<system-reminder>` tags, swap agents, and gate on hook returns — each of those is a potential deadlock in a scripted spawn |
+| `OMC_SKIP_HOOKS=*` | All OMC hooks (comma-separated list; `*` = all) | Even with the layer active, this skip-list suppresses the individual hook scripts. Use when you want *most* of OMC but not specific hooks (e.g. `OMC_SKIP_HOOKS=session-start,status-line`) |
+| `CLAUDE_DISABLE_SESSION_HOOKS=1` | Claude Code's own SessionStart / Stop hooks defined in `.claude/settings.json` | Independent of OMC. A project-level hook that tries to read stdin ("Did you mean to commit?") will hang the unattended child |
+
+## Why a hook hangs an unattended child
+
+Hooks run synchronously and can:
+- Print to stdout → shows up in the parent's `stream-json` parser as unparseable JSON, polluting the log but usually harmless.
+- Read from stdin → **deadlocks** the child because the parent's auto-yes pipe is already consumed by the main prompt. This is the load-bearing failure mode.
+- Exit non-zero → blocks the operation the hook is gating (e.g. a `PreToolUse` hook that refuses) and the unattended prompt has no way to override.
+
+Setting all three env vars together is the conservative move: even if you "only" use OMC, a project-level Claude hook in the target working directory can still trip you up.
+
+## Where each is honored
+
+- `DISABLE_OMC` — read by `~/.claude/CLAUDE.md` guards and by OMC hook scripts themselves; universal kill-switch.
+- `OMC_SKIP_HOOKS` — honored by the OMC hook dispatcher. Supports comma-separated names or `*`.
+- `CLAUDE_DISABLE_SESSION_HOOKS` — read by Claude Code's harness for `SessionStart`/`SessionEnd`. Does **not** disable `PreToolUse`/`PostToolUse` hooks. If you need those off too, set `--dangerously-skip-permissions` (which bypasses permission hooks) and/or temporarily move `.claude/settings.json` aside.
+
+## Pitfalls
+
+- **These vars only work on the spawned child.** Setting them in your shell doesn't help if the Node spawner re-inherits a clean env or another wrapper re-exports them. Pass them explicitly in `spawn({ env: { ...process.env, DISABLE_OMC: '1', ... } })`.
+- **`OMC_SKIP_HOOKS=*` is not the same as `DISABLE_OMC=1`.** The latter turns off the whole layer (including context injection, skills, agents). The former only silences hook scripts. For a truly cold unattended run, set all three.
+- **They silence logs you might actually want.** If a hook would have warned "this repo has uncommitted changes before `hub-import`", you won't see it. Pair unattended runs with explicit pre-flight checks in the parent script rather than relying on hooks.
+- **`PreToolUse` hooks not covered by `CLAUDE_DISABLE_SESSION_HOOKS`.** A `PreToolUse` hook that expects human input will still hang. Audit `.claude/settings.json` in the target dir or fall back to `--dangerously-skip-permissions`.
+
+## When you *don't* want to set these
+
+- Interactive local development — the hooks are a feature, not a bug.
+- Security-sensitive pipelines where a `PreToolUse` hook is your last line of defense against an agent running `rm -rf /`. Don't bypass the very thing you installed to catch bad runs.
+
+## Related
+
+- Skill: `claude-cli-unattended-wrapper` — the spawn pattern where these env vars live.
+- Knowledge: `dangerously-skip-permissions-for-unattended-loops` — paired trade-off for permission prompts.

--- a/knowledge/reference/clearcut-source-and-client-type-constants.md
+++ b/knowledge/reference/clearcut-source-and-client-type-constants.md
@@ -1,0 +1,64 @@
+---
+name: clearcut-source-and-client-type-constants
+summary: Shipping events to Google Clearcut requires two well-known numeric constants in every LogRequest: `log_source` (assigned per project — chrome-devtools-mcp uses 2839) and `client_info.client_type` (47 for CLI-like tools), wrapped around a `source_extension_json` stringified event.
+category: reference
+confidence: medium
+tags: [clearcut, google-telemetry, constants, batch-format]
+source_type: extracted-from-git
+source_url: https://github.com/ChromeDevTools/chrome-devtools-mcp.git
+source_ref: main
+source_commit: 0a6aaa52ebacb2db834ffa437863e5844aa3730b
+source_project: chrome-devtools-mcp
+source_path: src/telemetry/watchdog/ClearcutSender.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Clearcut LogRequest Constants
+
+## Context
+
+Google's internal Clearcut logging endpoint (`https://play.googleapis.com/log?format=json_proto`) accepts batches of events in a specific envelope shape. Every event must include per-project constants so the pipeline routes and rate-limits correctly.
+
+## The fact / decision / pitfall
+
+Fixed constants used by chrome-devtools-mcp:
+
+- `LOG_SOURCE = 2839` — Clearcut project ID for chrome-devtools-mcp. Google-internal allocation; different project = different ID.
+- `CLIENT_TYPE = 47` — indicates "CLI/tool-ish client" (vs. mobile app, web, etc.). Stable across projects.
+- `DEFAULT_CLEARCUT_ENDPOINT = 'https://play.googleapis.com/log?format=json_proto'`
+- `MIN_RATE_LIMIT_WAIT_MS = 30_000` — honor `next_request_wait_millis` from response, but clamp to at least 30s to avoid tight-looping on bugs.
+- `DEFAULT_FLUSH_INTERVAL_MS = 15 * 60 * 1000` — 15-minute idle flush cadence.
+- `SHUTDOWN_TIMEOUT_MS = 5_000` — bound on the final flush race.
+- `SESSION_ROTATION_INTERVAL_MS = 24 * 60 * 60 * 1000` — rotate `session_id` daily.
+- `MAX_BUFFER_SIZE = 1000` — drop-oldest overflow.
+
+Envelope shape:
+
+```json
+{
+  "log_source": 2839,
+  "request_time_ms": "1713407232000",
+  "client_info": { "client_type": 47 },
+  "log_event": [
+    { "event_time_ms": "1713407230000", "source_extension_json": "{...stringified event...}" }
+  ]
+}
+```
+
+Response:
+
+```json
+{ "next_request_wait_millis": 60000 }
+```
+
+## Evidence
+
+- `src/telemetry/watchdog/ClearcutSender.ts` — all constants and envelope formatting.
+- `src/telemetry/types.ts` — `LogRequest`, `LogResponse`, and per-event `ChromeDevToolsMcpExtension` shapes.
+
+## Implications
+
+- If you're shipping a different Google-Cloud tool, you need your own `log_source`. It's not negotiable; Clearcut rejects unknown IDs.
+- Honoring `next_request_wait_millis` is what keeps the endpoint happy. Clients that ignore it get dropped silently.
+- `source_extension_json` is the escape hatch — arbitrary JSON as a string. It's how you ship structured event payloads without a server-side schema change.
+- For non-Google pipelines, the *shape* of "envelope + batch + next_wait hint" is reusable even if the constants aren't. It's a good blueprint for any batch telemetry.

--- a/knowledge/reference/config-dir-layout.md
+++ b/knowledge/reference/config-dir-layout.md
@@ -1,0 +1,62 @@
+---
+name: config-dir-layout
+summary: Full layout of ~/.craft-agent/ including app-level config/credentials/preferences/themes and per-workspace subdirs for sessions, sources, skills, statuses, automations.
+category: reference
+tags: [filesystem, config, workspaces, layout]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: README.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# `~/.craft-agent/` directory layout
+
+The entire user state for Craft Agents lives under one directory tree. Layout:
+
+```
+~/.craft-agent/
+├── config.json              # Main config: workspace list, LLM connection registry
+├── credentials.enc          # AES-256-GCM encrypted credentials (all workspaces)
+├── preferences.json         # User prefs (theme mode, default model, etc.)
+├── theme.json               # App-level theme
+└── workspaces/
+    └── {workspace-id}/
+        ├── config.json        # Workspace settings
+        ├── theme.json         # Workspace theme (overrides app)
+        ├── automations.json   # Event-driven automation rules (version 2 schema)
+        ├── automations-history.jsonl  # Append-only audit trail
+        ├── sessions/
+        │   └── {session-id}/
+        │       ├── session.jsonl     # Header + messages (JSONL)
+        │       ├── long_responses/   # Saved large tool results
+        │       └── plans/            # SubmitPlan artifacts
+        ├── sources/
+        │   └── {slug}/
+        │       ├── config.json
+        │       └── .credential-cache.json  # Decrypted per-session, user-scoped (0600)
+        ├── skills/
+        │   └── {slug}/
+        │       └── SKILL.md    # gray-matter frontmatter + markdown body
+        └── statuses/
+            └── config.json     # Custom status workflow (Todo/In Progress/...)
+```
+
+### Alternate locations
+- **Multi-instance dev**: `~/.craft-agent-1`, `~/.craft-agent-2`, ... via `CRAFT_CONFIG_DIR` env.
+- **Packaged app logs**: macOS `~/Library/Logs/@craft-agent/electron/main.log`, Windows `%APPDATA%\@craft-agent\electron\logs\main.log`, Linux `~/.config/@craft-agent/electron/logs/main.log`.
+- **uv cache**: `~/.cache/uv/` (Python tools — pinned 3.12 auto-installed on first use, ~20MB).
+
+### Portability properties
+- Deleting a workspace = `rm -rf workspaces/{id}/`. No cross-cutting state elsewhere to clean up.
+- Moving a workspace folder to another machine works IF you also copy the workspace-level config.json into the new `workspaces/` and regenerate session-path tokens. Session JSONL files use `{{SESSION_PATH}}` tokens so they don't carry the old absolute path (see `packages/shared/src/sessions/jsonl.ts`).
+- Credentials stay at the app level — not per-workspace — because users don't want to re-auth Gmail 3 times for 3 workspaces.
+
+### .credential-cache.json
+Transient file written by the Electron main process so stdio MCP subprocesses can read secrets without having them in env. Scoped per source slug, not per session. Chmod 0600. Never commit / share / sync.
+
+### Automations file
+`automations.json` is a Version 2 schema; keyed by event name (`LabelAdd`, `SchedulerTick`, ...) to arrays of matcher+actions. Validated on load; errors dropped with warnings rather than crashing.

--- a/knowledge/reference/craft-cli-command-surface.md
+++ b/knowledge/reference/craft-cli-command-surface.md
@@ -1,0 +1,53 @@
+---
+name: craft-cli-command-surface
+summary: One-page reference for the craft-cli command taxonomy: info/health, resource listing, session ops, streaming send, power-user invoke/listen, self-contained run, and the 21-step --validate-server.
+category: reference
+tags: [cli, rpc, reference]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: docs/cli.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# craft-cli command surface
+
+The CLI is a thin WebSocket client for the Craft Agent server, used for scripting, CI, and validation. Its command surface is partitioned into 5 groups:
+
+1. **Info & health**
+   - `ping` — connectivity + latency, returns client ID.
+   - `health` — credential store health check.
+   - `versions` — server runtime versions.
+
+2. **Resource listing** (supports `--json` for jq-friendly output):
+   - `workspaces`, `sessions`, `connections`, `sources`.
+
+3. **Session operations**:
+   - `session create [--name] [--mode]`
+   - `session messages <id>` — prints message history.
+   - `session delete <id>`
+   - `cancel <id>` — cancel in-progress processing.
+
+4. **Send / stream**:
+   - `send <id> <message>` — subscribes to session events and streams to stdout. Emits `text_delta` inline, `[tool: name]` markers for tool_start, truncated tool_result (200 chars), errors to stderr (exit 1), clean completion (exit 0), user interrupt (exit 130).
+   - Accepts piped stdin if the message arg is omitted or `--stdin` is set.
+
+5. **Power user**:
+   - `invoke <channel> [json-args...]` — raw RPC call.
+   - `listen <channel>` — subscribe to push events until Ctrl+C.
+
+6. **Self-contained runs**:
+   - `run <prompt>` — spawns a headless server, creates a session, sends the prompt, streams, and exits. No separate server setup. Accepts `--workspace-dir`, repeatable `--source <slug>`, `--output-format text|stream-json`, `--mode`, `--no-cleanup`, LLM config flags.
+   - `--validate-server` — 21-step integration test. Auto-spawns a server when no `--url`. MUTATES workspace state (creates + deletes a temp session, source, skill). Continue-on-failure; summarizes at end.
+
+### Connection resolution
+Flags beat env vars: `--url` / `CRAFT_SERVER_URL`, `--token` / `CRAFT_SERVER_TOKEN`, `--workspace` (auto-detected), `--timeout`, `--tls-ca` for self-signed certs, `--send-timeout` for `send`.
+
+### Why this taxonomy matters
+It mirrors the server RPC channel groups (`system:*`, `sessions:*`, `sources:*`, `skills:*`, `LLM_Connection:*`) one-to-one. Adding a server channel + CLI sub-command is a mechanical, parallel change; no surprise translations.
+
+### Sources
+`docs/cli.md`, `apps/cli/src/index.ts`, `apps/cli/src/commands.test.ts`.

--- a/registry.json
+++ b/registry.json
@@ -2294,6 +2294,121 @@
       "category": "observability",
       "path": "skills/observability/anonymous-posthog-telemetry/SKILL.md",
       "version": "1.0.0"
+    },
+    "chunked-tts-with-crossfade": {
+      "category": "ml-ops",
+      "path": "skills/ml-ops/chunked-tts-with-crossfade/SKILL.md",
+      "version": "1.0.0"
+    },
+    "claude-agent-sdk-multi-provider-bridge": {
+      "category": "agent-sdk",
+      "path": "skills/agent-sdk/claude-agent-sdk-multi-provider-bridge/SKILL.md",
+      "version": "1.0.0"
+    },
+    "claude-cli-grace-kill-after-success-result": {
+      "category": "integration",
+      "path": "skills/integration/claude-cli-grace-kill-after-success-result/SKILL.md",
+      "version": "1.0.0"
+    },
+    "claude-cli-unattended-wrapper": {
+      "category": "operations",
+      "path": "skills/operations/claude-cli-unattended-wrapper/SKILL.md",
+      "version": "1.0.0"
+    },
+    "claude-code-stream-json-driver": {
+      "category": "agents",
+      "path": "skills/agents/claude-code-stream-json-driver/SKILL.md",
+      "version": "1.0.0"
+    },
+    "clearcut-batch-flush-with-retry": {
+      "category": "telemetry",
+      "path": "skills/telemetry/clearcut-batch-flush-with-retry/SKILL.md",
+      "version": "1.0.0"
+    },
+    "cli-output-format-dispatch-with-template": {
+      "category": "cli",
+      "path": "skills/cli/cli-output-format-dispatch-with-template/SKILL.md",
+      "version": "1.0.0"
+    },
+    "cli-serve-blocking-exit": {
+      "category": "cli",
+      "path": "skills/cli/cli-serve-blocking-exit/SKILL.md",
+      "version": "1.0.0"
+    },
+    "cmake-cuda-extension-with-git-submodule-vendoring": {
+      "category": "build-system",
+      "path": "skills/build-system/cmake-cuda-extension-with-git-submodule-vendoring/SKILL.md",
+      "version": "1.0.0"
+    },
+    "code-review": {
+      "category": "engineering",
+      "path": "skills/engineering/code-review/SKILL.md",
+      "version": "1.0.0"
+    },
+    "coding-agent-cli-backend-interface": {
+      "category": "agents",
+      "path": "skills/agents/coding-agent-cli-backend-interface/SKILL.md",
+      "version": "1.0.0"
+    },
+    "completion-signal-detector": {
+      "category": "workflow",
+      "path": "skills/workflow/completion-signal-detector/SKILL.md",
+      "version": "1.0.0"
+    },
+    "comprehensive-gpu-kernel-testing-harness": {
+      "category": "testing-gpu",
+      "path": "skills/testing-gpu/comprehensive-gpu-kernel-testing-harness/SKILL.md",
+      "version": "1.0.0"
+    },
+    "computer-use-agent": {
+      "category": "integration",
+      "path": "skills/integration/computer-use-agent/SKILL.md",
+      "version": "1.0.0"
+    },
+    "confidence-lowering-by-source-factor": {
+      "category": "integration",
+      "path": "skills/integration/confidence-lowering-by-source-factor/SKILL.md",
+      "version": "1.0.0"
+    },
+    "config-json-architecture-dispatch": {
+      "category": "model-loading",
+      "path": "skills/model-loading/config-json-architecture-dispatch/SKILL.md",
+      "version": "1.0.0"
+    },
+    "consistency-check": {
+      "category": "qa",
+      "path": "skills/qa/consistency-check/SKILL.md",
+      "version": "1.0.0"
+    },
+    "content-audit": {
+      "category": "qa",
+      "path": "skills/qa/content-audit/SKILL.md",
+      "version": "1.0.0"
+    },
+    "content-disposition-filename-fallback": {
+      "category": "web",
+      "path": "skills/web/content-disposition-filename-fallback/SKILL.md",
+      "version": "1.0.0"
+    },
+    "content-type-info-metadata-embedding": {
+      "category": "data",
+      "path": "skills/data/content-type-info-metadata-embedding/SKILL.md",
+      "version": "1.0.0"
+    },
+    "contextual-identifier-detectors-overlap-resolution": {
+      "category": "safety",
+      "path": "skills/safety/contextual-identifier-detectors-overlap-resolution/SKILL.md",
+      "version": "1.0.0"
+    },
+    "cosine-similarity-diff-for-fp8-numerics": {
+      "category": "testing-gpu",
+      "path": "skills/testing-gpu/cosine-similarity-diff-for-fp8-numerics/SKILL.md",
+      "version": "1.0.0"
+    },
+    "coverage-data-file-under-pytest-cache": {
+      "category": "build",
+      "path": "skills/build/coverage-data-file-under-pytest-cache/SKILL.md",
+      "version": "1.0.0"
     }
   },
   "knowledge": {
@@ -4204,6 +4319,114 @@
     "android-ios-feature-parity-gap": {
       "category": "mobile",
       "path": "knowledge/mobile/android-ios-feature-parity-gap.md"
+    },
+    "ci-gpg-signing-batch-mode-non-interactive": {
+      "category": "ci-cd",
+      "path": "knowledge/ci-cd/ci-gpg-signing-batch-mode-non-interactive.md"
+    },
+    "ci-push-race-condition-retry-rebase-loop": {
+      "category": "ci-cd",
+      "path": "knowledge/ci-cd/ci-push-race-condition-retry-rebase-loop.md"
+    },
+    "claude-cli-hook-bypass-envs": {
+      "category": "reference",
+      "path": "knowledge/reference/claude-cli-hook-bypass-envs.md"
+    },
+    "claude-session-resume-semantics": {
+      "category": "api",
+      "path": "knowledge/api/claude-session-resume-semantics.md"
+    },
+    "claude-stream-json-protocol": {
+      "category": "api",
+      "path": "knowledge/api/claude-stream-json-protocol.md"
+    },
+    "claudecode-env-breaks-nested-spawn": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/claudecode-env-breaks-nested-spawn.md"
+    },
+    "claudecode-env-var-leakage": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/claudecode-env-var-leakage.md"
+    },
+    "clearcut-source-and-client-type-constants": {
+      "category": "reference",
+      "path": "knowledge/reference/clearcut-source-and-client-type-constants.md"
+    },
+    "cli-implemented-in-rust-for-speed": {
+      "category": "arch",
+      "path": "knowledge/arch/cli-implemented-in-rust-for-speed.md"
+    },
+    "cli-release-accompanies-prod-deploy": {
+      "category": "decision",
+      "path": "knowledge/decision/cli-release-accompanies-prod-deploy.md"
+    },
+    "cli-release-via-git-tag": {
+      "category": "api",
+      "path": "knowledge/api/cli-release-via-git-tag.md"
+    },
+    "clipboard-context-lazy-initialization": {
+      "category": "clipboard",
+      "path": "knowledge/clipboard/clipboard-context-lazy-initialization.md"
+    },
+    "clipboard-ownership-protocol": {
+      "category": "clipboard",
+      "path": "knowledge/clipboard/clipboard-ownership-protocol.md"
+    },
+    "codex-oauth-strips-vars-at-spawn": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/codex-oauth-strips-vars-at-spawn.md"
+    },
+    "codex-seatbelt-ignores-network-access": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/codex-seatbelt-ignores-network-access.md"
+    },
+    "collaborative-design-principles": {
+      "category": "collaboration",
+      "path": "knowledge/collaboration/collaborative-design-principles.md"
+    },
+    "compute-sanitizer-needs-temp-cublaslt-workspace": {
+      "category": "pytorch-integration",
+      "path": "knowledge/pytorch-integration/compute-sanitizer-needs-temp-cublaslt-workspace.md"
+    },
+    "condition-based-waiting": {
+      "category": "engineering",
+      "path": "knowledge/engineering/condition-based-waiting.md"
+    },
+    "config-dir-layout": {
+      "category": "reference",
+      "path": "knowledge/reference/config-dir-layout.md"
+    },
+    "config-minimization-min-json": {
+      "category": "arch",
+      "path": "knowledge/arch/config-minimization-min-json.md"
+    },
+    "config-system-four-tiers": {
+      "category": "configuration",
+      "path": "knowledge/configuration/config-system-four-tiers.md"
+    },
+    "connect-via-devtools-active-port-file": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/connect-via-devtools-active-port-file.md"
+    },
+    "connection-type-enum-design": {
+      "category": "networking",
+      "path": "knowledge/networking/connection-type-enum-design.md"
+    },
+    "content-types-knowledge-base-minified": {
+      "category": "arch",
+      "path": "knowledge/arch/content-types-knowledge-base-minified.md"
+    },
+    "content-types-knowledge-base-vs-model-outputs": {
+      "category": "domain",
+      "path": "knowledge/domain/content-types-knowledge-base-vs-model-outputs.md"
+    },
+    "cowork-backend-auto-detection-priority": {
+      "category": "linux-sandbox",
+      "path": "knowledge/linux-sandbox/cowork-backend-auto-detection-priority.md"
+    },
+    "craft-cli-command-surface": {
+      "category": "reference",
+      "path": "knowledge/reference/craft-cli-command-surface.md"
     }
   }
 }

--- a/skills/agent-sdk/claude-agent-sdk-multi-provider-bridge/SKILL.md
+++ b/skills/agent-sdk/claude-agent-sdk-multi-provider-bridge/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: claude-agent-sdk-multi-provider-bridge
+description: Drive non-Anthropic providers (OpenRouter, Ollama, Vercel AI Gateway, any Anthropic-compatible endpoint) through the Claude Agent SDK by swapping base URL + auth env, and route Google/OpenAI/Copilot through a parallel Pi SDK backend with a shared AgentBackend interface.
+category: agent-sdk
+version: 1.0.0
+version_origin: extracted
+tags: [claude-agent-sdk, multi-provider, pi-sdk, backend-abstraction]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: packages/shared/src/agent/backend/factory.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Multi-provider agent behind one AgentBackend
+
+## When to use
+- App wants "use Claude, but also OpenAI, Gemini, Llama-via-Ollama, Codex, Copilot" without maintaining N bespoke client stacks.
+- Claude Agent SDK already handles Claude and any Anthropic-compatible endpoint; a second SDK (Pi) covers OpenAI/Google/Copilot idioms.
+- Need a single `AgentBackend` interface so session storage, tool dispatch, event adapters don't branch per provider.
+
+## How it works
+1. Define a common `AgentBackend` interface: `start(options)`, `query(messages)`, `abort()`, event stream, permission callbacks. Both `ClaudeAgent` and `PiAgent` implement it.
+2. **Driver registry** keyed by `provider`:
+   ```ts
+   const DRIVER_REGISTRY: Record<AgentProvider, ProviderDriver> = {
+     anthropic: anthropicDriver,
+     pi: piDriver,
+   };
+   ```
+3. Each LLM connection record carries `providerType` (`anthropic`, `openai`, `google`, `openrouter`, `groq`, `mistral`, `xai`, ...) and `authType` (`apiKey`, `oauth`, `claudeMax`, ...).
+4. For Anthropic-family providers, `anthropicDriver` resolves the API key / OAuth token and sets `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` (or `ANTHROPIC_API_KEY`) before instantiating the Claude SDK. That's ALL it takes to point at OpenRouter or Ollama.
+5. For Pi-family providers, `piDriver` configures `@mariozechner/pi-ai` with provider-specific auth (`GOOGLE_API_KEY`, Codex OAuth, Copilot device-code flow).
+6. A shared **event adapter** translates each SDK's stream into the app's normalized `AgentEvent` type; Claude and Pi have separate adapters but produce the same output shape.
+
+## Example
+```ts
+// Configure Claude SDK to talk to OpenRouter:
+const env = {
+  ...process.env,
+  ANTHROPIC_BASE_URL: 'https://openrouter.ai/api/v1',
+  ANTHROPIC_AUTH_TOKEN: userOpenRouterKey,
+};
+const q = query({ prompt, options: { ...base, model: 'anthropic/claude-opus-4.7' } });
+```
+
+```ts
+// Shared dispatch
+function createAgent(conn: LlmConnection): AgentBackend {
+  const driver = DRIVER_REGISTRY[getProvider(conn.providerType)];
+  return driver.create(conn);
+}
+```
+
+## Gotchas
+- OpenRouter uses `provider/model-name` slugs, not bare model names - surface that in the UI.
+- Ollama has no auth; pass an empty string for `ANTHROPIC_AUTH_TOKEN` but the env var must exist or the SDK will complain.
+- The Pi SDK is ESM-only; your build pipeline needs `bun build --target=bun --format=esm` or it breaks at runtime.
+- Don't leak provider-specific fields through the event adapter - keep `AgentEvent` canonical so UI code doesn't sprout `if (provider === …)`.

--- a/skills/agents/claude-code-stream-json-driver/SKILL.md
+++ b/skills/agents/claude-code-stream-json-driver/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: claude-code-stream-json-driver
+description: Drive the Claude Code CLI non-interactively via stream-json — build input on stdin, parse typed events on stdout, handle session resume and token usage.
+category: agents
+version: 1.0.0
+tags: [claude-code, stream-json, cli, llm, streaming]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- You're building a server or daemon that needs to run Claude Code autonomously (no TTY, no user confirmation).
+- You need streaming events (text, tool_use, tool_result) not just a final answer.
+- You want to persist session IDs so the user can resume later.
+
+## Steps
+
+1. Invoke Claude with the stream-json protocol flags:
+   ```
+   claude -p \
+     --output-format stream-json \
+     --input-format  stream-json \
+     --verbose \
+     --strict-mcp-config \
+     --permission-mode bypassPermissions \
+     [--model <id>] [--max-turns <n>] \
+     [--append-system-prompt <text>] \
+     [--resume <session_id>] \
+     [--mcp-config <path-to-temp-json>]
+   ```
+2. Write the user prompt to stdin as one JSON line, then close stdin:
+   ```go
+   input := map[string]any{
+     "type": "user",
+     "message": map[string]any{
+       "role": "user",
+       "content": []map[string]string{{"type": "text", "text": prompt}},
+     },
+   }
+   b, _ := json.Marshal(input)
+   stdin.Write(append(b, '\n'))
+   stdin.Close()
+   ```
+3. Read stdout line-by-line with a large buffer (tool results can be huge):
+   ```go
+   scanner := bufio.NewScanner(stdout)
+   scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+   for scanner.Scan() {
+     var msg claudeSDKMessage
+     if err := json.Unmarshal(scanner.Bytes(), &msg); err != nil { continue }
+     switch msg.Type {
+     case "assistant": handleAssistantBlocks(msg) // text, thinking, tool_use
+     case "user":      handleToolResultBlocks(msg)
+     case "system":    sessionID = msg.SessionID
+     case "result":    finalText = msg.ResultText; isError = msg.IsError
+     case "log":       forwardLog(msg.Log)
+     }
+   }
+   ```
+4. Accumulate token usage per model name from `message.usage` on assistant events:
+   ```go
+   u := usage[content.Model]
+   u.InputTokens  += content.Usage.InputTokens
+   u.OutputTokens += content.Usage.OutputTokens
+   u.CacheReadTokens  += content.Usage.CacheReadInputTokens
+   u.CacheWriteTokens += content.Usage.CacheCreationInputTokens
+   usage[content.Model] = u
+   ```
+5. Block protocol-critical flags from any user-provided `custom_args` so they don't break the wire format:
+   ```go
+   var claudeBlockedArgs = map[string]blockedArgMode{
+     "-p":                blockedStandalone,
+     "--output-format":   blockedWithValue,
+     "--input-format":    blockedWithValue,
+     "--permission-mode": blockedWithValue,
+     "--mcp-config":      blockedWithValue,
+   }
+   ```
+6. Strip parent-Claude env leakage before spawning:
+   ```go
+   func isFilteredChildEnvKey(key string) bool {
+     return key == "CLAUDECODE" ||
+            strings.HasPrefix(key, "CLAUDECODE_") ||
+            strings.HasPrefix(key, "CLAUDE_CODE_")
+   }
+   ```
+7. On failed runs where you requested `--resume <id>` and Claude emitted a different session ID, signal the caller to retry with fresh session by reporting empty session ID:
+   ```go
+   if failed && requestedResume != "" && emitted != "" && emitted != requestedResume {
+     return ""
+   }
+   return emitted
+   ```
+
+## Example
+
+Minimal Go wrapper is ~200 LOC; see `server/pkg/agent/claude.go` in the source repo for the full reference implementation.
+
+## Caveats
+
+- `--permission-mode bypassPermissions` makes the run fully autonomous — use only in a sandboxed environment you trust.
+- If the sandbox refuses to pass MCP config by value, write the JSON to a temp file and pass `--mcp-config <path>`; clean up the file after the goroutine that owns the process exits.
+- 10MB max-token is a reasonable upper bound for Read/Write tool results; bump if you see "token too long" errors.
+- Don't read stderr line-by-line; pipe it to a logger that Debug-level logs lines so noise doesn't dominate.

--- a/skills/agents/coding-agent-cli-backend-interface/SKILL.md
+++ b/skills/agents/coding-agent-cli-backend-interface/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: coding-agent-cli-backend-interface
+description: Unified Go/TS interface for invoking any coding-agent CLI (Claude, Codex, OpenCode, Gemini, Cursor, etc.) behind one streaming Execute/Session/Result contract.
+category: agents
+version: 1.0.0
+tags: [agents, cli, abstraction, streaming, llm]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- Your product spawns multiple coding-agent CLIs and needs a single API to drive them.
+- Each agent speaks a slightly different stream format (JSON-lines, event-stream, custom).
+- You want to add a new agent provider without touching the UI or server routing layer.
+
+## Steps
+
+1. Define the contract once:
+   ```go
+   type Backend interface {
+       Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error)
+   }
+   type ExecOptions struct {
+       Cwd, Model, SystemPrompt string
+       MaxTurns                 int
+       Timeout                  time.Duration
+       ResumeSessionID          string
+       CustomArgs               []string
+       McpConfig                json.RawMessage
+   }
+   type Session struct {
+       Messages <-chan Message   // streaming, closed on completion
+       Result   <-chan Result    // exactly one value then closed
+   }
+   type Message struct {
+       Type    MessageType  // text | thinking | tool-use | tool-result | status | error | log
+       Content string
+       Tool    string
+       CallID  string
+       Input   map[string]any
+       Output  string
+       Level   string
+   }
+   type Result struct {
+       Status     string  // completed | failed | aborted | timeout
+       Output     string
+       Error      string
+       DurationMs int64
+       SessionID  string
+       Usage      map[string]TokenUsage
+   }
+   ```
+2. Factory dispatches by name:
+   ```go
+   func New(agentType string, cfg Config) (Backend, error) {
+       switch agentType {
+       case "claude":   return &claudeBackend{cfg}, nil
+       case "codex":    return &codexBackend{cfg}, nil
+       case "opencode": return &opencodeBackend{cfg}, nil
+       // ...
+       default: return nil, fmt.Errorf("unknown agent type: %q", agentType)
+       }
+   }
+   ```
+3. Each backend follows the same pattern:
+   - Resolve binary path; `exec.LookPath` early to fail fast with a clear error.
+   - Build args (protocol-critical flags hardcoded; user `CustomArgs` pass through a deny-list filter).
+   - Spawn with a wrapping context + timeout + `WaitDelay`.
+   - Stream stdout line-by-line through a buffered scanner with a 10MB max-token size.
+   - Push parsed messages onto the Messages channel (non-blocking drop if full — final output is accumulated separately).
+   - On exit, classify outcome: `context.DeadlineExceeded` → "timeout", `context.Canceled` → "aborted", exit error → "failed", else "completed".
+4. Common helpers (shared by all backends):
+   - `mergeEnv` that strips parent-agent env keys (e.g. `CLAUDECODE_*`) to prevent child-in-parent session leakage.
+   - `filterCustomArgs` per-backend deny-list for protocol flags.
+   - `writeMcpConfigToTemp` for agents that accept `--mcp-config <path>`.
+   - `resolveSessionID` to distinguish "resume succeeded" from "fresh session with same failure".
+5. Provide a stable launch header per provider for UI display:
+   ```go
+   var launchHeaders = map[string]string{
+       "claude":   "claude (stream-json)",
+       "codex":    "codex app-server",
+       "opencode": "opencode run (json)",
+       // ...
+   }
+   ```
+
+## Example
+
+```go
+backend, err := agent.New("claude", agent.Config{ ExecutablePath: "/usr/local/bin/claude" })
+session, err := backend.Execute(ctx, "fix the login bug", agent.ExecOptions{ Cwd: wd, Timeout: 20*time.Minute })
+for msg := range session.Messages {
+    switch msg.Type {
+    case agent.MessageText:      uiStream.Text(msg.Content)
+    case agent.MessageToolUse:   uiStream.ToolStart(msg.Tool, msg.CallID, msg.Input)
+    case agent.MessageToolResult: uiStream.ToolEnd(msg.CallID, msg.Output)
+    }
+}
+result := <-session.Result
+persistUsage(result.SessionID, result.Usage)
+```
+
+## Caveats
+
+- Bounded channels (e.g. 256) prevent memory blowup under slow consumers but mean some streaming messages can be dropped — always accumulate final output into `Result.Output` as a safety net.
+- Token usage is per-model, not per-session: a run that switches Claude models mid-conversation has a map with multiple keys.
+- When adding a new backend, mirror `claudeBackend` structure exactly; the similarity is on purpose — it's what lets the orchestrator treat all providers uniformly.

--- a/skills/build-system/cmake-cuda-extension-with-git-submodule-vendoring/SKILL.md
+++ b/skills/build-system/cmake-cuda-extension-with-git-submodule-vendoring/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: cmake-cuda-extension-with-git-submodule-vendoring
+description: Build a PyTorch CUDA extension with CMake, vendoring CUTLASS and fmt as git submodules, plus a pre-built-wheel fast path for CI via GitHub releases.
+category: build-system
+version: 1.0.0
+version_origin: extracted
+tags: [cmake, pytorch-extension, git-submodule, cuda-build, wheel, ci]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - setup.py
+  - CMakeLists.txt
+  - install.sh
+imported_at: 2026-04-18T13:12:58Z
+---
+
+# CMake CUDA Extension With Git-Submodule Vendoring
+
+## What / Why
+CUTLASS / CUTE / fmt are tightly coupled to kernel code — version skew = silent miscompiles. Vendoring via git submodule pins exact commits and avoids every user becoming a CUTLASS debugger. A CMake build keeps the CUDA compilation flags centralized. For CI, a `DG_FORCE_BUILD` env switch lets users download a pre-built wheel from GitHub releases when a matching Python × PyTorch × CUDA tag exists, skipping the 15-minute local compile.
+
+## Procedure
+1. **Add submodules.**
+   ```
+   git submodule add https://github.com/nvidia/cutlass.git third-party/cutlass
+   git submodule add https://github.com/fmtlib/fmt.git     third-party/fmt
+   ```
+2. **Pin exact commits** via `git submodule update --init --recursive` in `install.sh`. Lock CUTLASS to a known-good tag.
+3. **`setup.py` branching.**
+   - If `DG_FORCE_BUILD` unset AND matching wheel exists at the releases URL: download, extract, install.
+   - Else: call into CMake via `CUDAExtension` / `torch.utils.cpp_extension.BuildExtension`.
+4. **`CMakeLists.txt` essentials.**
+   - `include_dirs += third-party/cutlass/include`, `third-party/cutlass/include/cute`, `third-party/fmt/include`, `deep_gemm/include`.
+   - `libraries += cudart nvrtc`.
+   - Flags: `-std=c++20 -O3 -fPIC`, PyTorch C++11 ABI alignment flag, CUDA arch list from `torch.utils.cpp_extension.CUDA_ARCHITECTURES`.
+5. **`develop.sh`** symlinks the include tree for in-place development; `install.sh` is the end-user wrapper.
+
+## Key design points
+- Pre-built wheel path is a **cache**, not a different code path. The same sources build the wheel and a local build — just shorter.
+- Header-only vendoring (CUTLASS, fmt) avoids static-lib ABI issues. If you need a compiled third-party lib, vendor source and build under your CMake, don't link externally.
+- Keep CUDA arch selection dynamic (from PyTorch), not hardcoded — users run SM80-SM100.
+
+## References
+- `setup.py` — wheel fast path + build invocation.
+- `CMakeLists.txt` — compile flags and include wiring.
+- `install.sh` / `develop.sh` — user-facing entry points.

--- a/skills/build/coverage-data-file-under-pytest-cache/SKILL.md
+++ b/skills/build/coverage-data-file-under-pytest-cache/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: coverage-data-file-under-pytest-cache
+description: Move coverage data files into .pytest_cache/.coverage so pytest-xdist worker fragments (.coverage.<host>.<pid>.<random>) end up inside the already-gitignored cache dir instead of polluting the repo root.
+category: build
+version: 1.0.0
+version_origin: extracted
+tags: [coverage, pytest-xdist, gitignore, dx]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/Tracer-Cloud/opensre.git
+source_ref: main
+source_commit: fb5ba0a1b4ef511d16c56a80f1f126b1f581d724
+source_project: opensre
+source_path: pyproject.toml
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Coverage Data File Under .pytest_cache
+
+## When to use
+You run tests with `pytest -n auto --cov` and end up with dozens of `.coverage.<hostname>.<pid>.<random>` files at the repo root. They look like garbage, accidentally get committed, and clutter `git status`. There's a one-line fix.
+
+## How it works
+Set `tool.coverage.run.data_file` to a path inside `.pytest_cache/`. pytest-xdist appends host/pid/random suffixes to whatever you set, so all the fragments land inside the already-gitignored cache directory.
+
+## Example
+```toml
+[tool.coverage.run]
+# With pytest-xdist (-n auto), each worker writes a fragment; put them under
+# .pytest_cache/ (already gitignored) instead of .coverage.<hostname>.* at repo root.
+data_file = ".pytest_cache/.coverage"
+```
+
+Combine with a Makefile clean target that explicitly nukes leftovers from older runs:
+```makefile
+clean:
+    find . -maxdepth 1 \( -name '.coverage' -o -name '.coverage.*' \) -delete 2>/dev/null || true
+```
+
+## Gotchas
+- `.pytest_cache/` is gitignored by default in most Python templates; verify yours has it.
+- If you use `coverage combine` separately (e.g. in CI to merge fragments from parallel jobs), point its input/output paths at the same `.pytest_cache/.coverage` location.
+- Doesn't change behaviour for single-worker `pytest --cov` — it just keeps the folder tidy.

--- a/skills/cli/cli-output-format-dispatch-with-template/SKILL.md
+++ b/skills/cli/cli-output-format-dispatch-with-template/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: cli-output-format-dispatch-with-template
+description: CLI accepts --format=json|jsonl|text and an optional --format-str with printf-style placeholders (%p path, %l label, %s score, %i mime, %g group, %b overwrite_reason).
+category: cli
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [magika, cli]
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Cli Output Format Dispatch With Template
+
+**Trigger:** Building a CLI that must output the same data in multiple formats (machine, human, custom column selection) without spawning child tools.
+
+## Steps
+
+- Define a Format enum: JSON, JSONL, TEXT, CUSTOM.
+- Parse the custom template string and recognize a fixed set of placeholders; reject unknown ones at parse time.
+- Substitute placeholders per result; default to TEXT (human-readable, colored if TTY).
+- For TEXT, align columns and use ANSI colors gated by isatty + --no-colors flag.
+- For JSON/JSONL/CUSTOM, never emit progress/warnings to stdout — keep stdout machine-parseable.
+- Document the placeholder set with examples in --help output.
+
+## Counter / Caveats
+
+- Keep the template grammar simple — no conditionals, no loops, just substitution.
+- Aligning columns with Unicode (CJK, emoji) breaks monospace assumptions; document the limitation.
+- Changing the default format between releases breaks user scripts; treat the default as a stable API.
+- Escape sequences (%, \t, \n) inside templates are confusing; show them in --help with examples.
+
+## Source
+
+Extracted from `magika` (https://github.com/google/magika.git @ main).
+
+Files of interest:
+- `rust/cli/src/main.rs:102-230`
+- `python/src/magika/cli/magika_client.py:70-85`

--- a/skills/cli/cli-output-format-dispatch-with-template/content.md
+++ b/skills/cli/cli-output-format-dispatch-with-template/content.md
@@ -1,0 +1,21 @@
+# cli-output-format-dispatch-with-template — extended notes
+
+This is an extracted draft from the **magika** project at commit `0a8cb9626b`.
+See `SKILL.md` for the procedure. Use the source references below to study the
+original implementation before adapting the pattern to a new codebase.
+
+## Source references
+
+- `rust/cli/src/main.rs:102-230`
+- `python/src/magika/cli/magika_client.py:70-85`
+
+## When this pattern is a fit
+
+Building a CLI that must output the same data in multiple formats (machine, human, custom column selection) without spawning child tools.
+
+## When to walk away
+
+- Keep the template grammar simple — no conditionals, no loops, just substitution.
+- Aligning columns with Unicode (CJK, emoji) breaks monospace assumptions; document the limitation.
+- Changing the default format between releases breaks user scripts; treat the default as a stable API.
+- Escape sequences (%, \t, \n) inside templates are confusing; show them in --help with examples.

--- a/skills/cli/cli-serve-blocking-exit/SKILL.md
+++ b/skills/cli/cli-serve-blocking-exit/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: cli-serve-blocking-exit
+description: In a CLI that wraps a long-running server, block on SIGINT/SIGTERM with a Promise instead of `process.exit(0)` so the underlying Bun.serve/Hono event loop keeps running.
+category: cli
+version: 1.0.0
+version_origin: extracted
+tags: [cli, signal-handling, bun, server, lifecycle]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/coleam00/Archon.git
+source_ref: dev
+source_commit: d89bc767d291f52687beea91c9fcf155459be0d9
+source_project: Archon
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# `archon serve`-Style: Block CLI on Signals Instead of Returning
+
+## When to use
+
+- You have a CLI whose typical subcommand returns an exit code (`0`/`1`) and that's fine.
+- One subcommand starts a long-running server (`serve`, `run`, `daemon`). If this subcommand returns and the CLI's outer switch calls `process.exit(exitCode)`, the server dies with it — even though `Bun.serve()` / Node `http.createServer().listen()` would normally keep the process alive.
+- You want Ctrl+C and SIGTERM to cleanly unblock, do any teardown, and only then `process.exit(0)`.
+
+## Steps
+
+1. **Write the subcommand as `async`** and return a number like any other command — but **before** returning, `await` on a promise that only resolves on signals:
+
+   ```ts
+   await new Promise<void>(resolve => {
+     process.once('SIGINT', resolve);
+     process.once('SIGTERM', resolve);
+   });
+   return 0;
+   ```
+
+   Use `once` (not `on`) so the handler auto-removes after firing — prevents double-teardown if both signals arrive.
+
+2. **Start the server first**, then await the signal promise. On unblock, the Promise resolves, `return 0` runs, and the outer CLI switch can do its own cleanup (close DB, shutdown telemetry) before `process.exit`.
+
+3. **Don't install SIGINT handlers during server import.** The subcommand module owns the signal handlers; installing them elsewhere makes lifecycle confusing.
+
+4. **Validate arguments before doing the long-running work.** Range-check ports etc., and return `1` on invalid input — failing early is cheap, failing after the server binds is expensive and confusing.
+
+5. **Guard binary-only subcommands** with a compile-time flag. Archon's `serveCommand` checks `BUNDLED_IS_BINARY` and rejects with a helpful message in dev mode:
+
+   ```ts
+   if (!BUNDLED_IS_BINARY) {
+     console.error('Error: `archon serve` is for compiled binaries only.');
+     console.error('For development, use: bun run dev');
+     return 1;
+   }
+   ```
+
+## Counter / Caveats
+
+- You need to return a value (even if always 0) so the type system / outer switch stay consistent.
+- If your server's internal code calls `process.exit()` on fatal errors, it will bypass this mechanism. Audit for stray `process.exit()` calls in the server path.
+- Multiple `once` handlers on the same signal are fine, but don't stack `on` — Node will call all registered handlers, which can fire cleanup multiple times.
+- For a web server that receives cleanup requests via HTTP (K8s preStop hook), you may want an additional in-band shutdown path in addition to signals.
+- On Windows, SIGTERM doesn't fire on `taskkill`; you get SIGBREAK from Ctrl+Break and SIGINT from Ctrl+C. Consider adding `SIGBREAK` to the listener set if you target Windows.
+
+## Evidence
+
+- `packages/cli/src/commands/serve.ts:74-77`:
+  ```ts
+  await new Promise<void>(resolve => {
+    process.once('SIGINT', resolve);
+    process.once('SIGTERM', resolve);
+  });
+  ```
+  with comment "Block forever — Bun.serve() keeps the event loop alive, but the CLI's process.exit(exitCode) would kill it."
+- Binary-only guard at `serve.ts:29-33` using `BUNDLED_IS_BINARY` from `@archon/paths`.
+- Port validation at `serve.ts:21-27` returns `1` before any server work.
+- Commit SHA: d89bc767d291f52687beea91c9fcf155459be0d9.

--- a/skills/data/content-type-info-metadata-embedding/SKILL.md
+++ b/skills/data/content-type-info-metadata-embedding/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: content-type-info-metadata-embedding
+description: Embed structured metadata per content type (mime_type, group, description, extensions, is_text) at codegen time so callers can convert predictions to human output or filter by group without lookup tables.
+category: data
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [magika, data]
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Content Type Info Metadata Embedding
+
+**Trigger:** Building a classifier whose output needs human-readable enrichment (MIME type, file extensions, broad category) at every call site.
+
+## Steps
+
+- Source metadata from a single canonical JSON (assets/content_types_kb.min.json).
+- Code generator emits a const TypeInfo struct per content type with all metadata fields.
+- Add an info() / get_info() method on the ContentType enum that returns the struct.
+- Standardize the group taxonomy (text, image, archive, executable, binary, …) and document it.
+- Allow filtering: content_types.filter(ct => ct.is_text) or ct.group == 'text'.
+- Test that every label has complete metadata at codegen time — missing fields fail the build.
+
+## Counter / Caveats
+
+- Metadata can be stale or wrong for obscure types; validate against real samples occasionally.
+- MIME type is not 1-to-1 with label (e.g. .txt vs text/markdown); use is_text for binary/text filtering.
+- Extensions list grows over time; document the preferred extension explicitly.
+- Custom group taxonomy may not align with IANA / file(1) groups; document the difference for integrators.
+
+## Source
+
+Extracted from `magika` (https://github.com/google/magika.git @ main).
+
+Files of interest:
+- `rust/gen/src/main.rs:65-82`
+- `python/src/magika/types/content_type_info.py`
+- `js/src/content-type-info.ts`
+- `go/magika/content.go`

--- a/skills/data/content-type-info-metadata-embedding/content.md
+++ b/skills/data/content-type-info-metadata-embedding/content.md
@@ -1,0 +1,23 @@
+# content-type-info-metadata-embedding — extended notes
+
+This is an extracted draft from the **magika** project at commit `0a8cb9626b`.
+See `SKILL.md` for the procedure. Use the source references below to study the
+original implementation before adapting the pattern to a new codebase.
+
+## Source references
+
+- `rust/gen/src/main.rs:65-82`
+- `python/src/magika/types/content_type_info.py`
+- `js/src/content-type-info.ts`
+- `go/magika/content.go`
+
+## When this pattern is a fit
+
+Building a classifier whose output needs human-readable enrichment (MIME type, file extensions, broad category) at every call site.
+
+## When to walk away
+
+- Metadata can be stale or wrong for obscure types; validate against real samples occasionally.
+- MIME type is not 1-to-1 with label (e.g. .txt vs text/markdown); use is_text for binary/text filtering.
+- Extensions list grows over time; document the preferred extension explicitly.
+- Custom group taxonomy may not align with IANA / file(1) groups; document the difference for integrators.

--- a/skills/engineering/code-review/SKILL.md
+++ b/skills/engineering/code-review/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: code-review
+description: "Performs an architectural and quality code review on a specified file or set of files. Checks for coding standard compliance, architectural pattern adherence, SOLID principles, testability, and performance concerns."
+argument-hint: "[path-to-file-or-directory]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Bash, Task
+agent: lead-programmer
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version: 1.0.0
+version_origin: extracted
+---
+
+## Phase 1: Load Target Files
+
+Read the target file(s) in full. Read CLAUDE.md for project coding standards.
+
+---
+
+## Phase 2: Identify Engine Specialists
+
+Read `.claude/docs/technical-preferences.md`, section `## Engine Specialists`. Note:
+
+- The **Primary** specialist (used for architecture and broad engine concerns)
+- The **Language/Code Specialist** (used when reviewing the project's primary language files)
+- The **Shader Specialist** (used when reviewing shader files)
+- The **UI Specialist** (used when reviewing UI code)
+
+If the section reads `[TO BE CONFIGURED]`, no engine is pinned — skip engine specialist steps.
+
+---
+
+## Phase 3: ADR Compliance Check
+
+Search for ADR references in the story file, commit messages, and header comments. Look for patterns like `ADR-NNN` or `docs/architecture/ADR-`.
+
+If no ADR references found, note: "No ADR references found — skipping ADR compliance check."
+
+For each referenced ADR: read the file, extract the **Decision** and **Consequences** sections, then classify any deviation:
+
+- **ARCHITECTURAL VIOLATION** (BLOCKING): Uses a pattern explicitly rejected in the ADR
+- **ADR DRIFT** (WARNING): Meaningfully diverges from the chosen approach without using a forbidden pattern
+- **MINOR DEVIATION** (INFO): Small difference from ADR guidance that doesn't affect overall architecture
+
+---
+
+## Phase 4: Standards Compliance
+
+Identify the system category (engine, gameplay, AI, networking, UI, tools) and evaluate:
+
+- [ ] Public methods and classes have doc comments
+- [ ] Cyclomatic complexity under 10 per method
+- [ ] No method exceeds 40 lines (excluding data declarations)
+- [ ] Dependencies are injected (no static singletons for game state)
+- [ ] Configuration values loaded from data files
+- [ ] Systems expose interfaces (not concrete class dependencies)
+
+---
+
+## Phase 5: Architecture and SOLID
+
+**Architecture:**
+- [ ] Correct dependency direction (engine <- gameplay, not reverse)
+- [ ] No circular dependencies between modules
+- [ ] Proper layer separation (UI does not own game state)
+- [ ] Events/signals used for cross-system communication
+- [ ] Consistent with established patterns in the codebase
+
+**SOLID:**
+- [ ] Single Responsibility: Each class has one reason to change
+- [ ] Open/Closed: Extendable without modification
+- [ ] Liskov Substitution: Subtypes substitutable for base types
+- [ ] Interface Segregation: No fat interfaces
+- [ ] Dependency Inversion: Depends on abstractions, not concretions
+
+---
+
+## Phase 6: Game-Specific Concerns
+
+- [ ] Frame-rate independence (delta time usage)
+- [ ] No allocations in hot paths (update loops)
+- [ ] Proper null/empty state handling
+- [ ] Thread safety where required
+- [ ] Resource cleanup (no leaks)
+
+---
+
+## Phase 7: Specialist Reviews (Parallel)
+
+Spawn all applicable specialists simultaneously via Task — do not wait for one before starting the next.
+
+### Engine Specialists
+
+If an engine is configured, determine which specialist applies to each file and spawn in parallel:
+
+- Primary language files (`.gd`, `.cs`, `.cpp`) → Language/Code Specialist
+- Shader files (`.gdshader`, `.hlsl`, shader graph) → Shader Specialist
+- UI screen/widget code → UI Specialist
+- Cross-cutting or unclear → Primary Specialist
+
+Also spawn the **Primary Specialist** for any file touching engine architecture (scene structure, node hierarchy, lifecycle hooks).
+
+### QA Testability Review
+
+For Logic and Integration stories, also spawn `qa-tester` via Task in parallel with the engine specialists. Pass:
+- The implementation files being reviewed
+- The story's `## QA Test Cases` section (the pre-written test specs from qa-lead)
+- The story's `## Acceptance Criteria`
+
+Ask the qa-tester to evaluate:
+- [ ] Are all test hooks and interfaces exposed (not hidden behind private/internal access)?
+- [ ] Do the QA test cases from the story's `## QA Test Cases` section map to testable code paths?
+- [ ] Are any acceptance criteria untestable as implemented (e.g., hardcoded values, no seam for injection)?
+- [ ] Does the implementation introduce any new edge cases not covered by the existing QA test cases?
+- [ ] Are there any observable side effects that should have a test but don't?
+
+For Visual/Feel and UI stories: qa-tester reviews whether the manual verification steps in `## QA Test Cases` are achievable with the implementation as written — e.g., "is the state the manual checker needs to reach actually reachable?"
+
+Collect all specialist findings before producing output.
+
+---
+
+## Phase 8: Output Review
+
+```
+## Code Review: [File/System Name]
+
+### Engine Specialist Findings: [N/A — no engine configured / CLEAN / ISSUES FOUND]
+[Findings from engine specialist(s), or "No engine configured." if skipped]
+
+### Testability: [N/A — Visual/Feel or Config story / TESTABLE / GAPS / BLOCKING]
+[qa-tester findings: test hooks, coverage gaps, untestable paths, new edge cases]
+[If BLOCKING: implementation must expose [X] before tests in ## QA Test Cases can run]
+
+### ADR Compliance: [NO ADRS FOUND / COMPLIANT / DRIFT / VIOLATION]
+[List each ADR checked, result, and any deviations with severity]
+
+### Standards Compliance: [X/6 passing]
+[List failures with line references]
+
+### Architecture: [CLEAN / MINOR ISSUES / VIOLATIONS FOUND]
+[List specific architectural concerns]
+
+### SOLID: [COMPLIANT / ISSUES FOUND]
+[List specific violations]
+
+### Game-Specific Concerns
+[List game development specific issues]
+
+### Positive Observations
+[What is done well -- always include this section]
+
+### Required Changes
+[Must-fix items before approval — ARCHITECTURAL VIOLATIONs always appear here]
+
+### Suggestions
+[Nice-to-have improvements]
+
+### Verdict: [APPROVED / APPROVED WITH SUGGESTIONS / CHANGES REQUIRED]
+```
+
+This skill is read-only — no files are written.
+
+---
+
+## Phase 9: Next Steps
+
+- If verdict is APPROVED: run `/story-done [story-path]` to close the story.
+- If verdict is CHANGES REQUIRED: fix the issues and re-run `/code-review`.
+- If an ARCHITECTURAL VIOLATION is found: run `/architecture-decision` to record the correct approach.

--- a/skills/integration/claude-cli-grace-kill-after-success-result/SKILL.md
+++ b/skills/integration/claude-cli-grace-kill-after-success-result/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: claude-cli-grace-kill-after-success-result
+description: When driving `claude -p --output-format stream-json`, treat a `result:success` event as completion even if the child doesn't self-exit; arm a 15s grace timer to kill, and return ok=true regardless of exit code.
+category: integration
+triggers:
+  - claude -p stream-json
+  - CLI hangs after result
+  - spawn timeout after success
+  - stream-json verbose
+tags:
+  - llm
+  - claude-code
+  - subprocess
+version: 1.0.0
+---
+
+# claude-cli-grace-kill-after-success-result
+
+`claude -p --output-format stream-json --verbose` sometimes emits the terminal `result` event but doesn't close its own stdout — the child stays resident until the outer timeout fires, which then reports a false failure even though work (drafts staged, $ billed) is complete.
+
+## Pattern
+
+Track `sawSuccessResult`. On the success event, arm a short grace timer that kills the child; on `close`, return success regardless of exit code if the flag is set.
+
+```js
+let sawSuccessResult = false, graceTimer = null;
+
+function onAssistantEvent(evt) {
+  if (evt.type === 'result' && evt.subtype === 'success') {
+    sawSuccessResult = true;
+    addUsage(evt.usage, evt.total_cost_usd);
+    graceTimer ??= setTimeout(() => { try { child.kill(); } catch {} }, 15000);
+  }
+}
+
+child.on('close', (code) => {
+  clearTimeout(timer); clearTimeout(graceTimer);
+  if (sawSuccessResult) return resolve({ ok: true, code, ... });
+  // real failure path below
+});
+```
+
+## Why 15 seconds
+
+Empirically the CLI exits within ~2s most of the time; a generous 15s window covers the tail without dragging the loop. Any longer and you pay the opportunity cost; any shorter risks racing a clean exit.
+
+## Symptom to recognize
+
+Logs show `[import] done $N.NNNN` followed much later by `[import] timeout after 2400s`, with drafts already written on disk. That ordering is the signal — success arrived, only the process failed to hang up.

--- a/skills/integration/computer-use-agent/SKILL.md
+++ b/skills/integration/computer-use-agent/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: computer-use-agent
+description: Build an agent that controls a computer (screenshots, clicks, keyboard) using ComputerTool.
+category: integration
+version: 1.0.0
+version_origin: extracted
+confidence: medium
+tags: [openai-agents, computer-use, automation, computer-tool, rpa]
+source_type: extracted-from-git
+source_url: https://github.com/openai/openai-agents-python.git
+source_ref: main
+source_commit: e80d2d2319eb300ac17ec496988b70246a5042d6
+source_project: openai-agents-python
+source_path: examples/tools/computer_use.py, src/agents/computer.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# computer-use-agent
+
+Use `ComputerTool` with a `Computer` implementation to give an agent the ability to take screenshots, click, type, and navigate a computer environment.
+
+## When to apply
+
+Browser automation, desktop GUI testing, or any task requiring interaction with a visual computer interface. Used with models that support computer use (e.g., `computer-use-preview`).
+
+## Core snippet
+
+```python
+import asyncio
+from agents import Agent, Runner
+from agents.tool import ComputerTool
+from agents.computer import AsyncComputer
+
+class MyComputer(AsyncComputer):
+    async def screenshot(self) -> str:
+        """Return base64-encoded PNG screenshot."""
+        # Implement using pyautogui, Playwright, etc.
+        return take_screenshot_base64()
+
+    async def click(self, x: int, y: int, button: str = "left") -> None:
+        """Click at coordinates."""
+        pyautogui.click(x, y, button=button)
+
+    async def type(self, text: str) -> None:
+        """Type text."""
+        pyautogui.write(text)
+
+    async def key(self, key: str) -> None:
+        """Press a key combination."""
+        pyautogui.hotkey(*key.split("+"))
+
+    @property
+    def dimensions(self) -> tuple[int, int]:
+        return (1920, 1080)
+
+    @property
+    def environment(self) -> str:
+        return "mac"  # "windows" | "linux" | "mac"
+
+async def main():
+    agent = Agent(
+        name="Computer operator",
+        instructions="Complete the task using the computer.",
+        tools=[ComputerTool(computer=MyComputer())],
+        model="computer-use-preview",
+    )
+    result = await Runner.run(agent, "Open a browser and navigate to python.org")
+    print(result.final_output)
+
+asyncio.run(main())
+```
+
+## Key notes
+
+- Must implement `AsyncComputer` (or `Computer` for sync); required methods: `screenshot`, `click`, `type`, `key`, `dimensions`, `environment`
+- Use models that support computer use (check OpenAI model docs)
+- `ComputerTool` handles the low-level protocol; your `Computer` impl handles actual execution
+- For sandboxed environments, `SandboxAgent` with `capabilities` may be more appropriate

--- a/skills/integration/confidence-lowering-by-source-factor/SKILL.md
+++ b/skills/integration/confidence-lowering-by-source-factor/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: confidence-lowering-by-source-factor
+description: Lower external asset confidence by a configurable factor to reflect source reliability
+category: integration
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [evolver, integration, trust, confidence]
+source_type: extracted-from-git
+source_url: https://github.com/EvoMap/evolver.git
+source_ref: main
+source_commit: 22773782475cecf43dc9c1af264bf5f9cacc28bc
+source_project: evolver
+source_paths:
+  - src/gep/a2a.js
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Source-factor confidence discount on ingest
+
+When ingesting an external asset, multiply its claimed confidence by a source-specific factor (e.g., 0.6 for untrusted, 0.9 for trusted) before staging. Encodes the epistemic truth that external evidence is weaker than locally validated evidence, and exposes the factor as an env var for operators.
+
+## Mechanism
+
+```js
+const factor = Number(process.env.A2A_EXTERNAL_CONFIDENCE_FACTOR ?? 0.6);
+asset.confidence = clamp(asset.confidence * factor, 0, 1);
+asset.confidence_origin = { source: 'external', factor };
+```
+
+Keep the original value in `confidence_raw` for auditability.
+
+## When to reuse
+
+Data-ingest pipelines that blend first-party and third-party signals, plugin registries, scoring systems that merge human and ML inputs.

--- a/skills/ml-ops/chunked-tts-with-crossfade/SKILL.md
+++ b/skills/ml-ops/chunked-tts-with-crossfade/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: chunked-tts-with-crossfade
+description: Generate long TTS outputs by sentence-splitting the input, generating each chunk independently, and concatenating with a short crossfade.
+category: ml-ops
+version: 1.0.0
+version_origin: extracted
+tags: [tts, audio, chunking, crossfade, long-form]
+source_type: extracted-from-git
+source_url: https://github.com/jamiepine/voicebox.git
+source_ref: main
+source_commit: 476abe07fc2c1587f4b3e3916134018ebacd143d
+source_project: voicebox
+confidence: high
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Chunked TTS with crossfade
+
+## When to use
+You need to synthesize text longer than a single-shot TTS backend can reliably handle (Chatterbox, Qwen TTS, and others degrade or hallucinate past ~800 characters). You want an engine-agnostic wrapper that splits, generates, and stitches audio back together with no user-visible seams.
+
+## Steps
+1. Fast-path short text: if `len(text) <= max_chars` (default 800), call `backend.generate()` once and return. Keep overhead at zero for the common case.
+2. Split at natural boundaries. Priority order:
+   - Last sentence end (`.`, `!`, `?`, plus CJK `。！？`) that is NOT preceded by a common abbreviation (`Mr`, `Dr`, `e.g`, `u.s`, etc.) and NOT immediately after a digit (decimal number).
+   - Last clause boundary (`;`, `:`, `,`, em-dash) if no sentence end is found.
+   - Last whitespace as a fallback.
+   - Hard cut only as the absolute fallback.
+3. Respect atomic tokens. If the backend supports paralinguistic tags like `[laugh]`, `[sigh]`, detect them with a bracket regex and never cut inside them; walk the hard-cut position back to just before the tag start if necessary.
+4. Generate each chunk independently. Vary the per-chunk seed deterministically (`chunk_seed = seed + i`) so the same `(text, seed)` pair always produces the same output while still breaking RNG-correlated artefacts between chunks.
+5. Apply an optional per-chunk trim function (silence / hallucination trim) before concatenation, so chunk boundaries align with speech not silence.
+6. Concatenate with a linear crossfade (default 50 ms). Compute overlap as `min(crossfade_samples, len(result), len(chunk))`; apply `fade_out * result[-overlap:] + fade_in * chunk[:overlap]` and then append the chunk tail. Support `crossfade_ms=0` for a hard cut when testing.
+
+## Counter / Caveats
+- A naive character-count split creates audible pops at sentence boundaries; the crossfade plus the trim step is what makes chunked output sound continuous.
+- The abbreviation list is locale-specific. Extend it for your text domain (legal, medical, technical) or you'll see sentences broken after `Ltd.` / `Fig.` etc.
+- Do not vary pitch/voice-prompt per chunk — only the seed. Changing the voice conditioning between chunks makes the result sound like two speakers.
+- Prefer a 50 ms crossfade. Longer crossfades start to bleed phonemes across the boundary, shorter ones leave clicks.
+
+Source references: `backend/utils/chunked_tts.py`, `backend/services/generation.py`.

--- a/skills/model-loading/config-json-architecture-dispatch/SKILL.md
+++ b/skills/model-loading/config-json-architecture-dispatch/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: config-json-architecture-dispatch
+description: Auto-detect model version from config.json architecture field and dispatch to the correct model class
+category: model-loading
+version: 1.0.0
+tags: [model-loading, config, dispatch, versioning, pytorch]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/OpenBMB/VoxCPM.git
+source_ref: main
+source_commit: 13605c5a0e6b99d6d3527a43bd1a4e0e69c8800e
+source_project: VoxCPM
+source_paths:
+  - src/voxcpm/core.py
+  - src/voxcpm/cli.py
+  - scripts/train_voxcpm_finetune.py
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+---
+
+# Auto-detect model version from config.json and dispatch to the correct model class
+
+## When to use
+Use this pattern when a model directory may contain different architecture generations and the loading code must stay backward-compatible. Instead of requiring callers to pass an explicit version flag, read the architecture string from the model's own `config.json` and dispatch automatically.
+
+Useful in both inference entry points (CLI / web app) and training scripts that need to instantiate the right class before applying LoRA configs.
+
+## Pattern
+
+### 1. Read architecture from config.json
+```python
+import json
+from pathlib import Path
+
+def _detect_architecture(model_path: str) -> str:
+    config_path = Path(model_path) / "config.json"
+    with open(config_path) as f:
+        config = json.load(f)
+    return config.get("architecture", "voxcpm").lower()
+```
+
+### 2. Map architecture string to model class
+```python
+from voxcpm.model.voxcpm import VoxCPMModel
+from voxcpm.model.voxcpm2 import VoxCPM2Model
+
+_ARCH_TO_CLASS = {
+    "voxcpm":  VoxCPMModel,
+    "voxcpm2": VoxCPM2Model,
+}
+
+def _get_model_class(arch: str):
+    cls = _ARCH_TO_CLASS.get(arch)
+    if cls is None:
+        raise ValueError(f"Unknown architecture: {arch!r}. Expected one of {list(_ARCH_TO_CLASS)}")
+    return cls
+```
+
+### 3. Dispatch at load time
+```python
+import logging
+logger = logging.getLogger(__name__)
+
+def load_model(model_path: str, lora_config=None):
+    arch = _detect_architecture(model_path)
+    model_cls = _get_model_class(arch)
+    logger.info("Detected architecture: %s → using %s", arch, model_cls.__name__)
+    return model_cls.from_local(model_path, lora_config=lora_config)
+```
+
+### 4. Apply LoRA config version-agnostically
+The LoRA config is passed identically regardless of version; each model class handles its own interpretation:
+```python
+# Training script pattern (scripts/train_voxcpm_finetune.py lines 93-101)
+arch = _detect_architecture(args.model_path)
+LoRAConfig = LoRAConfigV2 if arch == "voxcpm2" else LoRAConfigV1
+lora_cfg = LoRAConfig(**lora_kwargs) if args.use_lora else None
+model = load_model(args.model_path, lora_config=lora_cfg)
+```
+
+## Source reference
+- Upstream: `OpenBMB/VoxCPM` @ `main` / `13605c5a`
+- Key files:
+  - `src/voxcpm/core.py:57-81` — central dispatch and config reading
+  - `src/voxcpm/cli.py:93-118` — CLI entry point using dispatch
+  - `scripts/train_voxcpm_finetune.py:93-101` — training-time version-aware LoRA selection
+
+## Notes
+- Always `.lower()` the architecture string before comparing — config files written by different tools may differ in case.
+- Default to the older architecture (`"voxcpm"`) when the key is absent; this preserves backward compatibility with checkpoints that pre-date the versioning field.
+- Log the detected architecture at INFO level so users can verify which model class was selected without reading source.

--- a/skills/operations/claude-cli-unattended-wrapper/SKILL.md
+++ b/skills/operations/claude-cli-unattended-wrapper/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: claude-cli-unattended-wrapper
+description: Spawn `claude -p` non-interactively from a Node parent process so a long-running loop can drive slash commands without any human at the keyboard. Layers a prompt tempfile, a piped "y\n" stream, hook-bypass env vars, and a stream-json consumer to keep the child from ever blocking.
+category: operations
+version: 1.0.0
+version_origin: extracted
+confidence: medium
+tags: [claude-code, cli, unattended, automation, spawn, stdin, stream-json, loop]
+source_type: extracted-from-project
+source_project: trending-hub-loop
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Claude CLI Unattended Wrapper
+
+## When to use
+
+You are running `claude -p "<slash command>"` from inside another process (daemon, pipeline, scheduled loop) and cannot have any interactive prompt — selection menu, "Proceed? [y/N]", permission ask — deadlock the child.
+
+## Shape (five concerns, each addressed separately)
+
+| Concern | Fix |
+|---|---|
+| Prompt too long for argv | Write prompt to a tempfile; `cat` it into `claude -p`'s stdin |
+| Interactive "y/N" mid-run | Append a file of `y\n` × 10 to the same pipe; any blocking read gets answered |
+| Slash-command own selection UI | Use its native `--yes` / non-interactive flag first; stdin is the safety net |
+| Permission prompt on tool use | `--dangerously-skip-permissions` (the parent *must* accept the blast radius) |
+| Parent hooks hijacking I/O | Env vars that tell the wrapping harness to stay out of this child's I/O |
+
+## Reference invocation (Node, cross-platform)
+
+```js
+const tmp    = path.join(os.tmpdir(), `prompt-${Date.now()}.txt`);
+const yesTmp = path.join(os.tmpdir(), `yes-${Date.now()}.txt`);
+fs.writeFileSync(tmp, promptText, 'utf8');
+fs.writeFileSync(yesTmp, 'y\n'.repeat(10), 'utf8');
+
+// `cat` exists on both git-bash/WSL on Windows and on *nix. Avoid `type` because
+// it mangles line endings and doesn't concat two files in a single stream.
+const cmd =
+  `cat "${tmp}" "${yesTmp}" | claude -p ` +
+  `--dangerously-skip-permissions --output-format stream-json --verbose`;
+
+const child = spawn(cmd, [], {
+  shell: true,
+  stdio: ['ignore', 'pipe', 'pipe'],
+  env: { ...process.env, DISABLE_OMC: '1', OMC_SKIP_HOOKS: '*', CLAUDE_DISABLE_SESSION_HOOKS: '1' },
+});
+```
+
+## Rules
+
+- **Prompt via stdin, not argv.** Argv length limits (≈32KB on Windows, ≈128KB on Linux) will bite once prompts include embedded URLs or context. Tempfile + pipe sidesteps it entirely and also dodges shell quote-escaping bugs.
+- **Concatenate the auto-yes file onto the same pipe.** Two separate `echo y` commands won't reach a child that only reads stdin once; a single `cat promptFile yesFile |` gives one continuous stream.
+- **Always set a timeout.** A stuck child can silently hold the pipeline forever. 30 min is a reasonable outer bound for a single slash command; anything longer is a bug. `setTimeout(() => child.kill(), timeoutMs)` then clean up on close.
+- **Clean the tempfiles in the close handler.** Both the happy path and the error path must `unlinkSync` the two tempfiles — otherwise `/tmp` fills up in loops that run thousands of times a day.
+- **Use `--output-format stream-json --verbose`.** That way the parent can parse each assistant message, tool_use, and result event line-by-line instead of waiting for the whole transcript. Pair it with a stream-json consumer (see linked skill).
+- **Phrase the prompt to pre-answer everything.** Even with the stdin safety net, the prompt itself should spell out: "answer 'y' to any interactive prompt", "if asked to select, choose 'all'", "do not ask me any follow-up questions". Belt *and* suspenders.
+
+## Counter / Caveats
+
+- `--dangerously-skip-permissions` is exactly what the name says. The child can run arbitrary `git clone`, `rm`, `curl`, etc. Accept this only if the parent has already fenced the child: scoped working dir, no production credentials in env, outbound network confined.
+- On Windows, `cat` is only present if git-bash or WSL is installed. PowerShell's `cat` is an alias for `Get-Content` which prints with CRLF and differs in concat behavior — don't use it. If you must run from pure cmd.exe, shell out via `bash -c "..."`.
+- The `y\n` stream answers anything that reads from stdin, which means you also auto-confirm destructive prompts you didn't anticipate. Audit the slash commands you run for any "really delete? [y/N]" paths before enabling this in production.
+- Hook-bypass env vars are specific to the OMC harness. If the parent is plain shell, they're no-ops — but costless. See linked knowledge entry.
+
+## Related
+
+- Knowledge: `claude-cli-hook-bypass-envs` — why those three env vars matter and what each turns off.
+- Knowledge: `dangerously-skip-permissions-for-unattended-loops` — risk accounting for the permission bypass.
+- Skill: `stream-json-assistant-event-router` — how to consume the child's `--output-format stream-json` output.

--- a/skills/qa/consistency-check/SKILL.md
+++ b/skills/qa/consistency-check/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: consistency-check
+description: "Scan all GDDs against the entity registry to detect cross-document inconsistencies: same entity with different stats, same item with different values, same formula with different variables. Grep-first approach — reads registry then targets only conflicting GDD sections rather than full document reads."
+argument-hint: "[full | since-last-review | entity:<name> | item:<name>]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write, Edit, Bash
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version: 1.0.0
+version_origin: extracted
+---
+
+# Consistency Check
+
+Detects cross-document inconsistencies by comparing all GDDs against the
+entity registry (`design/registry/entities.yaml`). Uses a grep-first approach:
+reads the registry once, then targets only the GDD sections that mention
+registered names — no full document reads unless a conflict needs investigation.
+
+**This skill is the write-time safety net.** It catches what `/design-system`'s
+per-section checks may have missed and what `/review-all-gdds`'s holistic review
+catches too late.
+
+**When to run:**
+- After writing each new GDD (before moving to the next system)
+- Before `/review-all-gdds` (so that skill starts with a clean baseline)
+- Before `/create-architecture` (inconsistencies poison downstream ADRs)
+- On demand: `/consistency-check entity:[name]` to check one entity specifically
+
+**Output:** Conflict report + optional registry corrections
+
+---
+
+## Phase 1: Parse Arguments and Load Registry
+
+**Modes:**
+- No argument / `full` — check all registered entries against all GDDs
+- `since-last-review` — check only GDDs modified since the last review report
+- `entity:<name>` — check one specific entity across all GDDs
+- `item:<name>` — check one specific item across all GDDs
+
+**Load the registry:**
+
+```
+Read path="design/registry/entities.yaml"
+```
+
+If the file does not exist or has no entries:
+> "Entity registry is empty. Run `/design-system` to write GDDs — the registry
+> is populated automatically after each GDD is completed. Nothing to check yet."
+
+Stop and exit.
+
+Build four lookup tables from the registry:
+- **entity_map**: `{ name → { source, attributes, referenced_by } }`
+- **item_map**: `{ name → { source, value_gold, weight, ... } }`
+- **formula_map**: `{ name → { source, variables, output_range } }`
+- **constant_map**: `{ name → { source, value, unit } }`
+
+Count total registered entries. Report:
+```
+Registry loaded: [N] entities, [N] items, [N] formulas, [N] constants
+Scope: [full | since-last-review | entity:name]
+```
+
+---
+
+## Phase 2: Locate In-Scope GDDs
+
+```
+Glob pattern="design/gdd/*.md"
+```
+
+Exclude: `game-concept.md`, `systems-index.md`, `game-pillars.md` — these are
+not system GDDs.
+
+For `since-last-review` mode:
+```bash
+git log --name-only --pretty=format: -- design/gdd/ | grep "\.md$" | sort -u
+```
+Limit to GDDs modified since the most recent `design/gdd/gdd-cross-review-*.md`
+file's creation date.
+
+Report the in-scope GDD list before scanning.
+
+---
+
+## Phase 3: Grep-First Conflict Scan
+
+For each registered entry, grep every in-scope GDD for the entry's name.
+Do NOT do full reads — extract only the matching lines and their immediate
+context (-C 3 lines).
+
+This is the core optimization: instead of reading 10 GDDs × 400 lines each
+(4,000 lines), you grep 50 entity names × 10 GDDs (50 targeted searches,
+each returning ~10 lines on a hit).
+
+### 3a: Entity Scan
+
+For each entity in entity_map:
+
+```
+Grep pattern="[entity_name]" glob="design/gdd/*.md" output_mode="content" -C 3
+```
+
+For each GDD hit, extract the values mentioned near the entity name:
+- any numeric attributes (counts, costs, durations, ranges, rates)
+- any categorical attributes (types, tiers, categories)
+- any derived values (totals, outputs, results)
+- any other attributes registered in entity_map
+
+Compare extracted values against the registry entry.
+
+**Conflict detection:**
+- Registry says `[entity_name].[attribute] = [value_A]`. GDD says `[entity_name] has [value_B]`. → **CONFLICT**
+- Registry says `[item_name].[attribute] = [value_A]`. GDD says `[item_name] is [value_B]`. → **CONFLICT**
+- GDD mentions `[entity_name]` but doesn't specify the attribute. → **NOTE** (no conflict, just unverifiable)
+
+### 3b: Item Scan
+
+For each item in item_map, grep all GDDs for the item name. Extract:
+- sell price / value / gold value
+- weight
+- stack rules (stackable / non-stackable)
+- category
+
+Compare against registry entry values.
+
+### 3c: Formula Scan
+
+For each formula in formula_map, grep all GDDs for the formula name. Extract:
+- variable names mentioned near the formula
+- output range or cap values mentioned
+
+Compare against registry entry:
+- Different variable names → **CONFLICT**
+- Output range stated differently → **CONFLICT**
+
+### 3d: Constant Scan
+
+For each constant in constant_map, grep all GDDs for the constant name. Extract:
+- Any numeric value mentioned near the constant name
+
+Compare against registry value:
+- Different number → **CONFLICT**
+
+---
+
+## Phase 4: Deep Investigation (Conflicts Only)
+
+For each conflict found in Phase 3, do a targeted full-section read of the
+conflicting GDD to get precise context:
+
+```
+Read path="design/gdd/[conflicting_gdd].md"
+```
+(Or use Grep with wider context if the file is large)
+
+Confirm the conflict with full context. Determine:
+1. **Which GDD is correct?** Check the `source:` field in the registry — the
+   source GDD is the authoritative owner. Any other GDD that contradicts it
+   is the one that needs updating.
+2. **Is the registry itself out of date?** If the source GDD was updated after
+   the registry entry was written (check git log), the registry may be stale.
+3. **Is this a genuine design change?** If the conflict represents an intentional
+   design decision, the resolution is: update the source GDD, update the registry,
+   then fix all other GDDs.
+
+For each conflict, classify:
+- **🔴 CONFLICT** — same named entity/item/formula/constant with different values
+  in different GDDs. Must resolve before architecture begins.
+- **⚠️ STALE REGISTRY** — source GDD value changed but registry not updated.
+  Registry needs updating; other GDDs may be correct already.
+- **ℹ️ UNVERIFIABLE** — entity mentioned but no comparable attribute stated.
+  Not a conflict; just noting the reference.
+
+---
+
+## Phase 5: Output Report
+
+```
+## Consistency Check Report
+Date: [date]
+Registry entries checked: [N entities, N items, N formulas, N constants]
+GDDs scanned: [N] ([list names])
+
+---
+
+### Conflicts Found (must resolve before architecture)
+
+🔴 [Entity/Item/Formula/Constant Name]
+   Registry (source: [gdd]): [attribute] = [value]
+   Conflict in [other_gdd].md: [attribute] = [different_value]
+   → Resolution needed: [which doc to change and to what]
+
+---
+
+### Stale Registry Entries (registry behind the GDD)
+
+⚠️ [Entry Name]
+   Registry says: [value] (written [date])
+   Source GDD now says: [new value]
+   → Update registry entry to match source GDD, then check referenced_by docs.
+
+---
+
+### Unverifiable References (no conflict, informational)
+
+ℹ️ [gdd].md mentions [entity_name] but states no comparable attributes.
+   No conflict detected. No action required.
+
+---
+
+### Clean Entries (no issues found)
+
+✅ [N] registry entries verified across all GDDs with no conflicts.
+
+---
+
+Verdict: PASS | CONFLICTS FOUND
+```
+
+**Verdict:**
+- **PASS** — no conflicts. Registry and GDDs agree on all checked values.
+- **CONFLICTS FOUND** — one or more conflicts detected. List resolution steps.
+
+---
+
+## Phase 6: Registry Corrections
+
+If stale registry entries were found, ask:
+> "May I update `design/registry/entities.yaml` to fix the [N] stale entries?"
+
+For each stale entry:
+- Update the `value` / attribute field
+- Set `revised:` to today's date
+- Add a YAML comment with the old value: `# was: [old_value] before [date]`
+
+If new entries were found in GDDs that are not in the registry, ask:
+> "Found [N] entities/items mentioned in GDDs that aren't in the registry yet.
+> May I add them to `design/registry/entities.yaml`?"
+
+Only add entries that appear in more than one GDD (true cross-system facts).
+
+**Never delete registry entries.** Set `status: deprecated` if an entry is removed
+from all GDDs.
+
+After writing: Verdict: **COMPLETE** — consistency check finished.
+If conflicts remain unresolved: Verdict: **BLOCKED** — [N] conflicts need manual resolution before architecture begins.
+
+### 6b: Append to Reflexion Log
+
+If any 🔴 CONFLICT entries were found (regardless of whether they were resolved),
+append an entry to `docs/consistency-failures.md` for each conflict:
+
+```markdown
+### [YYYY-MM-DD] — /consistency-check — 🔴 CONFLICT
+**Domain**: [system domain(s) involved]
+**Documents involved**: [source GDD] vs [conflicting GDD]
+**What happened**: [specific conflict — entity name, attribute, differing values]
+**Resolution**: [how it was fixed, or "Unresolved — manual action needed"]
+**Pattern**: [generalised lesson, e.g. "Item values defined in combat GDD were not
+referenced in economy GDD before authoring — always check entities.yaml first"]
+```
+
+Only append if `docs/consistency-failures.md` exists. If the file is missing,
+skip this step silently — do not create the file from this skill.
+
+---
+
+## Next Steps
+
+- **If PASS**: Run `/review-all-gdds` for holistic design-theory review, or
+  `/create-architecture` if all MVP GDDs are complete.
+- **If CONFLICTS FOUND**: Fix the flagged GDDs, then re-run
+  `/consistency-check` to confirm resolution.
+- **If STALE REGISTRY**: Update the registry (Phase 6), then re-run to verify.
+- Run `/consistency-check` after writing each new GDD to catch issues early,
+  not at architecture time.

--- a/skills/qa/content-audit/SKILL.md
+++ b/skills/qa/content-audit/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: content-audit
+description: "Audit GDD-specified content counts against implemented content. Identifies what's planned vs built."
+argument-hint: "[system-name | --summary | (no arg = full audit)]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write
+agent: producer
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version: 1.0.0
+version_origin: extracted
+---
+
+When this skill is invoked:
+
+Parse the argument:
+- No argument → full audit across all systems
+- `[system-name]` → audit that single system only
+- `--summary` → summary table only, no file write
+
+---
+
+## Phase 1 — Context Gathering
+
+1. **Read `design/gdd/systems-index.md`** for the full list of systems, their
+   categories, and MVP/priority tier.
+
+2. **L0 pre-scan**: Before full-reading any GDDs, Grep all GDD files for
+   `## Summary` sections plus common content-count keywords:
+   ```
+   Grep pattern="(## Summary|N enemies|N levels|N items|N abilities|enemy types|item types)" glob="design/gdd/*.md" output_mode="files_with_matches"
+   ```
+   For a single-system audit: skip this step and go straight to full-read.
+   For a full audit: full-read only the GDDs that matched content-count keywords.
+   GDDs with no content-count language (pure mechanics GDDs) are noted as
+   "No auditable content counts" without a full read.
+
+3. **Full-read in-scope GDD files** (or the single system GDD if a system
+   name was given).
+
+4. **For each GDD, extract explicit content counts or lists.** Look for patterns
+   like:
+   - "N enemies" / "enemy types:" / list of named enemies
+   - "N levels" / "N areas" / "N maps" / "N stages"
+   - "N items" / "N weapons" / "N equipment pieces"
+   - "N abilities" / "N skills" / "N spells"
+   - "N dialogue scenes" / "N conversations" / "N cutscenes"
+   - "N quests" / "N missions" / "N objectives"
+   - Any explicit enumerated list (bullet list of named content pieces)
+
+4. **Build a content inventory table** from the extracted data:
+
+   | System | Content Type | Specified Count/List | Source GDD |
+   |--------|-------------|---------------------|------------|
+
+   Note: If a GDD describes content qualitatively but gives no count, record
+   "Unspecified" and flag it — unspecified counts are a design gap worth noting.
+
+---
+
+## Phase 2 — Implementation Scan
+
+For each content type found in Phase 1, scan the relevant directories to count
+what has been implemented. Use Glob and Grep to locate files.
+
+**Levels / Areas / Maps:**
+- Glob `assets/**/*.tscn`, `assets/**/*.unity`, `assets/**/*.umap`
+- Glob `src/**/*.tscn`, `src/**/*.unity`
+- Look for scene files in subdirectories named `levels/`, `areas/`, `maps/`,
+  `worlds/`, `stages/`
+- Count unique files that appear to be level/scene definitions (not UI scenes)
+
+**Enemies / Characters / NPCs:**
+- Glob `assets/data/**/enemies/**`, `assets/data/**/characters/**`
+- Glob `src/**/enemies/**`, `src/**/characters/**`
+- Look for `.json`, `.tres`, `.asset`, `.yaml` data files defining entity stats
+- Look for scene/prefab files in character subdirectories
+
+**Items / Equipment / Loot:**
+- Glob `assets/data/**/items/**`, `assets/data/**/equipment/**`,
+  `assets/data/**/loot/**`
+- Look for `.json`, `.tres`, `.asset` data files
+
+**Abilities / Skills / Spells:**
+- Glob `assets/data/**/abilities/**`, `assets/data/**/skills/**`,
+  `assets/data/**/spells/**`
+- Look for `.json`, `.tres`, `.asset` data files
+
+**Dialogue / Conversations / Cutscenes:**
+- Glob `assets/**/*.dialogue`, `assets/**/*.csv`, `assets/**/*.ink`
+- Grep for dialogue data files in `assets/data/`
+
+**Quests / Missions:**
+- Glob `assets/data/**/quests/**`, `assets/data/**/missions/**`
+- Look for `.json`, `.yaml` definition files
+
+**Engine-specific notes (acknowledge in the report):**
+- Counts are approximations — the skill cannot perfectly parse every engine
+  format or distinguish editor-only files from shipped content
+- Scene files may include both gameplay content and system/UI scenes; the scan
+  counts all matches and notes this caveat
+
+---
+
+## Phase 3 — Gap Report
+
+Produce the gap table:
+
+```
+| System | Content Type | Specified | Found | Gap | Status |
+|--------|-------------|-----------|-------|-----|--------|
+```
+
+**Status categories:**
+- `COMPLETE` — Found ≥ Specified (100%+)
+- `IN PROGRESS` — Found is 50–99% of Specified
+- `EARLY` — Found is 1–49% of Specified
+- `NOT STARTED` — Found is 0
+
+**Priority flags:**
+Flag a system as `HIGH PRIORITY` in the report if:
+- Status is `NOT STARTED` or `EARLY`, AND
+- The system is tagged MVP or Vertical Slice in the systems index, OR
+- The systems index shows the system is blocking downstream systems
+
+**Summary line:**
+- Total content items specified (sum of all Specified column values)
+- Total content items found (sum of all Found column values)
+- Overall gap percentage: `(Specified - Found) / Specified * 100`
+
+---
+
+## Phase 4 — Output
+
+### Full audit and single-system modes
+
+Present the gap table and summary to the user. Ask: "May I write the full report to `docs/content-audit-[YYYY-MM-DD].md`?"
+
+If yes, write the file:
+
+```markdown
+# Content Audit — [Date]
+
+## Summary
+- **Total specified**: [N] content items across [M] systems
+- **Total found**: [N]
+- **Gap**: [N] items ([X%] unimplemented)
+- **Scope**: [Full audit | System: name]
+
+> Note: Counts are approximations based on file scanning.
+> The audit cannot distinguish shipped content from editor/test assets.
+> Manual verification is recommended for any HIGH PRIORITY gaps.
+
+## Gap Table
+
+| System | Content Type | Specified | Found | Gap | Status |
+|--------|-------------|-----------|-------|-----|--------|
+
+## HIGH PRIORITY Gaps
+
+[List systems flagged HIGH PRIORITY with rationale]
+
+## Per-System Breakdown
+
+### [System Name]
+- **GDD**: `design/gdd/[file].md`
+- **Content types audited**: [list]
+- **Notes**: [any caveats about scan accuracy for this system]
+
+## Recommendation
+
+Focus implementation effort on:
+1. [Highest-gap HIGH PRIORITY system]
+2. [Second system]
+3. [Third system]
+
+## Unspecified Content Counts
+
+The following GDDs describe content without giving explicit counts.
+Consider adding counts to improve auditability:
+[List of GDDs and content types with "Unspecified"]
+```
+
+After writing the report, ask:
+
+> "Would you like to create backlog stories for any of the content gaps?"
+
+If yes: for each system the user selects, suggest a story title and point them
+to `/create-stories [epic-slug]` or `/quick-design` depending on the size of the gap.
+
+### --summary mode
+
+Print the Gap Table and Summary directly to conversation. Do not write a file.
+End with: "Run `/content-audit` without `--summary` to write the full report."
+
+---
+
+## Phase 5 — Next Steps
+
+After the audit, recommend the highest-value follow-up actions:
+
+- If any system is `NOT STARTED` and MVP-tagged → "Run `/design-system [name]` to
+  add missing content counts to the GDD before implementation begins."
+- If total gap is >50% → "Run `/sprint-plan` to allocate content work across upcoming sprints."
+- If backlog stories are needed → "Run `/create-stories [epic-slug]` for each HIGH PRIORITY gap."
+- If `--summary` was used → "Run `/content-audit` (no flag) to write the full report to `docs/`."
+
+Verdict: **COMPLETE** — content audit finished.

--- a/skills/safety/contextual-identifier-detectors-overlap-resolution/SKILL.md
+++ b/skills/safety/contextual-identifier-detectors-overlap-resolution/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: contextual-identifier-detectors-overlap-resolution
+description: Detect sensitive identifiers (pods, namespaces, IPs, emails, accounts) using context-anchored regex (e.g. preceded by "namespace=") and resolve overlapping matches by keeping the longest earliest one to avoid corrupting splice replacements.
+category: safety
+version: 1.0.0
+version_origin: extracted
+tags: [regex, masking, identifiers, kubernetes, infrastructure]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/Tracer-Cloud/opensre.git
+source_ref: main
+source_commit: fb5ba0a1b4ef511d16c56a80f1f126b1f581d724
+source_project: opensre
+source_path: app/masking/detectors.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Contextual Identifier Detectors with Overlap Resolution
+
+## When to use
+You need regex detectors for infrastructure identifiers but generic words like `frontend` or `worker` should NOT match. Anchoring to a label like `namespace=foo` or `kube_cluster:bar` and capturing only group(1) is the trick. Then you must resolve overlaps before splicing replacements into the source string.
+
+## How it works
+- Each detector is a `re.Pattern` anchored on the identifier label (`namespace`, `cluster`, `service`).
+- The capture group(1) holds just the value, so the label is preserved.
+- `_resolve_overlaps` sorts matches by `(start ASC, length DESC)` and drops any candidate whose span shares a single character with an already-kept match. Required because reverse-order splicing corrupts when spans overlap.
+
+## Example
+```python
+_NAMESPACE_RE = re.compile(
+    r"\b(?:kube_namespace|namespace|ns)[=:\s]+([a-z0-9][-a-z0-9]*)\b",
+    re.IGNORECASE,
+)
+_CLUSTER_RE = re.compile(
+    r"\b(?:kube_cluster|eks_cluster|cluster(?:_name)?)[=:\s]+"
+    r"([a-zA-Z0-9][-a-zA-Z0-9_]{1,})\b", re.IGNORECASE,
+)
+
+def _resolve_overlaps(matches):
+    by_start = sorted(matches, key=lambda m: (m.start, -(m.end - m.start)))
+    result = []
+    for m in by_start:
+        if any(
+            kept.start < m.end and kept.end > m.start and kept is not m
+            for kept in result
+        ):
+            continue
+        result.append(m)
+    return sorted(result, key=lambda m: m.start)
+```
+
+## Gotchas
+- For DNS-style hostnames, exclude `.` from the inner character class so the outer `(?:\.LABEL)*` cannot backtrack exponentially (CodeQL ReDoS).
+- Account ID detectors `\b\d{12}\b` will catch any 12-digit number — pair with policy gating so you can opt out per environment.
+- When two detectors match overlapping regions, pick the longest. `[KIND_0]` placeholder for the inner span will mangle output if the outer span is replaced first.

--- a/skills/telemetry/clearcut-batch-flush-with-retry/SKILL.md
+++ b/skills/telemetry/clearcut-batch-flush-with-retry/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: clearcut-batch-flush-with-retry
+description: Buffer telemetry events in-memory with drop-oldest overflow, flush on a timer, optimistically remove events before send, requeue on transient errors, honor server-provided `next_request_wait_millis`, and race a final flush with a shutdown deadline.
+category: telemetry
+version: 1.0.0
+version_origin: extracted
+tags: [telemetry, batching, retry, clearcut, shutdown]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/ChromeDevTools/chrome-devtools-mcp.git
+source_ref: main
+source_commit: 0a6aaa52ebacb2db834ffa437863e5844aa3730b
+source_project: chrome-devtools-mcp
+source_path: src/telemetry/watchdog/ClearcutSender.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Telemetry Batch Flush with Retry and Shutdown Drain
+
+## When to use
+
+- You're shipping low-value-per-event telemetry to a batch endpoint (Google Clearcut, any log pipeline) and want to minimize request overhead.
+- Events arrive continuously; sending per-event wastes requests and money.
+- You need to honor server-side rate-limit hints and survive transient network flakiness without losing events.
+
+## How it works
+
+- Buffer events in a bounded array (`MAX_BUFFER_SIZE = 1000`). On enqueue, if the buffer is full, drop the *oldest* event with a log line (never tail-drop — you want to keep most-recent behavior visible).
+- Single-shot flush timer: default 15 min. Only start it when the first event arrives; don't spin a perpetual timer on an idle process.
+- On flush: guard with `#isFlushing`, copy `buffer` to a local and empty it *before* the network call (prevents a shutdown race from double-sending), then send.
+- Response handling: `response.ok` → read `next_request_wait_millis` and clamp to `MIN_RATE_LIMIT_WAIT_MS` (e.g. 30s) for the next flush. 5xx/429 → transient: requeue at the *front* so order is preserved. 4xx other → permanent: drop and log.
+- Shutdown path: clear the flush timer, enqueue a synthetic `server_shutdown` event, then `await Promise.race([finalFlush(), setTimeout(SHUTDOWN_TIMEOUT_MS)])`. Never `await` flush unbounded on exit.
+- Rotate `session_id` at a fixed interval (e.g. 24h) so long-running processes get session breaks in the data.
+
+## Example
+
+```ts
+async #flush() {
+  if (this.#isFlushing) return;
+  if (this.#buffer.length === 0) { this.#scheduleFlush(this.#flushIntervalMs); return; }
+  this.#isFlushing = true;
+  let nextDelay = this.#flushIntervalMs;
+  const eventsToSend = [...this.#buffer];
+  this.#buffer = []; // remove first, so a concurrent #finalFlush won't double-send
+  try {
+    const result = await this.#sendBatch(eventsToSend);
+    if (result.success) {
+      if (result.nextRequestWaitMs !== undefined)
+        nextDelay = Math.max(result.nextRequestWaitMs, MIN_RATE_LIMIT_WAIT_MS);
+    } else if (result.isPermanentError) {
+      logger('Permanent error, dropped', eventsToSend.length, 'events');
+    } else { // transient: requeue at front, keep order
+      this.#buffer = [...eventsToSend, ...this.#buffer];
+    }
+  } catch (e) {
+    this.#buffer = [...eventsToSend, ...this.#buffer];
+  } finally {
+    this.#isFlushing = false;
+    this.#scheduleFlush(nextDelay);
+  }
+}
+
+async sendShutdownEvent() {
+  if (this.#flushTimer) clearTimeout(this.#flushTimer);
+  this.enqueueEvent({server_shutdown: {}});
+  await Promise.race([this.#finalFlush(), new Promise(r => setTimeout(r, SHUTDOWN_TIMEOUT_MS))]);
+}
+```
+
+## Gotchas
+
+- The "remove from buffer before send, restore on transient error" order is load-bearing. The opposite order (send-then-remove) loses events if a simultaneous shutdown path calls `finalFlush` on the same buffer.
+- Set an `AbortController` with a `REQUEST_TIMEOUT_MS` (e.g. 30s) on fetch. A hung endpoint without a timeout keeps the flush guard set and stalls shutdown.
+- Distinguish 429 (retry) from 4xx other (drop). A lot of retry systems treat all 4xx as permanent and silently bleed rate-limited events.
+- Requeue at the *front* of the buffer on transient errors to preserve chronological order. Appending shuffles the timeline.
+- `session_id` should be stable for the session but rotated for very long processes (daemon mode). Include it in every event envelope.

--- a/skills/testing-gpu/comprehensive-gpu-kernel-testing-harness/SKILL.md
+++ b/skills/testing-gpu/comprehensive-gpu-kernel-testing-harness/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: comprehensive-gpu-kernel-testing-harness
+description: Test GPU kernels by running random-shape sweeps against a FP32 reference, using tolerance-aware diff metrics that account for quantization noise, plus TFLOPS/bandwidth bench.
+category: testing-gpu
+version: 1.0.0
+version_origin: extracted
+tags: [testing, gpu-kernels, quantization, benchmarking, numerical-validation]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - tests/test_mega_moe.py
+  - tests/test_fp8_fp4.py
+  - deep_gemm/testing/__init__.py
+imported_at: 2026-04-18T13:12:58Z
+---
+
+# Comprehensive GPU Kernel Testing Harness
+
+## What / Why
+Low-precision GEMM kernels cannot be compared against a `torch.matmul` baseline with a fixed `atol` — quantization error is shape-and-granularity-dependent. A proper test harness generates random shapes, computes a BF16/FP32 reference *with the same quantization*, compares via a tolerance-aware diff, and tracks performance so accuracy improvements don't silently regress throughput.
+
+## Procedure
+1. **Shape sweep.** Parametrize `m ∈ [1, 8192]`, `n, k ∈ [256, 16384]`, vary channel dims for MoE; include edge cases (`m=1`, `k=gran_k`, non-multiples of block sizes).
+2. **Reference pipeline.**
+   - Cast inputs to FP32.
+   - Apply the *same* per-token/per-block quantization recipe (`per_token_cast_to_fp8`) used by the kernel.
+   - Dequantize back to FP32.
+   - Matmul in FP32 for ground truth.
+3. **Tolerance-aware diff.**
+   - `calc_diff(actual, expected)` uses relative error, with `atol` scaled by `gran_k` (coarser granularity → looser tolerance).
+   - For FP4 weights: `atol ≈ 0.02` is typical; for FP8: `atol ≈ 0.005`.
+4. **Performance bench.** `bench(fn, num_warmup, num_runs)` returns median μs; convert to TFLOPS via `2 × m × n × k / time`; compare against roofline (MFU %).
+5. **Distributed flows.** Run MoE tests under `torch.distributed` with a reference kernel (e.g., DeepEP) on the same synthetic data to catch rank-coordination bugs.
+
+## Key design points
+- Never compare low-precision output against `torch.matmul(bf16)` — the reference must share the quantization step, or you're measuring "FP8 vs FP32" instead of "our kernel vs reference FP8".
+- Separate correctness and perf into different test files so CI can skip perf on non-GPU runners.
+- Log the shape, config (block_m/n/k, num_stages), and MFU in every bench output — regressions are shape-specific.
+
+## References
+- `deep_gemm/testing/__init__.py` — `calc_diff`, `bench`, shape generators.
+- `tests/test_fp8_fp4.py` — GEMM correctness sweep.
+- `tests/test_mega_moe.py` — distributed MoE correctness + bench against DeepEP.

--- a/skills/testing-gpu/cosine-similarity-diff-for-fp8-numerics/SKILL.md
+++ b/skills/testing-gpu/cosine-similarity-diff-for-fp8-numerics/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: cosine-similarity-diff-for-fp8-numerics
+description: Compare two tensors with `1 - 2*sum(x*y)/sum(x^2 + y^2)` instead of absolute max-diff — scale-insensitive, handles all-zero tensors, and gives an interpretable "fraction of disagreement" for FP8/FP4 reference-testing.
+category: testing-gpu
+version: 1.0.0
+version_origin: extracted
+tags: [numeric-testing, fp8, fp4, cosine-similarity, tolerance, gpu-testing]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - deep_gemm/testing/numeric.py
+  - tests/generators.py
+imported_at: 2026-04-18T13:30:00Z
+---
+
+# Scale-Invariant Tensor Diff For Low-Precision GEMMs
+
+## When to use
+You're reference-testing a low-precision (FP8, FP4) GEMM against a BF16/FP32 truth. The usual `(x - y).abs().max()` is hostile:
+- If `x` and `y` both have large dynamic range, max-diff is dominated by the single largest element even if 99% of the tensor matches.
+- If one scaling factor is off, max-diff exaggerates. What you actually care about is "are they the same direction, roughly the same length".
+- Max-diff doesn't map to a meaningful per-kernel tolerance — you end up tuning per-test magic numbers.
+
+A cosine-similarity-style metric gives you a single scale-invariant number in roughly `[0, 2]`, and `< 0.001` is a clean bar for exact FP8 work.
+
+## Steps
+1. **Cast to double** before summing so a 10⁸-element tensor doesn't overflow or lose bits to FP32 summation:
+   ```python
+   x, y = x.double(), y.double()
+   ```
+2. **Compute the denominator** — sum of squared norms:
+   ```python
+   denominator = (x * x + y * y).sum()
+   ```
+3. **Handle the all-zero degenerate case** before dividing:
+   ```python
+   if denominator == 0:  # both x and y are all zero
+       return 0.0
+   ```
+   Without this guard you'd get NaN. Zero is the semantically correct answer (they agree perfectly on "all zero").
+4. **Cosine score, flipped to "diff":**
+   ```python
+   sim = 2 * (x * y).sum() / denominator
+   return 1 - sim
+   ```
+   - `sim == 1` iff `x == y`; `sim ∈ [-1, 1]` in general.
+   - `diff = 1 - sim` maps to `[0, 2]`, with 0 = identical, 2 = negated.
+5. **Set per-precision tolerances** at the test level, not inside the metric:
+   ```python
+   def max_diff(self) -> float:
+       if self.is_fp4_a and self.is_fp4_b: return 0.02
+       if self.is_fp4_a or self.is_fp4_b: return 0.01
+       return 0.001  # FP8 baseline
+   ```
+   Separate tolerances encode the precision hierarchy explicitly.
+
+## Evidence (from DeepGEMM)
+- `deep_gemm/testing/numeric.py:5-11`: the `calc_diff` implementation with the `denominator == 0` guard.
+- `tests/generators.py:64-69`: the precision-tier tolerance table (`QuantConfig.max_diff()`).
+
+## Counter / Caveats
+- **This metric doesn't catch uniform shifts.** `x + 1000` has cosine 1 with `x`. If you care about bias, add a `(x - y).abs().mean() / x.abs().mean()` check alongside.
+- **Cast to `double` costs memory.** A 100M-element tensor becomes 800MB of doubles. For 10B+ tensors, chunk the computation or stay in FP32 with Kahan summation.
+- **`0.001` is FP8-tight on DeepGEMM's workloads.** A noisier kernel (e.g. an indexer with relu weights) legitimately exceeds it. Don't copy the number blindly — measure what your clean reference produces and set tolerance accordingly.
+- **For grouped GEMMs with per-group scales**, compute diff per-group and take the max. Single scalar over the whole concatenated tensor can hide a single bad expert.

--- a/skills/web/content-disposition-filename-fallback/SKILL.md
+++ b/skills/web/content-disposition-filename-fallback/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: content-disposition-filename-fallback
+description: Derive a best-guess filename + extension from an HTTP response by checking Content-Disposition header first, then the URL's basename, then falling back to nothing — with quote stripping and robust extraction.
+category: web
+version: 1.0.0
+tags: [web, http, content-disposition, filename, ingestion, python]
+source_type: extracted-from-git
+source_url: https://github.com/microsoft/markitdown.git
+source_ref: main
+source_commit: 604bba13da2f43b756b49122cb65bdedb85b1dff
+source_project: markitdown
+source_path: packages/markitdown/src/markitdown/_markitdown.py
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version_origin: extracted
+---
+
+# HTTP filename fallback chain: Content-Disposition → URL path → nothing
+
+When ingesting a remote file you need a filename (for extension-based handler dispatch, for display, or for reporting). Servers are inconsistent about what they tell you, so follow a strict fallback chain and don't assume any one source is present.
+
+## The chain
+
+```python
+import os, re
+from urllib.parse import urlparse
+import requests
+
+def infer_filename_and_extension(response: requests.Response) -> tuple[str | None, str | None]:
+    filename: str | None = None
+    extension: str | None = None
+
+    # 1. Content-Disposition header — most authoritative when present.
+    cd = response.headers.get("content-disposition")
+    if cd:
+        m = re.search(r"filename=([^;]+)", cd)
+        if m:
+            filename = m.group(1).strip().strip('"').strip("'")
+            _, _ext = os.path.splitext(filename)
+            if _ext:
+                extension = _ext
+
+    # 2. URL path — use the last path segment if it has an extension.
+    if filename is None:
+        parsed = urlparse(response.url)
+        _, _ext = os.path.splitext(parsed.path)
+        if _ext:                                    # has-extension implies "this looks file-like"
+            filename = os.path.basename(parsed.path)
+            extension = _ext
+
+    # 3. Give up — caller may rely on mimetype + content sniffing instead.
+    return filename, extension
+```
+
+## Why exactly this order
+
+- **Content-Disposition** (RFC 6266) is the server's deliberate declaration: "this should be saved as X." When present, trust it over the URL.
+- **URL basename** is usually reliable for static-file servers (`/reports/q4.pdf`), but unreliable for endpoints that generate content from a slug (`/download/abc123`).
+- **Nothing** — many endpoints return no filename signal at all. Your downstream code must cope with `filename = None` via mimetype-based dispatch or content sniffing (see `multi-signal-mime-detection-stream-info`).
+
+## Edge cases covered by the regex
+
+- `Content-Disposition: attachment; filename=report.pdf` → `report.pdf`
+- `Content-Disposition: attachment; filename="report.pdf"` → `report.pdf` (`.strip('"')`)
+- `Content-Disposition: attachment; filename='report.pdf'` → `report.pdf` (`.strip("'")`)
+- `Content-Disposition: inline; filename=report.pdf; filename*=UTF-8''report.pdf` — the simple regex picks the first `filename=`, which is fine; `filename*` is usually the same in ASCII-named cases.
+
+## Edge cases the simple version misses
+
+- **`filename*` RFC 5987 encoding.** For UTF-8/Unicode names (Japanese, emoji, etc.), servers use `filename*=UTF-8''%E4%B8%AD%E6%96%87.pdf`. If you need that, use the `werkzeug.http.parse_options_header` parser or the `email.message.Message` header parser — the regex above won't decode them.
+- **Semicolons in quoted values.** Pathological but legal: `filename="report; final.pdf"`. The regex `[^;]+` terminates at the first `;`. For robust parsing, use `werkzeug.http.parse_options_header` which understands the grammar.
+- **Missing path extension.** URLs like `/downloads/12345` have no extension in the path. You'll get `filename = None`; that's correct.
+- **Query strings.** `urlparse(...).path` excludes the query, so `?download=1` doesn't corrupt the basename.
+
+## Robust variant (recommended for production)
+
+```python
+from werkzeug.http import parse_options_header
+
+def infer_filename_and_extension_robust(response):
+    cd = response.headers.get("content-disposition", "")
+    _, params = parse_options_header(cd)
+    filename = params.get("filename*") or params.get("filename")
+    if filename:
+        _, ext = os.path.splitext(filename)
+        return filename, ext or None
+
+    parsed = urlparse(response.url)
+    _, ext = os.path.splitext(parsed.path)
+    if ext:
+        return os.path.basename(parsed.path), ext
+    return None, None
+```
+
+`parse_options_header` handles RFC 5987 encoding and quoted values correctly.
+
+## Putting it together with mimetype
+
+```python
+def stream_info_from_response(resp):
+    filename, extension = infer_filename_and_extension(resp)
+    mimetype, charset = None, None
+    if "content-type" in resp.headers:
+        parts = resp.headers["content-type"].split(";")
+        mimetype = parts.pop(0).strip()
+        for part in parts:
+            if part.strip().startswith("charset="):
+                v = part.split("=", 1)[1].strip()
+                if v: charset = v
+    return StreamInfo(
+        mimetype=mimetype, extension=extension, charset=charset,
+        filename=filename, url=resp.url,
+    )
+```
+
+## Anti-patterns
+
+- **Trusting `url.split("/")[-1]` as the filename.** Doesn't handle query strings; doesn't detect "this path doesn't point to a file."
+- **Using `response.url.endswith(".pdf")` to pick a handler.** Query strings (`?v=2`) break this; some servers redirect `.pdf` URLs to a generated endpoint without an extension.
+- **Downloading before filename extraction.** The URL and headers give you what you need to pick a handler *before* streaming gigabytes.
+- **Ignoring quotes in Content-Disposition.** Raw `filename="report.pdf"` becomes `"report.pdf"` (with literal quotes) unless you strip.
+
+## Variations
+
+- **For streaming APIs** (no Content-Disposition, no extension), fall straight to content sniffing (`magika`) on the first buffered chunk.
+- **For S3 / presigned URLs**, parse the URL *path* ignoring the query signature: `urlparse(url).path` already does this.
+- **For proxied downloads**, pass `response.history[-1].url` if you want the original URL rather than the final-redirect URL.

--- a/skills/workflow/completion-signal-detector/SKILL.md
+++ b/skills/workflow/completion-signal-detector/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: completion-signal-detector
+description: Detect AI "I'm done" signals in loop prompts using `<promise>SIGNAL</promise>` tags as primary, with a restrictive end-of-output / own-line plain match as legacy fallback.
+category: workflow
+version: 1.0.0
+version_origin: extracted
+tags: [workflow, loop, completion, signal, regex]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/coleam00/Archon.git
+source_ref: dev
+source_commit: d89bc767d291f52687beea91c9fcf155459be0d9
+source_project: Archon
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# AI Completion Signal Detector (`<promise>` Tag + Restrictive Plain Fallback)
+
+## When to use
+
+- You run an AI inside a `loop:` node that continues until the model emits a "done" signal. The model's output is free-form prose, so you need a robust way to distinguish "the model thinks it's finished" from "the model said the word 'COMPLETE' in passing."
+- Naive `output.includes('COMPLETE')` false-positives constantly (the model says "not COMPLETE yet", "ABORT if COMPLETE fails", "the COMPLETE signal means…").
+- You want a primary format that is **impossible to confuse with prose** and a fallback that handles models which forget the tag.
+
+## Steps
+
+1. **Define the primary format as XML-like tags**: `<promise>COMPLETE</promise>`. Tell the model in the system prompt: "When finished, emit `<promise>COMPLETE</promise>` on its own."
+   Tags win over plain signals because they are visually distinct in prose, easy for regex, and rarely appear by accident.
+2. **Detect with a case-insensitive regex** that tolerates whitespace around the signal:
+   ```ts
+   new RegExp(`<promise>\\s*${escapeRegExp(signal)}\\s*</promise>`, 'i')
+   ```
+3. **Add a restrictive plain-signal fallback** only for legacy prompts that haven't been updated. Two patterns, OR-ed:
+   - **End-of-output:** the signal is the last non-whitespace token, optionally followed by punctuation:
+     ```ts
+     new RegExp(`${escapeRegExp(signal)}[\\s.,;:!?]*$`)
+     ```
+   - **Own line:** the signal occupies its own line (no other content on that line):
+     ```ts
+     new RegExp(`^\\s*${escapeRegExp(signal)}\\s*$`, 'm')
+     ```
+4. **Always `escapeRegExp(signal)` first** — users may configure signals with regex metacharacters.
+5. **Strip tags before sending output to the user.** Archon has `stripCompletionTags(content)` which removes `<promise>[\s\S]*?</promise>` so the user never sees the internal signal.
+6. **Pair signal detection with an optional deterministic check** (`until_bash:` in Archon) — a shell command whose exit-0 also means "done." The loop exits when **either** the signal **or** the bash check fires. This gives you a deterministic escape hatch when the AI is unreliable.
+7. **Never treat `<promise>` substring match alone as enough.** A model saying "I promise to continue" should not match. The closing tag is required.
+
+## Counter / Caveats
+
+- Pick a **distinctive** signal string. Archon uses `TASK_COMPLETE`, `LOOP_DONE`, etc. — all-caps, compound, unlikely in prose.
+- **Don't** loosen the plain fallback to "anywhere in output." That's exactly the false-positive class the tag format exists to avoid. Archon's plain rule is deliberately strict.
+- For interactive approval loops (human-in-the-loop), gate the signal additionally on "did the user actually provide input this iteration?" — the AI shouldn't self-approve on iteration zero. Archon does this via `interactiveFirstRun = loop.interactive && !isLoopResume`.
+- Case-insensitive matches **only for the tags**, not the signal body. `<Promise>COMPLETE</Promise>` should match; `<promise>complete</promise>` should not (unless your signal is itself lowercase).
+
+## Evidence
+
+- `packages/workflows/src/executor-shared.ts:362-400`: full `detectCompletionSignal` + `stripCompletionTags` + `escapeRegExp`.
+- Primary pattern at `executor-shared.ts:384`: `<promise>\\s*${signal}\\s*</promise>` (case-insensitive).
+- Plain fallback patterns at `executor-shared.ts:392-393`: end-of-output + own-line.
+- Used in `packages/workflows/src/dag-executor.ts:1750` to decide loop-node completion, OR-combined with `until_bash` at :1786.
+- Interactive-first-run gate at `dag-executor.ts:1817-1818`.
+- Commit SHA: d89bc767d291f52687beea91c9fcf155459be0d9.


### PR DESCRIPTION
## Batch
- batch 4/24

## Knowledge (27)
- `ci-cd/ci-gpg-signing-batch-mode-non-interactive`
- `ci-cd/ci-push-race-condition-retry-rebase-loop`
- `reference/claude-cli-hook-bypass-envs`
- `api/claude-session-resume-semantics`
- `api/claude-stream-json-protocol`
- `pitfall/claudecode-env-breaks-nested-spawn`
- `pitfall/claudecode-env-var-leakage`
- `reference/clearcut-source-and-client-type-constants`
- `arch/cli-implemented-in-rust-for-speed`
- `decision/cli-release-accompanies-prod-deploy`
- `api/cli-release-via-git-tag`
- `clipboard/clipboard-context-lazy-initialization`
- `clipboard/clipboard-ownership-protocol`
- `pitfall/codex-oauth-strips-vars-at-spawn`
- `pitfall/codex-seatbelt-ignores-network-access`
- `collaboration/collaborative-design-principles`
- `pytorch-integration/compute-sanitizer-needs-temp-cublaslt-workspace`
- `engineering/condition-based-waiting`
- `reference/config-dir-layout`
- `arch/config-minimization-min-json`
- _... and 7 more_

## Skills (23)
- `ml-ops/chunked-tts-with-crossfade`
- `agent-sdk/claude-agent-sdk-multi-provider-bridge`
- `integration/claude-cli-grace-kill-after-success-result`
- `operations/claude-cli-unattended-wrapper`
- `agents/claude-code-stream-json-driver`
- `telemetry/clearcut-batch-flush-with-retry`
- `cli/cli-output-format-dispatch-with-template`
- `cli/cli-serve-blocking-exit`
- `build-system/cmake-cuda-extension-with-git-submodule-vendoring`
- `engineering/code-review`
- `agents/coding-agent-cli-backend-interface`
- `workflow/completion-signal-detector`
- `testing-gpu/comprehensive-gpu-kernel-testing-harness`
- `integration/computer-use-agent`
- `integration/confidence-lowering-by-source-factor`
- `model-loading/config-json-architecture-dispatch`
- `qa/consistency-check`
- `qa/content-audit`
- `web/content-disposition-filename-fallback`
- `data/content-type-info-metadata-embedding`
- _... and 3 more_

## Source
- project: F:/workspace/tool (bulk extract)
- batch plan: .omc/batch-plan.json

## Post-merge
After squash-merge, run step 7 to re-anchor skill tags at the merge commit.