### PR TITLE
Publish batch 6/24: 19 knowledge + 31 skills

### DIFF
--- a/index.json
+++ b/index.json
@@ -152,6 +152,24 @@
   },
   {
     "kind": "knowledge",
+    "name": "device-revocation-status-codes-contract",
+    "slug": "device-revocation-status-codes-contract",
+    "category": "api",
+    "description": "",
+    "tags": [
+      "api",
+      "http-status",
+      "powersync",
+      "devices",
+      "auth"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/auth/device-revocation-status-codes-contract.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "endpoint-service-dual-pattern",
     "slug": "endpoint-service-dual-pattern",
     "category": "api",
@@ -556,6 +574,24 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/arch/data-patch-package-for-migrations.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "devtools-frontend-reused-as-library",
+    "slug": "devtools-frontend-reused-as-library",
+    "category": "arch",
+    "description": "The project imports pieces of Chrome DevTools Frontend (`TraceEngine`, `PerformanceTraceFormatter`, `HeapSnapshotModel`, `IssuesManager`, `CrUXManager`) as a library dependency, so tool output matches what users see in the real DevTools panels.",
+    "tags": [
+      "devtools",
+      "library-reuse",
+      "trace-engine",
+      "heap-snapshot",
+      "third-party"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/devtools-frontend-reused-as-library.md",
     "has_content": true
   },
   {
@@ -2044,6 +2080,56 @@
   },
   {
     "kind": "knowledge",
+    "name": "dual-backend-claude-and-pi",
+    "slug": "dual-backend-claude-and-pi",
+    "category": "architecture",
+    "description": "Why Craft Agents runs two AgentBackend implementations (Claude SDK + Pi SDK) side by side instead of a single abstraction — different provider ergonomics, auth flows, and model capabilities.",
+    "tags": [
+      "agent-sdk",
+      "pi-sdk",
+      "backend",
+      "provider-routing"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/architecture/dual-backend-claude-and-pi.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "dynamic-uv-python-scripts",
+    "slug": "dynamic-uv-python-scripts",
+    "category": "architecture",
+    "description": "Craft Agents ships a bundled uv binary and a set of PEP-723 self-dependency Python scripts (pdf_tool, docx_tool, xlsx_tool, markitdown, ical_tool, ...) so document-handling tools work without asking the user to install Python.",
+    "tags": [
+      "python",
+      "uv",
+      "pep-723",
+      "document-tools"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/architecture/dynamic-uv-python-scripts.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "effect-ts-layer-dependency-injection-for-testing",
+    "slug": "effect-ts-layer-dependency-injection-for-testing",
+    "category": "architecture",
+    "description": "Effect.ts Layers provide compile-time dependency injection; compose layers to swap real services with test stubs",
+    "tags": [
+      "effect-ts",
+      "testing",
+      "architecture"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/architecture/effect-ts-layer-dependency-injection-for-testing.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "ci-gpg-signing-batch-mode-non-interactive",
     "slug": "ci-gpg-signing-batch-mode-non-interactive",
     "category": "ci-cd",
@@ -2114,6 +2200,24 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/clipboard/clipboard-ownership-protocol.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "display-orientation-rotation-handling",
+    "slug": "display-orientation-rotation-handling",
+    "category": "codecs",
+    "description": "Cache RotationMode per display and apply during capture (DXGI, Quartz, X11) — don't re-probe per frame.",
+    "tags": [
+      "codecs",
+      "display",
+      "handling",
+      "orientation",
+      "rotation"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/codecs/display-orientation-rotation-handling.md",
     "has_content": true
   },
   {
@@ -2777,6 +2881,42 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/decision/dataavro-json-wrapper-pattern.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "desktop-route-categories",
+    "slug": "desktop-route-categories",
+    "category": "decision",
+    "description": "Every path in a tab-based Electron desktop app falls into exactly one of three categories — session routes, transition flows (overlays), or error/stale states (auto-healed).",
+    "tags": [
+      "electron",
+      "desktop",
+      "routing",
+      "tabs",
+      "overlay"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/desktop-route-categories.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "directory-rename-is-atomic-not-file-rename",
+    "slug": "directory-rename-is-atomic-not-file-rename",
+    "category": "decision",
+    "description": "",
+    "tags": [
+      "atomicity",
+      "rename",
+      "filesystem",
+      "distributed",
+      "jit-cache"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/jit-compilation/directory-rename-is-atomic-not-file-rename.md",
     "has_content": true
   },
   {
@@ -3684,6 +3824,23 @@
   },
   {
     "kind": "knowledge",
+    "name": "dockerfile-server-design-choices",
+    "slug": "dockerfile-server-design-choices",
+    "category": "devops",
+    "description": "Why Dockerfile.server uses oven/bun:1.3-slim, creates a non-root craftagents user, chmod's with find -not -perm, and ships the CJS-bundled MCP helpers — each choice solved a real production issue.",
+    "tags": [
+      "docker",
+      "bun",
+      "non-root",
+      "image-optimization"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/devops/dockerfile-server-design-choices.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "a11y-uid-tool-targeting-over-selectors",
     "slug": "a11y-uid-tool-targeting-over-selectors",
     "category": "domain",
@@ -3988,6 +4145,41 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/llm-agents/agent-runner-loop-semantics.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "dflash-block-diffusion-overview",
+    "slug": "dflash-block-diffusion-overview",
+    "category": "llm-agents",
+    "description": "DFlash is a block-diffusion draft model for speculative decoding — drafts a whole block of tokens in parallel using target hidden states as cross-context, then a single target forward verifies them.",
+    "tags": [
+      "speculative-decoding",
+      "block-diffusion",
+      "draft-model",
+      "dflash"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/llm-agents/dflash-block-diffusion-overview.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "easyedit-framework",
+    "slug": "easyedit-framework",
+    "category": "llm-fundamentals",
+    "description": "EasyEdit is a unified Python framework from ZJU-NLP for editing factual knowledge in pretrained LLMs.",
+    "tags": [
+      "easyedit",
+      "knowledge-editing",
+      "rome",
+      "memit",
+      "fact-editing"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/llm-fundamentals/easyedit-framework.md",
     "has_content": true
   },
   {
@@ -4815,6 +5007,23 @@
   },
   {
     "kind": "knowledge",
+    "name": "dev-sh-auto-setup-idempotent",
+    "slug": "dev-sh-auto-setup-idempotent",
+    "category": "pitfall",
+    "description": "make dev should auto-detect worktree vs main, create the right env file, install deps, start DB, run migrations, start services — idempotent on re-run.",
+    "tags": [
+      "makefile",
+      "dev-setup",
+      "idempotent",
+      "onboarding"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/dev-sh-auto-setup-idempotent.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "distributed-tracing-implementation-pitfall",
     "slug": "distributed-tracing-implementation-pitfall",
     "category": "pitfall",
@@ -4872,6 +5081,22 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/pitfall/domain-driven-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "drive-by-refactor-beyond-bug-fix",
+    "slug": "drive-by-refactor-beyond-bug-fix",
+    "category": "pitfall",
+    "description": "Asked to fix \"empty emails crash the validator\", LLMs also tighten email regex, add username length/alnum checks, and add docstrings. That pollutes the diff and can introduce new bugs. Fix only the reported issue.",
+    "tags": [
+      "diff-hygiene",
+      "surgical-changes",
+      "bug-fix-discipline"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/drive-by-refactor-beyond-bug-fix.md",
     "has_content": true
   },
   {
@@ -6681,6 +6906,25 @@
   },
   {
     "kind": "knowledge",
+    "name": "display-enumeration-winapi-structs",
+    "slug": "display-enumeration-winapi-structs",
+    "category": "platform/windows",
+    "description": "DisplayInfo protobuf encodes width, height, HiDPI scaling, monitor index mapping.",
+    "tags": [
+      "display",
+      "enumeration",
+      "platform",
+      "structs",
+      "winapi",
+      "windows"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/windows/display-enumeration-winapi-structs.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "alert-extraction-single-llm-call-pattern",
     "slug": "alert-extraction-single-llm-call-pattern",
     "category": "reference",
@@ -6793,6 +7037,83 @@
   },
   {
     "kind": "knowledge",
+    "name": "dex2jar-apk-to-jar-intermediate-conversion",
+    "slug": "dex2jar-apk-to-jar-intermediate-conversion",
+    "category": "reference",
+    "description": "dex2jar (`d2j-dex2jar`) converts Android DEX bytecode to standard Java JAR so that JVM-only decompilers (Fernflower/Vineflower, CFR, Procyon) can process APK content that they cannot read natively.",
+    "tags": [
+      "android",
+      "dex2jar",
+      "dex",
+      "apk",
+      "jvm",
+      "bytecode",
+      "conversion",
+      "reverse-engineering",
+      "reference"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/reference/dex2jar-apk-to-jar-intermediate-conversion.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "dflash-backend-support-matrix",
+    "slug": "dflash-backend-support-matrix",
+    "category": "reference",
+    "description": "Quick-reference table of which inference backends support DFlash, their install commands, required flags, and model coverage — distilled from the DFlash README.",
+    "tags": [
+      "dflash",
+      "vllm",
+      "sglang",
+      "transformers",
+      "mlx",
+      "speculative-decoding",
+      "reference"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/reference/dflash-backend-support-matrix.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "docs-mcp-always-on",
+    "slug": "docs-mcp-always-on",
+    "category": "reference",
+    "description": "Craft Agents wires craft-agents-docs as an always-available MCP server pointing at https://agents.craft.do/docs/mcp inside craft-agent.ts — not a user-configurable source — so the agent always has access to product docs for search.",
+    "tags": [
+      "mcp",
+      "docs",
+      "always-on",
+      "craft-agents-docs"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/reference/docs-mcp-always-on.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "dual-sided-worker-pool-toggle",
+    "slug": "dual-sided-worker-pool-toggle",
+    "category": "reference",
+    "description": "An evolver node only accepts hub-dispatched tasks when BOTH sides are turned on — local `WORKER_ENABLED=1` env var AND the \"Worker\" toggle on the evomap.ai node dashboard. Either side off means zero task flow, with no error; silent no-op is by design.",
+    "tags": [
+      "worker-pool",
+      "dual-sided-toggle",
+      "env-config",
+      "hub-side",
+      "gotcha"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/reference/dual-sided-worker-pool-toggle.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "vector-clock-ui-dominance-tri-state-color",
     "slug": "vector-clock-ui-dominance-tri-state-color",
     "category": "reference",
@@ -6892,6 +7213,24 @@
   },
   {
     "kind": "knowledge",
+    "name": "docs-claude-context",
+    "slug": "docs-claude-context",
+    "category": "workflow",
+    "description": "Claude context file for docs directory — guidelines for documentation authoring",
+    "tags": [
+      "game-studios",
+      "ccgs",
+      "claude-md",
+      "documentation",
+      "context"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/workflow/docs-claude-context.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "dropin-module-reality-check-before-wire",
     "slug": "dropin-module-reality-check-before-wire",
     "category": "workflow",
@@ -6960,6 +7299,18 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/qa/content-audit",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "dev-story",
+    "slug": "dev-story",
+    "category": "",
+    "description": "\"Read a story file and implement it. Loads the full context (story, GDD requirement, ADR guidelines, control manifest), routes to the right programmer agent for the system and engine, implements the code and test, and confirms each acceptance criterion. The core implementation skill — run after /story-readiness, before /code-review and /story-done.\"",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/production/dev-story",
     "has_content": false
   },
   {
@@ -7082,6 +7433,41 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/agents/coding-agent-cli-backend-interface",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "draft-release-notes-from-git-log",
+    "slug": "draft-release-notes-from-git-log",
+    "category": "agents",
+    "description": "Keep a non-destructive [Unreleased] changelog draft in sync with the actual diff since the last tag, using git log + GitHub's generate-notes API.",
+    "tags": [
+      "changelog",
+      "releases",
+      "git",
+      "github-cli",
+      "documentation"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/agents/draft-release-notes-from-git-log",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "dynamic-system-prompt",
+    "slug": "dynamic-system-prompt",
+    "category": "agents",
+    "description": "Generate agent instructions dynamically at runtime from a context object.",
+    "tags": [
+      "openai-agents",
+      "instructions",
+      "dynamic-prompt",
+      "context"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/agents/dynamic-system-prompt",
     "has_content": false
   },
   {
@@ -8112,6 +8498,43 @@
     "version": "1.0.0",
     "path": "skills/architecture/accepts-then-convert-two-phase-dispatch",
     "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "document-converter-priority-registry",
+    "slug": "document-converter-priority-registry",
+    "category": "architecture",
+    "description": "Pluggable converter registry where each candidate declares a numeric priority, registrations are prepended, and dispatch re-sorts stably per call so the most recently registered converter at a priority wins.",
+    "tags": [
+      "architecture",
+      "registry",
+      "dispatch",
+      "plugin",
+      "priority",
+      "python"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/architecture/document-converter-priority-registry",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "device-revocation-reset-flow",
+    "slug": "device-revocation-reset-flow",
+    "category": "auth",
+    "description": "Implement a graceful credentials-invalid reset for PowerSync-style apps so account-deleted (410) or device-revoked (403) clients drop their local DB, clear localStorage, and restart signed-out without crashes.",
+    "tags": [
+      "auth",
+      "powersync",
+      "devices",
+      "session",
+      "reset"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/auth/device-revocation-reset-flow",
+    "has_content": true
   },
   {
     "kind": "skill",
@@ -10273,6 +10696,23 @@
   },
   {
     "kind": "skill",
+    "name": "docker-find-chmod-fast-readability",
+    "slug": "docker-find-chmod-fast-readability",
+    "category": "build",
+    "description": "In a Dockerfile RUN layer, use find -not -perm to touch ONLY files missing a permission bit instead of chmod -R — cuts image build time from minutes to seconds on big node_modules trees.",
+    "tags": [
+      "docker",
+      "chmod",
+      "performance",
+      "node_modules"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/build/docker-find-chmod-fast-readability",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "cmake-cuda-extension-with-git-submodule-vendoring",
     "slug": "cmake-cuda-extension-with-git-submodule-vendoring",
     "category": "build-system",
@@ -10288,6 +10728,25 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/build-system/cmake-cuda-extension-with-git-submodule-vendoring",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "develop-script-with-inplace-submodule-symlinks",
+    "slug": "develop-script-with-inplace-submodule-symlinks",
+    "category": "build-system",
+    "description": "Ship a `develop.sh` that symlinks vendored submodule includes (CUTLASS, fmt) into the package's include tree, then runs `python setup.py build` and symlinks the resulting `.so` back into the source package — editable-install for a CUDA extension.",
+    "tags": [
+      "develop-mode",
+      "setup-py",
+      "cuda-extension",
+      "symlinks",
+      "editable-install",
+      "submodules"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/build-system/develop-script-with-inplace-submodule-symlinks",
     "has_content": false
   },
   {
@@ -11187,6 +11646,25 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/codecs/android-mediacodec-jni-wrapper",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "dxgi-texture-capturer-gpu-optimization",
+    "slug": "dxgi-texture-capturer-gpu-optimization",
+    "category": "codecs",
+    "description": "Direct3D 11 GPU-accelerated capture with IDXGIOutputDuplication, texture reuse and rotation.",
+    "tags": [
+      "capturer",
+      "codecs",
+      "dxgi",
+      "gpu",
+      "optimization",
+      "texture"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/codecs/dxgi-texture-capturer-gpu-optimization",
     "has_content": false
   },
   {
@@ -12594,6 +13072,23 @@
   },
   {
     "kind": "skill",
+    "name": "docker-compose-selfhost-stack",
+    "slug": "docker-compose-selfhost-stack",
+    "category": "devops",
+    "description": "Single docker-compose.selfhost.yml that starts postgres + backend + frontend for one-command self-hosting, with sensible defaults and a one-shot make target.",
+    "tags": [
+      "docker-compose",
+      "self-hosting",
+      "postgres",
+      "deployment"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/docker-compose-selfhost-stack",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "docker-compose-service-inventory-files",
     "slug": "docker-compose-service-inventory-files",
     "category": "devops",
@@ -12628,6 +13123,41 @@
     "version": "1.0.0",
     "path": "skills/devops/docker-compose-v1-v2-auto-detect",
     "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "docker-multistage-go-alpine",
+    "slug": "docker-multistage-go-alpine",
+    "category": "devops",
+    "description": "Two-stage Docker build for a Go service — golang:alpine builder stage produces static binaries, alpine runtime stage ships them minimally with ca-certificates and tzdata.",
+    "tags": [
+      "docker",
+      "go",
+      "alpine",
+      "multistage",
+      "production-image"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/docker-multistage-go-alpine",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "docker-smoke-test-loop",
+    "slug": "docker-smoke-test-loop",
+    "category": "devops",
+    "description": "Run a one-shot docker container, tail its logs for a readiness sentinel, then fire an integration test against the exposed port - with layered fallbacks when the CLI is unavailable.",
+    "tags": [
+      "docker",
+      "smoke-test",
+      "ci",
+      "readiness-probe"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/docker-smoke-test-loop",
+    "has_content": false
   },
   {
     "kind": "skill",
@@ -12872,6 +13402,25 @@
   },
   {
     "kind": "skill",
+    "name": "docker-entrypoint-gosu-bind-mount",
+    "slug": "docker-entrypoint-gosu-bind-mount",
+    "category": "docker",
+    "description": "Write a Docker ENTRYPOINT that `mkdir -p`s required subdirs on first run, `chown`s them, then drops from root to a non-root user with `gosu` — so bind mounts \"just work\" and named volumes keep their inherited perms.",
+    "tags": [
+      "docker",
+      "entrypoint",
+      "gosu",
+      "bind-mount",
+      "non-root",
+      "privileges"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/docker/docker-entrypoint-gosu-bind-mount",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "document-release",
     "slug": "document-release",
     "category": "docs",
@@ -12968,6 +13517,41 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "skills/docs/ubiquitous-language",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "drainable-worker-pattern-for-queue-based-async",
+    "slug": "drainable-worker-pattern-for-queue-based-async",
+    "category": "effect-ts",
+    "description": "Use queue-based workers with drain() signals instead of timing-sensitive sleeps for deterministic async test synchronization",
+    "tags": [
+      "effect-ts",
+      "testing",
+      "async",
+      "workers"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/effect-ts/drainable-worker-pattern-for-queue-based-async",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "drag-drop-widget-composition",
+    "slug": "drag-drop-widget-composition",
+    "category": "flutter",
+    "description": "Draggable widget composition for UI controls (dragable_divider, popup_menu reordering).",
+    "tags": [
+      "composition",
+      "drag",
+      "drop",
+      "flutter",
+      "widget"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/flutter/drag-drop-widget-composition",
     "has_content": false
   },
   {
@@ -13641,6 +14225,43 @@
   },
   {
     "kind": "skill",
+    "name": "distributed-filesystem-safe-atomic-cache-with-fsync",
+    "slug": "distributed-filesystem-safe-atomic-cache-with-fsync",
+    "category": "jit-compilation",
+    "description": "Make a JIT compiler cache safe under concurrent multi-rank writes on NFS by compiling to a tmp dir, fsyncing recursively, and atomically renaming the directory.",
+    "tags": [
+      "concurrency",
+      "distributed-systems",
+      "cache",
+      "filesystem",
+      "jit"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/jit-compilation/distributed-filesystem-safe-atomic-cache-with-fsync",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "dual-driver-runtime-api-abstraction",
+    "slug": "dual-driver-runtime-api-abstraction",
+    "category": "jit-compilation",
+    "description": "Hide the CUDA Driver API vs Runtime API split behind a single `load_kernel` / `launch_kernel` / `construct_launch_config` surface, using typedefs and `#ifdef` to pick the implementation at compile time.",
+    "tags": [
+      "cuda",
+      "driver-api",
+      "runtime-api",
+      "abstraction",
+      "jit",
+      "portability"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/jit-compilation/dual-driver-runtime-api-abstraction",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "agent-handoff-routing",
     "slug": "agent-handoff-routing",
     "category": "llm-agents",
@@ -13672,6 +14293,71 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/llm-agents/agents-as-tools",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "deterministic-agent-chain",
+    "slug": "deterministic-agent-chain",
+    "category": "llm-agents",
+    "description": "Chain multiple agents sequentially in code, feeding each agent's output as the next agent's input.",
+    "tags": [
+      "openai-agents",
+      "pipeline",
+      "deterministic",
+      "chaining",
+      "structured-output"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/llm-agents/deterministic-agent-chain",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "dispatching-parallel-agents",
+    "slug": "dispatching-parallel-agents",
+    "category": "llm-agents",
+    "description": "Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/llm-agents/dispatching-parallel-agents",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "draft-model-bind-to-target-modules",
+    "slug": "draft-model-bind-to-target-modules",
+    "category": "llm-agents",
+    "description": "Share embed_tokens and lm_head from the target LLM into a draft model at runtime by duck-typing the wrapper layout, so the draft does not ship its own embedding matrix.",
+    "tags": [
+      "speculative-decoding",
+      "weight-sharing",
+      "huggingface",
+      "mlx",
+      "embeddings"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/llm-agents/draft-model-bind-to-target-modules",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "easyedit-rome-knowledge-edit",
+    "slug": "easyedit-rome-knowledge-edit",
+    "category": "llm-agents",
+    "description": "Edit a specific fact in GPT-2-XL using EasyEdit and the ROME method, verified with the Messi football-to-basketball example.",
+    "tags": [
+      "model-editing",
+      "easyedit",
+      "rome",
+      "knowledge-editing"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/llm-agents/easyedit-rome-knowledge-edit",
     "has_content": false
   },
   {
@@ -13740,6 +14426,24 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/ml-ops/chunked-tts-with-crossfade",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "deterministic-torch-seed-bundle",
+    "slug": "deterministic-torch-seed-bundle",
+    "category": "ml-ops",
+    "description": "Five-line block that seeds random / numpy / torch / CUDA / cudnn consistently so benchmarks and regression tests are reproducible run-to-run.",
+    "tags": [
+      "pytorch",
+      "reproducibility",
+      "seeding",
+      "cudnn",
+      "benchmark"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/ml-ops/deterministic-torch-seed-bundle",
     "has_content": false
   },
   {
@@ -13847,6 +14551,61 @@
   },
   {
     "kind": "skill",
+    "name": "detached-daemon-lifecycle-cli",
+    "slug": "detached-daemon-lifecycle-cli",
+    "category": "ops",
+    "description": "Give a node script a drop-in start/stop/restart/status/log/check CLI by discovering processes via ps-args pattern match rather than trusting a PID file, persisting a best-effort PID, escalating SIGTERM → wait → SIGKILL on stop, and defining \"healthy\" as \"process exists AND log has been written within MAX_SILENCE_MS.\"",
+    "tags": [
+      "daemon",
+      "lifecycle",
+      "pid-file",
+      "sigterm",
+      "stagnation-detection",
+      "cli"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/ops/detached-daemon-lifecycle-cli",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "dxgi-com-pointer-wrapper-raii",
+    "slug": "dxgi-com-pointer-wrapper-raii",
+    "category": "patterns",
+    "description": "Custom ComPtr<T> with Drop-based COM reference counting for DXGI objects.",
+    "tags": [
+      "com",
+      "dxgi",
+      "patterns",
+      "pointer",
+      "raii",
+      "wrapper"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/patterns/dxgi-com-pointer-wrapper-raii",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "display-device-enumeration-platform",
+    "slug": "display-device-enumeration-platform",
+    "category": "platform",
+    "description": "Per-OS display enumeration: Windows EnumDisplayDevices, macOS CGDisplayCopyAllDisplays, Linux XRandR.",
+    "tags": [
+      "device",
+      "display",
+      "enumeration",
+      "platform"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/platform/display-device-enumeration-platform",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "a11y-tree-snapshot-with-uids",
     "slug": "a11y-tree-snapshot-with-uids",
     "category": "puppeteer",
@@ -13861,6 +14620,24 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/puppeteer/a11y-tree-snapshot-with-uids",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "dual-mode-cublaslt-handle-workspace",
+    "slug": "dual-mode-cublaslt-handle-workspace",
+    "category": "pytorch-integration",
+    "description": "Manage a cuBLASLt handle + workspace two ways (self-owned vs PyTorch-managed, persistent vs per-call) so your library works under compute-sanitizer, older PyTorch versions, and high-throughput prod builds — selected by env var at init.",
+    "tags": [
+      "cublaslt",
+      "pytorch",
+      "workspace",
+      "compute-sanitizer",
+      "handle-management"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/pytorch-integration/dual-mode-cublaslt-handle-workspace",
     "has_content": false
   },
   {
@@ -13914,6 +14691,24 @@
   },
   {
     "kind": "skill",
+    "name": "detached-update-check-with-local-cache",
+    "slug": "detached-update-check-with-local-cache",
+    "category": "reliability",
+    "description": "Check for package updates in a detached child subprocess with a 24h local cache so startup stays fast, notification is fresh, and network failure never blocks the user.",
+    "tags": [
+      "cli",
+      "update-check",
+      "caching",
+      "npm",
+      "ux"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/reliability/detached-update-check-with-local-cache",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "android-apk-multi-engine-decompilation",
     "slug": "android-apk-multi-engine-decompilation",
     "category": "reverse-engineering",
@@ -13950,6 +14745,26 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/reverse-engineering/androidmanifest-to-network-call-flow-tracing",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "dex2jar-bridge-apk-to-fernflower",
+    "slug": "dex2jar-bridge-apk-to-fernflower",
+    "category": "reverse-engineering",
+    "description": "Convert Android DEX bytecode to a standard JVM JAR with dex2jar so that Fernflower or Vineflower — which cannot read APK/DEX directly — can decompile it.",
+    "tags": [
+      "dex2jar",
+      "fernflower",
+      "vineflower",
+      "dex",
+      "apk",
+      "android",
+      "reverse-engineering"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/reverse-engineering/dex2jar-bridge-apk-to-fernflower",
     "has_content": false
   },
   {
@@ -14019,6 +14834,24 @@
     "triggers": [],
     "version": "2.0.0",
     "path": "skills/security/cso",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "easyjailbreak-pair-attack-pipeline",
+    "slug": "easyjailbreak-pair-attack-pipeline",
+    "category": "security",
+    "description": "Use EasyJailbreak to run the PAIR attack against a target LLM using an attack model, target model, and evaluator.",
+    "tags": [
+      "jailbreak",
+      "easyjailbreak",
+      "pair",
+      "llm-safety",
+      "red-team"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/security/easyjailbreak-pair-attack-pipeline",
     "has_content": false
   },
   {
@@ -14140,6 +14973,24 @@
   },
   {
     "kind": "skill",
+    "name": "dev-sidecar-placeholder-binary",
+    "slug": "dev-sidecar-placeholder-binary",
+    "category": "tauri",
+    "description": "Satisfy Tauri's build-time sidecar requirement in dev mode by emitting a minimal valid PE / shell-script placeholder.",
+    "tags": [
+      "tauri",
+      "dev-experience",
+      "placeholder-binary",
+      "windows-pe",
+      "cross-platform"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/tauri/dev-sidecar-placeholder-binary",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "clearcut-batch-flush-with-retry",
     "slug": "clearcut-batch-flush-with-retry",
     "category": "telemetry",
@@ -14154,6 +15005,24 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/telemetry/clearcut-batch-flush-with-retry",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "detached-watchdog-telemetry-process",
+    "slug": "detached-watchdog-telemetry-process",
+    "category": "telemetry",
+    "description": "Run telemetry shipping in a detached child process fed by the parent over stdin, so telemetry never blocks tool execution and gets a guaranteed flush-on-parent-death window.",
+    "tags": [
+      "telemetry",
+      "watchdog",
+      "child-process",
+      "ipc",
+      "reliability"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/telemetry/detached-watchdog-telemetry-process",
     "has_content": false
   },
   {
@@ -14222,6 +15091,24 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/testing/devex-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "e2e-default-login-helper",
+    "slug": "e2e-default-login-helper",
+    "category": "testing",
+    "description": "Reusable Playwright loginAsDefault helper that authenticates via API (send-code + verify-code), injects the token into localStorage, and navigates to a workspace-scoped URL.",
+    "tags": [
+      "playwright",
+      "e2e",
+      "auth",
+      "fixtures",
+      "testing"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/testing/e2e-default-login-helper",
     "has_content": false
   },
   {

--- a/knowledge/arch/devtools-frontend-reused-as-library.md
+++ b/knowledge/arch/devtools-frontend-reused-as-library.md
@@ -1,0 +1,49 @@
+---
+name: devtools-frontend-reused-as-library
+summary: The project imports pieces of Chrome DevTools Frontend (`TraceEngine`, `PerformanceTraceFormatter`, `HeapSnapshotModel`, `IssuesManager`, `CrUXManager`) as a library dependency, so tool output matches what users see in the real DevTools panels.
+category: arch
+confidence: high
+tags: [devtools, library-reuse, trace-engine, heap-snapshot, third-party]
+source_type: extracted-from-git
+source_url: https://github.com/ChromeDevTools/chrome-devtools-mcp.git
+source_ref: main
+source_commit: 0a6aaa52ebacb2db834ffa437863e5844aa3730b
+source_project: chrome-devtools-mcp
+source_path: src/third_party/index.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# DevTools Frontend as a Library
+
+## Context
+
+Implementing "parse this performance trace" or "aggregate this heap snapshot by class" from scratch means re-deriving dozens of heuristics that the real Chrome DevTools panels already apply. Duplicating that logic in user space is unmaintainable — every Chrome release would invalidate your implementation.
+
+## The fact / decision / pitfall
+
+chrome-devtools-mcp bundles select namespaces from `devtools-frontend` as library imports:
+
+- `DevTools.TraceEngine.TraceModel` — the same engine that powers the Performance panel. Feed it raw trace events, get a `parsedTrace` with `insights` (LCP breakdown, document latency, network stall, render-blocking requests, etc.).
+- `DevTools.PerformanceTraceFormatter` — formats `parsedTrace` into the same summary text DevTools would show.
+- `DevTools.PerformanceInsightFormatter` — formats individual insight models.
+- `DevTools.HeapSnapshotModel.HeapSnapshotProxy` + `HeapSnapshotWorkerProxy` — parse a `.heapsnapshot` file and answer aggregate queries.
+- `DevTools.IssueAggregator`, `DevTools.createIssuesFromProtocolIssue` — turn raw Audits-panel CDP issues into the aggregated-issue model used in the Issues tab.
+- `DevTools.CrUXManager` — fetches Core Web Vitals field data from Google's CrUX API for URLs in a trace.
+- `DevTools.AgentFocus.fromParsedTrace` — gives the formatters the view they expect.
+
+Some imports use `@ts-expect-error` comments to cross protocol-type boundaries where the public types have drifted from DevTools' internal types.
+
+## Evidence
+
+- `src/trace-processing/parse.ts` — `const engine = DevTools.TraceEngine.TraceModel.Model.createWithAllHandlers();` then `engine.parse(events)`.
+- `src/tools/performance.ts::populateCruxData` — calls `DevTools.CrUXManager.instance()` and passes its own Clearcut/CrUX endpoint.
+- `src/HeapSnapshotManager.ts` — drives a `HeapSnapshotWorkerProxy` with a streamed file.
+- `src/PageCollector.ts::PageEventSubscriber` — uses `DevTools.IssueAggregator` and `DevTools.IssuesManagerEvents.ISSUE_ADDED`.
+
+## Implications
+
+- Performance output, heap aggregation output, and issue categorization will drift with Chrome version. Pin the dependency and document known-good Chrome major versions.
+- You cannot easily extract just one file from devtools-frontend without pulling transitive dependencies (Common, Platform, etc.). Vendor intentionally.
+- The CrUX API key in `populateCruxData` is public (the project explicitly acknowledges this) — treat it as a shared rate-limited resource, not a secret. If you hammer it in tests, use a test fixture instead.
+- Downstream agents see the *same* summaries humans do. That's the value — debugging conversations translate across the human/agent boundary.
+- Updating devtools-frontend is the project's highest-risk dependency bump. CI must include tests that parse representative traces and heap snapshots and assert stable output.

--- a/knowledge/architecture/dual-backend-claude-and-pi.md
+++ b/knowledge/architecture/dual-backend-claude-and-pi.md
@@ -1,0 +1,39 @@
+---
+name: dual-backend-claude-and-pi
+summary: Why Craft Agents runs two AgentBackend implementations (Claude SDK + Pi SDK) side by side instead of a single abstraction — different provider ergonomics, auth flows, and model capabilities.
+category: architecture
+tags: [agent-sdk, pi-sdk, backend, provider-routing]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: packages/shared/src/agent/backend
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Dual backend: Claude Agent SDK + Pi SDK
+
+Craft Agents deliberately runs two separate agent backends behind one `AgentBackend` interface (`packages/shared/src/agent/backend/types.ts`):
+
+1. **Claude backend** (`claude-agent.ts`) wraps `@anthropic-ai/claude-agent-sdk`. Handles: Anthropic API key, Claude Max/Pro OAuth, and every Anthropic-compatible endpoint (OpenRouter, Vercel AI Gateway, Ollama, custom) via `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` swap.
+2. **Pi backend** (`pi-agent.ts`) wraps `@mariozechner/pi-ai` / `@mariozechner/pi-coding-agent`. Handles: Google AI Studio API keys, ChatGPT Plus via Codex OAuth, GitHub Copilot OAuth (device-code flow), OpenAI API keys.
+
+### Why not one abstraction?
+
+The two SDKs have fundamentally different event models (Claude streams `message_delta` + `tool_use`; Pi emits its own shape) and their capability matrices overlap only partially (tool use, vision, extended thinking are supported differently). Trying to unify them at the raw-event level erases useful provider-specific features; instead, the app unifies at the **event adapter** layer (`backend/claude/event-adapter.ts`, `backend/pi/event-adapter.ts`), both emitting the app's canonical `AgentEvent`.
+
+### Driver registry
+
+`packages/shared/src/agent/backend/factory.ts` keeps a `DRIVER_REGISTRY: Record<AgentProvider, ProviderDriver>` that's a thin dispatch table. New providers attach as drivers, not forks of the agent class.
+
+### Trade-offs
+
+- **Duplication**: session tool parity has to be tested separately (`session-tool-parity.test.ts` exists in BOTH backends) because mocks can't cover the real SDK event stream.
+- **Bundle size**: both SDKs ship. The Pi SDK is ESM-only, which forces the `bun build --target=bun --format=esm` + `--external koffi` workaround (see `scripts/electron-build-main.ts`).
+- **Provider routing**: `resolveAuthEnvVars()` in `config/llm-connections.ts` is the single place where "what env does this provider need" is decided. Any new provider touches only this function + one driver.
+
+### Takeaway
+
+When you can't get meaningful unification from an abstraction, let the duplication live at the adapter boundary. The price is two test surfaces; the benefit is clean provider-specific code.

--- a/knowledge/architecture/dynamic-uv-python-scripts.md
+++ b/knowledge/architecture/dynamic-uv-python-scripts.md
@@ -1,0 +1,57 @@
+---
+name: dynamic-uv-python-scripts
+summary: Craft Agents ships a bundled uv binary and a set of PEP-723 self-dependency Python scripts (pdf_tool, docx_tool, xlsx_tool, markitdown, ical_tool, ...) so document-handling tools work without asking the user to install Python.
+category: architecture
+tags: [python, uv, pep-723, document-tools]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: apps/electron/resources/scripts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Dynamic uv + Python document toolchain
+
+### Why Python, not JS
+Document processing (PDF extraction, Office format conversion, iCal parsing) has MUCH better library coverage in Python than JS. markitdown, pypandoc, openpyxl, python-docx, icalendar, PIL — all mature.
+
+### The zero-install approach
+Shipping Python with an Electron app is painful (large, platform-specific). Craft Agents uses `uv` instead:
+
+1. Build-time: download the uv binary for each target platform (darwin-arm64 / darwin-x64 / win32-x64 / linux-x64) into `resources/bin/<platform>-<arch>/uv{,.exe}`.
+2. Ship only the relevant binary per installer via electron-builder per-platform extraResources.
+3. Electron main process sets `CRAFT_UV`, `CRAFT_SCRIPTS` env vars and prepends `resources/bin` to PATH.
+4. User invokes a tool (e.g. `pdf-tool`); wrapper script does `exec "$CRAFT_UV" run --script "$CRAFT_SCRIPTS/pdf_tool.py" "$@"`.
+5. uv auto-downloads a pinned Python 3.12 to `~/.cache/uv/` on first use (~20MB, one-time).
+6. PEP 723 inline script dependencies are parsed from `# /// script` blocks; uv creates an ephemeral venv, installs deps, runs the script.
+
+### Smoke tests
+`bun run test:doc-tools` invokes `python3 -m unittest apps.electron.resources.scripts.tests.test_*_smoke` — runs each tool's sanity test. Runs in CI against the same Python scripts that ship.
+
+### Script shape
+```python
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["markitdown"]
+# ///
+import sys
+from markitdown import MarkItDown
+# ... tool logic reading stdin / args, emitting stdout
+```
+
+### Windows parity
+Windows ships both a bare script (POSIX wrapper) AND `.cmd` variant (e.g. `pdf-tool` + `pdf-tool.cmd`). Build scripts copy both during resource assembly; bundler excludes the non-target one per platform.
+
+### Trade-offs
+- Extra ~20MB for uv per installer arch, plus another ~20MB at user's first-use.
+- First invocation is ~5s (Python download + venv setup). Subsequent calls are instant.
+- uv caches per-script deps; rare dep upgrades might leave some stale caches (manual cleanup via `uv cache clean`).
+
+### Reference
+- `apps/electron/resources/scripts/` — Python scripts.
+- `apps/electron/resources/bin/` — uv binaries + wrapper scripts.
+- `scripts/build/common.ts` — `downloadUv(config)` logic.
+- `apps/electron/src/main/index.ts` — env wiring for CRAFT_UV and PATH.

--- a/knowledge/architecture/effect-ts-layer-dependency-injection-for-testing.md
+++ b/knowledge/architecture/effect-ts-layer-dependency-injection-for-testing.md
@@ -1,0 +1,40 @@
+---
+name: effect-ts-layer-dependency-injection-for-testing
+summary: Effect.ts Layers provide compile-time dependency injection; compose layers to swap real services with test stubs
+type: knowledge
+category: architecture
+confidence: high
+tags: [effect-ts, testing, architecture]
+source_type: extracted-from-git
+source_url: https://github.com/pingdotgg/t3code.git
+source_ref: main
+source_commit: 9df3c640210fecccb58f7fbc735f81ca0ee011bd
+source_project: t3code
+imported_at: 2026-04-18
+evidence:
+  - apps/server/src/orchestration/Layers
+  - apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+---
+
+## Fact
+Effect.ts's `Layer` abstraction is a function that returns an Effect producing a service interface. Services are tagged (`Tag`) for identification. You compose layers with `Layer.provide()` to wire dependencies. This allows tests to substitute real services with stubs without modifying test code.
+
+## Why it matters
+1. **No mocking libraries needed** — just implement the service interface in a test version
+2. **Compile-time safety** — if a service is missing or incompatible, TypeScript catches it
+3. **Deterministic tests** — test services return fixed values, no randomness or side effects
+4. **Reusable test layers** — build a layer once, use in many tests
+5. **Gradual adoption** — real code uses real layers, tests swap in stubs; no changes to real code needed
+
+## Evidence
+- Server code defines layers like `OrchestrationEngine`, `CheckpointReactor` using `Layer.effect(..., () => ...)`
+- Test files import same services and layer them together with test doubles
+- OrchestrationEngine.test.ts shows: compose GitCore stub + real OrchestrationEngine to test orchestration logic in isolation
+
+## How to apply
+- Define each service as a `Tag` and `Layer.effect(TAG, () => Effect producing interface)`
+- In tests, create a stub object implementing the same interface
+- Build test layer: `const stubGit = Layer.succeed(GitCore, { executeGit: () => ... })`
+- Compose: `const testLayers = Layer.compose(stubGit, realOrchestration)`
+- Run test: `const result = yield* testEffect.pipe(Effect.provide(testLayers))`
+- Document test layer composition in test files so maintainers know what's stubbed

--- a/knowledge/auth/device-revocation-status-codes-contract.md
+++ b/knowledge/auth/device-revocation-status-codes-contract.md
@@ -1,0 +1,50 @@
+---
+name: device-revocation-status-codes-contract
+type: knowledge
+category: api
+confidence: high
+source: thunderbolt/docs/powersync-account-devices.md
+source_type: extracted-from-git
+source_url: https://github.com/thunderbird/thunderbolt.git
+source_ref: main
+source_commit: 9d9c18ba511decfd3b45fc0f72c265d83355fe95
+source_project: thunderbolt
+imported_at: 2026-04-18T00:00:00Z
+linked_skills: [device-revocation-reset-flow]
+tags: [api, http-status, powersync, devices, auth]
+---
+
+# Device / account status code contract for PowerSync clients
+
+Client-server contract used by PowerSync token/upload endpoints to signal account and device state. Codes are load-bearing — the client branches on them to decide "reset everything" vs "just retry later".
+
+| Code | Body | Meaning | Client action |
+|------|------|---------|---------------|
+| **410 Gone** | `{ code: 'ACCOUNT_DELETED' }` | The user no longer exists | Full reset, navigate to `/account-deleted` |
+| **403 Forbidden** | `{ code: 'DEVICE_DISCONNECTED' }` | This `X-Device-ID` is revoked | Full reset, navigate to `/` |
+| **409 Conflict** | `{ code: 'DEVICE_ID_TAKEN' }` | `X-Device-ID` is claimed by a different user | Reset and mint a new device id |
+| **400** | `{ code: 'DEVICE_ID_REQUIRED' }` | Missing `X-Device-ID` header | Fix client code; developer error |
+| **401** | (generic) | Invalid/expired token | Attempt refresh; do **not** reset |
+| **204** | (empty) | Idempotent success on revoke | Nothing; the action already happened |
+
+## Required request headers for PowerSync token + upload
+
+- `Authorization: Bearer <session-token>`
+- `X-Device-ID: <localStorage device id>` (required on upload; required on token for revoke-awareness)
+- `X-Device-Name: <label>` (optional, only on token; updates the `devices.name` column)
+
+## Why the codes matter
+
+- **401 vs 410/403**: 401 is recoverable (token refresh). 410/403 are terminal for this device and must trigger a full local wipe because the backend can't send selective deletes fast enough to prevent crashes.
+- **409 vs new device**: a fresh uuidv7 from the client is cheap, and the reset flow already clears localStorage, so the safest recovery is to reset and let the app re-register from zero.
+- **Idempotent 204 on revoke**: prevents retry storms from the device-management UI.
+
+## CORS note
+
+`X-Device-ID`, `X-Device-Name`, and other custom headers must be added to the backend's `corsAllowHeaders` list; otherwise browser preflight fails silently. See the linked cors-allow-headers knowledge.
+
+## Evidence
+
+- `docs/powersync-account-devices.md:98-205`
+- `docs/delete-account-and-revoke-device.md:37-65`
+- `backend/src/config/settings.ts:52-63`

--- a/knowledge/codecs/display-orientation-rotation-handling.md
+++ b/knowledge/codecs/display-orientation-rotation-handling.md
@@ -1,0 +1,28 @@
+---
+name: display-orientation-rotation-handling
+type: knowledge
+category: codecs
+summary: Cache RotationMode per display and apply during capture (DXGI, Quartz, X11) — don't re-probe per frame.
+confidence: medium
+tags: [codecs, display, handling, orientation, rotation]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: libs/scrap/src/common/convert.rs
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Display Orientation Rotation Handling
+
+## Fact
+Cache RotationMode per display and apply during capture (DXGI, Quartz, X11) — don't re-probe per frame.
+
+## Why it matters
+Re-probing per frame degrades FPS; invalidate cache only on display-change events.
+
+## Evidence
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- `libs/scrap/src/common/convert.rs`

--- a/knowledge/decision/desktop-route-categories.md
+++ b/knowledge/decision/desktop-route-categories.md
@@ -1,0 +1,31 @@
+---
+name: desktop-route-categories
+summary: Every path in a tab-based Electron desktop app falls into exactly one of three categories — session routes, transition flows (overlays), or error/stale states (auto-healed).
+category: decision
+tags: [electron, desktop, routing, tabs, overlay]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: CLAUDE.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+Every URL/path in the desktop app must fall into exactly one category. Picking the wrong one reproduces bugs you've already fixed.
+
+- **Session routes** — workspace-scoped pages (`/:slug/issues`, `/:slug/settings`). Rendered by the per-tab memory router under `WorkspaceRouteLayout`. These are legitimate tab destinations.
+- **Transition flows** — pre-workspace / one-shot actions (create workspace, accept invite). NOT routes. They live as `WindowOverlay` state, dispatched when the navigation adapter sees a magic path (`push('/workspaces/new')` or `push('/invite/<id>')`). Shared view (`NewWorkspacePage`, `InvitePage`) is the content; the overlay wrapper supplies platform chrome.
+- **Error/stale states** — "workspace not available", tabs pointing at a revoked workspace. NOT pages. `WorkspaceRouteLayout` auto-heals by dropping the stale tab group from the store; the user never lands on an explicit error screen. Web keeps `NoAccessPage` (shareable URL makes the error state meaningful); desktop has no URL bar so stale = heal silently.
+
+## Why
+
+Desktop has different constraints from web: no URL bar, per-tab memory router, tabs grouped per workspace, and a native title bar that requires a drag strip. Treating all paths as "routes" imports web-centric assumptions that don't fit. Error screens in particular are meaningless on desktop because the user can't paste a URL to reach them; auto-heal is better UX.
+
+Adding a new pre-workspace flow on desktop: register a new `WindowOverlay` type in `stores/window-overlay-store.ts`. Do NOT add it to `routes.tsx`. If the flow appears on both platforms, add the route on web AND the overlay type on desktop — the shared view component stays identical.
+
+## Evidence
+
+- CLAUDE.md, "Desktop-specific Rules" → "Route categories" section.
+- Desktop `routes.tsx` vs `stores/window-overlay-store.ts` split.

--- a/knowledge/devops/dockerfile-server-design-choices.md
+++ b/knowledge/devops/dockerfile-server-design-choices.md
@@ -1,0 +1,58 @@
+---
+name: dockerfile-server-design-choices
+summary: Why Dockerfile.server uses oven/bun:1.3-slim, creates a non-root craftagents user, chmod's with find -not -perm, and ships the CJS-bundled MCP helpers — each choice solved a real production issue.
+category: devops
+tags: [docker, bun, non-root, image-optimization]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: Dockerfile.server
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Dockerfile.server design choices
+
+Annotated rationale for each non-obvious line in `Dockerfile.server`:
+
+### `FROM oven/bun:1.3-slim`
+- Pin the Bun minor version for reproducibility.
+- `-slim` over full: smaller image, no unnecessary Node/Python/build-essential.
+
+### `apt-get install -y ca-certificates git ripgrep`
+- `ca-certificates`: for TLS to Anthropic/GitHub/etc.
+- `git`: required by the Claude Agent SDK for certain workspace introspection tools.
+- `ripgrep`: the SDK ships a `rg` per-platform, but some environments prefer the distro one; having both avoids `ENOENT rg` errors when the SDK's own vendor is filtered out by our build.
+
+### `groupadd -r craftagents; useradd -r -g craftagents -m -d /home/craftagents`
+Create a dedicated non-root user. Claude Code SDK refuses to run as root (nesting/safety guard), so even if operators forget `--user`, the default USER is already safe.
+
+### Two-pass manifest copy then `bun install --frozen-lockfile`
+Classic Docker caching trick: copying just `package.json` + `bun.lock` before source lets the install layer cache across source changes. Saves minutes on every code-only rebuild.
+
+### Build MCP helpers in the image
+```
+RUN bun build packages/session-mcp-server/src/index.ts --outfile=...
+    --target=node --format=cjs
+```
+These CJS bundles are required at runtime by `runtime-resolver.ts`. Building in-image avoids shipping the full dev toolchain.
+
+### Build web UI assets (`bunx vite build --config apps/webui/vite.config.ts`)
+If the server is configured with `CRAFT_WEBUI_DIR=/app/apps/webui/dist`, it serves a browser UI on the RPC port.
+
+### Pre-create `/home/craftagents/.craft-agent`
+Docker named volumes inherit dir permissions from existing target. If the mount point doesn't exist at image build time, the volume comes up owned by root regardless of the `--user` flag.
+
+### `find /app -not -perm -o=r -exec chmod o+r {} +`
+The clever optimization — touch only files that lack the read bit. Regular `chmod -R` on `/app` (huge `node_modules`) takes minutes and bloats the image layer. The `find` variant writes only deltas. See the `docker-find-chmod-fast-readability` skill.
+
+### `chmod -R 777 /home/craftagents`
+Deliberately relaxed on the home dir because `--user $(id -u):$(id -g)` substitution at runtime needs write access to `.craft-agent/`. Not a security issue: that dir is user-controlled data, not executable code.
+
+### `USER craftagents`
+Final user. Paired with README advice: `docker run --user $(id -u):$(id -g) -e HOME=/home/craftagents` — hostUID writes to volumes with host ownership, avoiding permission-mismatch hell.
+
+### ENV defaults
+`CRAFT_RPC_HOST=0.0.0.0`, `CRAFT_RPC_PORT=9100`, `CRAFT_BUNDLED_ASSETS_ROOT=/app/apps/electron` — container-sensible defaults that work with `docker run -p 9100:9100` out of the box.

--- a/knowledge/jit-compilation/directory-rename-is-atomic-not-file-rename.md
+++ b/knowledge/jit-compilation/directory-rename-is-atomic-not-file-rename.md
@@ -1,0 +1,48 @@
+---
+name: directory-rename-is-atomic-not-file-rename
+type: knowledge
+category: decision
+confidence: high
+source: DeepGEMM
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - csrc/jit/compiler.hpp
+  - csrc/jit/kernel_runtime.hpp
+tags: [atomicity, rename, filesystem, distributed, jit-cache]
+imported_at: 2026-04-18T13:30:00Z
+---
+
+# For Multi-File Cache Entries, Rename the *Directory*, Not the Files
+
+## Fact / Decision
+When committing a multi-file JIT cache entry (`kernel.cu` + `kernel.cubin` + optional `.ptx`/`.sass`), rename the *containing directory* from `tmp_xxx` to `cache_final_name` as the last atomic step. Do **not** create the final directory and write each file into it one by one — that creates a window where the directory exists but is partially populated, and a peer reader sees a "cache hit" that's actually broken.
+
+## Why it matters
+Directory rename (`rename(2)`) is atomic on POSIX-compliant local filesystems, NFSv4, Lustre, GPFS, and BeeGFS. Either the final path exists with all files, or it doesn't exist at all. There is no middle state.
+
+Per-file rename is also atomic, but the *set* of per-file renames isn't — a reader that does `if exists(dir/A) and exists(dir/B)` can observe `A` before `B` lands. This is exactly the failure mode DeepGEMM's `check_validity` was built to detect:
+
+```cpp
+if (not std::filesystem::exists(dir / "kernel.cu")
+    or not std::filesystem::exists(dir / "kernel.cubin")) {
+    printf("Corrupted JIT cache directory (missing kernel.cu or kernel.cubin): ...");
+    DG_HOST_ASSERT(false and "Corrupted JIT cache directory");
+}
+```
+
+With the directory-rename pattern, this check should be unreachable — the directory either exists fully populated or doesn't exist. When it *does* trigger, it tells you someone used the wrong commit pattern (or manually edited the cache).
+
+## Evidence
+- `csrc/jit/compiler.hpp:108-149`: DeepGEMM's `build()` method. The key steps are (1) make tmp dir, (2) write all files into it, (3) fsync recursively, (4) `std::filesystem::rename(tmp_dir, final_dir)`. Comments spell out the reasoning:
+  > NOTES: renaming a directory is atomic on both local and distributed filesystems, avoiding the stale inode issue that occurs when renaming individual files
+- `csrc/jit/kernel_runtime.hpp:96-110`: `check_validity` — the runtime check that should never fail if the commit discipline holds.
+
+## Caveats / When this doesn't apply
+- **`rename` to an existing non-empty directory fails** with `EEXIST` / `ENOTEMPTY`. That's how you detect that another rank won the race — it's not an error, just means you lose and should clean up your tmp dir.
+- **Moving across filesystems is not atomic.** `rename` requires the source and destination on the same mount. If your tmp dir is on `/tmp` (tmpfs) and your cache is on `/mnt/nfs/...`, `rename` will fall back to copy+unlink, which breaks atomicity.
+- **Windows `MoveFile` is not truly atomic** in the same sense. Directory-rename-as-commit is a Unix idiom; on Windows use `MoveFileEx(MOVEFILE_REPLACE_EXISTING)` with caveats.
+- **Symlinks as the "commit point" are an alternative** (e.g. `ln -sfn tmp_xxx cache`), but they have their own race windows on NFS. Rename is simpler.

--- a/knowledge/llm-agents/dflash-block-diffusion-overview.md
+++ b/knowledge/llm-agents/dflash-block-diffusion-overview.md
@@ -1,0 +1,44 @@
+---
+name: dflash-block-diffusion-overview
+summary: DFlash is a block-diffusion draft model for speculative decoding — drafts a whole block of tokens in parallel using target hidden states as cross-context, then a single target forward verifies them.
+category: llm-agents
+tags: [speculative-decoding, block-diffusion, draft-model, dflash]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/z-lab/dflash.git
+source_ref: main
+source_commit: 1fe684b00efba56490d920d15eeb9ba6e4471751
+source_project: dflash
+source_path: README.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# DFlash: block diffusion for speculative decoding
+
+## What it is
+DFlash is a *small* transformer that drafts `block_size` tokens at once, in parallel, conditioned on hidden states from selected layers of a *target* LLM. One target forward then verifies the entire block, accepting the longest matching prefix plus one bonus target token.
+
+- Paper: https://arxiv.org/abs/2602.06036
+- Blog: https://z-lab.ai/projects/dflash/
+- Repo: https://github.com/z-lab/dflash
+
+## Why "block diffusion"
+Classical speculative decoding drafts tokens *autoregressively* from a small model — each draft token depends on the previous one. DFlash instead predicts all `block_size - 1` positions from a `[last_accepted, MASK, MASK, ...]` input in one forward pass, analogous to masked diffusion denoising. The draft model architecture (Qwen3 block, rotary emb, RMSNorm) is re-used from the target family but trained bidirectionally (`is_causal=False`).
+
+## Architecture fingerprints
+- Draft concatenates target hidden states from `target_layer_ids` (interpolated across target depth) and projects them down via an `nn.Linear(concat_dim, hidden_size)`.
+- Draft shares `embed_tokens` and `lm_head` with the target at inference (via `bind()`), so the deployed draft checkpoint is only the transformer body + `fc` projector.
+- Mask token is per-model (`config.dflash_config.mask_token_id`).
+
+## Supported backends
+| Backend | Status | Notes |
+|---|---|---|
+| vLLM | nightly | `--speculative-config '{"method": "dflash", ...}'` |
+| SGLang | in-tree | `--speculative-algorithm DFLASH` |
+| HF Transformers | limited | Qwen3 and Llama-3.1-8B-Instruct only |
+| MLX (Apple) | experimental | incl. sliding-window draft KV |
+
+## Why this matters for your work
+- The verify + accept loop is generic and reusable for any block-parallel draft.
+- The MLX implementation is the only one in the ecosystem that does KV rollback for Gated-Delta-Net (non-trimmable) caches — worth studying if you target Qwen3.5 MoE.
+- Default target-layer interpolation (`[1, ..., num_target_layers - 3]`) is a usable heuristic when you don't have a trained layer map.

--- a/knowledge/llm-fundamentals/easyedit-framework.md
+++ b/knowledge/llm-fundamentals/easyedit-framework.md
@@ -1,0 +1,43 @@
+---
+name: easyedit-framework
+summary: EasyEdit is a unified Python framework from ZJU-NLP for editing factual knowledge in pretrained LLMs.
+category: llm-fundamentals
+tags: [easyedit, knowledge-editing, rome, memit, fact-editing]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/zjunlp/EasyEdit
+source_ref: main
+source_commit: f84c04268794ef94f8949808bbc14ab8636763a0
+source_project: dive-into-llms
+source_path: documents/chapter3/README.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# EasyEdit Framework for LLM Knowledge Editing
+
+## Overview
+
+EasyEdit is a unified Python framework from ZJU-NLP for editing factual knowledge in pretrained LLMs. It provides a standard BaseEditor interface across multiple editing algorithms and models.
+
+## Key Facts
+
+- BaseEditor.from_hparams(hparams): loads the model and algorithm specified by a YAML hparams file.
+- editor.edit() accepts: prompts, ground_truth, target_new, subject, optional locality_inputs / portability_inputs.
+- Returns: metrics dict (reliability, generality, locality, portability), edited_model, and weights_copy.
+- keep_original_weight=True: apply edit on a copy; False: edit in-place (faster, lower memory).
+- Supported algorithms: ROME, MEMIT, FT-W, SERAC, GRACE, MEND, KN, and more.
+- Supported models: GPT-2-XL, GPT-J, GPT-NeoX, LLaMA, Baichuan, Qwen, Mistral.
+- Wikipedia statistics for ROME are precomputed and cached; downloaded on first run.
+- Colab demo: https://colab.research.google.com/drive/1KkyWqyV3BjXCWfdrrgbR-QS3AAokVZbr
+
+## Taxonomy
+
+Editing algorithms:
+- Locate-and-edit (FFN weight modification): ROME, MEMIT, KN
+- Meta-learning: MEND (hypernetwork to predict edits)
+- Fine-tuning: FT-W (targeted gradient descent)
+- Memory retrieval: SERAC, GRACE (external memory)
+
+## References
+- https://github.com/zjunlp/EasyEdit
+- https://github.com/Lordog/dive-into-llms/tree/main/documents/chapter3

--- a/knowledge/pitfall/dev-sh-auto-setup-idempotent.md
+++ b/knowledge/pitfall/dev-sh-auto-setup-idempotent.md
@@ -1,0 +1,38 @@
+---
+name: dev-sh-auto-setup-idempotent
+summary: make dev should auto-detect worktree vs main, create the right env file, install deps, start DB, run migrations, start services — idempotent on re-run.
+category: pitfall
+tags: [makefile, dev-setup, idempotent, onboarding]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: CONTRIBUTING.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+`make dev` (via `scripts/dev.sh`) is a single command that new contributors and returning devs both run. It does:
+
+1. Auto-detect whether you're in a main checkout or a worktree (git worktree status + env file presence).
+2. Create the appropriate env file (`.env` or `.env.worktree`) if missing.
+3. Verify prerequisites (Node.js, pnpm, Go, Docker) — print a clear error with install links on miss.
+4. `pnpm install`.
+5. Ensure the shared Postgres container is running (start it if not).
+6. Create the per-checkout application database if it doesn't exist.
+7. Run migrations.
+8. Start backend + frontend.
+
+## Why
+
+Re-running `make dev` must be safe. If a step is already done (DB exists, deps installed, migrations up to date), skip it silently. The whole script should complete in a few seconds on a warm machine — cold start is where the heavy work happens.
+
+"Re-run is safe" also means no destructive operations hidden in setup — no `DROP DATABASE`, no `pnpm install --force`. If the user wants a clean slate there's a separate destructive target (`make clean` + `docker compose down -v`).
+
+Clear error messages on prerequisite miss (`pnpm not found, install with: brew install pnpm`) are load-bearing for contributor onboarding.
+
+## Evidence
+
+- `CONTRIBUTING.md` "First-Time Setup" → "Quick Start" section.
+- `Makefile:175-176` — `dev:` target delegating to `scripts/dev.sh`.

--- a/knowledge/pitfall/drive-by-refactor-beyond-bug-fix.md
+++ b/knowledge/pitfall/drive-by-refactor-beyond-bug-fix.md
@@ -1,0 +1,40 @@
+---
+name: drive-by-refactor-beyond-bug-fix
+summary: Asked to fix "empty emails crash the validator", LLMs also tighten email regex, add username length/alnum checks, and add docstrings. That pollutes the diff and can introduce new bugs. Fix only the reported issue.
+category: pitfall
+tags: [diff-hygiene, surgical-changes, bug-fix-discipline]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/forrestchang/andrej-karpathy-skills.git
+source_ref: main
+source_commit: c9a44ae835fa2f5765a697216692705761a53f40
+source_project: andrej-karpathy-skills
+source_path: EXAMPLES.md#surgical-changes-example-1
+imported_at: 2026-04-18T08:26:22Z
+---
+
+# Pitfall — Drive-by refactor during a bug fix
+
+## Symptom
+Prompt: "Fix the bug where empty emails crash the validator."
+
+LLM diff:
+- Fixes the empty-email path. ✅
+- Tightens email regex to require a `.` after `@`. ⚠ not requested, may reject valid addresses.
+- Adds `len(username) < 3` rule. ⚠ new business rule.
+- Adds `username.isalnum()` rule. ⚠ new business rule.
+- Adds module docstring. ⚠ unrelated.
+
+Each extra change is a potential regression with no tests and no approval.
+
+## Surgical diff
+```diff
+  def validate_user(user_data):
+-     if not user_data.get('email'):
++     email = user_data.get('email', '')
++     if not email or not email.strip():
+          raise ValueError("Email required")
+```
+
+## Test
+Every changed line must trace to the user's bug report. If a reviewer asks "why did this line change?" and the answer is "to improve things," revert it.

--- a/knowledge/reference/dex2jar-apk-to-jar-intermediate-conversion.md
+++ b/knowledge/reference/dex2jar-apk-to-jar-intermediate-conversion.md
@@ -1,0 +1,91 @@
+---
+name: dex2jar-apk-to-jar-intermediate-conversion
+summary: dex2jar (`d2j-dex2jar`) converts Android DEX bytecode to standard Java JAR so that JVM-only decompilers (Fernflower/Vineflower, CFR, Procyon) can process APK content that they cannot read natively.
+category: reference
+confidence: medium
+tags: [android, dex2jar, dex, apk, jvm, bytecode, conversion, reverse-engineering, reference]
+source_type: extracted-from-git
+source_url: https://github.com/SimoneAvogadro/android-reverse-engineering-skill.git
+source_ref: master
+source_commit: ddeb9bc33272db1e34107fd286098bb1e9896e51
+source_project: android-reverse-engineering-skill
+source_path: plugins/android-reverse-engineering/skills/android-reverse-engineering/references/setup-guide.md
+imported_at: 2026-04-18T03:36:29Z
+linked_skills: [android-apk-multi-engine-decompilation]
+---
+
+# dex2jar APK→JAR Intermediate Conversion
+
+## Purpose
+
+Android ships bytecode as DEX (Dalvik Executable), not standard JVM class files. Most Java decompilers (Fernflower, Vineflower, CFR, Procyon) only read JVM bytecode. dex2jar bridges the gap by converting DEX → JAR of standard `.class` files, enabling any JVM decompiler to process Android content.
+
+jadx is the exception — it reads DEX directly and doesn't need this step.
+
+## Install
+
+### GitHub Releases
+
+```bash
+# Download latest from https://github.com/pxb1988/dex2jar/releases/latest
+unzip dex-tools-*.zip -d ~/dex2jar
+export PATH="$HOME/dex2jar:$PATH"
+```
+
+### Homebrew
+
+```bash
+brew install dex2jar
+```
+
+### Verify
+
+```bash
+d2j-dex2jar --help
+```
+
+## Core invocation
+
+```bash
+# -f overwrites existing output
+d2j-dex2jar -f -o output.jar app.apk
+```
+
+Works on `.apk` and `.dex` inputs. For multi-dex APKs the tool merges all DEX files into a single output JAR by default.
+
+## Full APK → Fernflower pipeline
+
+```bash
+# Step 1: DEX → JAR
+d2j-dex2jar -f -o app-converted.jar app.apk
+
+# Step 2: Decompile
+java -jar vineflower.jar -dgs=1 -mpm=60 app-converted.jar output/
+
+# Step 3: Extract the resulting source JAR
+unzip -o output/app-converted.jar -d output/sources/
+```
+
+## Common failures
+
+| Symptom | Cause / workaround |
+|---|---|
+| `ZipException` on `.apk` | Non-standard APK ZIP structure; fall back to jadx which reads DEX directly |
+| Missing `classes2.dex` in output | Multi-dex APK was only partially processed; run against each `classes*.dex` individually after unzipping the APK |
+| Output JAR has no `.class` files | dex2jar silently skipped unknown opcodes — usually newer Android runtime features; try a newer dex2jar release or use jadx |
+
+## Which decompiler to pair with it
+
+- **Vineflower** — recommended modern JVM decompiler (active maintenance, best modern-Java support).
+- **Fernflower** — the JetBrains original; same CLI as Vineflower.
+- **CFR / Procyon** — alternative JVM decompilers; useful for cross-validation.
+
+## When to skip dex2jar entirely
+
+Prefer jadx (direct DEX reader) when:
+
+- You only need one engine on an APK.
+- You need resource decoding alongside source decompilation.
+- The APK is very large and the two-step pipeline would be slow.
+
+Use dex2jar whenever jadx output has errors or warnings on specific classes, and you want Fernflower/Vineflower's output for those classes as a second opinion.

--- a/knowledge/reference/dflash-backend-support-matrix.md
+++ b/knowledge/reference/dflash-backend-support-matrix.md
@@ -1,0 +1,40 @@
+---
+name: dflash-backend-support-matrix
+summary: Quick-reference table of which inference backends support DFlash, their install commands, required flags, and model coverage — distilled from the DFlash README.
+category: reference
+tags: [dflash, vllm, sglang, transformers, mlx, speculative-decoding, reference]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/z-lab/dflash.git
+source_ref: main
+source_commit: 1fe684b00efba56490d920d15eeb9ba6e4471751
+source_project: dflash
+source_path: README.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# DFlash backend support matrix
+
+## Install and launch (condensed from upstream README)
+
+| Backend | Install | Launch / use | Model scope |
+|---|---|---|---|
+| **vLLM** (nightly) | `uv pip install -e ".[vllm]"` then `uv pip install -U vllm --torch-backend=auto --extra-index-url https://wheels.vllm.ai/nightly` | `vllm serve <target> --speculative-config '{"method":"dflash","model":"<draft>","num_speculative_tokens":15}' --attention-backend flash_attn` | All listed DFlash drafts |
+| **SGLang** | `uv pip install -e ".[sglang]"` | `python -m sglang.launch_server --speculative-algorithm DFLASH --speculative-draft-model-path <draft> --attention-backend trtllm_mha --speculative-draft-attention-backend fa4` | All listed DFlash drafts |
+| **Transformers** | `uv pip install -e ".[transformers]"` (pins `transformers==4.57.1`) | `draft.spec_generate(input_ids, max_new_tokens, target=target, stop_token_ids, temperature)` | **Qwen3 and Llama-3.1-8B-Instruct only** |
+| **MLX** | `pip install -e ".[mlx]"` | `stream_generate(model, draft, tokenizer, prompt, block_size=16, max_tokens, temperature)` — optional `sliding_window_size` on draft | Qwen3 / Qwen3.5 family on Apple Silicon |
+
+## Models with published DFlash drafts
+- Qwen3.6-35B-A3B (preview), Kimi-K2.5, Qwen3.5-4B/9B/27B/35B-A3B, Qwen3-Coder-Next / 30B-A3B
+- gpt-oss-20b, gpt-oss-120b
+- Qwen3-4B/8B non-thinking variants (b16)
+- Llama-3.1-8B-Instruct (UltraChat variant)
+- *Coming*: Qwen3.5-122B-A10B, Qwen3.5-397B-A17B, GLM-5.1
+
+## Flags worth remembering
+- `--enable-thinking` is *incompatible* with Qwen3-4B / Qwen3-8B DFlash drafts — they were not trained with thinking traces.
+- SGLang schedule-overlap v2 is experimental: `SGLANG_ENABLE_SPEC_V2=1`, `SGLANG_ENABLE_DFLASH_SPEC_V2=1`, `SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1` — set only if you want to ride the bleeding edge.
+- MLX `sliding_window_size` on the *draft* bounds KV growth for ultra-long-context use; leave `None` for default unbounded behaviour.
+
+## Datasets used by `python -m dflash.benchmark`
+gsm8k, math500, humaneval, mbpp, mt-bench. They are auto-downloaded as JSONL into `cache/` on first run.

--- a/knowledge/reference/docs-mcp-always-on.md
+++ b/knowledge/reference/docs-mcp-always-on.md
@@ -1,0 +1,39 @@
+---
+name: docs-mcp-always-on
+summary: Craft Agents wires craft-agents-docs as an always-available MCP server pointing at https://agents.craft.do/docs/mcp inside craft-agent.ts — not a user-configurable source — so the agent always has access to product docs for search.
+category: reference
+tags: [mcp, docs, always-on, craft-agents-docs]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: packages/shared/src/agent/claude-agent.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Always-on docs MCP
+
+### What
+Regardless of user configuration, the Craft Agents agent always has access to the `craft-agents-docs` MCP server — a Mintlify-backed HTTP MCP at `https://agents.craft.do/docs/mcp`. Lets the agent search product docs / source setup guides in-session ("how do I connect Linear?").
+
+### How
+Hardcoded in `packages/shared/src/agent/claude-agent.ts` as part of the SDK options, not in the sources registry. Previously was a "built-in source" (`packages/shared/src/sources/builtin-sources.ts` returned it); was moved to an always-available MCP entry to skip source-enabling UX friction.
+
+### Why the move
+As a source, users had to "enable" it or see it cluttering their source list. As an always-on MCP, it's invisible to users but always available to the agent. The agent mentions it implicitly: when you ask "how do I set up Slack", the agent calls `craft-agents-docs` tools without prompting you to connect anything.
+
+### User impact
+Quiet improvement — nothing to enable, it "just works". The docs source slug `craft-agents-docs` still exists for backward compatibility but `getBuiltinSources()` returns empty.
+
+### Replication pattern for other apps
+If your agent app has first-party docs that should always be searchable:
+1. Wire the MCP server directly into your agent's options, not through the user-facing sources system.
+2. Mark it distinct in `_displayName` so UI can show "searching docs" rather than pretending it's a generic source.
+3. Keep the hardcoded URL in a single constant so rebranding / domain change is a one-liner.
+
+### Reference
+- `packages/shared/src/agent/claude-agent.ts` (where the always-available MCP gets added).
+- `packages/shared/src/sources/builtin-sources.ts` (deprecated place, now returns empty).
+- The `mintlify` provider-name hint in `builtin-sources.ts` (comments) documents the migration.

--- a/knowledge/reference/dual-sided-worker-pool-toggle.md
+++ b/knowledge/reference/dual-sided-worker-pool-toggle.md
@@ -1,0 +1,43 @@
+---
+name: dual-sided-worker-pool-toggle
+summary: An evolver node only accepts hub-dispatched tasks when BOTH sides are turned on — local `WORKER_ENABLED=1` env var AND the "Worker" toggle on the evomap.ai node dashboard. Either side off means zero task flow, with no error; silent no-op is by design.
+category: reference
+tags: [worker-pool, dual-sided-toggle, env-config, hub-side, gotcha]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/EvoMap/evolver.git
+source_ref: main
+source_commit: 4c51382092f9cb125d3ec55475861ead8d1463a6
+source_project: evolver
+source_paths:
+  - README.md (WORKER_ENABLED vs. the Website Toggle section)
+imported_at: 2026-04-18T03:00:00Z
+---
+
+# Worker Pool Two-Sided Enable Rule
+
+The Evolver worker pool has two independent kill switches, *both* of which must be on:
+
+| Side | Control | Scope | What it does |
+|---|---|---|---|
+| Local | `WORKER_ENABLED=1` env var | The evolver daemon process | Advertises worker metadata in heartbeats; accepts task payloads |
+| Hub | Website toggle on node detail page at evomap.ai | Hub-side scheduling | Tells the hub whether to dispatch tasks to this node |
+
+If either side is off, the node will not pick up work — and the failure is **silent**, no error log. That's the common debugging trap.
+
+## Recommended setup flow
+
+1. Set `WORKER_ENABLED=1` in the local `.env`.
+2. Start the daemon: `node index.js --loop`.
+3. Go to evomap.ai, find the node, turn on the **Worker** toggle.
+4. Confirm by watching the heartbeat response for task pushes.
+
+## Related env vars
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `WORKER_ENABLED` | unset | Local on/off |
+| `WORKER_DOMAINS` | empty | Comma-list of accepted task domains (e.g. `repair,harden`) |
+| `WORKER_MAX_LOAD` | `5` | Advertised concurrent capacity — a scheduling hint for the hub, **not** a local concurrency cap |
+
+Key gotcha: `WORKER_MAX_LOAD` advertises but does not enforce. A misbehaving hub could push more than the advertised load; the local runtime does not reject.

--- a/knowledge/windows/display-enumeration-winapi-structs.md
+++ b/knowledge/windows/display-enumeration-winapi-structs.md
@@ -1,0 +1,28 @@
+---
+name: display-enumeration-winapi-structs
+type: knowledge
+category: platform/windows
+summary: DisplayInfo protobuf encodes width, height, HiDPI scaling, monitor index mapping.
+confidence: medium
+tags: [display, enumeration, platform, structs, winapi, windows]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: src/platform/windows.rs
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Display Enumeration Winapi Structs
+
+## Fact
+DisplayInfo protobuf encodes width, height, HiDPI scaling, monitor index mapping.
+
+## Why it matters
+Shape of the wire message that everyone else consumes — keep it stable.
+
+## Evidence
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- `src/platform/windows.rs`

--- a/knowledge/workflow/docs-claude-context.md
+++ b/knowledge/workflow/docs-claude-context.md
@@ -1,0 +1,48 @@
+---
+name: docs-claude-context
+summary: Claude context file for docs directory — guidelines for documentation authoring
+category: workflow
+confidence: medium
+tags: [game-studios, ccgs, claude-md, documentation, context]
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+source_path: docs/CLAUDE.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Docs Directory
+
+When authoring or editing files in this directory, follow these standards.
+
+## Architecture Decision Records (`docs/architecture/`)
+
+Use the ADR template: `.claude/docs/templates/architecture-decision-record.md`
+
+**Required sections:** Title, Status, Context, Decision, Consequences,
+ADR Dependencies, Engine Compatibility, GDD Requirements Addressed
+
+**Status lifecycle:** `Proposed` → `Accepted` → `Superseded`
+- Never skip `Accepted` — stories referencing a `Proposed` ADR are auto-blocked
+- Use `/architecture-decision` to create ADRs through the guided flow
+
+**TR Registry:** `docs/architecture/tr-registry.yaml`
+- Stable requirement IDs (e.g. `TR-MOV-001`) that link GDD requirements to stories
+- Never renumber existing IDs — only append new ones
+- Updated by `/architecture-review` Phase 8
+
+**Control Manifest:** `docs/architecture/control-manifest.md`
+- Flat programmer rules sheet: Required / Forbidden / Guardrails per layer
+- Date-stamped `Manifest Version:` in header
+- Stories embed this version; `/story-done` checks for staleness
+
+**Validation:** Run `/architecture-review` after completing a set of ADRs.
+
+## Engine Reference (`docs/engine-reference/`)
+
+Version-pinned engine API snapshots. **Always check here before using any
+engine API** — the LLM's training data predates the pinned engine version.
+
+Current engine: see `docs/engine-reference/godot/VERSION.md`

--- a/registry.json
+++ b/registry.json
@@ -2409,6 +2409,161 @@
       "category": "build",
       "path": "skills/build/coverage-data-file-under-pytest-cache/SKILL.md",
       "version": "1.0.0"
+    },
+    "detached-daemon-lifecycle-cli": {
+      "category": "ops",
+      "path": "skills/ops/detached-daemon-lifecycle-cli/SKILL.md",
+      "version": "1.0.0"
+    },
+    "detached-update-check-with-local-cache": {
+      "category": "reliability",
+      "path": "skills/reliability/detached-update-check-with-local-cache/SKILL.md",
+      "version": "1.0.0"
+    },
+    "detached-watchdog-telemetry-process": {
+      "category": "telemetry",
+      "path": "skills/telemetry/detached-watchdog-telemetry-process/SKILL.md",
+      "version": "1.0.0"
+    },
+    "deterministic-agent-chain": {
+      "category": "llm-agents",
+      "path": "skills/llm-agents/deterministic-agent-chain/SKILL.md",
+      "version": "1.0.0"
+    },
+    "deterministic-torch-seed-bundle": {
+      "category": "ml-ops",
+      "path": "skills/ml-ops/deterministic-torch-seed-bundle/SKILL.md",
+      "version": "1.0.0"
+    },
+    "dev-sidecar-placeholder-binary": {
+      "category": "tauri",
+      "path": "skills/tauri/dev-sidecar-placeholder-binary/SKILL.md",
+      "version": "1.0.0"
+    },
+    "dev-story": {
+      "category": "production",
+      "path": "skills/production/dev-story/SKILL.md",
+      "version": "1.0.0"
+    },
+    "develop-script-with-inplace-submodule-symlinks": {
+      "category": "build-system",
+      "path": "skills/build-system/develop-script-with-inplace-submodule-symlinks/SKILL.md",
+      "version": "1.0.0"
+    },
+    "device-revocation-reset-flow": {
+      "category": "auth",
+      "path": "skills/auth/device-revocation-reset-flow/SKILL.md",
+      "version": "1.0.0"
+    },
+    "dex2jar-bridge-apk-to-fernflower": {
+      "category": "reverse-engineering",
+      "path": "skills/reverse-engineering/dex2jar-bridge-apk-to-fernflower/SKILL.md",
+      "version": "1.0.0"
+    },
+    "dispatching-parallel-agents": {
+      "category": "llm-agents",
+      "path": "skills/llm-agents/dispatching-parallel-agents/SKILL.md",
+      "version": "1.0.0"
+    },
+    "display-device-enumeration-platform": {
+      "category": "platform",
+      "path": "skills/platform/display-device-enumeration-platform/SKILL.md",
+      "version": "1.0.0"
+    },
+    "distributed-filesystem-safe-atomic-cache-with-fsync": {
+      "category": "jit-compilation",
+      "path": "skills/jit-compilation/distributed-filesystem-safe-atomic-cache-with-fsync/SKILL.md",
+      "version": "1.0.0"
+    },
+    "docker-compose-selfhost-stack": {
+      "category": "devops",
+      "path": "skills/devops/docker-compose-selfhost-stack/SKILL.md",
+      "version": "1.0.0"
+    },
+    "docker-entrypoint-gosu-bind-mount": {
+      "category": "docker",
+      "path": "skills/docker/docker-entrypoint-gosu-bind-mount/SKILL.md",
+      "version": "1.0.0"
+    },
+    "docker-find-chmod-fast-readability": {
+      "category": "build",
+      "path": "skills/build/docker-find-chmod-fast-readability/SKILL.md",
+      "version": "1.0.0"
+    },
+    "docker-multistage-go-alpine": {
+      "category": "devops",
+      "path": "skills/devops/docker-multistage-go-alpine/SKILL.md",
+      "version": "1.0.0"
+    },
+    "docker-smoke-test-loop": {
+      "category": "devops",
+      "path": "skills/devops/docker-smoke-test-loop/SKILL.md",
+      "version": "1.0.0"
+    },
+    "document-converter-priority-registry": {
+      "category": "architecture",
+      "path": "skills/architecture/document-converter-priority-registry/SKILL.md",
+      "version": "1.0.0"
+    },
+    "draft-model-bind-to-target-modules": {
+      "category": "llm-agents",
+      "path": "skills/llm-agents/draft-model-bind-to-target-modules/SKILL.md",
+      "version": "1.0.0"
+    },
+    "draft-release-notes-from-git-log": {
+      "category": "agents",
+      "path": "skills/agents/draft-release-notes-from-git-log/SKILL.md",
+      "version": "1.0.0"
+    },
+    "drag-drop-widget-composition": {
+      "category": "flutter",
+      "path": "skills/flutter/drag-drop-widget-composition/SKILL.md",
+      "version": "1.0.0"
+    },
+    "drainable-worker-pattern-for-queue-based-async": {
+      "category": "effect-ts",
+      "path": "skills/effect-ts/drainable-worker-pattern-for-queue-based-async/SKILL.md",
+      "version": "1.0.0"
+    },
+    "dual-driver-runtime-api-abstraction": {
+      "category": "jit-compilation",
+      "path": "skills/jit-compilation/dual-driver-runtime-api-abstraction/SKILL.md",
+      "version": "1.0.0"
+    },
+    "dual-mode-cublaslt-handle-workspace": {
+      "category": "pytorch-integration",
+      "path": "skills/pytorch-integration/dual-mode-cublaslt-handle-workspace/SKILL.md",
+      "version": "1.0.0"
+    },
+    "dxgi-com-pointer-wrapper-raii": {
+      "category": "patterns",
+      "path": "skills/patterns/dxgi-com-pointer-wrapper-raii/SKILL.md",
+      "version": "1.0.0"
+    },
+    "dxgi-texture-capturer-gpu-optimization": {
+      "category": "codecs",
+      "path": "skills/codecs/dxgi-texture-capturer-gpu-optimization/SKILL.md",
+      "version": "1.0.0"
+    },
+    "dynamic-system-prompt": {
+      "category": "agents",
+      "path": "skills/agents/dynamic-system-prompt/SKILL.md",
+      "version": "1.0.0"
+    },
+    "e2e-default-login-helper": {
+      "category": "testing",
+      "path": "skills/testing/e2e-default-login-helper/SKILL.md",
+      "version": "1.0.0"
+    },
+    "easyedit-rome-knowledge-edit": {
+      "category": "llm-agents",
+      "path": "skills/llm-agents/easyedit-rome-knowledge-edit/SKILL.md",
+      "version": "1.0.0"
+    },
+    "easyjailbreak-pair-attack-pipeline": {
+      "category": "security",
+      "path": "skills/security/easyjailbreak-pair-attack-pipeline/SKILL.md",
+      "version": "1.0.0"
     }
   },
   "knowledge": {
@@ -4427,6 +4582,82 @@
     "craft-cli-command-surface": {
       "category": "reference",
       "path": "knowledge/reference/craft-cli-command-surface.md"
+    },
+    "desktop-route-categories": {
+      "category": "decision",
+      "path": "knowledge/decision/desktop-route-categories.md"
+    },
+    "dev-sh-auto-setup-idempotent": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/dev-sh-auto-setup-idempotent.md"
+    },
+    "device-revocation-status-codes-contract": {
+      "category": "auth",
+      "path": "knowledge/auth/device-revocation-status-codes-contract.md"
+    },
+    "devtools-frontend-reused-as-library": {
+      "category": "arch",
+      "path": "knowledge/arch/devtools-frontend-reused-as-library.md"
+    },
+    "dex2jar-apk-to-jar-intermediate-conversion": {
+      "category": "reference",
+      "path": "knowledge/reference/dex2jar-apk-to-jar-intermediate-conversion.md"
+    },
+    "dflash-backend-support-matrix": {
+      "category": "reference",
+      "path": "knowledge/reference/dflash-backend-support-matrix.md"
+    },
+    "dflash-block-diffusion-overview": {
+      "category": "llm-agents",
+      "path": "knowledge/llm-agents/dflash-block-diffusion-overview.md"
+    },
+    "directory-rename-is-atomic-not-file-rename": {
+      "category": "jit-compilation",
+      "path": "knowledge/jit-compilation/directory-rename-is-atomic-not-file-rename.md"
+    },
+    "display-enumeration-winapi-structs": {
+      "category": "windows",
+      "path": "knowledge/windows/display-enumeration-winapi-structs.md"
+    },
+    "display-orientation-rotation-handling": {
+      "category": "codecs",
+      "path": "knowledge/codecs/display-orientation-rotation-handling.md"
+    },
+    "dockerfile-server-design-choices": {
+      "category": "devops",
+      "path": "knowledge/devops/dockerfile-server-design-choices.md"
+    },
+    "docs-claude-context": {
+      "category": "workflow",
+      "path": "knowledge/workflow/docs-claude-context.md"
+    },
+    "docs-mcp-always-on": {
+      "category": "reference",
+      "path": "knowledge/reference/docs-mcp-always-on.md"
+    },
+    "drive-by-refactor-beyond-bug-fix": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/drive-by-refactor-beyond-bug-fix.md"
+    },
+    "dual-backend-claude-and-pi": {
+      "category": "architecture",
+      "path": "knowledge/architecture/dual-backend-claude-and-pi.md"
+    },
+    "dual-sided-worker-pool-toggle": {
+      "category": "reference",
+      "path": "knowledge/reference/dual-sided-worker-pool-toggle.md"
+    },
+    "dynamic-uv-python-scripts": {
+      "category": "architecture",
+      "path": "knowledge/architecture/dynamic-uv-python-scripts.md"
+    },
+    "easyedit-framework": {
+      "category": "llm-fundamentals",
+      "path": "knowledge/llm-fundamentals/easyedit-framework.md"
+    },
+    "effect-ts-layer-dependency-injection-for-testing": {
+      "category": "architecture",
+      "path": "knowledge/architecture/effect-ts-layer-dependency-injection-for-testing.md"
     }
   }
 }

--- a/skills/agents/draft-release-notes-from-git-log/SKILL.md
+++ b/skills/agents/draft-release-notes-from-git-log/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: draft-release-notes-from-git-log
+description: Keep a non-destructive [Unreleased] changelog draft in sync with the actual diff since the last tag, using git log + GitHub's generate-notes API.
+category: agents
+version: 1.0.0
+version_origin: extracted
+tags: [changelog, releases, git, github-cli, documentation]
+source_type: extracted-from-git
+source_url: https://github.com/jamiepine/voicebox.git
+source_ref: main
+source_commit: 476abe07fc2c1587f4b3e3916134018ebacd143d
+source_project: voicebox
+confidence: high
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Draft release notes from git log
+
+## When to use
+You maintain a human-readable `CHANGELOG.md` (Keep-a-Changelog style) and want the `[Unreleased]` section to stay honest during development so it's one command away from being stamped into a release.
+
+## Steps
+1. Detect the last tag: `LAST_TAG=$(git tag --list "v*" --sort=-v:refname | head -n 1)`. This is the scope boundary for the draft.
+2. Gather three raw inputs:
+   - `git log --oneline "$LAST_TAG"..HEAD` — the actual commits in order.
+   - `gh api repos/:owner/:repo/releases/generate-notes -f tag_name="vNEXT" -f target_commitish=$(git rev-parse HEAD) -f previous_tag_name="$LAST_TAG" --jq '.body'` — GitHub's auto-generated PR-title list.
+   - `git diff --stat "$LAST_TAG"..HEAD` — which areas changed, for theme clustering.
+3. Draft a narrative: one strong opening paragraph (what this release is about, why it matters, tied to concrete changes), one optional paragraph on major technical shifts, then themed bullet groups (`### Feature group`, `### Bug Fixes`) with PR links where known.
+4. Replace **only** the body between `## [Unreleased]` and the next `## [` heading. Preserve the `[Unreleased]` heading itself so the file always has that section first after the header comments. Never touch stamped release sections.
+5. Do not commit, tag, or bump. The draft lives as a dirty file in the working tree and can be regenerated freely — "non-destructive working copy".
+6. If `git log "$LAST_TAG"..HEAD` is empty, leave the section empty and tell the caller there's nothing to draft.
+
+## Counter / Caveats
+- Be factual and specific — every claim must trace to a commit or PR. Fabricated "improvements" get flagged by maintainers.
+- Lead with prose, not bullets. The narrative is what readers consume; bullets are supporting evidence.
+- Skip trivial chores (typo fixes, CI tweaks) unless they're the bulk of the release — otherwise the notes bury the important work.
+- Match the voice of previous entries in the same CHANGELOG — look at the last two stamped sections for tone.
+- Downstream skills (release-bump) depend on this draft being up-to-date before stamping. Re-run whenever a meaningful PR lands.
+
+Source references: `.agents/skills/draft-release-notes/SKILL.md` (the full workflow this skill extracts), `CHANGELOG.md` (the format target).

--- a/skills/agents/dynamic-system-prompt/SKILL.md
+++ b/skills/agents/dynamic-system-prompt/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: dynamic-system-prompt
+description: Generate agent instructions dynamically at runtime from a context object.
+category: agents
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [openai-agents, instructions, dynamic-prompt, context]
+source_type: extracted-from-git
+source_url: https://github.com/openai/openai-agents-python.git
+source_ref: main
+source_commit: e80d2d2319eb300ac17ec496988b70246a5042d6
+source_project: openai-agents-python
+source_path: examples/basic/dynamic_system_prompt.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# dynamic-system-prompt
+
+Pass a callable to `Agent.instructions` instead of a static string. The callable receives `RunContextWrapper[TContext]` and the agent, returns a `str`. This enables per-user or per-request instruction customization.
+
+## When to apply
+
+When the agent's system prompt depends on runtime data (user role, session config, locale, A/B flags). Avoids maintaining multiple agent instances for minor prompt variants.
+
+## Core snippet
+
+```python
+from dataclasses import dataclass
+from typing import Literal
+from agents import Agent, RunContextWrapper, Runner
+
+@dataclass
+class CustomContext:
+    style: Literal["haiku", "pirate", "robot"]
+
+def custom_instructions(
+    run_context: RunContextWrapper[CustomContext], agent: Agent[CustomContext]
+) -> str:
+    context = run_context.context
+    if context.style == "haiku":
+        return "Only respond in haikus."
+    elif context.style == "pirate":
+        return "Respond as a pirate."
+    else:
+        return "Respond as a robot and say 'beep boop' a lot."
+
+agent = Agent(
+    name="Chat agent",
+    instructions=custom_instructions,
+)
+
+async def main():
+    context = CustomContext(style="pirate")
+    result = await Runner.run(agent, "Tell me a joke.", context=context)
+    print(result.final_output)
+```
+
+## Key notes
+
+- `instructions` can be a `str` or `Callable[[RunContextWrapper[T], Agent[T]], str]`
+- The callable may also be async: `async def my_instructions(ctx, agent) -> str:`
+- Context object is typed; use `Agent[CustomContext]` for type-checked access

--- a/skills/architecture/document-converter-priority-registry/SKILL.md
+++ b/skills/architecture/document-converter-priority-registry/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: document-converter-priority-registry
+description: Pluggable converter registry where each candidate declares a numeric priority, registrations are prepended, and dispatch re-sorts stably per call so the most recently registered converter at a priority wins.
+category: architecture
+version: 1.0.0
+tags: [architecture, registry, dispatch, plugin, priority, python]
+source_type: extracted-from-git
+source_url: https://github.com/microsoft/markitdown.git
+source_ref: main
+source_commit: 604bba13da2f43b756b49122cb65bdedb85b1dff
+source_project: markitdown
+source_path: packages/markitdown/src/markitdown/_markitdown.py
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version_origin: extracted
+---
+
+# Document Converter Priority Registry
+
+Generic pluggable-dispatch pattern: a host owns an ordered list of `(converter, priority)` registrations and picks one per request by (a) sorting stably by priority, (b) walking the sorted list, (c) asking each one "can you handle this?" (`accepts()`), and (d) calling `convert()` on the first that says yes. New registrations are `insert(0, ...)` so, at equal priority, **the most recently registered wins** — giving late-loaded plugins a way to shadow a built-in without changing core code.
+
+## When to use
+
+- You have a polymorphic handler contract (parser, converter, serializer, router).
+- Built-in implementations must coexist with runtime-registered plugins.
+- The order of tries matters: specific beats generic, newer beats older at the same priority.
+- Priorities are fixed per converter but may change between calls (re-sort each call).
+
+## The shape
+
+```python
+from dataclasses import dataclass
+from typing import List
+
+PRIORITY_SPECIFIC_FILE_FORMAT = 0.0   # specific: PDF, DOCX, Wikipedia
+PRIORITY_GENERIC_FILE_FORMAT  = 10.0  # catch-all: text/*, html
+
+@dataclass(kw_only=True, frozen=True)
+class ConverterRegistration:
+    converter: "DocumentConverter"
+    priority: float
+
+class Host:
+    def __init__(self):
+        self._converters: List[ConverterRegistration] = []
+
+    def register_converter(self, converter, *, priority: float = PRIORITY_SPECIFIC_FILE_FORMAT):
+        # insert at index 0 so later registrations win stable-sort ties
+        self._converters.insert(0, ConverterRegistration(converter=converter, priority=priority))
+
+    def dispatch(self, *args, **kwargs):
+        # Re-sort on every call — priorities may change between calls.
+        # `sorted` is stable → same-priority entries keep insertion order.
+        for reg in sorted(self._converters, key=lambda r: r.priority):
+            if reg.converter.accepts(*args, **kwargs):
+                return reg.converter.convert(*args, **kwargs)
+```
+
+## Why these three choices
+
+1. **Lower priority value = tried first.** Counter-intuitive, but useful: "specific format" = priority 0, "generic catch-all" = priority 10. New plugins can pick any float to slot themselves in. Document this loudly to avoid confusion.
+2. **Insert at head + stable sort.** Equal-priority registrations preserve insertion order, and the most-recent insertion lands at the front of the tie-group. Plugins can override built-ins without extra API.
+3. **Re-sort per call.** Priorities are rare to change, but cheap to re-sort (N is small). Avoids a stale-cache bug class if a converter exposes a mutable priority.
+
+## Plugin override in practice
+
+Built-in registrations (all priority 0 except the three generic ones at 10):
+
+```python
+self.register_converter(PlainTextConverter(), priority=10.0)   # generic
+self.register_converter(HtmlConverter(),      priority=10.0)   # generic
+self.register_converter(PdfConverter())                         # specific, p=0
+self.register_converter(DocxConverter())                        # specific, p=0
+# ...
+```
+
+A plugin then shadows the PDF handler by simply doing:
+
+```python
+host.register_converter(MyPdfConverter())   # also priority 0 → now at head of tie group → wins
+```
+
+No introspection, no unregister step, no plugin lifecycle API.
+
+## Plugin loader glue
+
+Load plugins via `importlib.metadata.entry_points`, wrap each in try/except so a broken plugin doesn't kill the host:
+
+```python
+from importlib.metadata import entry_points
+for ep in entry_points(group="markitdown.plugin"):
+    try:
+        plugin = ep.load()
+        plugin.register_converters(host)
+    except Exception:
+        warn(f"Plugin '{ep.name}' failed to load ... skipping:\n{traceback.format_exc()}")
+```
+
+See companion skill `python-entrypoint-plugin-loader` for the full pattern.
+
+## Anti-patterns
+
+- **Using a `dict[str, Converter]` by extension.** Collapses plugin override, forces one-handler-per-extension, can't encode "try these in order."
+- **Reversed priority (higher = first).** You'll save ten minutes on read-intuition but lose hours when a plugin author picks the wrong sign and their handler never runs. Pick one convention and document it.
+- **Single sorted list, no re-sort.** Subtle bug: if any converter exposes a settable priority, your cached sort goes stale.
+- **`append()` instead of `insert(0)`.** At equal priority you now favor the *oldest* registration, which is the opposite of what plugin authors expect.
+
+## Variations
+
+- **Multi-hit dispatch.** For "chain of responsibility where every responder must run," iterate without `break` — still uses the same sorted list.
+- **Failover.** If `convert()` raises a retriable error, record it and fall through to the next converter (markitdown does this; see companion skill `accepts-then-convert-two-phase-dispatch`).
+- **Multiple guesses.** If the request's signal (e.g., mimetype) is ambiguous, iterate over multiple input guesses in an outer loop and the sorted converter list in an inner loop.

--- a/skills/auth/device-revocation-reset-flow/SKILL.md
+++ b/skills/auth/device-revocation-reset-flow/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: device-revocation-reset-flow
+description: Implement a graceful credentials-invalid reset for PowerSync-style apps so account-deleted (410) or device-revoked (403) clients drop their local DB, clear localStorage, and restart signed-out without crashes.
+category: auth
+confidence: high
+version: 1.0.0
+version_origin: extracted
+source_type: extracted-from-git
+source_url: https://github.com/thunderbird/thunderbolt.git
+source_ref: main
+source_commit: 9d9c18ba511decfd3b45fc0f72c265d83355fe95
+source_project: thunderbolt
+imported_at: 2026-04-18T00:00:00Z
+tags: [auth, powersync, devices, session, reset]
+linked_knowledge: [device-revocation-status-codes-contract]
+---
+
+## When to use
+
+A user deletes their account, or revokes a device from elsewhere. The revoked device is still running; you need it to cleanly reset without crashing when PowerSync sync wipes its local data.
+
+## Steps
+
+1. **Track device identity**: on first launch, mint a `deviceId` (uuidv7) and store it in `localStorage`. Send it as `X-Device-ID` on every PowerSync token request and `X-Device-Name` when you want to label it in the devices list.
+2. **Backend device gate**: the `GET /powersync/token` handler, when given `X-Device-ID`, looks up the row in `devices`. If `status === 'REVOKED'` or `revoked_at IS NOT NULL`, return **403** with `{ code: 'DEVICE_DISCONNECTED' }` and no token. If the user no longer exists, return **410 Gone** with `{ code: 'ACCOUNT_DELETED' }`. If an existing `deviceId` is claimed by another user, return **409** with `{ code: 'DEVICE_ID_TAKEN' }`.
+3. **Client connector**: when the token response is 410 or 403+DEVICE_DISCONNECTED or 409+DEVICE_ID_TAKEN, dispatch a `window.dispatchEvent(new CustomEvent('powersyncCredentialsInvalid', { detail: { reason } }))` event. Do **not** reset inside the connector — keep the reset in a React listener so it runs even if AuthProvider has already unmounted.
+4. **Sync-row listener**: watch the current device's row via React Query with `getDevice(db, deviceId)` and key `['devices', deviceId]`. When the synced row has `revoked_at` or `status === 'REVOKED'`, trigger the reset.
+5. **Reset handler**: `setSyncEnabled(false)` → `localStorage.clear()` → `resetAppDir()` (delete the SQLite file and app dir) → `window.location.replace('/')` (or `/account-deleted` for the 410 path).
+6. **Sequence guard**: use refs (`hasTriggeredResetRef`, `hadDeviceOnceRef`) so you don't fire reset twice. For "device row missing", only trigger reset if you previously *had* the row — otherwise the first load before sync finishes would look indistinguishable from a delete.
+
+## Counter / Caveats
+
+- Mount the listener hook inside `AuthProvider` *before* its early return. Once the backend deletes the user, PowerSync sync wipes settings, `cloudUrl` disappears, and `AuthProvider` returns `null`. If the listener lived under those children, it never fires and the app wedges.
+- Do not use 401 as a reset trigger. 401 is generic auth failure (stale token, clock skew) — treat it as a refresh hint, not a destructive signal.
+- Revoke is idempotent: returning 204 on an already-revoked device keeps retry loops from hammering the DB.
+
+## Evidence
+
+- `src/hooks/use-powersync-credentials-invalid-listener.ts:1-113`
+- `docs/powersync-account-devices.md:98-205`
+- `docs/delete-account-and-revoke-device.md`

--- a/skills/auth/device-revocation-reset-flow/content.md
+++ b/skills/auth/device-revocation-reset-flow/content.md
@@ -1,0 +1,62 @@
+# Device revocation / account deletion reset flow
+
+The invariant: a revoked device must end up in a clean signed-out state without data corruption or crash, *whether or not* PowerSync gets a chance to tell it first.
+
+Two signal paths converge on the same reset:
+
+## Signal A: token refresh HTTP codes
+
+- **410 Gone** with `{ code: 'ACCOUNT_DELETED' }` → the user is gone on the backend.
+- **403 Forbidden** with `{ code: 'DEVICE_DISCONNECTED' }` → this specific `X-Device-ID` is revoked.
+- **409** with `{ code: 'DEVICE_ID_TAKEN' }` → another user registered the id; reset and mint a new one.
+
+The PowerSync connector dispatches a `powersyncCredentialsInvalid` CustomEvent with a `reason` discriminator. Reset lives in a React hook, not the connector.
+
+## Signal B: synced `devices` row
+
+Watch the current device's row with React Query:
+
+```ts
+const { data = [], isFetched } = useQuery({
+  queryKey: ['devices', deviceId],
+  query: toCompilableQuery(getDevice(db, deviceId)),
+})
+```
+
+When `data[0]?.revokedAt` becomes truthy, run the reset. This gives an *immediate* response as soon as the sync frame arrives; we don't have to wait for the next token refresh.
+
+## The "device row missing" gotcha
+
+If the backend deleted the user, PowerSync eventually syncs DELETE ops that erase the `devices` row. But on a brand-new app launch before the first sync completes, the row is *also* missing. Treating missing as revoked would wipe a legitimate user's data on a cold start.
+
+Guard: track `hadDeviceOnceRef`. Only treat a missing device as "deleted elsewhere" if you previously saw the row in this session.
+
+## The reset itself
+
+```ts
+const performCredentialsInvalidReset = async (redirectTo: string) => {
+  await clearLocalData()          // setSyncEnabled(false) + localStorage.clear() + reset app dir
+  window.location.replace(redirectTo)
+}
+```
+
+`/account-deleted` for 410, `/` for 403.
+
+## Why it must live inside AuthProvider, above the early return
+
+```tsx
+export const AuthProvider = ({ children }) => {
+  usePowerSyncCredentialsInvalidListener()     // <- BEFORE the early return
+
+  const value = useAuthValue()
+  if (!value) return null                       // <- Would unmount the listener
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+```
+
+When the account is deleted, sync wipes settings, cloudUrl disappears, and `useAuthValue()` returns null. If the listener were a child, unmount would stop it firing the reset. Placing it above the early return keeps it alive long enough to run.
+
+## Evidence
+
+- `src/hooks/use-powersync-credentials-invalid-listener.ts:1-113`
+- `docs/powersync-account-devices.md:98-205`

--- a/skills/build-system/develop-script-with-inplace-submodule-symlinks/SKILL.md
+++ b/skills/build-system/develop-script-with-inplace-submodule-symlinks/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: develop-script-with-inplace-submodule-symlinks
+description: Ship a `develop.sh` that symlinks vendored submodule includes (CUTLASS, fmt) into the package's include tree, then runs `python setup.py build` and symlinks the resulting `.so` back into the source package — editable-install for a CUDA extension.
+category: build-system
+version: 1.0.0
+version_origin: extracted
+tags: [develop-mode, setup-py, cuda-extension, symlinks, editable-install, submodules]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - develop.sh
+  - install.sh
+  - build.sh
+  - setup.py
+imported_at: 2026-04-18T13:30:00Z
+---
+
+# In-Place Dev Mode For A CUDA Extension With Vendored Submodules
+
+## When to use
+Your Python package ships a native CUDA extension (pybind11 + `CUDAExtension`) and vendors large C++ header-only dependencies (CUTLASS, fmt) as git submodules. `pip install -e .` doesn't give you what you want because:
+- The submodule headers need to live *inside* the installed `package/include/` tree (for runtime JIT to find them), but your source tree has them at `third-party/cutlass/include/cutlass/`.
+- You want to rebuild iteratively without reinstalling the wheel.
+
+Solution: a tiny `develop.sh` that creates header symlinks and builds to the source tree.
+
+## Steps
+1. **Capture the user's original CWD** so the script is callable from anywhere:
+   ```bash
+   original_dir=$(pwd)
+   script_dir=$(realpath "$(dirname "$0")")
+   cd "$script_dir"
+   ```
+2. **Symlink submodule headers into the package's `include/` dir.** The symlink is idempotent (`ln -sf`) so you can re-run freely:
+   ```bash
+   ln -sf $script_dir/third-party/cutlass/include/cutlass  deep_gemm/include
+   ln -sf $script_dir/third-party/cutlass/include/cute     deep_gemm/include
+   ```
+   Result: `deep_gemm/include/cutlass` points to `third-party/cutlass/include/cutlass`. At runtime, your JIT wrapper passes `-I<package>/include` and NVCC resolves the chain transparently.
+3. **Clean previous build artifacts** to avoid `.so` staleness:
+   ```bash
+   rm -rf build dist *.egg-info
+   ```
+4. **Build the C extension in place:** `python setup.py build`. This puts `.so` under `build/lib.linux-x86_64-*-cpython*/`.
+5. **Symlink the built `.so` back into the source package** so `import <package>` from the source tree finds it:
+   ```bash
+   so_file=$(find build -name "*.so" -type f | head -n 1)
+   ln -sf "../$so_file" deep_gemm/
+   ```
+6. **Restore CWD:** `cd "$original_dir"`.
+7. **Provide `install.sh` as the parallel "real" installer** — same prelude, but `bdist_wheel` + `pip install --force-reinstall dist/*.whl`. The wheel-path builds its own `include/` copy via `CustomBuildPy.prepare_includes()` (a `shutil.copytree` rather than a symlink, because wheels can't contain symlinks).
+
+## Evidence (from DeepGEMM)
+- `develop.sh:6-8`: submodule header symlinks.
+- `develop.sh:13`: `python setup.py build` — no `--inplace` flag; artifacts end up under `build/`.
+- `develop.sh:16-22`: find `.so` and symlink it into `deep_gemm/`.
+- `install.sh:9-10`: wheel path (`bdist_wheel` + `pip install --force-reinstall`).
+- `setup.py:114-166`: `CustomBuildPy.prepare_includes()` does `shutil.copytree` for the wheel so symlinks don't leak into the shipped package.
+
+## Counter / Caveats
+- **Symlinks on Windows need `mklink /D`** or developer-mode enabled. This script is Linux-only as written; gating by `$OSTYPE` is a mild extension.
+- **`pip install -e .` alone is not enough** because `CUDAExtension` doesn't set up the include-tree layout the JIT needs. Hence the custom shell script — there is no stock `setup.py develop` equivalent.
+- **If a submodule header moves across versions, the symlink dangles silently.** Run `develop.sh` after every `git submodule update` to refresh.
+- **CI should not use this path** — CI builds a wheel via `install.sh` so the `include/` tree is a real copy.

--- a/skills/build/docker-find-chmod-fast-readability/SKILL.md
+++ b/skills/build/docker-find-chmod-fast-readability/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: docker-find-chmod-fast-readability
+description: In a Dockerfile RUN layer, use find -not -perm to touch ONLY files missing a permission bit instead of chmod -R — cuts image build time from minutes to seconds on big node_modules trees.
+category: build
+version: 1.0.0
+version_origin: extracted
+tags: [docker, chmod, performance, node_modules]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: Dockerfile.server
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# chmod smart in Docker (find -not -perm)
+
+## When to use
+- You want world-readable app files inside a container so `docker run --user $(id -u):$(id -g)` works for arbitrary host users.
+- Your `/app` has hundreds of thousands of files (node_modules - looking at you).
+- `chmod -R o+r /app` takes minutes and explodes the layer size.
+
+## How it works
+`chmod -R` walks every inode and writes the new mode unconditionally. `find -not -perm` only invokes chmod on files that actually need it:
+
+```dockerfile
+RUN find /app -not -perm -o=r -exec chmod o+r {} + && \
+    find /app -type d -not -perm -o=x -exec chmod o+x {} +
+```
+
+- `-o=r` / `-o=x` = "other has read/execute". `-not -perm -o=r` = "other is missing read".
+- `-exec chmod o+r {} +` = batch up arguments (like xargs), one chmod per batch instead of per file.
+- Directory pass is separate because you want `o+x` (traversability) not `o+r` on dirs if you're being precise.
+
+## Example
+Slow:
+```dockerfile
+RUN chmod -R o+r /app  # ~3 minutes on 300k files
+```
+
+Fast:
+```dockerfile
+RUN find /app -not -perm -o=r -exec chmod o+r {} + && \
+    find /app -type d -not -perm -o=x -exec chmod o+x {} +
+# ~15 seconds, and the layer is tiny because most files didn't actually change
+```
+
+## Gotchas
+- Layer size: `chmod -R` rewrites every file even if mode didn't change, bloating the diff layer. The `find` approach writes only deltas.
+- Don't forget BOTH passes - if you only o+r, dirs without o+x make files unreachable.
+- `-exec {} +` > `-exec {} \;` by 10-100x because it batches.
+- Symlinks: by default `chmod` follows, `find` doesn't; add `-L` if symlink targets matter.
+- This trick is especially valuable for images that wrap Node/Bun monorepos.

--- a/skills/codecs/dxgi-texture-capturer-gpu-optimization/SKILL.md
+++ b/skills/codecs/dxgi-texture-capturer-gpu-optimization/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: dxgi-texture-capturer-gpu-optimization
+description: Direct3D 11 GPU-accelerated capture with IDXGIOutputDuplication, texture reuse and rotation.
+category: codecs
+version: 1.0.0
+version_origin: extracted
+tags: [capturer, codecs, dxgi, gpu, optimization, texture]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: libs/scrap/src/dxgi/mod.rs
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Dxgi Texture Capturer Gpu Optimization
+
+## When to use
+Direct3D 11 GPU-accelerated capture with IDXGIOutputDuplication, texture reuse and rotation.
+
+## Source context
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- Demonstrated in: `libs/scrap/src/dxgi/mod.rs`
+
+## Why this generalizes
+Reusable template for any Windows GPU capture tool.
+
+## Next steps before publishing
+- Read the source files above and rewrite this as a product-agnostic `how-to` — keep the pattern, drop rustdesk-specific names.
+- Add a minimal code example in the target language (Rust + Dart / Rust only / etc.).
+- List 2-3 gotchas you hit while reproducing it.

--- a/skills/devops/docker-compose-selfhost-stack/SKILL.md
+++ b/skills/devops/docker-compose-selfhost-stack/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: docker-compose-selfhost-stack
+description: Single docker-compose.selfhost.yml that starts postgres + backend + frontend for one-command self-hosting, with sensible defaults and a one-shot make target.
+category: devops
+version: 1.0.0
+tags: [docker-compose, self-hosting, postgres, deployment]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- You're shipping an open-source product with a "self-host in 5 minutes" story.
+- Users should get a working local stack with one command, and `.env` should be safe-by-default.
+
+## Steps
+
+1. Create `docker-compose.selfhost.yml` with three services and a healthcheck-gated backend:
+   ```yaml
+   name: myapp
+   services:
+     postgres:
+       image: pgvector/pgvector:pg17
+       environment:
+         POSTGRES_DB: ${POSTGRES_DB:-myapp}
+         POSTGRES_USER: ${POSTGRES_USER:-myapp}
+         POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-myapp}
+       volumes: [pgdata:/var/lib/postgresql/data]
+       healthcheck:
+         test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-myapp}"]
+         interval: 5s
+         retries: 5
+     backend:
+       build: { context: ., dockerfile: Dockerfile }
+       depends_on: { postgres: { condition: service_healthy } }
+       ports: ["${PORT:-8080}:8080"]
+       environment:
+         DATABASE_URL: postgres://${POSTGRES_USER:-myapp}:${POSTGRES_PASSWORD:-myapp}@postgres:5432/${POSTGRES_DB:-myapp}
+         JWT_SECRET: ${JWT_SECRET:-change-me-in-production}
+         APP_ENV: ${APP_ENV:-production}   # safe default
+     frontend:
+       build:
+         context: .
+         dockerfile: Dockerfile.web
+         args:
+           REMOTE_API_URL: http://backend:8080
+       depends_on: [backend]
+       ports: ["${FRONTEND_PORT:-3000}:3000"]
+   volumes:
+     pgdata:
+   ```
+2. Add a `make selfhost` target that auto-creates `.env` and generates a random JWT secret on first run:
+   ```makefile
+   selfhost:
+       @if [ ! -f .env ]; then \
+         cp .env.example .env; \
+         JWT=$$(openssl rand -hex 32); \
+         sed -i "s/^JWT_SECRET=.*/JWT_SECRET=$$JWT/" .env; \
+       fi
+       docker compose -f docker-compose.selfhost.yml up -d --build
+       @for i in $$(seq 1 30); do \
+         curl -sf http://localhost:$${PORT:-8080}/health > /dev/null && break; \
+         sleep 2; \
+       done
+       @curl -sf http://localhost:$${PORT:-8080}/health && echo "✓ Stack is running!"
+   ```
+3. `.env.example` lists every knob (ports, email provider, OAuth) with safe defaults and comments for secrets.
+
+## Example
+
+User journey:
+
+```bash
+git clone https://github.com/org/app.git
+cd app
+make selfhost
+# ✓ Stack is running!
+# Frontend: http://localhost:3000
+# Backend:  http://localhost:8080
+```
+
+## Caveats
+
+- `JWT_SECRET` defaulting to `change-me-in-production` is intentional: users who skip the `.env` step get a loud, searchable string in logs. Auto-generate via `openssl rand -hex 32` to silently make the default safe.
+- Default `APP_ENV=production` so any "dev master password" feature is off unless explicitly enabled.
+- The 30-attempt health poll covers slow first-run Docker image pulls.

--- a/skills/devops/docker-multistage-go-alpine/SKILL.md
+++ b/skills/devops/docker-multistage-go-alpine/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: docker-multistage-go-alpine
+description: Two-stage Docker build for a Go service — golang:alpine builder stage produces static binaries, alpine runtime stage ships them minimally with ca-certificates and tzdata.
+category: devops
+version: 1.0.0
+tags: [docker, go, alpine, multistage, production-image]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- Deploying a Go backend service via Docker.
+- You want a small, fast-to-pull image without shipping the Go toolchain in production.
+- You have multiple binaries from the same module (server, CLI, migrator).
+
+## Steps
+
+1. **Builder stage** — full Go toolchain, layer-caches deps before source:
+   ```dockerfile
+   FROM golang:1.26-alpine AS builder
+   RUN apk add --no-cache git
+   WORKDIR /src
+   COPY server/go.mod server/go.sum ./server/
+   RUN cd server && go mod download
+   COPY server/ ./server/
+   ARG VERSION=dev
+   ARG COMMIT=unknown
+   RUN cd server && CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" -o bin/server ./cmd/server
+   RUN cd server && CGO_ENABLED=0 go build -ldflags "-s -w" -o bin/migrate ./cmd/migrate
+   ```
+   - `CGO_ENABLED=0` → static binary, runs on plain alpine.
+   - `-s -w` → strip symbol and DWARF tables (~30% smaller).
+   - `-X main.version` → inject version/commit at link time.
+2. **Runtime stage** — minimal alpine with only what the binary needs at runtime:
+   ```dockerfile
+   FROM alpine:3.21
+   RUN apk add --no-cache ca-certificates tzdata
+   WORKDIR /app
+   COPY --from=builder /src/server/bin/server .
+   COPY --from=builder /src/server/bin/migrate .
+   COPY server/migrations/ ./migrations/
+   COPY docker/entrypoint.sh .
+   RUN sed -i 's/\r$//' entrypoint.sh && chmod +x entrypoint.sh
+   EXPOSE 8080
+   ENTRYPOINT ["./entrypoint.sh"]
+   ```
+   - `ca-certificates` for HTTPS, `tzdata` for time-zone-aware scheduling.
+   - `sed -i 's/\r$//'` on entrypoint handles Windows checkouts with CRLF.
+3. Pass version metadata at build time:
+   ```bash
+   docker build --build-arg VERSION=$(git describe --tags) --build-arg COMMIT=$(git rev-parse --short HEAD) -t app .
+   ```
+
+## Example
+
+Final image size for a mid-size Go service: ~30-50 MB (vs ~800 MB for a naive single-stage with the toolchain).
+
+## Caveats
+
+- If your code uses cgo (e.g. sqlite), drop `CGO_ENABLED=0` and switch runtime to `alpine:3.21` → add `libc6-compat` or run on `gcr.io/distroless/cc`.
+- Multiple binaries in the same image bloat it; if you deploy them as separate containers, split into separate Dockerfiles.

--- a/skills/devops/docker-smoke-test-loop/SKILL.md
+++ b/skills/devops/docker-smoke-test-loop/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: docker-smoke-test-loop
+description: Run a one-shot docker container, tail its logs for a readiness sentinel, then fire an integration test against the exposed port - with layered fallbacks when the CLI is unavailable.
+category: devops
+version: 1.0.0
+version_origin: extracted
+tags: [docker, smoke-test, ci, readiness-probe]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: scripts/docker-smoke-test.sh
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Docker smoke-test loop
+
+## When to use
+- CI needs to verify a freshly built image actually boots and accepts connections.
+- You have a sentinel line your server prints on ready (e.g. `CRAFT_SERVER_URL=...`).
+- Want cleanup guaranteed even on failure.
+- Different CI environments have different tooling (sometimes no CLI, no node, no nc).
+
+## How it works
+1. **Deterministic container name + token**: `CONTAINER_NAME="craft-smoke-$$"` (PID of the script, avoids collisions when tests run in parallel), `TOKEN="smoke-test-$(openssl rand -hex 16)"`.
+2. **Cleanup trap before anything else**:
+   ```sh
+   cleanup() { docker logs "$CONTAINER_NAME" 2>/dev/null || true; docker rm -f "$CONTAINER_NAME" 2>/dev/null || true; }
+   trap cleanup EXIT
+   ```
+   Guarantees logs flush to CI output and container is removed even if the script exits abnormally. The `|| true` swallows errors when the container never got created.
+3. **Run the container detached**: `docker run -d --name ... -p PORT:9100 -e TOKEN ...`.
+4. **Readiness loop** polls two conditions each second:
+   - Still running? `docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME"` - if no, dump logs and exit 1 immediately.
+   - Ready? `docker logs "$CONTAINER_NAME" 2>&1 | grep -q "CRAFT_SERVER_URL="` - match the server's own stdout signal.
+   Timeout defaults to 30s via `SMOKE_TEST_TIMEOUT` env.
+5. **Layered test invocation**:
+   - If `bun` + `apps/cli/src/index.ts` exist, run the real CLI validator.
+   - Else try a tiny node-based WebSocket ping: `new WebSocket(url, { headers: { 'x-craft-token': TOKEN }})`.
+   - Else just `nc -z 127.0.0.1 $PORT` to confirm the port is listening.
+   - Else warn but don't fail - container-is-running counts as a weak smoke signal.
+
+## Example
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+IMAGE="${1:?Usage: smoke.sh <image>}"
+CONTAINER="smoke-$$"
+TOKEN="$(openssl rand -hex 16)"
+trap 'docker logs "$CONTAINER" 2>/dev/null || true; docker rm -f "$CONTAINER" 2>/dev/null || true' EXIT
+
+docker run -d --name "$CONTAINER" -p 9100:9100 -e "TOKEN=$TOKEN" "$IMAGE"
+
+for _ in $(seq 30); do
+  docker inspect -f '{{.State.Running}}' "$CONTAINER" | grep -q true || { docker logs "$CONTAINER"; exit 1; }
+  docker logs "$CONTAINER" 2>&1 | grep -q "SERVER_URL=" && break
+  sleep 1
+done
+
+nc -z 127.0.0.1 9100 && echo OK
+```
+
+## Gotchas
+- `docker logs | grep` is cheap but re-reads the whole log each iteration. Fine for small outputs, not for logs-per-second servers.
+- The readiness sentinel must be on **stdout** or **stderr** and flushed promptly - buffered output breaks the probe.
+- `trap ... EXIT` fires on normal exit AND signals; combined with `set -e` it's the cleanest cleanup pattern.
+- Use `$$` not `$RANDOM` for the container name in CI - deterministic per test-runner PID makes debugging easier.

--- a/skills/docker/docker-entrypoint-gosu-bind-mount/SKILL.md
+++ b/skills/docker/docker-entrypoint-gosu-bind-mount/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: docker-entrypoint-gosu-bind-mount
+description: Write a Docker ENTRYPOINT that `mkdir -p`s required subdirs on first run, `chown`s them, then drops from root to a non-root user with `gosu` — so bind mounts "just work" and named volumes keep their inherited perms.
+category: docker
+version: 1.0.0
+version_origin: extracted
+tags: [docker, entrypoint, gosu, bind-mount, non-root, privileges]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/coleam00/Archon.git
+source_ref: dev
+source_commit: d89bc767d291f52687beea91c9fcf155459be0d9
+source_project: Archon
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Docker ENTRYPOINT: `mkdir -p` Subdirs + `gosu` Drop to Non-Root
+
+## When to use
+
+- You ship a Docker image that expects a persistent data directory (e.g. `/.archon/`) and users mount it via **either** named volume **or** bind mount.
+  - Named volumes inherit the image-layer's perms/ownership on first use — fine.
+  - Bind mounts do **not** — they start with whatever perms the host directory has. Subdirs that the image baked in are **gone**, and your container's non-root user typically can't write them.
+- A naive fix "run container as root" is a security regression. Tools like Claude Code explicitly refuse to run as root with `--dangerously-skip-permissions`.
+- You want one image that boots correctly under both mount styles, for root and non-root container invocations.
+
+## Steps
+
+1. **Install `gosu`** in the image (Debian-based: `apt-get install -y gosu`). It's a minimal setuid-like helper that drops privileges cleanly — unlike `su` / `sudo`, it doesn't fork a subshell or interfere with signals.
+
+2. **Write `docker-entrypoint.sh`** that (in order):
+   - `set -e` for strict error handling.
+   - `mkdir -p` every subdirectory your app needs inside the mount point. This is the whole point — named volumes copy these from the image, bind mounts don't.
+   - Detect whether we're root: `if [ "$(id -u)" = "0" ]`. If yes:
+     - `chown -Rh <user>:<user> /mount` (with a clear error message on failure: "volume may be read-only or mounted with incompatible options"; `exit 1`).
+     - Set `RUNNER="gosu appuser"`.
+   - Otherwise (already non-root via `--user` or K8s `securityContext`):
+     - Set `RUNNER=""`.
+
+3. **Do any auth / setup steps as the target user** via `$RUNNER`:
+   - `$RUNNER git config --global …` — configure git as appuser if you need per-user settings.
+   - `$RUNNER bun run setup-auth` — run one-shot auth setup.
+
+4. **`exec $RUNNER <main-command>`** — the `exec` replaces the shell so the main process becomes PID 1 and receives SIGTERM directly, enabling graceful shutdown. Without `exec`, the shell swallows signals.
+
+5. **Handle CRLF on Windows hosts.** `COPY docker-entrypoint.sh /usr/local/bin/` followed by `RUN sed -i 's/\r$//' /usr/local/bin/docker-entrypoint.sh && chmod +x`. This prevents `/bin/bash^M: bad interpreter` errors when the repo is cloned on Windows without `core.autocrlf=input`.
+
+6. **Pre-configure `safe.directory`** for git operations if the mount will contain git repos owned by a different UID than the container user. Example:
+
+   ```dockerfile
+   RUN gosu appuser git config --global --add safe.directory '/.archon/workspaces' \
+    && gosu appuser git config --global --add safe.directory '/.archon/workspaces/*' \
+    && gosu appuser git config --global --add safe.directory '/.archon/worktrees' \
+    && gosu appuser git config --global --add safe.directory '/.archon/worktrees/*'
+   ```
+
+   This prevents "fatal: detected dubious ownership" errors when bind mounts have non-appuser UIDs.
+
+7. **Use a credential helper for tokens**, not `~/.gitconfig`. Archon embeds a bash function so `GH_TOKEN` stays in env, never in a file:
+
+   ```bash
+   $RUNNER git config --global credential."https://github.com".helper \
+     '!f() { echo "username=x-access-token"; echo "password=${GH_TOKEN}"; }; f'
+   ```
+
+## Counter / Caveats
+
+- Don't `chown` every file on the volume — `-R` on a large mount (many GB) adds seconds to boot. `-Rh` follows no symlinks, which is usually what you want. If boot time matters, chown **only** the known subdirs you `mkdir`ed.
+- `gosu` is **not** `su` and **not** `sudo`. It doesn't run PAM, doesn't spawn a login shell, doesn't alter env vars. That's the feature, not a bug.
+- If you want the container to run fully read-only (`docker run --read-only`), the entrypoint's `mkdir -p` needs a writable subdirectory (tmpfs mount on `/mount/tmp`), or you need to pre-create everything in the image and skip the chown step.
+- When running in Kubernetes with `securityContext.fsGroup`, the cluster may already fix ownership on bind-equivalent mounts, making your chown redundant but not harmful. Keep the check for portability.
+- Don't call `chown -R` when the mount might be read-only (ConfigMap / secrets volume). Guard with `if ! chown … 2>/dev/null` and exit with a clear message.
+
+## Evidence
+
+- `docker-entrypoint.sh` (32 lines): full script with `set -e`, `mkdir -p`, root-detect + `chown -Rh`, `RUNNER=""` fallback, credential-helper-as-bash-function for GH_TOKEN, `exec $RUNNER`.
+- `Dockerfile`:
+  - `gosu` in system install at line 67-77.
+  - Non-root user creation + data-dir perms at lines 119-126.
+  - `safe.directory` pre-configuration at lines 175-179.
+  - CRLF strip at lines 182-185.
+- Commit SHA: d89bc767d291f52687beea91c9fcf155459be0d9.

--- a/skills/effect-ts/drainable-worker-pattern-for-queue-based-async/SKILL.md
+++ b/skills/effect-ts/drainable-worker-pattern-for-queue-based-async/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: drainable-worker-pattern-for-queue-based-async
+description: Use queue-based workers with drain() signals instead of timing-sensitive sleeps for deterministic async test synchronization
+category: effect-ts
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [effect-ts, testing, async, workers]
+source_type: extracted-from-git
+source_url: https://github.com/pingdotgg/t3code.git
+source_ref: main
+source_commit: 9df3c640210fecccb58f7fbc735f81ca0ee011bd
+source_project: t3code
+imported_at: 2026-04-18
+evidence:
+  - packages/shared/src/DrainableWorker.ts
+  - apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+  - apps/server/src/orchestration/Layers/CheckpointReactor.ts
+---
+
+## When to Apply
+- You have async work (side effects, external I/O, event processing) that needs to complete before test assertions
+- Tests are timing-sensitive and flaky due to `Effect.sleep` or polling loops
+- You want to avoid timers and arbitrary delays in test suites
+- You're using Effect.ts with a scope-based lifecycle
+
+## Steps
+1. Define a work item type `A` representing enqueue payloads
+2. Create a processing effect `(item: A) => Effect.Effect<void, E, R>` that consumes items
+3. Call `makeDrainableWorker(process)` to fork a worker into your scope
+4. Enqueue work via `worker.enqueue(item)` — wrapped atomically with queue state tracking
+5. In tests, call `yield* worker.drain()` to block until queue is empty AND current item finishes
+6. Assert after drain resolves — all queued work is complete
+
+## Example
+```typescript
+const worker = yield* makeDrainableWorker((msg: Message) =>
+  Effect.gen(function*() {
+    yield* processMessage(msg)
+  })
+)
+
+yield* worker.enqueue({ type: 'turn.start', threadId })
+yield* worker.drain()  // blocks until message is fully processed
+assert(someState.updated === true)
+```
+
+## Counter / Caveats
+- Worker is scoped; it stops when scope closes
+- Only useful if you can express side effects as Effect — not for external callbacks
+- `drain()` is a transaction; concurrent enqueues may race; use in single-threaded test contexts
+- Exceptional exits from process() do not drain — handle/report errors explicitly

--- a/skills/flutter/drag-drop-widget-composition/SKILL.md
+++ b/skills/flutter/drag-drop-widget-composition/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: drag-drop-widget-composition
+description: Draggable widget composition for UI controls (dragable_divider, popup_menu reordering).
+category: flutter
+version: 1.0.0
+version_origin: extracted
+tags: [composition, drag, drop, flutter, widget]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: flutter/lib/desktop/widgets/
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Drag Drop Widget Composition
+
+## When to use
+Draggable widget composition for UI controls (dragable_divider, popup_menu reordering).
+
+## Source context
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- Demonstrated in: `flutter/lib/desktop/widgets/`
+
+## Why this generalizes
+Reusable for any Flutter desktop with reorderable panels.
+
+## Next steps before publishing
+- Read the source files above and rewrite this as a product-agnostic `how-to` — keep the pattern, drop rustdesk-specific names.
+- Add a minimal code example in the target language (Rust + Dart / Rust only / etc.).
+- List 2-3 gotchas you hit while reproducing it.

--- a/skills/jit-compilation/distributed-filesystem-safe-atomic-cache-with-fsync/SKILL.md
+++ b/skills/jit-compilation/distributed-filesystem-safe-atomic-cache-with-fsync/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: distributed-filesystem-safe-atomic-cache-with-fsync
+description: Make a JIT compiler cache safe under concurrent multi-rank writes on NFS by compiling to a tmp dir, fsyncing recursively, and atomically renaming the directory.
+category: jit-compilation
+version: 1.0.0
+version_origin: extracted
+tags: [concurrency, distributed-systems, cache, filesystem, jit]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - csrc/jit/compiler.hpp
+imported_at: 2026-04-18T13:12:58Z
+---
+
+# Distributed-Filesystem-Safe Atomic Cache With fsync
+
+## What / Why
+When multiple ranks of a training job share a JIT cache on a network filesystem, naive "write file then hope" patterns corrupt the cache: half-written `.cubin`, stale inodes, races between ranks. The fix is single-step atomic commit: compile into a private temp directory, fsync everything, then `rename(tmp_dir, cache_dir)`. Rename of a directory is atomic on most filesystems (local, NFSv4, Lustre) — exactly one rank wins.
+
+## Procedure
+1. **Key.** Compute `cache_key = hash(name + signature + flags + code + include_hash)`; use as the final cache directory name.
+2. **Fast-path hit.** If `cache_dir` exists and `KernelRuntime::check_validity(cache_dir)` passes (kernel.cu + kernel.cubin both present), load and return.
+3. **Compile into tmp.** `tmp_dir = make_tmp_dir()` → random UUID path, sibling of `cache_dir`. Compile the kernel there (`kernel.cu` → `kernel.cubin` via NVCC or NVRTC).
+4. **Fsync.** Walk the tmp dir, `fsync()` every file; then `fsync()` the dir itself. On NFS this forces server-side durability so peers see the contents post-rename.
+5. **Atomic commit.** `std::filesystem::rename(tmp_dir, cache_dir, ec)`. If the rename fails with `EEXIST`/`ENOTEMPTY` (peer beat us), call `safe_remove_all(tmp_dir)` (wrapped `rm -rf` that ignores ENOENT).
+6. **Re-read from canonical path.** Either way, load the runtime from `cache_dir` — guarantees every rank ends up with bit-identical bytes.
+
+## Key design points
+- **Directory rename, not file rename.** Per-file rename has race windows where the cache dir is partially populated; directory rename is all-or-nothing.
+- **fsync is mandatory on NFS.** Without it, readers may see an empty file or a dir with zero-byte children.
+- **`safe_remove_all` is the right loser behavior.** Don't error out; the winner's cache is what you want anyway.
+
+## Anti-pattern (don't do this)
+```cpp
+// BAD: per-file write + rename has a window where cache_dir is half-populated
+write(cache_dir / "kernel.cu");
+write(cache_dir / "kernel.cubin");  // crash here → corrupted cache
+```
+
+## References
+- `csrc/jit/compiler.hpp` — `compile()` with atomic rename path.
+- `csrc/jit/kernel_runtime.hpp` — `check_validity()` guard used on the fast path.

--- a/skills/jit-compilation/dual-driver-runtime-api-abstraction/SKILL.md
+++ b/skills/jit-compilation/dual-driver-runtime-api-abstraction/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: dual-driver-runtime-api-abstraction
+description: Hide the CUDA Driver API vs Runtime API split behind a single `load_kernel` / `launch_kernel` / `construct_launch_config` surface, using typedefs and `#ifdef` to pick the implementation at compile time.
+category: jit-compilation
+version: 1.0.0
+version_origin: extracted
+tags: [cuda, driver-api, runtime-api, abstraction, jit, portability]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - csrc/jit/handle.hpp
+  - csrc/jit/kernel_runtime.hpp
+imported_at: 2026-04-18T13:30:00Z
+---
+
+# Dual Driver/Runtime API Abstraction For JIT Kernel Loading
+
+## When to use
+You have a JIT runtime that must ship as a single library but support two target platforms:
+- Older CUDA toolchains (driver-only: `cuModuleLoad`, `cuLaunchKernelEx`, `CUfunction`).
+- Newer CUDA toolchains (runtime API: `cudaLibraryLoadFromFile`, `cudaLaunchKernelExC`, `cudaKernel_t`) where the runtime API is preferred because PyTorch/Triton already initialize it.
+
+A naive codebase sprinkles `#ifdef` across every call site. This skill isolates the split to one header.
+
+## Steps
+1. **Pick a single variable name per concept.** Typedef:
+   ```cpp
+   using LibraryHandle    = /* CUmodule / CUlibrary / cudaLibrary_t */;
+   using KernelHandle     = /* CUfunction / cudaKernel_t */;
+   using LaunchConfigHandle = /* CUlaunchConfig / cudaLaunchConfig_t */;
+   using LaunchAttrHandle = /* CUlaunchAttribute / cudaLaunchAttribute */;
+   ```
+2. **Gate the typedefs on a single define.**
+   ```cpp
+   #if CUDART_VERSION >= 12080 and defined(DG_JIT_USE_RUNTIME_API)
+     // runtime API typedefs
+   #else
+     // driver API typedefs, with a nested #if CUDA_VERSION >= 12040
+     // for the `cuLibraryEnumerateKernels` path
+   #endif
+   ```
+3. **Wrap each operation with the same three functions:**
+   - `load_kernel(cubin_path, func_name, &library_opt)` → `KernelHandle`
+   - `unload_library(library)` → `void` (ignore `cudaErrorCudartUnloading` / `CUDA_ERROR_DEINITIALIZED`)
+   - `construct_launch_config(kernel, stream, smem_size, grid, block, cluster_dim, enable_pdl)` → `LaunchConfigHandle`
+   - `launch_kernel(kernel, config, args...)` variadic wrapper that builds `void *ptr_args[]`.
+4. **Unify error handling** with one macro `DG_CUDA_UNIFIED_CHECK` that resolves to either `DG_CUDA_RUNTIME_CHECK` or `DG_CUDA_DRIVER_CHECK`. Callers write only `DG_CUDA_UNIFIED_CHECK(load_kernel(...));` and never branch.
+5. **Keep driver symbols lazy-loaded** (via `dlsym` on `libcuda.so.1` — see the `DECL_LAZY_CUDA_DRIVER_FUNCTION` macro) so the library doesn't hard-link a driver symbol that may be absent in the runtime-API build.
+6. **Use a static `LaunchAttrHandle attrs[N]`** inside `construct_launch_config`, then increment `config.numAttrs` as you add cluster / PDL attributes. Both APIs accept the same attribute layout by design.
+
+## Evidence (from DeepGEMM)
+- `csrc/jit/handle.hpp:48-114`: runtime-API branch uses `cudaLibraryLoadFromFile` + `cudaLibraryGetKernel`.
+- `csrc/jit/handle.hpp:118-220`: driver-API branch uses `cuModuleLoad` / `cuLibraryLoadFromFile` depending on whether CUDA 12.4+ gives `cuLibraryEnumerateKernels` (then the kernel can be located by enumeration instead of a symbol name lookup).
+- `csrc/jit/handle.hpp:89-107,192-210`: attribute-array setup is byte-for-byte identical across the two implementations — that is what lets the caller `LaunchRuntime::launch` be API-agnostic.
+- `csrc/jit/kernel_runtime.hpp:141-162`: `LaunchRuntime<Derived>::launch` never mentions driver/runtime; it just calls `construct_launch_config` and `Derived::launch_impl`.
+
+## Counter / Caveats
+- **Driver symbols must stay `dlsym`-loaded.** If you link `cuLibraryLoadFromFile` directly, a system without that CUDA version will fail at process start — even for the runtime-API build path.
+- **`cuLibraryEnumerateKernels` needs CUDA Driver 12.4+**, not just CUDA Toolkit 12.4. You need both runtime header and runtime driver available. DeepGEMM gates this with `#if CUDA_VERSION >= 12040` and falls back to symbol-name lookup.
+- **Handles are not interchangeable across implementations.** A kernel loaded via the runtime API cannot be launched via `cuLaunchKernelEx`. Keep the abstraction total.

--- a/skills/llm-agents/deterministic-agent-chain/SKILL.md
+++ b/skills/llm-agents/deterministic-agent-chain/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: deterministic-agent-chain
+description: Chain multiple agents sequentially in code, feeding each agent's output as the next agent's input.
+category: llm-agents
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [openai-agents, pipeline, deterministic, chaining, structured-output]
+source_type: extracted-from-git
+source_url: https://github.com/openai/openai-agents-python.git
+source_ref: main
+source_commit: e80d2d2319eb300ac17ec496988b70246a5042d6
+source_project: openai-agents-python
+source_path: examples/agent_patterns/deterministic.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# deterministic-agent-chain
+
+Orchestrate a multi-step pipeline in code: each agent runs, produces output, and your code decides whether and how to invoke the next agent. More predictable than LLM-driven handoffs.
+
+## When to apply
+
+Linear workflows where each step is clearly defined (generate → validate → refine). Use structured output from intermediate agents to branch logic in code.
+
+## Core snippet
+
+```python
+import asyncio
+from pydantic import BaseModel
+from agents import Agent, Runner, trace
+
+story_outline_agent = Agent(
+    name="story_outline_agent",
+    instructions="Generate a very short story outline based on the user's input.",
+)
+
+class OutlineCheckerOutput(BaseModel):
+    good_quality: bool
+    is_scifi: bool
+
+outline_checker_agent = Agent(
+    name="outline_checker_agent",
+    instructions="Read the given story outline, judge quality and determine if it is scifi.",
+    output_type=OutlineCheckerOutput,
+)
+
+story_agent = Agent(
+    name="story_agent",
+    instructions="Write a short story based on the given outline.",
+    output_type=str,
+)
+
+async def main():
+    with trace("Deterministic story flow"):
+        outline_result = await Runner.run(story_outline_agent, "Write a short sci-fi story.")
+        checker_result = await Runner.run(outline_checker_agent, outline_result.final_output)
+        checker_output = checker_result.final_output_as(OutlineCheckerOutput)
+
+        if not checker_output.good_quality or not checker_output.is_scifi:
+            print("Outline didn't pass quality check, stopping.")
+            return
+
+        story_result = await Runner.run(story_agent, outline_result.final_output)
+        print(story_result.final_output)
+
+asyncio.run(main())
+```
+
+## Key notes
+
+- Use `result.final_output_as(Model)` to get a typed intermediate result for branching
+- Each `Runner.run()` call is independent; pass outputs explicitly as strings or item lists
+- Wrap in `trace()` to view all steps in the OpenAI Traces dashboard as one workflow
+- More predictable cost/latency than fully autonomous multi-agent flows

--- a/skills/llm-agents/dispatching-parallel-agents/SKILL.md
+++ b/skills/llm-agents/dispatching-parallel-agents/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: dispatching-parallel-agents
+description: Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies
+category: llm-agents
+version: 1.0.0
+version_origin: extracted
+source_type: extracted-from-git
+source_url: https://github.com/obra/superpowers.git
+source_ref: main
+source_commit: b55764852ac78870e65c6565fb585b6cd8b3c5c9
+source_project: superpowers
+imported_at: 2026-04-18T06:36:49Z
+---
+
+# Dispatching Parallel Agents
+
+## Overview
+
+You delegate tasks to specialized agents with isolated context. By precisely crafting their instructions and context, you ensure they stay focused and succeed at their task. They should never inherit your session's context or history — you construct exactly what they need. This also preserves your own context for coordination work.
+
+When you have multiple unrelated failures (different test files, different subsystems, different bugs), investigating them sequentially wastes time. Each investigation is independent and can happen in parallel.
+
+**Core principle:** Dispatch one agent per independent problem domain. Let them work concurrently.
+
+## When to Use
+
+```dot
+digraph when_to_use {
+    "Multiple failures?" [shape=diamond];
+    "Are they independent?" [shape=diamond];
+    "Single agent investigates all" [shape=box];
+    "One agent per problem domain" [shape=box];
+    "Can they work in parallel?" [shape=diamond];
+    "Sequential agents" [shape=box];
+    "Parallel dispatch" [shape=box];
+
+    "Multiple failures?" -> "Are they independent?" [label="yes"];
+    "Are they independent?" -> "Single agent investigates all" [label="no - related"];
+    "Are they independent?" -> "Can they work in parallel?" [label="yes"];
+    "Can they work in parallel?" -> "Parallel dispatch" [label="yes"];
+    "Can they work in parallel?" -> "Sequential agents" [label="no - shared state"];
+}
+```
+
+**Use when:**
+- 3+ test files failing with different root causes
+- Multiple subsystems broken independently
+- Each problem can be understood without context from others
+- No shared state between investigations
+
+**Don't use when:**
+- Failures are related (fix one might fix others)
+- Need to understand full system state
+- Agents would interfere with each other
+
+## The Pattern
+
+### 1. Identify Independent Domains
+
+Group failures by what's broken:
+- File A tests: Tool approval flow
+- File B tests: Batch completion behavior
+- File C tests: Abort functionality
+
+Each domain is independent - fixing tool approval doesn't affect abort tests.
+
+### 2. Create Focused Agent Tasks
+
+Each agent gets:
+- **Specific scope:** One test file or subsystem
+- **Clear goal:** Make these tests pass
+- **Constraints:** Don't change other code
+- **Expected output:** Summary of what you found and fixed
+
+### 3. Dispatch in Parallel
+
+```typescript
+// In Claude Code / AI environment
+Task("Fix agent-tool-abort.test.ts failures")
+Task("Fix batch-completion-behavior.test.ts failures")
+Task("Fix tool-approval-race-conditions.test.ts failures")
+// All three run concurrently
+```
+
+### 4. Review and Integrate
+
+When agents return:
+- Read each summary
+- Verify fixes don't conflict
+- Run full test suite
+- Integrate all changes
+
+## Agent Prompt Structure
+
+Good agent prompts are:
+1. **Focused** - One clear problem domain
+2. **Self-contained** - All context needed to understand the problem
+3. **Specific about output** - What should the agent return?
+
+```markdown
+Fix the 3 failing tests in src/agents/agent-tool-abort.test.ts:
+
+1. "should abort tool with partial output capture" - expects 'interrupted at' in message
+2. "should handle mixed completed and aborted tools" - fast tool aborted instead of completed
+3. "should properly track pendingToolCount" - expects 3 results but gets 0
+
+These are timing/race condition issues. Your task:
+
+1. Read the test file and understand what each test verifies
+2. Identify root cause - timing issues or actual bugs?
+3. Fix by:
+   - Replacing arbitrary timeouts with event-based waiting
+   - Fixing bugs in abort implementation if found
+   - Adjusting test expectations if testing changed behavior
+
+Do NOT just increase timeouts - find the real issue.
+
+Return: Summary of what you found and what you fixed.
+```
+
+## Common Mistakes
+
+**❌ Too broad:** "Fix all the tests" - agent gets lost
+**✅ Specific:** "Fix agent-tool-abort.test.ts" - focused scope
+
+**❌ No context:** "Fix the race condition" - agent doesn't know where
+**✅ Context:** Paste the error messages and test names
+
+**❌ No constraints:** Agent might refactor everything
+**✅ Constraints:** "Do NOT change production code" or "Fix tests only"
+
+**❌ Vague output:** "Fix it" - you don't know what changed
+**✅ Specific:** "Return summary of root cause and changes"
+
+## When NOT to Use
+
+**Related failures:** Fixing one might fix others - investigate together first
+**Need full context:** Understanding requires seeing entire system
+**Exploratory debugging:** You don't know what's broken yet
+**Shared state:** Agents would interfere (editing same files, using same resources)
+
+## Real Example from Session
+
+**Scenario:** 6 test failures across 3 files after major refactoring
+
+**Failures:**
+- agent-tool-abort.test.ts: 3 failures (timing issues)
+- batch-completion-behavior.test.ts: 2 failures (tools not executing)
+- tool-approval-race-conditions.test.ts: 1 failure (execution count = 0)
+
+**Decision:** Independent domains - abort logic separate from batch completion separate from race conditions
+
+**Dispatch:**
+```
+Agent 1 → Fix agent-tool-abort.test.ts
+Agent 2 → Fix batch-completion-behavior.test.ts
+Agent 3 → Fix tool-approval-race-conditions.test.ts
+```
+
+**Results:**
+- Agent 1: Replaced timeouts with event-based waiting
+- Agent 2: Fixed event structure bug (threadId in wrong place)
+- Agent 3: Added wait for async tool execution to complete
+
+**Integration:** All fixes independent, no conflicts, full suite green
+
+**Time saved:** 3 problems solved in parallel vs sequentially
+
+## Key Benefits
+
+1. **Parallelization** - Multiple investigations happen simultaneously
+2. **Focus** - Each agent has narrow scope, less context to track
+3. **Independence** - Agents don't interfere with each other
+4. **Speed** - 3 problems solved in time of 1
+
+## Verification
+
+After agents return:
+1. **Review each summary** - Understand what changed
+2. **Check for conflicts** - Did agents edit same code?
+3. **Run full suite** - Verify all fixes work together
+4. **Spot check** - Agents can make systematic errors
+
+## Real-World Impact
+
+From debugging session (2025-10-03):
+- 6 failures across 3 files
+- 3 agents dispatched in parallel
+- All investigations completed concurrently
+- All fixes integrated successfully
+- Zero conflicts between agent changes

--- a/skills/llm-agents/draft-model-bind-to-target-modules/SKILL.md
+++ b/skills/llm-agents/draft-model-bind-to-target-modules/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: draft-model-bind-to-target-modules
+description: Share embed_tokens and lm_head from the target LLM into a draft model at runtime by duck-typing the wrapper layout, so the draft does not ship its own embedding matrix.
+category: llm-agents
+version: 1.0.0
+version_origin: extracted
+tags: [speculative-decoding, weight-sharing, huggingface, mlx, embeddings]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/z-lab/dflash.git
+source_ref: main
+source_commit: 1fe684b00efba56490d920d15eeb9ba6e4471751
+source_project: dflash
+source_path: dflash/model_mlx.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Draft Model → Target Module Binding
+
+## When to use
+- You train a draft / speculative / LoRA head model and want to avoid shipping the target's embedding and output projection (which can be hundreds of MB).
+- You need to support several target wrappers (`CausalLM`, multimodal `language_model`, MLX `mlx_lm` models) without hard-coding attribute paths.
+- You want a one-call `bind(target)` that populates `self.embed_tokens` and `self.lm_head` on the draft.
+
+## Pattern
+
+```python
+def bind(self, target_model):
+    # Walk known wrapper layouts to find inner transformer.
+    if hasattr(target_model, "embed_tokens"):
+        inner = target_model
+    elif hasattr(target_model, "model") and hasattr(target_model.model, "embed_tokens"):
+        inner = target_model.model
+    elif (hasattr(target_model, "language_model")
+          and hasattr(target_model.language_model, "model")
+          and hasattr(target_model.language_model.model, "embed_tokens")):
+        inner = target_model.language_model.model
+    else:
+        raise AttributeError(f"Cannot find embed_tokens in {type(target_model).__name__}")
+
+    self.embed_tokens = inner.embed_tokens
+
+    # lm_head: prefer explicit head, fall back to tied embeddings (`as_linear`).
+    lm = getattr(target_model, "language_model", target_model)
+    self.lm_head = (
+        getattr(target_model, "lm_head", None)
+        or getattr(lm, "lm_head", None)
+        or self.embed_tokens.as_linear        # tied weights case
+    )
+    return self
+```
+
+## Why three branches
+1. `AutoModelForCausalLM` — target is already the inner transformer + head, `embed_tokens` sits at `target.embed_tokens` or `target.model.embed_tokens` depending on the architecture.
+2. `LlavaForConditionalGeneration` / VLM wrappers — the LLM is nested under `.language_model.model`.
+3. Plain `mlx_lm` transformer — exposes `embed_tokens` at the top level.
+
+## Tied-weight fallback
+`self.embed_tokens.as_linear` turns a tied embedding matrix into an `nn.Linear` view so logits computation still works when `lm_head is None`. This is common for MLX models and some Qwen variants.
+
+## Gotchas
+- Call `bind()` *after* the target is loaded and before the first draft forward — binding attaches live module references, not copies.
+- If you later move the target to another device/dtype, the draft sees it automatically because the attributes are references; you do not need to re-bind.
+- Do not call `bind()` twice with different targets — `self.embed_tokens` would dangle on the old target when you drop it.

--- a/skills/llm-agents/easyedit-rome-knowledge-edit/SKILL.md
+++ b/skills/llm-agents/easyedit-rome-knowledge-edit/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: easyedit-rome-knowledge-edit
+description: Edit a specific fact in GPT-2-XL using EasyEdit and the ROME method, verified with the Messi football-to-basketball example.
+category: llm-agents
+version: 1.0.0
+version_origin: extracted
+tags: [model-editing, easyedit, rome, knowledge-editing]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/Lordog/dive-into-llms.git
+source_ref: main
+source_commit: f84c04268794ef94f8949808bbc14ab8636763a0
+source_project: dive-into-llms
+source_path: documents/chapter3/README.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# EasyEdit + ROME Knowledge Editing
+
+## When to use
+- Change a specific factual belief in a pretrained LLM without full retraining.
+- Using EasyEdit with ROME or MEMIT algorithm.
+- Verify the edit is reliable, general, and does not damage unrelated knowledge.
+
+## Steps
+
+1. Install EasyEdit:
+
+```bash
+git clone https://github.com/zjunlp/EasyEdit.git && cd EasyEdit
+pip install -r requirements.txt
+```
+
+2. Load ROME hyperparameters:
+
+```python
+from easyeditor import ROMEHyperParams, BaseEditor
+hparams = ROMEHyperParams.from_hparams('./hparams/ROME/gpt2-xl.yaml')
+```
+
+3. Prepare edit data:
+
+```python
+prompts      = ['Question: What sport does Lionel Messi play? Answer:']
+ground_truth = ['football']
+target_new   = ['basketball']
+subject      = ['Lionel Messi']
+```
+
+4. Run the edit:
+
+```python
+editor = BaseEditor.from_hparams(hparams)
+metrics, edited_model, _ = editor.edit(
+    prompts=prompts,
+    ground_truth=ground_truth,
+    target_new=target_new,
+    subject=subject,
+    keep_original_weight=False
+)
+```
+
+5. Verify with generation comparison before and after the edit.
+
+## Pitfalls
+- First edit downloads Wikipedia corpus and precomputes per-layer stats (./data/stats); allow extra time.
+- For batch-editing multiple facts, use MEMIT.
+- Locality inputs must be passed to editor.edit() explicitly to get locality metrics.
+
+## Source
+- Chapter 3 of dive-into-llms - documents/chapter3/README.md

--- a/skills/ml-ops/deterministic-torch-seed-bundle/SKILL.md
+++ b/skills/ml-ops/deterministic-torch-seed-bundle/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: deterministic-torch-seed-bundle
+description: Five-line block that seeds random / numpy / torch / CUDA / cudnn consistently so benchmarks and regression tests are reproducible run-to-run.
+category: ml-ops
+version: 1.0.0
+version_origin: extracted
+tags: [pytorch, reproducibility, seeding, cudnn, benchmark]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/z-lab/dflash.git
+source_ref: main
+source_commit: 1fe684b00efba56490d920d15eeb9ba6e4471751
+source_project: dflash
+source_path: dflash/benchmark.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Deterministic PyTorch Seed Bundle
+
+## When to use
+- You compare two inference runs (baseline vs speculative, LoRA A vs B) and need sampling / tie-breaking to be identical.
+- You want a single block you can paste at the top of any benchmark or regression test.
+
+## Pattern
+
+```python
+import random, numpy as np, torch
+
+random.seed(0)
+np.random.seed(0)
+torch.manual_seed(0)
+torch.cuda.manual_seed_all(0)
+torch.backends.cudnn.deterministic = True
+torch.backends.cudnn.benchmark = False
+```
+
+## Why each line matters
+- `random.seed` — Python's `random` is used by HF `datasets`, dataset shufflers, many sampling utilities.
+- `np.random.seed` — seeds NumPy-backed code paths (e.g. tokenizers, some HF transforms). NumPy's default RNG is still global in pre-1.17 style code.
+- `torch.manual_seed` — PyTorch CPU RNG.
+- `torch.cuda.manual_seed_all` — every visible CUDA device's RNG (as opposed to `manual_seed` which only hits device 0).
+- `cudnn.deterministic = True` — forces deterministic convolution / attention kernels when available.
+- `cudnn.benchmark = False` — stops cuDNN from picking the fastest kernel per input shape, which varies across runs.
+
+## Gotchas
+- Deterministic cuDNN is *slower*; only enable it for reproducibility runs, not production throughput benchmarks.
+- Some ops have no deterministic kernel (e.g., `scatter_add`). Wrap your experiment in `torch.use_deterministic_algorithms(True)` to surface these as errors rather than silent nondeterminism.
+- Multiprocess dataloaders need `worker_init_fn` to also seed their own `random` / `numpy` — the parent's seed does not propagate.
+- If you also call `random.seed(42)` inside a library (like dflash's benchmark does), the *later* seed wins; double-seeding can mask bugs.

--- a/skills/ops/detached-daemon-lifecycle-cli/SKILL.md
+++ b/skills/ops/detached-daemon-lifecycle-cli/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: detached-daemon-lifecycle-cli
+description: Give a node script a drop-in start/stop/restart/status/log/check CLI by discovering processes via ps-args pattern match rather than trusting a PID file, persisting a best-effort PID, escalating SIGTERM → wait → SIGKILL on stop, and defining "healthy" as "process exists AND log has been written within MAX_SILENCE_MS."
+category: ops
+version: 1.0.0
+version_origin: extracted
+tags: [daemon, lifecycle, pid-file, sigterm, stagnation-detection, cli]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/EvoMap/evolver.git
+source_ref: main
+source_commit: 4c51382092f9cb125d3ec55475861ead8d1463a6
+source_project: evolver
+source_paths:
+  - src/ops/lifecycle.js
+imported_at: 2026-04-18T03:00:00Z
+---
+
+# Detached Daemon Lifecycle CLI
+
+A small pattern for "I want `node foo.js --loop` to behave like a well-behaved system daemon without pulling in pm2, systemd, or launchd."
+
+## CLI surface
+
+```
+node lifecycle.js start     # spawn detached, write PID file, exit
+node lifecycle.js stop      # SIGTERM all matching procs, wait up to 5s, SIGKILL stragglers
+node lifecycle.js restart   # stop + 2s delay + start
+node lifecycle.js status    # list running PIDs with cmdlines; {running: false} otherwise
+node lifecycle.js log       # tail -n 20 of the shared log file
+node lifecycle.js check     # checkHealth(); if unhealthy, auto-restart
+```
+
+Exactly six verbs. Anything more is feature creep.
+
+## Process discovery: don't trust the PID file alone
+
+A stale PID file is the number-one footgun. Always cross-check against the live process table:
+
+```js
+function getRunningPids() {
+  const out = execSync('ps -e -o pid,args', { encoding: 'utf8' });
+  return out.split('\n')
+    .map(l => l.trim())
+    .filter(l => l && !l.startsWith('PID'))
+    .map(l => { const [pid, ...rest] = l.split(/\s+/); return [parseInt(pid, 10), rest.join(' ')]; })
+    .filter(([pid, cmd]) =>
+      pid !== process.pid &&
+      cmd.includes('node') && cmd.includes('index.js') && cmd.includes('--loop')
+    )
+    .map(([pid]) => pid)
+    .filter(isPidRunning);
+}
+```
+
+The PID file is a *hint for stop*, not the source of truth. Discovery by cmdline-signature survives PID reuse, accidental file deletion, and crashes during write.
+
+## Spawn as truly detached
+
+```js
+const out = fs.openSync(LOG_FILE, 'a');
+const err = fs.openSync(LOG_FILE, 'a');
+const child = spawn('node', [script, '--loop'], {
+  detached: true,
+  stdio: ['ignore', out, err],
+  cwd: WORKSPACE_ROOT,
+  env,
+});
+child.unref();
+fs.writeFileSync(PID_FILE, String(child.pid));
+```
+
+Three things to get right: `detached: true`, `child.unref()`, and redirecting stdout/stderr to file descriptors — not streams the parent owns.
+
+## Stop: escalate, don't hard-kill
+
+```js
+pids.forEach(p => { try { process.kill(p, 'SIGTERM'); } catch {} });
+for (let i = 0; i < 10 && getRunningPids().length; i++) execSync('sleep 0.5');
+getRunningPids().forEach(p => { try { process.kill(p, 'SIGKILL'); } catch {} });
+```
+
+Five seconds of grace is almost always enough for a well-behaved Node loop to flush and exit. Immediate SIGKILL truncates log buffers and leaves half-written state files.
+
+## Health: liveness AND progress
+
+```js
+function checkHealth() {
+  if (!getRunningPids().length) return { healthy: false, reason: 'not_running' };
+  const silenceMs = Date.now() - fs.statSync(LOG_FILE).mtimeMs;
+  if (silenceMs > MAX_SILENCE_MS) {
+    return { healthy: false, reason: 'stagnation', silenceMinutes: Math.round(silenceMs / 60000) };
+  }
+  return { healthy: true };
+}
+```
+
+"Alive but silent" is the single most common failure mode of a long-running loop. Define healthy as *both* PID exists *and* log mtime is recent. Pair `check` with a cron/systemd timer that runs every few minutes and auto-restarts on stagnation.
+
+## PID locations, when to clean
+
+- `${WORKSPACE_ROOT}/memory/evolver_loop.pid` — daemon PID (deleted by `stop`).
+- `${REPO_ROOT}/evolver.pid` — "cross-process lock" PID some evolver loops create themselves (also deleted by `stop`).
+
+Stopping must delete both, or a future `start` will report "already running" off a zombie file.
+
+## Portability caveat
+
+The `ps -e -o pid,args` trick is POSIX-only. For Windows, swap to `tasklist /v /fo csv` or `wmic process` and match on the command line. Keep the predicate (`node`, `index.js`, `--loop`) identical across platforms.

--- a/skills/patterns/dxgi-com-pointer-wrapper-raii/SKILL.md
+++ b/skills/patterns/dxgi-com-pointer-wrapper-raii/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: dxgi-com-pointer-wrapper-raii
+description: Custom ComPtr<T> with Drop-based COM reference counting for DXGI objects.
+category: patterns
+version: 1.0.0
+version_origin: extracted
+tags: [com, dxgi, patterns, pointer, raii, wrapper]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: libs/scrap/src/dxgi/mod.rs
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Dxgi Com Pointer Wrapper Raii
+
+## When to use
+Custom ComPtr<T> with Drop-based COM reference counting for DXGI objects.
+
+## Source context
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- Demonstrated in: `libs/scrap/src/dxgi/mod.rs`
+
+## Why this generalizes
+Reusable for Windows COM interop in Rust.
+
+## Next steps before publishing
+- Read the source files above and rewrite this as a product-agnostic `how-to` — keep the pattern, drop rustdesk-specific names.
+- Add a minimal code example in the target language (Rust + Dart / Rust only / etc.).
+- List 2-3 gotchas you hit while reproducing it.

--- a/skills/platform/display-device-enumeration-platform/SKILL.md
+++ b/skills/platform/display-device-enumeration-platform/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: display-device-enumeration-platform
+description: Per-OS display enumeration: Windows EnumDisplayDevices, macOS CGDisplayCopyAllDisplays, Linux XRandR.
+category: platform
+version: 1.0.0
+version_origin: extracted
+tags: [device, display, enumeration, platform]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: [src/platform/windows.rs, src/platform/macos.rs, src/platform/linux.rs]
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Display Device Enumeration Platform
+
+## When to use
+Per-OS display enumeration: Windows EnumDisplayDevices, macOS CGDisplayCopyAllDisplays, Linux XRandR.
+
+## Source context
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- Demonstrated in: `src/platform/windows.rs`, `src/platform/macos.rs`, `src/platform/linux.rs`
+
+## Why this generalizes
+Reusable pattern for multi-monitor apps.
+
+## Next steps before publishing
+- Read the source files above and rewrite this as a product-agnostic `how-to` — keep the pattern, drop rustdesk-specific names.
+- Add a minimal code example in the target language (Rust + Dart / Rust only / etc.).
+- List 2-3 gotchas you hit while reproducing it.

--- a/skills/production/dev-story/SKILL.md
+++ b/skills/production/dev-story/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: dev-story
+description: "Read a story file and implement it. Loads the full context (story, GDD requirement, ADR guidelines, control manifest), routes to the right programmer agent for the system and engine, implements the code and test, and confirms each acceptance criterion. The core implementation skill — run after /story-readiness, before /code-review and /story-done."
+argument-hint: "[story-path]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write, Bash, Task, AskUserQuestion
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version: 1.0.0
+version_origin: extracted
+---
+
+# Dev Story
+
+This skill bridges planning and code. It reads a story file in full, assembles
+all the context a programmer needs, routes to the correct specialist agent, and
+drives implementation to completion — including writing the test.
+
+**The loop for every story:**
+```
+/qa-plan sprint           ← define test requirements before sprint begins
+/story-readiness [path]   ← validate before starting
+/dev-story [path]         ← implement it  (this skill)
+/code-review [files]      ← review it
+/story-done [path]        ← verify and close it
+```
+
+**After all sprint stories are done:** run `/team-qa sprint` to execute the full QA cycle and get a sign-off verdict before advancing the project stage.
+
+**Output:** Source code + test file in the project's `src/` and `tests/` directories.
+
+---
+
+## Phase 1: Find the Story
+
+**If a path is provided**: read that file directly.
+
+**If no argument**: check `production/session-state/active.md` for the active
+story. If found, confirm: "Continuing work on [story title] — is that correct?"
+If not found, ask: "Which story are we implementing?" Glob
+`production/epics/**/*.md` and list stories with Status: Ready.
+
+---
+
+## Phase 2: Load Full Context
+
+**Before loading any context, verify required files exist.** Extract the ADR path from the story's `ADR Governing Implementation` field, then check:
+
+| File | Path | If missing |
+|------|------|------------|
+| TR registry | `docs/architecture/tr-registry.yaml` | **STOP** — "TR registry not found. Run `/create-epics` to generate it." |
+| Governing ADR | path from story's ADR field | **STOP** — "ADR file [path] not found. Run `/architecture-decision` to create it, or correct the filename in the story's ADR field." |
+| Control manifest | `docs/architecture/control-manifest.md` | **WARN and continue** — "Control manifest not found — layer rules cannot be checked. Run `/create-control-manifest`." |
+
+If the TR registry or governing ADR is missing, set the story status to **BLOCKED** in the session state and do not spawn any programmer agent.
+
+Read all of the following simultaneously — these are independent reads. Do not start implementation until all context is loaded:
+
+### The story file
+Extract and hold:
+- **Story title, ID, layer, type** (Logic / Integration / Visual/Feel / UI / Config/Data)
+- **TR-ID** — the GDD requirement identifier
+- **Governing ADR** reference
+- **Manifest Version** embedded in story header
+- **Acceptance Criteria** — every checkbox item, verbatim
+- **Implementation Notes** — the ADR guidance section in the story
+- **Out of Scope** boundaries
+- **Test Evidence** — the required test file path
+- **Dependencies** — what must be DONE before this story
+
+### The TR registry
+Read `docs/architecture/tr-registry.yaml`. Look up the story's TR-ID.
+Read the current `requirement` text — this is the source of truth for what the
+GDD requires now. Do not rely on any inline text in the story file (may be stale).
+
+### The governing ADR
+Read `docs/architecture/[adr-file].md`. Extract:
+- The full Decision section
+- The Implementation Guidelines section (this is what the programmer follows)
+- The Engine Compatibility section (post-cutoff APIs, known risks)
+- The ADR Dependencies section
+
+### The control manifest
+Read `docs/architecture/control-manifest.md`. Extract the rules for this story's layer:
+- Required patterns
+- Forbidden patterns
+- Performance guardrails
+
+Check: does the story's embedded Manifest Version match the current manifest header date?
+If they differ, use `AskUserQuestion` before proceeding:
+- Prompt: "Story was written against manifest v[story-date]. Current manifest is v[current-date]. New rules may apply. How do you want to proceed?"
+- Options:
+  - `[A] Update story manifest version and implement with current rules (Recommended)`
+  - `[B] Implement with old rules — I accept the risk of non-compliance`
+  - `[C] Stop here — I want to review the manifest diff first`
+
+If [A]: edit the story file's `Manifest Version:` field to the current manifest date before spawning the programmer. Then read the manifest carefully for new rules.
+If [B]: read the manifest carefully for new rules anyway, and note the version mismatch in the Phase 6 summary under "Deviations".
+If [C]: stop. Do not spawn any agent. Let the user review and re-run `/dev-story`.
+
+### Dependency validation
+
+After extracting the **Dependencies** list from the story file, validate each:
+
+1. Glob `production/epics/**/*.md` to find each dependency story file.
+2. Read its `Status:` field.
+3. If any dependency has Status other than `Complete` or `Done`:
+   - Use `AskUserQuestion`:
+     - Prompt: "Story '[current story]' depends on '[dependency title]' which is currently [status], not Complete. How do you want to proceed?"
+     - Options:
+       - `[A] Proceed anyway — I accept the dependency risk`
+       - `[B] Stop — I'll complete the dependency first`
+       - `[C] The dependency is done but status wasn't updated — mark it Complete and continue`
+   - If [B]: set story status to **BLOCKED** in session state and stop. Do not spawn any programmer agent.
+   - If [C]: ask "May I update [dependency path] Status to Complete?" before continuing.
+   - If [A]: note in Phase 6 summary under "Deviations": "Implemented with incomplete dependency: [dependency title] — [status]."
+
+If a dependency file cannot be found: warn "Dependency story not found: [path]. Verify the path or create the story file."
+
+---
+
+### Engine reference
+Read `.claude/docs/technical-preferences.md`:
+- `Engine:` value — determines which programmer agents to use
+- Naming conventions (class names, file names, signal/event names)
+- Performance budgets (frame budget, memory ceiling)
+- Forbidden patterns
+
+---
+
+## Phase 3: Route to the Right Programmer
+
+Based on the story's **Layer**, **Type**, and **system name**, determine which
+specialist to spawn via Task.
+
+**Config/Data stories — skip agent spawning entirely:**
+If the story's Type is `Config/Data`, no programmer agent or engine specialist is needed. Jump directly to Phase 4 (Config/Data note). The implementation is a data file edit — no routing table evaluation, no engine specialist.
+
+### Primary agent routing table
+
+| Story context | Primary agent |
+|---|---|
+| Foundation layer — any type | `engine-programmer` |
+| Any layer — Type: UI | `ui-programmer` |
+| Any layer — Type: Visual/Feel | `gameplay-programmer` (implements) |
+| Core or Feature — gameplay mechanics | `gameplay-programmer` |
+| Core or Feature — AI behaviour, pathfinding | `ai-programmer` |
+| Core or Feature — networking, replication | `network-programmer` |
+| Config/Data — no code | No agent needed (see Phase 4 Config note) |
+
+### Engine specialist — always spawn as secondary for code stories
+
+Read the `Engine Specialists` section of `.claude/docs/technical-preferences.md`
+to get the configured primary specialist. Spawn them alongside the primary agent
+when the story involves engine-specific APIs, patterns, or the ADR has HIGH
+engine risk.
+
+| Engine | Specialist agents available |
+|--------|----------------------------|
+| Godot 4 | `godot-specialist`, `godot-gdscript-specialist`, `godot-shader-specialist` |
+| Unity | `unity-specialist`, `unity-ui-specialist`, `unity-shader-specialist` |
+| Unreal Engine | `unreal-specialist`, `ue-gas-specialist`, `ue-blueprint-specialist`, `ue-umg-specialist`, `ue-replication-specialist` |
+
+**When engine risk is HIGH** (from the ADR or VERSION.md): always spawn the engine
+specialist, even for non-engine-facing stories. High risk means the ADR records
+assumptions about post-cutoff engine APIs that need expert verification.
+
+---
+
+## Phase 4: Implement
+
+Spawn the chosen programmer agent(s) via Task with the full context package:
+
+Provide the agent with:
+1. The complete story file content
+2. The current GDD requirement text (from TR registry)
+3. The ADR Decision + Implementation Guidelines (verbatim — do not summarise)
+4. The control manifest rules for this layer
+5. The engine naming conventions and performance budgets
+6. Any engine-specific notes from the ADR Engine Compatibility section
+7. The test file path that must be created
+8. Explicit instruction: **implement this story and write the test**
+
+The agent should:
+- Create or modify files in `src/` following the ADR guidelines
+- Respect all Required and Forbidden patterns from the control manifest
+- Stay within the story's Out of Scope boundaries (do not touch unrelated files)
+- Write clean, doc-commented public APIs
+
+### Config/Data stories (no agent needed)
+
+For Type: Config/Data stories, no programmer agent is required. The implementation
+is editing a data file. Read the story's acceptance criteria and make the specified
+changes to the data file directly. Note which values were changed and what they
+changed from/to.
+
+### Visual/Feel stories
+
+Spawn `gameplay-programmer` to implement the code/animation calls. Note that
+Visual/Feel acceptance criteria cannot be auto-verified — the "does it feel right?"
+check happens in `/story-done` via manual confirmation.
+
+---
+
+## Phase 5: Write the Test
+
+For **Logic** and **Integration** stories, the test must be written as part of
+this implementation — not deferred to later.
+
+Remind the programmer agent:
+
+> "The test file for this story is required at: `[path from Test Evidence section]`.
+> The story cannot be closed via `/story-done` without it. Write the test
+> alongside the implementation, not after."
+
+Test requirements (from coding-standards.md):
+- File name: `[system]_[feature]_test.[ext]`
+- Function names: `test_[scenario]_[expected_outcome]`
+- Each acceptance criterion must have at least one test function covering it
+- No random seeds, no time-dependent assertions, no external I/O
+- Test the formula bounds from the GDD Formulas section
+
+For **Visual/Feel** and **UI** stories: no automated test. Remind the agent to
+note in the implementation summary what manual evidence will be needed:
+"Evidence doc required at `production/qa/evidence/[slug]-evidence.md`."
+
+For **Config/Data** stories: no test file. A smoke check will serve as evidence.
+
+---
+
+## Phase 6: Collect and Summarise
+
+After the programmer agent(s) complete, collect:
+
+- Files created or modified (with paths)
+- Test file created (path and number of test functions written)
+- Any deviations from the story's Out of Scope boundary (flag these)
+- Any questions or blockers the agent surfaced
+- Any engine-specific risks the specialist flagged
+
+Present a concise implementation summary:
+
+```
+## Implementation Complete: [Story Title]
+
+**Files changed**:
+- `src/[path]` — created / modified ([brief description])
+- `tests/[path]` — test file ([N] test functions)
+
+**Acceptance criteria covered**:
+- [x] [criterion] — implemented in [file:function]
+- [x] [criterion] — covered by test [test_name]
+- [ ] [criterion] — DEFERRED: requires playtest (Visual/Feel)
+
+**Deviations from scope**: [None] or [list files touched outside story boundary]
+**Engine risks flagged**: [None] or [specialist finding]
+**Blockers**: [None] or [describe]
+
+Ready for: `/code-review [file1] [file2]` then `/story-done [story-path]`
+```
+
+---
+
+## Phase 7: Update Session State
+
+Silently append to `production/session-state/active.md`:
+
+```
+## Session Extract — /dev-story [date]
+- Story: [story-path] — [story title]
+- Files changed: [comma-separated list]
+- Test written: [path, or "None — Visual/Feel/Config story"]
+- Blockers: [None, or description]
+- Next: /code-review [files] then /story-done [story-path]
+```
+
+Create `active.md` if it does not exist. Confirm: "Session state updated."
+
+---
+
+## Error Recovery Protocol
+
+If any spawned agent (via Task) returns BLOCKED, errors, or cannot complete:
+
+1. **Surface immediately**: Report "[AgentName]: BLOCKED — [reason]" to the user before continuing to dependent phases
+2. **Assess dependencies**: Check whether the blocked agent's output is required by subsequent phases. If yes, do not proceed past that dependency point without user input.
+3. **Offer options** via AskUserQuestion with choices:
+   - Skip this agent and note the gap in the final report
+   - Retry with narrower scope
+   - Stop here and resolve the blocker first
+4. **Always produce a partial report** — output whatever was completed. Never discard work because one agent blocked.
+
+Common blockers:
+- Input file missing (story not found, GDD absent) → redirect to the skill that creates it
+- ADR status is Proposed → do not implement; run `/architecture-decision` first
+- Scope too large → split into two stories via `/create-stories`
+- Conflicting instructions between ADR and story → surface the conflict, do not guess
+- Manifest version mismatch → show diff to user, ask whether to proceed with old rules or update story first
+
+## Collaborative Protocol
+
+- **File writes are delegated** — all source code, test files, and evidence docs are written by sub-agents spawned via Task. Each sub-agent enforces the "May I write to [path]?" protocol individually. This orchestrator does not write files directly.
+- **Load before implementing** — do not start coding until all context is loaded
+  (story, TR-ID, ADR, manifest, engine prefs). Incomplete context produces code
+  that drifts from design.
+- **The ADR is the law** — implementation must follow the ADR's Implementation
+  Guidelines. If the guidelines conflict with what seems "better," flag it in the
+  summary rather than silently deviating.
+- **Stay in scope** — the Out of Scope section is a contract. If implementing
+  the story requires touching an out-of-scope file, stop and surface it:
+  "Implementing [criterion] requires modifying [file], which is out of scope.
+  Shall I proceed or create a separate story?"
+- **Test is not optional for Logic/Integration** — do not mark implementation
+  complete without the test file existing
+- **Visual/Feel criteria are deferred, not skipped** — mark them as DEFERRED
+  in the summary; they will be manually verified in `/story-done`
+- **Ask before large structural decisions** — if the story requires an
+  architectural pattern not covered by the ADR, surface it before implementing:
+  "The ADR doesn't specify how to handle [case]. My plan is [X]. Proceed?"
+
+---
+
+## Recommended Next Steps
+
+- Run `/code-review [file1] [file2]` to review the implementation before closing the story
+- Run `/story-done [story-path]` to verify acceptance criteria and mark the story complete
+- After all sprint stories are done: run `/team-qa sprint` for the full QA cycle before advancing the project stage

--- a/skills/pytorch-integration/dual-mode-cublaslt-handle-workspace/SKILL.md
+++ b/skills/pytorch-integration/dual-mode-cublaslt-handle-workspace/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: dual-mode-cublaslt-handle-workspace
+description: Manage a cuBLASLt handle + workspace two ways (self-owned vs PyTorch-managed, persistent vs per-call) so your library works under compute-sanitizer, older PyTorch versions, and high-throughput prod builds — selected by env var at init.
+category: pytorch-integration
+version: 1.0.0
+version_origin: extracted
+tags: [cublaslt, pytorch, workspace, compute-sanitizer, handle-management]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - csrc/jit/device_runtime.hpp
+imported_at: 2026-04-18T13:30:00Z
+---
+
+# Dual-Mode cuBLASLt Handle And Workspace Management
+
+## When to use
+You embed cuBLASLt calls in a PyTorch extension. The "obvious" pattern — `at::cuda::getCurrentCUDABlasLtHandle()` + one reusable `torch::Tensor` workspace — breaks in three places:
+1. **Older PyTorch** (pre-2.3) doesn't expose `getCurrentCUDABlasLtHandle`.
+2. **`at::cuda::getCurrentCUDABlasLtHandle` has measurable CPU overhead** in some PyTorch versions — you don't want that on the critical path of small-shape GEMMs.
+3. **`compute-sanitizer`** shuts down the CUDA runtime before your workspace tensor's destructor runs, triggering `cudaErrorCudartUnloading` as your destructor runs `cudaFree`.
+
+You need all four (handle, workspace) × (self-managed, PyTorch-managed) or (persistent, per-call) combinations to be reachable by env var without recompiling.
+
+## Steps
+1. **Compile-time feature gate** for the PyTorch handle helper:
+   ```cpp
+   #define PYTORCH_SUPPORTS_GET_CUBLASLT_HANDLE \
+       (TORCH_VERSION_MAJOR > 2 or (TORCH_VERSION_MAJOR == 2 and TORCH_VERSION_MINOR >= 3))
+   ```
+2. **Two boolean flags, two env vars:**
+   ```cpp
+   use_pytorch_managed_cublaslt_handle = get_env<int>("DG_USE_PYTORCH_CUBLASLT_HANDLE", 0) > 0;
+   use_temp_cublaslt_workspace         = get_env<int>("DG_USE_TEMP_CUBLASLT_WORKSPACE",  0) > 0;
+   ```
+   Defaults: self-owned handle + persistent workspace. Both flags are independent — four combinations.
+3. **At init, assert the compile-time support lines up with the runtime flag:**
+   ```cpp
+   #if not PYTORCH_SUPPORTS_GET_CUBLASLT_HANDLE
+   DG_HOST_ASSERT(not use_pytorch_managed_cublaslt_handle
+                  and "PyTorch does not support getting the cuBLASLt handle");
+   #endif
+   ```
+4. **Create a self-owned handle lazily (in the constructor)** unless PyTorch is managing it:
+   ```cpp
+   if (not use_pytorch_managed_cublaslt_handle)
+       DG_CUBLASLT_CHECK(cublasLtCreate(&cublaslt_handle));
+   ```
+   Destructor must symmetrically destroy, but only if we created it.
+5. **Create the persistent workspace on the CUDA device**, unless `temp` mode:
+   ```cpp
+   if (not use_temp_cublaslt_workspace)
+       cublaslt_workspace = torch::empty({kCublasLtWorkspaceSize},
+                                          dtype(torch::kByte).device(at::kCUDA));
+   ```
+6. **Accessor functions read the flags:**
+   ```cpp
+   cublasLtHandle_t get_cublaslt_handle() const {
+       if (use_pytorch_managed_cublaslt_handle)
+           return at::cuda::getCurrentCUDABlasLtHandle();
+       return cublaslt_handle;
+   }
+   torch::Tensor get_cublaslt_workspace() const {
+       if (use_temp_cublaslt_workspace)
+           return torch::empty({kCublasLtWorkspaceSize}, dtype(torch::kByte).device(at::kCUDA));
+       return cublaslt_workspace;
+   }
+   ```
+7. **Document the compute-sanitizer workflow** — "set `DG_USE_TEMP_CUBLASLT_WORKSPACE=1` when running `compute-sanitizer`" — so users don't chase the `cudaErrorCudartUnloading` error.
+
+## Evidence (from DeepGEMM)
+- `csrc/jit/device_runtime.hpp:9-10`: the PYTORCH_SUPPORTS_GET_CUBLASLT_HANDLE version gate.
+- `csrc/jit/device_runtime.hpp:31-49`: the env var reads, compile-time assertion, and the two independent object allocations.
+- `csrc/jit/device_runtime.hpp:40-42`: the compute-sanitizer rationale in a comment ("triggers `cudaErrorCudartUnloading` when the workspace tensor is destructed after CUDA driver shutdown").
+- `csrc/jit/device_runtime.hpp:56-70`: the two accessors with branch on flag.
+
+## Counter / Caveats
+- **`at::cuda::getCurrentCUDABlasLtHandle` in modern PyTorch has been optimized.** On PyTorch ≥ 2.4 the overhead is sub-microsecond, so the default flip back to PyTorch-managed may make sense once you drop older support.
+- **Creating a 32 MB per-call workspace is expensive** — `torch::empty` allocates via the PyTorch caching allocator, which is fast, but the tensor bookkeeping is not free. Only enable `temp` mode when you have to.
+- **Two boolean flags → four combinations**, but not all are equally useful. Persistent workspace + PyTorch handle is the standard prod config. Document which combinations are tested.

--- a/skills/reliability/detached-update-check-with-local-cache/SKILL.md
+++ b/skills/reliability/detached-update-check-with-local-cache/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: detached-update-check-with-local-cache
+description: Check for package updates in a detached child subprocess with a 24h local cache so startup stays fast, notification is fresh, and network failure never blocks the user.
+category: reliability
+version: 1.0.0
+version_origin: extracted
+tags: [cli, update-check, caching, npm, ux]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/ChromeDevTools/chrome-devtools-mcp.git
+source_ref: main
+source_commit: 0a6aaa52ebacb2db834ffa437863e5844aa3730b
+source_project: chrome-devtools-mcp
+source_path: src/utils/check-for-updates.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Detached Update Check with Local Cache
+
+## When to use
+
+- You ship a CLI on npm (or similar) and want users to see "Update available" without a startup latency penalty or offline fragility.
+- Current process must read a recent cached version *synchronously-ish* (a single `fs.readFile`), while the actual HTTP check happens in the background for next time.
+
+## How it works
+
+- On startup: read `~/.cache/<app>/latest.json` if present. If `cachedVersion > currentVersion`, print the upgrade notice now. This is the only user-visible effect.
+- Check the file `mtime`; if younger than 24h, return and skip the refresh.
+- Otherwise, touch/create the cache file's mtime immediately (so concurrent processes don't all race to refresh), then spawn a detached child (`node check-latest-version.js <cachePath>`) with `stdio: 'ignore'` and `child.unref()`. The child fetches `https://registry.npmjs.org/<pkg>/latest`, writes `{version}` to the cache, and exits. The parent returns immediately.
+- Respect a `NO_UPDATE_CHECK` env var as a hard opt-out for CI / corp networks.
+- Use an `isChecking` module-level flag so repeated calls within a single process don't stack.
+
+## Example
+
+```ts
+export async function checkForUpdates(message: string) {
+  if (isChecking || process.env.MYAPP_NO_UPDATE_CHECKS) return;
+  isChecking = true;
+  const cachePath = path.join(os.homedir(), '.cache', 'myapp', 'latest.json');
+  let cachedVersion, stats;
+  try { stats = await fs.stat(cachePath); cachedVersion = JSON.parse(await fs.readFile(cachePath, 'utf8')).version; } catch {}
+  if (cachedVersion && semver.lt(CURRENT_VERSION, cachedVersion)) {
+    console.warn(`\nUpdate available: ${CURRENT_VERSION} -> ${cachedVersion}\n${message}\n`);
+  }
+  if (stats && Date.now() - stats.mtimeMs < 24 * 60 * 60 * 1000) return;
+  try { // pre-touch to claim the refresh slot
+    await fs.mkdir(path.dirname(cachePath), {recursive: true});
+    if (stats) await fs.utimes(cachePath, new Date(), new Date());
+    else await fs.writeFile(cachePath, JSON.stringify({version: CURRENT_VERSION}));
+  } catch {}
+  const child = child_process.spawn(process.execPath, [CHECK_SCRIPT, cachePath], {detached: true, stdio: 'ignore'});
+  child.unref();
+}
+
+// check-latest-version.js (background worker)
+const res = await fetch('https://registry.npmjs.org/mypkg/latest');
+if (res.ok) {
+  const {version} = await res.json();
+  await fs.writeFile(cachePath, JSON.stringify({version}));
+}
+```
+
+## Gotchas
+
+- Pre-touch the mtime *before* spawning the subprocess. Otherwise 10 parallel CLI invocations all spawn and race on the same file.
+- The subprocess must swallow all errors silently — network flakiness must never surface to the parent.
+- Cache is `os.homedir()/.cache` on Linux/macOS; on Windows use `%LOCALAPPDATA%`. Don't put update state under `Application Support` or `AppData\Roaming` — it's not per-machine user transient state.
+- Don't gate tool functionality on the update check. It must be best-effort; the notification is the only allowed effect.
+- When showing the notice, link the user to an exact upgrade command (`npm i -g mypkg@latest`) — otherwise they have to google.

--- a/skills/reverse-engineering/dex2jar-bridge-apk-to-fernflower/SKILL.md
+++ b/skills/reverse-engineering/dex2jar-bridge-apk-to-fernflower/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: dex2jar-bridge-apk-to-fernflower
+description: Convert Android DEX bytecode to a standard JVM JAR with dex2jar so that Fernflower or Vineflower — which cannot read APK/DEX directly — can decompile it.
+category: reverse-engineering
+version: 1.0.0
+tags: [dex2jar, fernflower, vineflower, dex, apk, android, reverse-engineering]
+source_type: extracted-from-git
+source_url: https://github.com/SimoneAvogadro/android-reverse-engineering-skill.git
+source_ref: master
+source_commit: ddeb9bc33272db1e34107fd286098bb1e9896e51
+source_project: android-reverse-engineering-skill
+source_path: plugins/android-reverse-engineering/skills/android-reverse-engineering/references/fernflower-usage.md
+imported_at: 2026-04-18T03:31:43Z
+confidence: medium
+version_origin: extracted
+---
+
+# dex2jar bridge: APK → JAR → Fernflower
+
+Fernflower / Vineflower only understand JVM bytecode (`.jar`, `.class`). Android ships Dalvik bytecode (`.dex`). `dex2jar` is the translator: it repackages the DEX entries inside an APK into a standard JAR that the JVM decompilers can consume.
+
+## When to use
+
+- You already have jadx output but want Fernflower's cleaner handling of specific classes.
+- You want to run both decompilers (`--engine both`) for comparison on APK input.
+- You're analyzing a DEX file directly (e.g. from `adb shell pm path` + `adb pull`).
+
+Skip this skill for inputs that are already `.jar` or `.aar` — Fernflower reads those directly (AAR via its bundled `classes.jar`).
+
+## Procedure
+
+1. **Install dex2jar** (one-time): `brew install dex2jar` on macOS, or download the release bundle from https://github.com/pxb1988/dex2jar/releases and put it on `PATH`. Verify with `d2j-dex2jar --help`.
+
+2. **Convert** the APK (or standalone DEX) to a JAR:
+
+   ```bash
+   d2j-dex2jar -f -o app-converted.jar app.apk
+   ```
+
+   Flags: `-f` force overwrite. `-o` sets the output path. dex2jar walks every `classes*.dex` inside the APK and merges them into the output JAR.
+
+3. **Decompile** the resulting JAR with Fernflower/Vineflower:
+
+   ```bash
+   java -jar "$FERNFLOWER_JAR_PATH" -dgs=1 -mpm=60 app-converted.jar output/
+   unzip -o output/app-converted.jar -d output/sources/
+   ```
+
+4. **(Optional) Target a single DEX** from a multi-dex APK:
+
+   ```bash
+   unzip app.apk 'classes*.dex' -d extracted/
+   d2j-dex2jar -f -o classes2.jar extracted/classes2.dex
+   ```
+
+   This is faster when you only need to re-decompile one DEX that jadx mishandled.
+
+## Counter / Caveats
+
+- **ZipException during dex2jar**: the APK has a non-standard ZIP structure (sometimes signed in odd ways, or repackaged). Fall back to jadx, which tolerates more variants.
+- dex2jar does not preserve Android resources; you still need jadx (or `apktool`) for AndroidManifest, layouts, drawables.
+- For `.aar` files, skip dex2jar — extract the AAR and point Fernflower at the embedded `classes.jar`.
+- The converted JAR contains JVM-legal bytecode but not necessarily semantically identical bytecode: some Dalvik-specific ops are translated heuristically. If a class behaves oddly in Fernflower output, double-check against jadx.
+
+## References
+
+- Upstream CLI wrapper: `scripts/decompile.sh` (automates `--engine fernflower` on APK input via this bridge)
+- dex2jar releases: https://github.com/pxb1988/dex2jar/releases

--- a/skills/security/easyjailbreak-pair-attack-pipeline/SKILL.md
+++ b/skills/security/easyjailbreak-pair-attack-pipeline/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: easyjailbreak-pair-attack-pipeline
+description: Use EasyJailbreak to run the PAIR attack against a target LLM using an attack model, target model, and evaluator.
+category: security
+version: 1.0.0
+version_origin: extracted
+tags: [jailbreak, easyjailbreak, pair, llm-safety, red-team]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/Lordog/dive-into-llms.git
+source_ref: main
+source_commit: f84c04268794ef94f8949808bbc14ab8636763a0
+source_project: dive-into-llms
+source_path: documents/chapter6/README.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# EasyJailbreak PAIR Attack Pipeline
+
+## When to use
+- Researching LLM safety via automated jailbreak attacks.
+- PAIR: attack LLM iteratively refines jailbreak prompts against a target LLM.
+- Reproducible framework with Selector, Mutator, Constraint, Evaluator modules.
+
+## Steps
+
+1. Install EasyJailbreak:
+
+```bash
+pip install easyjailbreak
+```
+
+2. Load models:
+
+```python
+from easyjailbreak.models.huggingface_model import from_pretrained, HuggingfaceModel
+attack_model = from_pretrained('lmsys/vicuna-13b-v1.5', model_name='vicuna_v1.1')
+target_model = HuggingfaceModel('meta-llama/Llama-2-7b-chat-hf', model_name='llama-2')
+```
+
+3. Load dataset and initialize seeds:
+
+```python
+from easyjailbreak.datasets import JailbreakDataset
+from easyjailbreak.seed.seed_random import SeedRandom
+dataset = JailbreakDataset(dataset='AdvBench')
+seeder = SeedRandom()
+seeder.new_seeds()
+```
+
+4. Run PAIR attack:
+
+```python
+from easyjailbreak.attacker.PAIR_chao_2023 import PAIR
+attacker = PAIR(
+    attack_model=attack_model,
+    target_model=target_model,
+    eval_model=eval_model,
+    jailbreak_datasets=dataset
+)
+attacker.attack(save_path='results.jsonl')
+```
+
+## Pitfalls
+- PAIR requires three models (attack, target, eval); GPU memory scales accordingly.
+- GPT-4 as eval model requires OpenAI API access (VPN in China).
+
+## Source
+- Chapter 6 of dive-into-llms - documents/chapter6/README.md

--- a/skills/tauri/dev-sidecar-placeholder-binary/SKILL.md
+++ b/skills/tauri/dev-sidecar-placeholder-binary/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: dev-sidecar-placeholder-binary
+description: Satisfy Tauri's build-time sidecar requirement in dev mode by emitting a minimal valid PE / shell-script placeholder.
+category: tauri
+version: 1.0.0
+version_origin: extracted
+tags: [tauri, dev-experience, placeholder-binary, windows-pe, cross-platform]
+source_type: extracted-from-git
+source_url: https://github.com/jamiepine/voicebox.git
+source_ref: main
+source_commit: 476abe07fc2c1587f4b3e3916134018ebacd143d
+source_project: voicebox
+confidence: medium
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Dev sidecar placeholder binary
+
+## When to use
+Tauri verifies sidecar binaries at compile time. In dev you want to run the backend manually (with hot-reload) but the missing sidecar breaks `tauri dev`. You need a byte-cheap placeholder that's just valid enough to pass Tauri's check without shipping anything that could be mistaken for the real server.
+
+## Steps
+1. Detect the current target triple via `rustc --print host-tuple`. Fall back to `process.platform` + `process.arch` heuristics if Rust is not installed. Target triples look like `x86_64-pc-windows-msvc`, `aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`.
+2. Skip if a real binary already exists. Use a size threshold (e.g. `>10000 bytes`) to distinguish the placeholder from the real 100+ MB sidecar, so the script is safe to run repeatedly.
+3. On Unix, write a tiny shell script that `echo`s a "start the real server with `bun run dev:server`" message and exits 1. `chmod 0o755` it.
+4. On Windows, emit a valid minimal PE. The absolute minimum PE requires: DOS header (MZ), a DOS stub, PE signature, COFF header (Machine=x86_64, 1 section), a PE32+ optional header, padded to a 512-byte file alignment. Embed the bytes in your script; don't shell out to `link.exe`.
+5. On the Tauri side, when `rx.recv()` returns `None` in dev (placeholder process exited), don't treat it as an error — probe port 17493 and, if a manually-started server is listening, reuse it. Print clear guidance to start the real server if not.
+6. Wire the generator into the monorepo's setup command (e.g. `bun run setup:dev` or `just _ensure-sidecar`) so contributors never see the Tauri error.
+
+## Counter / Caveats
+- Do NOT ship the placeholder to end users. Filter `src-tauri/binaries/` by size in your release script to catch accidents.
+- The minimum PE is sensitive to byte layout; test on actual Windows before relying on it. If Windows refuses to load it, the contributor sees `ERROR_BAD_EXE_FORMAT` and is confused.
+- Watch the binary-name convention: `voicebox-server-<target-triple>` with `.exe` on Windows. Tauri requires the exact name per platform.
+- Keep the placeholder exit code non-zero so Tauri reports the intentional failure; dev-mode detection branches on that.
+
+Source references: `scripts/setup-dev-sidecar.js`, `tauri/src-tauri/src/main.rs` (dev-mode branches in `start_server`).

--- a/skills/telemetry/detached-watchdog-telemetry-process/SKILL.md
+++ b/skills/telemetry/detached-watchdog-telemetry-process/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: detached-watchdog-telemetry-process
+description: Run telemetry shipping in a detached child process fed by the parent over stdin, so telemetry never blocks tool execution and gets a guaranteed flush-on-parent-death window.
+category: telemetry
+version: 1.0.0
+version_origin: extracted
+tags: [telemetry, watchdog, child-process, ipc, reliability]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/ChromeDevTools/chrome-devtools-mcp.git
+source_ref: main
+source_commit: 0a6aaa52ebacb2db834ffa437863e5844aa3730b
+source_project: chrome-devtools-mcp
+source_path: src/telemetry/WatchdogClient.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Watchdog Child Process for Telemetry
+
+## When to use
+
+- Your app emits telemetry events but can't afford to block tool calls on network I/O, retries, or rate-limit backoff.
+- Events are low-value individually but matter in aggregate; losing a handful on crash is acceptable, dropping the whole buffer on normal exit is not.
+- You want telemetry completely gone in tests and opt-outs, not just a no-op flag.
+
+## How it works
+
+- Parent process spawns a `node watchdog/main.js` as a detached child with `stdio: ['pipe', 'ignore', 'ignore']` and `child.unref()` so the child doesn't keep the parent alive on its own.
+- Parent `.send(msg)` writes `JSON.stringify(msg) + '\n'` to the child's stdin. Messages are fire-and-forget; if stdin is destroyed the parent logs and drops.
+- Child reads newline-delimited JSON via `readline.createInterface({input: process.stdin})`. It buffers events (e.g. 1000-entry ring with drop-oldest overflow) and flushes on a timer.
+- Parent-death detection: child listens on `stdin.on('end')`, `stdin.on('close')`, and `process.on('disconnect')`. Any of those fires a shutdown path that sends a `server_shutdown` event, runs a short final-flush with a 5s race against `setTimeout`, then exits.
+- Config flows via argv at spawn time (`--parent-pid=`, `--app-version=`, `--clearcut-endpoint=`, `--log-file=`). No shared filesystem state between parent and child during a session.
+
+## Example
+
+```ts
+// WatchdogClient.ts - parent side
+const child = spawn(process.execPath, [watchdogPath,
+  `--parent-pid=${process.pid}`,
+  `--app-version=${appVersion}`,
+  `--os-type=${osType}`,
+  ...(logFile ? [`--log-file=${logFile}`] : []),
+], { stdio: ['pipe', 'ignore', 'ignore'], detached: true });
+child.unref();
+function send(msg) {
+  if (child.stdin && !child.stdin.destroyed) {
+    child.stdin.write(JSON.stringify(msg) + '\n');
+  }
+}
+
+// watchdog/main.ts - child side
+process.stdin.on('end', () => onParentDeath('stdin end'));
+process.stdin.on('close', () => onParentDeath('stdin close'));
+readline.createInterface({input: process.stdin}).on('line', line => {
+  const msg = JSON.parse(line);
+  sender.enqueueEvent(msg.payload);
+});
+function onParentDeath(reason) {
+  sender.sendShutdownEvent().finally(() => process.exit(0));
+}
+```
+
+## Gotchas
+
+- If you don't call `child.unref()`, node won't exit while the watchdog is alive — your CLI looks hung.
+- `stdio: 'pipe'` for stdin is required for IPC; stdout/stderr should be `'ignore'` or redirected, or the detached child's output will appear mid-prompt in a TTY parent.
+- On normal parent exit, stdin `end` fires before the child sees disconnect — listen to both so detached vs. IPC-parented spawns both shut down.
+- Use `{detached: true}` *and* `unref()`. `detached` alone on Windows doesn't decouple the child's console.
+- Race `finalFlush()` against `setTimeout(SHUTDOWN_TIMEOUT_MS)` — never `await` a network call unconditionally in a shutdown path, or a hung endpoint can hold your process open.
+- Ship an opt-out env var that is checked in the parent *before* spawning the watchdog; a running-but-idle watchdog still uses memory and file handles.

--- a/skills/testing/e2e-default-login-helper/SKILL.md
+++ b/skills/testing/e2e-default-login-helper/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: e2e-default-login-helper
+description: Reusable Playwright loginAsDefault helper that authenticates via API (send-code + verify-code), injects the token into localStorage, and navigates to a workspace-scoped URL.
+category: testing
+version: 1.0.0
+tags: [playwright, e2e, auth, fixtures, testing]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- Playwright E2E suite against a real backend + frontend in dev/staging.
+- You have a stable test user and want to skip the browser login flow.
+
+## Steps
+
+1. Define constants for the default E2E user:
+   ```ts
+   const DEFAULT_E2E_NAME = "E2E User";
+   const DEFAULT_E2E_EMAIL = "e2e@myapp.test";
+   const DEFAULT_E2E_WORKSPACE = "e2e-workspace";
+   ```
+2. Helper that uses `TestApiClient` for the API calls, then injects the token into browser storage:
+   ```ts
+   export async function loginAsDefault(page: Page): Promise<string> {
+     const api = new TestApiClient();
+     await api.login(DEFAULT_E2E_EMAIL, DEFAULT_E2E_NAME);
+     const workspace = await api.ensureWorkspace("E2E Workspace", DEFAULT_E2E_WORKSPACE);
+
+     const token = api.getToken();
+     await page.goto("/login");                    // start from a safe URL
+     await page.evaluate((t) => {
+       localStorage.setItem("myapp_token", t);
+     }, token);
+     await page.goto(`/${workspace.slug}/issues`);
+     await page.waitForURL("**/issues", { timeout: 10000 });
+     return workspace.slug;
+   }
+   ```
+3. In test specs:
+   ```ts
+   let api: TestApiClient;
+   test.beforeEach(async ({ page }) => {
+     api = await createTestApi();
+     await loginAsDefault(page);
+   });
+   test.afterEach(() => api.cleanup());
+   ```
+
+## Example
+
+```ts
+test("create and view an issue", async ({ page }) => {
+  const issue = await api.createIssue("Test Issue");
+  await page.goto(`/e2e-workspace/issues/${issue.id}`);
+  await expect(page.getByText("Test Issue")).toBeVisible();
+});
+```
+
+## Caveats
+
+- `loginAsDefault` starts with `page.goto("/login")` before writing to localStorage. Without that, `page.evaluate` may run on `about:blank` where localStorage writes don't persist.
+- Tests that exercise the login flow itself shouldn't use this helper — they need to go through the UI. Name them `*-login.spec.ts` and opt out.
+- If the storage key or token format changes, update the helper first; Playwright tests will surface the breakage fast but the fix is in one place.


### PR DESCRIPTION
## Batch
- batch 6/24

## Knowledge (19)
- `decision/desktop-route-categories`
- `pitfall/dev-sh-auto-setup-idempotent`
- `auth/device-revocation-status-codes-contract`
- `arch/devtools-frontend-reused-as-library`
- `reference/dex2jar-apk-to-jar-intermediate-conversion`
- `reference/dflash-backend-support-matrix`
- `llm-agents/dflash-block-diffusion-overview`
- `jit-compilation/directory-rename-is-atomic-not-file-rename`
- `windows/display-enumeration-winapi-structs`
- `codecs/display-orientation-rotation-handling`
- `devops/dockerfile-server-design-choices`
- `workflow/docs-claude-context`
- `reference/docs-mcp-always-on`
- `pitfall/drive-by-refactor-beyond-bug-fix`
- `architecture/dual-backend-claude-and-pi`
- `reference/dual-sided-worker-pool-toggle`
- `architecture/dynamic-uv-python-scripts`
- `llm-fundamentals/easyedit-framework`
- `architecture/effect-ts-layer-dependency-injection-for-testing`

## Skills (31)
- `ops/detached-daemon-lifecycle-cli`
- `reliability/detached-update-check-with-local-cache`
- `telemetry/detached-watchdog-telemetry-process`
- `llm-agents/deterministic-agent-chain`
- `ml-ops/deterministic-torch-seed-bundle`
- `tauri/dev-sidecar-placeholder-binary`
- `production/dev-story`
- `build-system/develop-script-with-inplace-submodule-symlinks`
- `auth/device-revocation-reset-flow`
- `reverse-engineering/dex2jar-bridge-apk-to-fernflower`
- `llm-agents/dispatching-parallel-agents`
- `platform/display-device-enumeration-platform`
- `jit-compilation/distributed-filesystem-safe-atomic-cache-with-fsync`
- `devops/docker-compose-selfhost-stack`
- `docker/docker-entrypoint-gosu-bind-mount`
- `build/docker-find-chmod-fast-readability`
- `devops/docker-multistage-go-alpine`
- `devops/docker-smoke-test-loop`
- `architecture/document-converter-priority-registry`
- `llm-agents/draft-model-bind-to-target-modules`
- _... and 11 more_

## Source
- project: F:/workspace/tool (bulk extract)
- batch plan: .omc/batch-plan.json

## Post-merge
After squash-merge, run step 7 to re-anchor skill tags at the merge commit.