### PR TITLE
Publish batch 8/24: 23 knowledge + 27 skills

### DIFF
--- a/index.json
+++ b/index.json
@@ -2044,6 +2044,42 @@
   },
   {
     "kind": "knowledge",
+    "name": "gep-asset-model",
+    "slug": "gep-asset-model",
+    "category": "architecture",
+    "description": "Evolver's GEP (Genome Evolution Protocol) stores evolution state as three on-disk assets — reusable Genes, success Capsules, and an append-only EvolutionEvents log — so every change is auditable and the selector can score candidates by signal match.",
+    "tags": [
+      "gep",
+      "evolver",
+      "genes",
+      "capsules",
+      "events",
+      "audit"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/architecture/gep-asset-model.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "gep-genome-evolution-protocol",
+    "slug": "gep-genome-evolution-protocol",
+    "category": "architecture",
+    "description": "Protocol for tracking and applying genome mutations as evolution genes and capsules",
+    "tags": [
+      "evolver",
+      "architecture",
+      "gep",
+      "reference"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/architecture/gep-genome-evolution-protocol.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "ci-gpg-signing-batch-mode-non-interactive",
     "slug": "ci-gpg-signing-batch-mode-non-interactive",
     "category": "ci-cd",
@@ -2085,6 +2121,25 @@
   },
   {
     "kind": "knowledge",
+    "name": "github-variables-version-management",
+    "slug": "github-variables-version-management",
+    "category": "ci-cd",
+    "description": "Storing version strings in GitHub Actions repository variables (not committed files) avoids merge conflicts on automated version bumps and provides a single source of truth accessible to both CI jobs and local scripts via the `gh` CLI.",
+    "tags": [
+      "github-actions",
+      "versioning",
+      "repository-variables",
+      "ci-cd",
+      "automation",
+      "merge-conflicts"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/ci-cd/github-variables-version-management.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "clipboard-context-lazy-initialization",
     "slug": "clipboard-context-lazy-initialization",
     "category": "clipboard",
@@ -2114,6 +2169,24 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/clipboard/clipboard-ownership-protocol.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "gdi-fallback-screen-capture",
+    "slug": "gdi-fallback-screen-capture",
+    "category": "codecs",
+    "description": "On Windows, try DXGI first; fall back to GDI for legacy/virtual displays that DXGI can't enumerate.",
+    "tags": [
+      "capture",
+      "codecs",
+      "fallback",
+      "gdi",
+      "screen"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/codecs/gdi-fallback-screen-capture.md",
     "has_content": true
   },
   {
@@ -3900,6 +3973,132 @@
   },
   {
     "kind": "knowledge",
+    "name": "godot-animation",
+    "slug": "godot-animation",
+    "category": "engine",
+    "description": "Godot engine reference for the animation module — APIs, patterns, and best practices",
+    "tags": [
+      "game-studios",
+      "ccgs",
+      "godot",
+      "engine-reference",
+      "animation"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/engine/godot-animation.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "godot-audio",
+    "slug": "godot-audio",
+    "category": "engine",
+    "description": "Godot engine reference for the audio module — APIs, patterns, and best practices",
+    "tags": [
+      "game-studios",
+      "ccgs",
+      "godot",
+      "engine-reference",
+      "audio"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/engine/godot-audio.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "godot-best-practices",
+    "slug": "godot-best-practices",
+    "category": "engine",
+    "description": "Current Godot best practices for CCGS projects — patterns and idioms to follow",
+    "tags": [
+      "game-studios",
+      "ccgs",
+      "godot",
+      "best-practices",
+      "engine-reference"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/engine/godot-best-practices.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "godot-breaking-changes",
+    "slug": "godot-breaking-changes",
+    "category": "engine",
+    "description": "Godot breaking changes log for the pinned version used in CCGS projects",
+    "tags": [
+      "game-studios",
+      "ccgs",
+      "godot",
+      "breaking-changes",
+      "migration"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/engine/godot-breaking-changes.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "godot-deprecated-apis",
+    "slug": "godot-deprecated-apis",
+    "category": "engine",
+    "description": "Deprecated Godot APIs to avoid in CCGS projects with recommended replacements",
+    "tags": [
+      "game-studios",
+      "ccgs",
+      "godot",
+      "deprecated",
+      "api-reference"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/engine/godot-deprecated-apis.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "godot-input",
+    "slug": "godot-input",
+    "category": "engine",
+    "description": "Godot engine reference for the input module — APIs, patterns, and best practices",
+    "tags": [
+      "game-studios",
+      "ccgs",
+      "godot",
+      "engine-reference",
+      "input"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/engine/godot-input.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "godot-navigation",
+    "slug": "godot-navigation",
+    "category": "engine",
+    "description": "Godot engine reference for the navigation module — APIs, patterns, and best practices",
+    "tags": [
+      "game-studios",
+      "ccgs",
+      "godot",
+      "engine-reference",
+      "navigation"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/engine/godot-navigation.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "condition-based-waiting",
     "slug": "condition-based-waiting",
     "category": "engineering",
@@ -3911,6 +4110,64 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/engineering/condition-based-waiting.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "flutter-rust-bridge-compatibility-matrix",
+    "slug": "flutter-rust-bridge-compatibility-matrix",
+    "category": "ffi",
+    "description": "flutter_rust_bridge v1.80 requires Rust edition 2021 and has platform-specific build tweaks for each target.",
+    "tags": [
+      "bridge",
+      "compatibility",
+      "ffi",
+      "flutter",
+      "matrix",
+      "rust"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/ffi/flutter-rust-bridge-compatibility-matrix.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "fp8-e4m3-vs-ue8m0-format-differences",
+    "slug": "fp8-e4m3-vs-ue8m0-format-differences",
+    "category": "fp8-quantization",
+    "description": "SM90 consumes FP32 scales + E4M3 FP8 values; SM100 expects packed UE8M0 (unsigned-exponent, no mantissa) int32 scales with different range/precision tradeoffs.",
+    "tags": [
+      "fp8",
+      "ue8m0",
+      "e4m3",
+      "quantization",
+      "data-format",
+      "hardware-specific"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/fp8-quantization/fp8-e4m3-vs-ue8m0-format-differences.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "git-workflow-issue-version-forensics",
+    "slug": "git-workflow-issue-version-forensics",
+    "category": "git-workflow",
+    "description": "For stale bug reports, verify whether the issue is still present by using `git log --until`/`--after` on the relevant file path and `git show <commit>:path` to view the code at the time the issue was filed — avoids wasting effort on already-fixed bugs.",
+    "tags": [
+      "git",
+      "debugging",
+      "issue-triage",
+      "forensics",
+      "blame",
+      "log",
+      "history"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/git-workflow/git-workflow-issue-version-forensics.md",
     "has_content": true
   },
   {
@@ -3988,6 +4245,24 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/llm-agents/agent-runner-loop-semantics.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "function-schema-generation",
+    "slug": "function-schema-generation",
+    "category": "llm-agents",
+    "description": "How @function_tool generates JSON schemas from Python function signatures, docstrings, and Pydantic models for LLM tool calling.",
+    "tags": [
+      "openai-agents",
+      "function-tool",
+      "json-schema",
+      "pydantic",
+      "type-hints"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/llm-agents/function-schema-generation.md",
     "has_content": true
   },
   {
@@ -4983,6 +5258,43 @@
   },
   {
     "kind": "knowledge",
+    "name": "fsync-directory-is-mandatory-before-rename",
+    "slug": "fsync-directory-is-mandatory-before-rename",
+    "category": "pitfall",
+    "description": "",
+    "tags": [
+      "fsync",
+      "directory",
+      "rename",
+      "nfs",
+      "posix",
+      "durability"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/jit-compilation/fsync-directory-is-mandatory-before-rename.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "gated-huggingface-hardcoded-config",
+    "slug": "gated-huggingface-hardcoded-config",
+    "category": "pitfall",
+    "description": "Some ML libraries hardcode the original HF repo id for config lookup; the app breaks when only a community fork (MLX / quantized) is cached.",
+    "tags": [
+      "huggingface",
+      "caching",
+      "mlx",
+      "transformers",
+      "offline"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/gated-huggingface-hardcoded-config.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "gh-pr-create-cwd-prefix-does-not-stick",
     "slug": "gh-pr-create-cwd-prefix-does-not-stick",
     "category": "pitfall",
@@ -5036,6 +5348,39 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/pitfall/git-reset-hard-bypasses-all-hooks.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "git-stale-branch-main-dot-dot-head",
+    "slug": "git-stale-branch-main-dot-dot-head",
+    "category": "pitfall",
+    "description": "On a stale contributor branch, `git diff main..HEAD` shows every main commit as a deletion — a 3-line PR looks like a 700-line revert.",
+    "tags": [
+      "git",
+      "code-review",
+      "squash-merge",
+      "github",
+      "triage"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/git-stale-branch-main-dot-dot-head.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "go-requires-cgo-onnxruntime",
+    "slug": "go-requires-cgo-onnxruntime",
+    "category": "pitfall",
+    "description": "The Go binding requires CGO + an externally installed ONNX Runtime C library.",
+    "tags": [
+      "magika",
+      "pitfall"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/go-requires-cgo-onnxruntime.md",
     "has_content": true
   },
   {
@@ -6662,6 +7007,25 @@
   },
   {
     "kind": "knowledge",
+    "name": "flatpak-portals-sandbox-workaround",
+    "slug": "flatpak-portals-sandbox-workaround",
+    "category": "platform/linux",
+    "description": "Flatpak uses XDG desktop portals for screen capture (screencast-portal) instead of direct X11/Wayland.",
+    "tags": [
+      "flatpak",
+      "linux",
+      "platform",
+      "portals",
+      "sandbox",
+      "workaround"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/linux/flatpak-portals-sandbox-workaround.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "android-ios-feature-parity-gap",
     "slug": "android-ios-feature-parity-gap",
     "category": "platform/mobile",
@@ -6789,6 +7153,60 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/reference/craft-cli-command-surface.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "file-layout-apps-vs-packages",
+    "slug": "file-layout-apps-vs-packages",
+    "category": "reference",
+    "description": "apps/ hold leaf-node deployables (cli, electron, viewer, webui); packages/ hold reusable libraries (core, shared, server-core, server, session-tools-core, session-mcp-server, pi-agent-server, ui) — a crisp boundary between \"ships to users\" and \"imported by ships\".",
+    "tags": [
+      "monorepo",
+      "layout",
+      "convention"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/reference/file-layout-apps-vs-packages.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "gep-protocol-auditable-assets",
+    "slug": "gep-protocol-auditable-assets",
+    "category": "reference",
+    "description": "Genome Evolution Protocol (GEP) represents an autonomous loop's \"DNA\" as three on-disk artifacts — reusable `Gene` definitions, success `Capsule`s, and an append-only `events.jsonl` — so every autonomous change has a signed, auditable trail.",
+    "tags": [
+      "gep",
+      "evolver",
+      "audit",
+      "genes",
+      "capsules",
+      "jsonl",
+      "autonomous-agent"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/reference/gep-protocol-auditable-assets.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "github-token-env-fallback-chain",
+    "slug": "github-token-env-fallback-chain",
+    "category": "reference",
+    "description": "When resolving a GitHub token from the environment in a tool that runs under both CI and human-local setups, check `GITHUB_TOKEN` → `GH_TOKEN` → `GITHUB_PAT` in that order, and treat \"no token found\" as silent-skip (not an error) for optional features like auto-issue reporting and release creation.",
+    "tags": [
+      "github-token",
+      "env-fallback",
+      "ci",
+      "gh-cli",
+      "graceful-degradation"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/reference/github-token-env-fallback-chain.md",
     "has_content": true
   },
   {
@@ -6964,6 +7382,30 @@
   },
   {
     "kind": "skill",
+    "name": "game-design-doc-review",
+    "slug": "game-design-doc-review",
+    "category": "",
+    "description": "\"Reviews a game design document for completeness, internal consistency, implementability, and adherence to project design standards. Run this before handing a design document to programmers.\"",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/design/game-design-doc-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "gate-check",
+    "slug": "gate-check",
+    "category": "",
+    "description": "\"Validate readiness to advance between development phases. Produces a PASS/CONCERNS/FAIL verdict with specific blockers and required artifacts. Use when user says 'are we ready to move to X', 'can we advance to production', 'check if we can start the next phase', 'pass the gate'.\"",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/production/gate-check",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "alert-time-window-with-buffer",
     "slug": "alert-time-window-with-buffer",
     "category": "agent-sdk",
@@ -7082,6 +7524,41 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/agents/coding-agent-cli-backend-interface",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "forcing-tool-use",
+    "slug": "forcing-tool-use",
+    "category": "agents",
+    "description": "Force the model to call a specific tool or any tool on the first turn using tool_choice in ModelSettings.",
+    "tags": [
+      "openai-agents",
+      "tool-choice",
+      "model-settings",
+      "forced-tool",
+      "reset-tool-choice"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/agents/forcing-tool-use",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "function-tool-registration",
+    "slug": "function-tool-registration",
+    "category": "agents",
+    "description": "Register a Python function as an agent tool using the @function_tool decorator.",
+    "tags": [
+      "openai-agents",
+      "tools",
+      "function-tool",
+      "pydantic"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/agents/function-tool-registration",
     "has_content": false
   },
   {
@@ -8111,6 +8588,41 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/architecture/accepts-then-convert-two-phase-dispatch",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "gep-environment-fingerprint",
+    "slug": "gep-environment-fingerprint",
+    "category": "architecture",
+    "description": "Compute and persist environment fingerprint for drift detection and state validation",
+    "tags": [
+      "evolver",
+      "architecture",
+      "fingerprint",
+      "drift-detection"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/architecture/gep-environment-fingerprint",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "go-middleware-context-injection",
+    "slug": "go-middleware-context-injection",
+    "category": "architecture",
+    "description": "Chi middleware that resolves workspace membership and injects workspace ID and member record into request.Context(), with typed accessors and shared context keys.",
+    "tags": [
+      "go",
+      "chi",
+      "middleware",
+      "multi-tenancy",
+      "context"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/architecture/go-middleware-context-injection",
     "has_content": false
   },
   {
@@ -10273,6 +10785,23 @@
   },
   {
     "kind": "skill",
+    "name": "file-stability-polling-for-fs-flush",
+    "slug": "file-stability-polling-for-fs-flush",
+    "category": "build",
+    "description": "Poll stat size every 100ms and only treat a file as \"ready\" after 3 consecutive unchanged readings — bridges the gap between bundler exit and OS filesystem flush on Windows / network volumes.",
+    "tags": [
+      "filesystem",
+      "flush",
+      "windows",
+      "build-tooling"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/build/file-stability-polling-for-fs-flush",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "cmake-cuda-extension-with-git-submodule-vendoring",
     "slug": "cmake-cuda-extension-with-git-submodule-vendoring",
     "category": "build-system",
@@ -10289,6 +10818,39 @@
     "version": "1.0.0",
     "path": "skills/build-system/cmake-cuda-extension-with-git-submodule-vendoring",
     "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "generate-tool-reference-with-token-counts",
+    "slug": "generate-tool-reference-with-token-counts",
+    "category": "build-tooling",
+    "description": "Generate your MCP tool reference docs by booting the real server, calling listTools, and including a tiktoken cl100k_base count in the title so you and your users can see the context-budget cost at a glance.",
+    "tags": [
+      "docs",
+      "codegen",
+      "tiktoken",
+      "tokens",
+      "mcp"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/build-tooling/generate-tool-reference-with-token-counts",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "github-actions-parallel-test-matrix",
+    "slug": "github-actions-parallel-test-matrix",
+    "category": "ci",
+    "description": "GitHub Actions workflow uses a strategy.matrix over OS × toolchain to run all tests in parallel, with continue-on-error for nightly so unstable toolchains don't block merges.",
+    "tags": [
+      "magika",
+      "ci"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/ci/github-actions-parallel-test-matrix",
+    "has_content": true
   },
   {
     "kind": "skill",
@@ -10593,6 +11155,24 @@
   },
   {
     "kind": "skill",
+    "name": "foreground-background-daemon-mode",
+    "slug": "foreground-background-daemon-mode",
+    "category": "cli",
+    "description": "CLI-managed daemon with foreground (for debug) and background (default, detached) modes, log-file path convention, and a status-check sub-command.",
+    "tags": [
+      "cli",
+      "daemon",
+      "background-process",
+      "logs",
+      "debugging"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/foreground-background-daemon-mode",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "freeze",
     "slug": "freeze",
     "category": "cli",
@@ -10606,6 +11186,24 @@
     "triggers": [],
     "version": "0.1.0",
     "path": "skills/cli/gstack/freeze",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "generate-cli-from-mcp-tool-list",
+    "slug": "generate-cli-from-mcp-tool-list",
+    "category": "cli",
+    "description": "Auto-generate a yargs-based CLI from an MCP server's tool list and JSON schemas so every tool becomes a subcommand with typed positional args for required fields and flags for optional ones.",
+    "tags": [
+      "cli",
+      "yargs",
+      "codegen",
+      "mcp",
+      "json-schema"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/generate-cli-from-mcp-tool-list",
     "has_content": false
   },
   {
@@ -10624,6 +11222,24 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "skills/cli/git-guardrails-claude-code",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "github-hmac-webhook-verify",
+    "slug": "github-hmac-webhook-verify",
+    "category": "cli",
+    "description": "Verify a GitHub webhook's `X-Hub-Signature-256` using HMAC-SHA-256 over the raw body with `timingSafeEqual`, with a same-length guard, prefix-masked logs on mismatch, and a 200-then-async processing pattern.",
+    "tags": [
+      "webhook",
+      "github",
+      "hmac",
+      "signature",
+      "security"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/github-hmac-webhook-verify",
     "has_content": false
   },
   {
@@ -11188,6 +11804,21 @@
     "version": "1.0.0",
     "path": "skills/codecs/android-mediacodec-jni-wrapper",
     "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "generated-enum-and-config-code-from-json-schema",
+    "slug": "generated-enum-and-config-code-from-json-schema",
+    "category": "codegen",
+    "description": "Build-time code generator that reads a JSON content-type knowledge base and emits per-language type-safe enums + const TypeInfo structs (MIME type, group, extensions, is_text).",
+    "tags": [
+      "magika",
+      "codegen"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/codegen/generated-enum-and-config-code-from-json-schema",
+    "has_content": true
   },
   {
     "kind": "skill",
@@ -12649,6 +13280,18 @@
   },
   {
     "kind": "skill",
+    "name": "finishing-a-development-branch",
+    "slug": "finishing-a-development-branch",
+    "category": "devops",
+    "description": "Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/finishing-a-development-branch",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "font-cache-alpine-locale-docker",
     "slug": "font-cache-alpine-locale-docker",
     "category": "devops",
@@ -12968,6 +13611,60 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "skills/docs/ubiquitous-language",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "goal-driven-verifiable-success-criteria",
+    "slug": "goal-driven-verifiable-success-criteria",
+    "category": "engineering",
+    "description": "Transform imperative tasks into verifiable goals. Define success criteria before implementing so the loop can self-terminate. Use for any non-trivial task, especially bug fixes and refactors.",
+    "tags": [
+      "tdd",
+      "verification",
+      "goal-setting",
+      "autonomous-loop"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/engineering/goal-driven-verifiable-success-criteria",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "flutter-rust-bridge-stream-sink-pattern",
+    "slug": "flutter-rust-bridge-stream-sink-pattern",
+    "category": "ffi",
+    "description": "StreamSink<String> for async event channeling from Rust to Flutter.",
+    "tags": [
+      "bridge",
+      "ffi",
+      "flutter",
+      "pattern",
+      "rust",
+      "sink"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/ffi/flutter-rust-bridge-stream-sink-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "get-package-reactive-bindings",
+    "slug": "get-package-reactive-bindings",
+    "category": "flutter",
+    "description": "GetX library for reactive variable binding (RxList, Rx<T>, onChanged) in Flutter UI.",
+    "tags": [
+      "bindings",
+      "flutter",
+      "get",
+      "package",
+      "reactive"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/flutter/get-package-reactive-bindings",
     "has_content": false
   },
   {
@@ -13549,6 +14246,23 @@
   },
   {
     "kind": "skill",
+    "name": "git-worktree-isolation-per-thread",
+    "slug": "git-worktree-isolation-per-thread",
+    "category": "git",
+    "description": "Use git worktrees to isolate filesystem state per conversation thread, avoiding conflicts between concurrent edits",
+    "tags": [
+      "git",
+      "worktree",
+      "concurrency",
+      "isolation"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/git/git-worktree-isolation-per-thread",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "jj-jujutsu-day-one-workflow",
     "slug": "jj-jujutsu-day-one-workflow",
     "category": "git",
@@ -13641,6 +14355,63 @@
   },
   {
     "kind": "skill",
+    "name": "github-trending-zero-dep-scraper",
+    "slug": "github-trending-zero-dep-scraper",
+    "category": "integration",
+    "description": "Scrape https://github.com/trending for the daily/weekly/monthly top repos using only Node's built-in `https` module — no cheerio, no puppeteer, no fetch polyfill. Parse the `<article class=\"Box-row\">` blocks with targeted regex and return a clean list of {owner, repo, language, starsToday}.",
+    "tags": [
+      "github",
+      "trending",
+      "scraper",
+      "html",
+      "zero-dep",
+      "nodejs",
+      "https"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/integration/github-trending-zero-dep-scraper",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "first-occurrence-config-print-with-set-memo",
+    "slug": "first-occurrence-config-print-with-set-memo",
+    "category": "jit-compilation",
+    "description": "Print a JIT-selected config the first time a given shape/desc is encountered, memoizing with `std::unordered_set<std::string>` keyed on the stringified descriptor — so each unique workload prints exactly once.",
+    "tags": [
+      "diagnostics",
+      "logging",
+      "jit",
+      "memoization",
+      "debug"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/jit-compilation/first-occurrence-config-print-with-set-memo",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "fnv1a-splitmix-hex-digest-for-cache-keys",
+    "slug": "fnv1a-splitmix-hex-digest-for-cache-keys",
+    "category": "jit-compilation",
+    "description": "Build a 128-bit deterministic hex digest for JIT cache keys using two FNV-1a streams with different seeds, finalized with split-mix64 — 40 lines, header-only, no crypto dependency.",
+    "tags": [
+      "hashing",
+      "cache-key",
+      "fnv1a",
+      "splitmix",
+      "deterministic",
+      "header-only"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/jit-compilation/fnv1a-splitmix-hex-digest-for-cache-keys",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "agent-handoff-routing",
     "slug": "agent-handoff-routing",
     "category": "llm-agents",
@@ -13672,6 +14443,24 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/llm-agents/agents-as-tools",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "file-path-reference-for-heavy-assets",
+    "slug": "file-path-reference-for-heavy-assets",
+    "category": "mcp",
+    "description": "For heavy MCP tool outputs (screenshots, traces, videos, heap snapshots), write the asset to a file and return only its path in the tool response — never inline megabytes of base64 into the response stream.",
+    "tags": [
+      "mcp",
+      "file-reference",
+      "token-budget",
+      "design-principle",
+      "assets"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/mcp/file-path-reference-for-heavy-assets",
     "has_content": false
   },
   {
@@ -13740,6 +14529,42 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/ml-ops/chunked-tts-with-crossfade",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "flash-attn-optional-import-fallback",
+    "slug": "flash-attn-optional-import-fallback",
+    "category": "ml-ops",
+    "description": "Try-import flash_attn and choose HuggingFace attn_implementation accordingly, falling back to torch sdpa with a loud warning that points the user to the fix.",
+    "tags": [
+      "transformers",
+      "attention",
+      "flash-attention",
+      "optional-dependency",
+      "fallback"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/ml-ops/flash-attn-optional-import-fallback",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "force-hf-offline-when-cached",
+    "slug": "force-hf-offline-when-cached",
+    "category": "ml-ops",
+    "description": "Force HF_HUB_OFFLINE=1 while loading a fully-cached model so transformers / mlx_audio don't make network calls on every startup.",
+    "tags": [
+      "huggingface",
+      "offline",
+      "caching",
+      "desktop-ml",
+      "startup-time"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/ml-ops/force-hf-offline-when-cached",
     "has_content": false
   },
   {
@@ -13847,6 +14672,24 @@
   },
   {
     "kind": "skill",
+    "name": "git-rollback-mode-selector",
+    "slug": "git-rollback-mode-selector",
+    "category": "operations",
+    "description": "Let operators pick how failed autonomous changes unwind — hard reset, stash-and-continue, or no-op — via one env var. The three modes trade audit-trail preservation against blast-radius containment.",
+    "tags": [
+      "git",
+      "rollback",
+      "autonomous-agent",
+      "recovery",
+      "operations"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/operations/git-rollback-mode-selector",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "a11y-tree-snapshot-with-uids",
     "slug": "a11y-tree-snapshot-with-uids",
     "category": "puppeteer",
@@ -13861,6 +14704,25 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/puppeteer/a11y-tree-snapshot-with-uids",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "filestream-seekable-buffer-fallback",
+    "slug": "filestream-seekable-buffer-fallback",
+    "category": "python",
+    "description": "If an input stream isn't seekable, slurp it into BytesIO before entering any multi-pass pipeline — lets every downstream consumer use tell()/seek() without worrying whether the source was a pipe, socket, or chunked HTTP body.",
+    "tags": [
+      "python",
+      "streams",
+      "bytesio",
+      "seekable",
+      "binaryio",
+      "ingestion"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/python/filestream-seekable-buffer-fallback",
     "has_content": false
   },
   {
@@ -15108,6 +15970,24 @@
     "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/full-inventory-over-sampling-prompt",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "full-stack-isolated-dev-env",
+    "slug": "full-stack-isolated-dev-env",
+    "category": "workflow",
+    "description": "Stand up a fully isolated backend + frontend + daemon dev environment per worktree with scripted auth bootstrap (login + PAT + workspace) for AI/CI workflows.",
+    "tags": [
+      "dev-env",
+      "worktree",
+      "isolation",
+      "automation",
+      "ci"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/full-stack-isolated-dev-env",
     "has_content": false
   },
   {

--- a/knowledge/architecture/gep-asset-model.md
+++ b/knowledge/architecture/gep-asset-model.md
@@ -1,0 +1,56 @@
+---
+name: gep-asset-model
+summary: Evolver's GEP (Genome Evolution Protocol) stores evolution state as three on-disk assets — reusable Genes, success Capsules, and an append-only EvolutionEvents log — so every change is auditable and the selector can score candidates by signal match.
+category: architecture
+tags: [gep, evolver, genes, capsules, events, audit]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/EvoMap/evolver.git
+source_ref: main
+source_commit: 4c51382092f9cb125d3ec55475861ead8d1463a6
+source_project: evolver
+source_paths:
+  - README.md (GEP Protocol section)
+  - SKILL.md (GEP Protocol section)
+  - assets/gep/genes.json
+  - assets/gep/capsules.json
+  - assets/gep/events.jsonl
+imported_at: 2026-04-18T03:00:00Z
+---
+
+# GEP Asset Model (Evolver reference)
+
+The Genome Evolution Protocol persists three files under `assets/gep/`:
+
+| File | Kind | What it holds |
+|---|---|---|
+| `genes.json` | JSON array | Reusable Gene definitions — named evolution strategies with validation commands and match signals |
+| `capsules.json` | JSON array | "Success Capsules" — snapshots of successful Gene applications (patterns known to work) |
+| `events.jsonl` | JSONL | Append-only EvolutionEvent log — one line per evolution iteration, with `intent`, `genes_used`, `outcome.status`, `outcome.reason` |
+
+## Why three files, not one
+
+- **Genes** are *what to try* — finite library, read often, edited rarely.
+- **Capsules** are *what has worked* — grow monotonically, used by the selector as priors.
+- **Events** are *what happened* — write-once, append-only; cheap to scan for recurring failure signatures without rewriting the file.
+
+Using JSONL for events (not JSON) is deliberate: an unclean shutdown leaves a well-formed prefix, not a syntactically-broken file.
+
+## Selector flow
+
+1. Scan `memory/` for runtime signals (errors, perf, patterns).
+2. Score Genes and Capsules against the signal set.
+3. Emit a JSON selector decision in the GEP prompt.
+4. After application, append an EvolutionEvent with the outcome.
+
+## Extraction safety
+
+External Gene/Capsule assets ingested via `scripts/a2a_ingest.js` land in an isolated candidate zone. Promotion to the local stores (`scripts/a2a_promote.js`) requires:
+
+1. Explicit `--validated` flag (operator verification).
+2. Gene `validation` commands pass the `isValidationCommandAllowed` gate (see `validation-command-whitelist-gate` skill).
+3. Promotion **never** overwrites an existing local Gene with the same ID.
+
+## Constraint callout
+
+The docs only permit the DNA emoji in evolver-authored content; all other emoji are disallowed. It's an enforced style rule, not a preference.

--- a/knowledge/architecture/gep-genome-evolution-protocol.md
+++ b/knowledge/architecture/gep-genome-evolution-protocol.md
@@ -1,0 +1,45 @@
+---
+name: gep-genome-evolution-protocol
+summary: Protocol for tracking and applying genome mutations as evolution genes and capsules
+category: architecture
+confidence: high
+tags: [evolver, architecture, gep, reference]
+source_type: extracted-from-git
+source_url: https://github.com/EvoMap/evolver.git
+source_ref: main
+source_commit: 22773782475cecf43dc9c1af264bf5f9cacc28bc
+source_project: evolver
+source_paths:
+  - README.md
+  - SKILL.md
+  - src/gep/
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# GEP — Genome Evolution Protocol
+
+GEP is Evolver's core mechanism for tracking agent self-evolution. Two primary asset types:
+
+- **Gene** — a small, content-addressed unit: prompt fragment, behavioral tweak, heuristic.
+- **Capsule** — a larger validated bundle: `prompt + tests + metadata`, promoted only after repeated successful validation.
+
+## Lifecycle
+
+1. **Analyze** — the agent inspects its runtime logs and event stream.
+2. **Propose** — it selects candidate improvements and produces a mutation.
+3. **Validate** — the mutation is run through canary tests; outcomes become events.
+4. **Solidify** — mutations with sufficient success streak and score are promoted to genes or capsules.
+
+## Identity and integrity
+
+Every asset is addressed by a content hash — identical bodies collapse to a single identity across agents. A success-streak counter and confidence score ride along on each asset.
+
+## Why track this
+
+- Auditability — every behavior change traces back to a specific event and diff.
+- Composability — genes stack; capsules version together.
+- Federation — content-addressed assets let a network of agents converge on the same canonical artifacts.
+
+## Reuse notes
+
+Adopt the *shape* (content-address, success streak, confidence, canary gate) before you adopt the name. The minimal useful surface is: hash, score, streak, and an append-only event log.

--- a/knowledge/ci-cd/github-variables-version-management.md
+++ b/knowledge/ci-cd/github-variables-version-management.md
@@ -1,0 +1,103 @@
+---
+name: github-variables-version-management
+summary: Storing version strings in GitHub Actions repository variables (not committed files) avoids merge conflicts on automated version bumps and provides a single source of truth accessible to both CI jobs and local scripts via the `gh` CLI.
+category: ci-cd
+tags: [github-actions, versioning, repository-variables, ci-cd, automation, merge-conflicts]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: medium
+---
+
+# GitHub Variables for Version Management
+
+## Context
+
+Projects that automatically track upstream dependency versions (a CLI tool,
+an Electron app, a language runtime) need to store the current upstream version
+somewhere. Common choices:
+- A committed file (`VERSION`, `version.txt`, a line in a shell script).
+- A git tag.
+- A CI/CD platform secret or variable.
+
+The committed-file approach causes frequent merge conflicts: when an automation
+bot updates `build.sh` with a new download URL, and a developer also has a
+branch with changes to `build.sh`, rebase conflicts occur on every upstream
+update cycle.
+
+## Observation
+
+GitHub Actions repository variables (Settings → Secrets and variables →
+Variables) provide a key-value store that is:
+- Not part of the git tree (no merge conflicts).
+- Readable from within any workflow via `${{ vars.VARIABLE_NAME }}`.
+- Readable from the `gh` CLI: `gh variable get VARIABLE_NAME`.
+- Writable from automation: `gh variable set VARIABLE_NAME --body "value"`.
+
+By storing the upstream version in a repository variable instead of a committed
+file, the automation bot can update it without touching any tracked file,
+eliminating the merge conflict vector entirely.
+
+The version can still be embedded into committed files (e.g., download URLs in
+a build script) when a release is triggered, but the canonical source of truth
+is the variable, not the committed value.
+
+## Why it happens
+
+git merge conflicts on version files arise because the file changes frequently
+(on every upstream release) and multiple branches coexist (developer feature
+branches, bot update branches). Every branch that touches the file needs to
+be rebased against the bot's changes.
+
+Repository variables live outside the git DAG entirely. Any number of branches
+can coexist, and no rebase is needed when the variable changes. The variable
+is only read at CI runtime.
+
+## Practical implication
+
+Define two types of variables:
+- **Wrapper/project version** (bumped manually by maintainers):
+  `REPO_VERSION` = `1.3.23`
+- **Upstream dependency version** (updated automatically by a CI job):
+  `UPSTREAM_VERSION` = `1.1.8629`
+
+Use them from CI:
+```yaml
+# In a workflow job:
+env:
+  VERSION: ${{ vars.REPO_VERSION }}
+  UPSTREAM_VERSION: ${{ vars.UPSTREAM_VERSION }}
+```
+
+Use them locally:
+```bash
+gh variable get UPSTREAM_VERSION
+gh variable set REPO_VERSION --body "1.3.24"
+```
+
+Tag releases combining both:
+```bash
+TAG="v$(gh variable get REPO_VERSION)+upstream$(gh variable get UPSTREAM_VERSION)"
+git tag "$TAG"
+git push origin "$TAG"
+```
+
+The automated version-check workflow pattern:
+1. Resolve the latest upstream version (API, Playwright, etc.).
+2. Compare against `UPSTREAM_VERSION` variable.
+3. If changed: update the variable, update any committed URLs/hashes, create
+   a release tag — all in sequence within one workflow run.
+4. The committed file update (if needed) happens via a bot commit on `main`,
+   but only for non-version-string content (download URLs, checksums) that
+   must be in the repo for non-CI builds.
+
+## Source reference
+
+- `CLAUDE.md`: "Versioning" section — describes `REPO_VERSION` and
+  `CLAUDE_DESKTOP_VERSION` variables, tag format, and manual bump commands.
+- `CLAUDE.md`: "Common Gotchas" — warns contributors to check the variable
+  before committing `build.sh` to avoid stale URLs.

--- a/knowledge/codecs/gdi-fallback-screen-capture.md
+++ b/knowledge/codecs/gdi-fallback-screen-capture.md
@@ -1,0 +1,28 @@
+---
+name: gdi-fallback-screen-capture
+type: knowledge
+category: codecs
+summary: On Windows, try DXGI first; fall back to GDI for legacy/virtual displays that DXGI can't enumerate.
+confidence: medium
+tags: [capture, codecs, fallback, gdi, screen]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: libs/scrap/src/dxgi/mod.rs
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Gdi Fallback Screen Capture
+
+## Fact
+On Windows, try DXGI first; fall back to GDI for legacy/virtual displays that DXGI can't enumerate.
+
+## Why it matters
+Virtual displays and RDP sessions often force the GDI path.
+
+## Evidence
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- `libs/scrap/src/dxgi/mod.rs`

--- a/knowledge/engine/godot-animation.md
+++ b/knowledge/engine/godot-animation.md
@@ -1,0 +1,91 @@
+---
+name: godot-animation
+summary: Godot engine reference for the animation module — APIs, patterns, and best practices
+category: engine
+confidence: medium
+tags: [game-studios, ccgs, godot, engine-reference, animation]
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+source_path: docs/engine-reference/godot/modules/animation.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Godot Animation — Quick Reference
+
+Last verified: 2026-02-12 | Engine: Godot 4.6
+
+## What Changed Since ~4.3 (LLM Cutoff)
+
+### 4.6 Changes
+- **IK system fully restored**: Complete inverse kinematics for 3D skeletons
+  - CCDIK, FABRIK, Jacobian IK, Spline IK, TwoBoneIK
+  - Applied via `SkeletonModifier3D` nodes (not the old IK approach)
+- **Animation editor QoL**: Solo/hide/lock/delete for Bezier node groups; draggable timeline
+
+### 4.5 Changes
+- **BoneConstraint3D**: Bind bones to other bones with modifiers
+  - `AimModifier3D`, `CopyTransformModifier3D`, `ConvertTransformModifier3D`
+
+### 4.3 Changes (in training data)
+- **AnimationMixer**: Base class for both AnimationPlayer and AnimationTree
+  - `method_call_mode` → `callback_mode_method`
+  - `playback_active` → `active`
+  - `bone_pose_updated` signal → `skeleton_updated`
+- **`Skeleton3D.add_bone()`**: Now returns `int32` (was `void`)
+
+## Current API Patterns
+
+### AnimationPlayer (unchanged API, new base class)
+```gdscript
+@onready var anim_player: AnimationPlayer = %AnimationPlayer
+
+func play_attack() -> void:
+    anim_player.play(&"attack")
+    await anim_player.animation_finished
+```
+
+### IK Setup (4.6 — NEW)
+```gdscript
+# Add SkeletonModifier3D-based IK nodes as children of Skeleton3D
+# Available types:
+# - SkeletonModifier3D (base)
+# - TwoBoneIK (arms, legs)
+# - FABRIK (chains, tentacles)
+# - CCDIK (tails, spines)
+# - Jacobian IK (complex multi-joint)
+# - Spline IK (along curves)
+
+# Configure in editor or code:
+# 1. Add IK modifier node as child of Skeleton3D
+# 2. Set target bone and tip bone
+# 3. Add a Marker3D as the IK target
+# 4. IK solver runs automatically each frame
+```
+
+### BoneConstraint3D (4.5 — NEW)
+```gdscript
+# Add as child of Skeleton3D
+# Types:
+# - AimModifier3D: Point bone at target
+# - CopyTransformModifier3D: Mirror another bone's transform
+# - ConvertTransformModifier3D: Remap transform values
+```
+
+### AnimationTree (base class changed in 4.3)
+```gdscript
+# AnimationTree now extends AnimationMixer (not Node directly)
+# Use AnimationMixer properties:
+@onready var anim_tree: AnimationTree = %AnimationTree
+
+func _ready() -> void:
+    anim_tree.active = true  # NOT playback_active (deprecated 4.3)
+```
+
+## Common Mistakes
+- Using `playback_active` instead of `active` (deprecated since 4.3)
+- Using `bone_pose_updated` signal instead of `skeleton_updated` (renamed in 4.3)
+- Using old IK approach instead of SkeletonModifier3D system (restored in 4.6)
+- Not checking `is AnimationMixer` when type-checking animation nodes

--- a/knowledge/engine/godot-audio.md
+++ b/knowledge/engine/godot-audio.md
@@ -1,0 +1,94 @@
+---
+name: godot-audio
+summary: Godot engine reference for the audio module — APIs, patterns, and best practices
+category: engine
+confidence: medium
+tags: [game-studios, ccgs, godot, engine-reference, audio]
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+source_path: docs/engine-reference/godot/modules/audio.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Godot Audio — Quick Reference
+
+Last verified: 2026-02-12 | Engine: Godot 4.6
+
+## What Changed Since ~4.3 (LLM Cutoff)
+
+No major breaking changes to the audio API in 4.4–4.6. The core audio system
+remains stable. Key updates are workflow improvements:
+
+### 4.6 Changes
+- **No audio-specific breaking changes** in this release
+
+### 4.5 Changes
+- **No audio-specific breaking changes** in this release
+
+## Current API Patterns
+
+### Playing Audio
+```gdscript
+@onready var sfx_player: AudioStreamPlayer = %SFXPlayer
+@onready var music_player: AudioStreamPlayer = %MusicPlayer
+
+func play_sfx(stream: AudioStream) -> void:
+    sfx_player.stream = stream
+    sfx_player.play()
+
+func play_music(stream: AudioStream, fade_time: float = 1.0) -> void:
+    var tween: Tween = create_tween()
+    tween.tween_property(music_player, "volume_db", -80.0, fade_time)
+    await tween.finished
+    music_player.stream = stream
+    music_player.volume_db = 0.0
+    music_player.play()
+```
+
+### 3D Spatial Audio
+```gdscript
+@onready var audio_3d: AudioStreamPlayer3D = %AudioPlayer3D
+
+func _ready() -> void:
+    audio_3d.max_distance = 50.0
+    audio_3d.attenuation_model = AudioStreamPlayer3D.ATTENUATION_INVERSE_DISTANCE
+    audio_3d.unit_size = 10.0
+```
+
+### Audio Buses
+```gdscript
+# Set bus volumes
+AudioServer.set_bus_volume_db(AudioServer.get_bus_index(&"Music"), volume_db)
+AudioServer.set_bus_volume_db(AudioServer.get_bus_index(&"SFX"), volume_db)
+
+# Mute a bus
+AudioServer.set_bus_mute(AudioServer.get_bus_index(&"Music"), true)
+```
+
+### Object Pooling for SFX
+```gdscript
+# Pre-create multiple AudioStreamPlayer nodes for concurrent sounds
+var _sfx_pool: Array[AudioStreamPlayer] = []
+
+func _ready() -> void:
+    for i in range(8):
+        var player := AudioStreamPlayer.new()
+        player.bus = &"SFX"
+        add_child(player)
+        _sfx_pool.append(player)
+
+func play_pooled(stream: AudioStream) -> void:
+    for player in _sfx_pool:
+        if not player.playing:
+            player.stream = stream
+            player.play()
+            return
+```
+
+## Common Mistakes
+- Creating new AudioStreamPlayer nodes at runtime instead of pooling
+- Not using audio buses for volume categories (Music, SFX, UI, Voice)
+- Using `_process()` for audio timing instead of signals (`finished`)

--- a/knowledge/engine/godot-best-practices.md
+++ b/knowledge/engine/godot-best-practices.md
@@ -1,0 +1,116 @@
+---
+name: godot-best-practices
+summary: Current Godot best practices for CCGS projects — patterns and idioms to follow
+category: engine
+confidence: medium
+tags: [game-studios, ccgs, godot, best-practices, engine-reference]
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+source_path: docs/engine-reference/godot/current-best-practices.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Godot — Current Best Practices
+
+Last verified: 2026-02-12 | Engine: Godot 4.6
+
+Practices that are **new or changed** since the model's training data (~4.3).
+This supplements (not replaces) the agent's built-in knowledge.
+
+## GDScript (4.5+)
+
+- **Variadic arguments**: Functions can accept arbitrary parameter counts
+  ```gdscript
+  func log_values(prefix: String, values: Variant...) -> void:
+      for v in values:
+          print(prefix, ": ", v)
+  ```
+
+- **Abstract classes and methods**: Use `@abstract` to enforce inheritance
+  ```gdscript
+  @abstract
+  class_name BaseEnemy extends CharacterBody3D
+
+  @abstract
+  func get_attack_pattern() -> Array[Attack]:
+      pass  # Subclasses MUST override
+  ```
+
+- **Script backtracing**: Detailed call stacks available even in Release builds
+
+## Physics (4.6)
+
+- **Jolt Physics is the default 3D engine** for new projects
+  - Better determinism and stability than GodotPhysics3D
+  - Some HingeJoint3D properties (`damp`) only work with GodotPhysics
+  - Switch: Project Settings → Physics → 3D → Physics Engine
+  - 2D physics unchanged (still Godot Physics 2D)
+
+## Rendering (4.6)
+
+- **D3D12 is the default backend on Windows** (was Vulkan) — for better driver compatibility
+- **Glow now processes before tonemapping** with screen blending mode — existing glow setups may look different
+- **SSR overhauled** — significant improvement in realism, stability, and performance
+- **AgX tonemapper** — new white point and contrast controls
+
+## Rendering (4.5)
+
+- **Shader Baker**: Pre-compile shaders to eliminate startup hitching
+- **SMAA 1x**: New AA option — sharper than FXAA, cheaper than TAA
+- **Stencil buffer**: Available for advanced masking/portal effects
+- **Bent normal maps**: Directional occlusion in normal map textures
+- **Specular occlusion**: Ambient occlusion now affects reflections
+
+## Accessibility (4.5+)
+
+- **Screen reader support**: Control nodes integrate with accessibility tools via AccessKit
+- **Live translation preview**: Test GUI layouts in different languages directly in-editor
+- **FoldableContainer**: New accordion-style UI node for collapsible sections
+- **Recursive Control disable**: Disable mouse/focus interactions for entire node hierarchies with a single property
+
+## Animation (4.5+)
+
+- **BoneConstraint3D**: Bind bones to other bones with modifiers
+  - AimModifier3D, CopyTransformModifier3D, ConvertTransformModifier3D
+
+## Animation (4.6)
+
+- **IK system fully restored**: Complete inverse kinematics reintroduced for 3D
+  - Available modifiers: CCDIK, FABRIK, Jacobian IK, Spline IK, TwoBoneIK
+  - Applied via `SkeletonModifier3D` nodes
+
+## Resources (4.5+)
+
+- **`duplicate_deep()`**: Explicit deep duplication for nested resource trees
+  - Old `duplicate()` behavior retained for backward compatibility
+  - Use `duplicate_deep()` when you need per-instance copies of nested resources
+
+## Navigation (4.5+)
+
+- **Dedicated 2D navigation server**: No longer proxied through 3D NavigationServer
+  - Reduces export binary size for 2D-only games
+
+## UI (4.6)
+
+- **Dual-focus system**: Mouse/touch focus is now separate from keyboard/gamepad focus
+  - Visual feedback differs depending on input method
+  - Consider this when designing custom focus behavior
+
+## Editor Workflow (4.6)
+
+- Flexible dock drag-and-drop with blue outline preview (including bottom panel)
+- Most panels support floating windows (except Debugger)
+- New keyboard shortcuts: Alt+O (Output), Alt+S (Shader)
+- Export variable auto-generation: drag resource from FileSystem into script editor
+- Live preview in Quick Open dialog when "Live Preview" enabled
+- New "Select Mode" (v key) prevents accidental transforms; old mode renamed "Transform Mode" (q key)
+
+## Platform (4.5+)
+
+- **visionOS export**: First new platform since open-sourcing (windowed app mode)
+- **SDL3 gamepad driver**: Better cross-platform gamepad support
+- **Android**: Edge-to-edge display, camera feed access, 16KB page support (Android 15+)
+- **Linux**: Wayland subwindow support for multi-window capability

--- a/knowledge/engine/godot-breaking-changes.md
+++ b/knowledge/engine/godot-breaking-changes.md
@@ -1,0 +1,85 @@
+---
+name: godot-breaking-changes
+summary: Godot breaking changes log for the pinned version used in CCGS projects
+category: engine
+confidence: medium
+tags: [game-studios, ccgs, godot, breaking-changes, migration]
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+source_path: docs/engine-reference/godot/breaking-changes.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Godot — Breaking Changes
+
+Last verified: 2026-02-12
+
+Changes between Godot versions, focused on post-LLM-cutoff changes (4.4+).
+
+## 4.5 → 4.6 (Jan 2026 — POST-CUTOFF, HIGH RISK)
+
+| Subsystem | Change | Details |
+|-----------|--------|---------|
+| Physics | Jolt is now the DEFAULT 3D physics engine | New projects use Jolt automatically. Existing projects keep their setting. Some HingeJoint3D properties (like `damp`) only work with GodotPhysics. |
+| Rendering | Glow processes BEFORE tonemapping | Was after tonemapping. Scenes with glow will look different. Adjust intensity/blend in WorldEnvironment. |
+| Rendering | D3D12 default on Windows | Was Vulkan. For better driver compatibility. |
+| Rendering | AgX tonemapper new controls | White point and contrast parameters added. |
+| Core | Quaternion initializes to identity | Was zero. Unlikely to affect most code but technically breaking. |
+| UI | Dual-focus system | Mouse/touch focus now separate from keyboard/gamepad focus. Visual feedback differs by input method. |
+| Animation | IK system fully restored | CCDIK, FABRIK, Jacobian IK, Spline IK, TwoBoneIK via SkeletonModifier3D nodes. |
+| Editor | New "Modern" theme default | Grayscale replaces blue-tint. Restore: Editor Settings → Interface → Theme → Style: Classic |
+| Editor | "Select Mode" keybind changed | New "Select Mode" (v key) prevents accidental transforms. Old mode renamed "Transform Mode" (q key). |
+| 2D | TileMapLayer scene tile rotation | Scene tiles can now be rotated like atlas tiles. |
+| Localization | CSV plural form support | No longer requires Gettext for plurals. Context columns added. |
+| C# | Automatic string extraction | Translation strings auto-extracted from C# code. |
+| Plugins | New EditorDock class | Specialized container for plugin docks with layout control. |
+
+## 4.4 → 4.5 (Late 2025 — POST-CUTOFF, HIGH RISK)
+
+| Subsystem | Change | Details |
+|-----------|--------|---------|
+| GDScript | Variadic arguments added | Functions can accept `...` arbitrary params — new language feature |
+| GDScript | `@abstract` decorator | Abstract classes and methods now enforceable |
+| GDScript | Script backtracing | Detailed call stacks available even in Release builds |
+| Rendering | Stencil buffer support | New capability for advanced visual effects |
+| Rendering | SMAA 1x antialiasing | New post-processing AA option |
+| Rendering | Shader Baker | Pre-compiles shaders — reportedly 20x faster startup on some demos |
+| Rendering | Bent normal maps, specular occlusion | New material features |
+| Accessibility | Screen reader support | Control nodes work with accessibility tools via AccessKit |
+| Editor | Live translation preview | Test GUI layouts in different languages in-editor |
+| Physics | 3D interpolation rearchitected | Moved from RenderingServer to SceneTree. API unchanged but internals differ. |
+| Animation | BoneConstraint3D | New: AimModifier3D, CopyTransformModifier3D, ConvertTransformModifier3D |
+| Resources | `duplicate_deep()` added | New explicit method for deep duplication of nested resources |
+| Navigation | Dedicated 2D navigation server | No longer a proxy to 3D navigation; smaller export for 2D games |
+| UI | FoldableContainer node | New accordion-style container for collapsible UI sections |
+| UI | Recursive Control behavior | Disable mouse/focus interactions across entire node hierarchies |
+| Platform | visionOS export support | New platform target |
+| Platform | SDL3 gamepad driver | Delegated gamepad handling to SDL library |
+| Platform | Android 16KB page support | Required for Google Play targeting Android 15+ |
+
+## 4.3 → 4.4 (Mid 2025 — NEAR CUTOFF, VERIFY)
+
+| Subsystem | Change | Details |
+|-----------|--------|---------|
+| Core | `FileAccess.store_*` return `bool` | Was `void`. Methods: `store_8`, `store_16`, `store_32`, `store_64`, `store_buffer`, `store_csv_line`, `store_double`, `store_float`, `store_half`, `store_line`, `store_pascal_string`, `store_real`, `store_string`, `store_var` |
+| Core | `OS.execute_with_pipe` | Added optional `blocking` parameter |
+| Core | `RegEx.compile/create_from_string` | Added optional `show_error` parameter |
+| Rendering | `RenderingDevice.draw_list_begin` | Many parameters removed; `breadcrumb` parameter added |
+| Rendering | Shader texture types | Parameter/return types changed from `Texture2D` to `Texture` |
+| Particles | `.restart()` method | Added optional `keep_seed` parameter (CPU/GPU 2D/3D) |
+| GUI | `RichTextLabel.push_meta` | Added optional `tooltip` parameter |
+| GUI | `GraphEdit.connect_node` | Added optional `keep_alive` parameter |
+
+## 4.2 → 4.3 (In Training Data — LOW RISK)
+
+| Subsystem | Change | Details |
+|-----------|--------|---------|
+| Animation | `Skeleton3D.add_bone` returns `int32` | Was `void` |
+| Animation | `bone_pose_updated` signal | Replaced by `skeleton_updated` |
+| TileMap | `TileMapLayer` replaces `TileMap` | One node per layer instead of multi-layer single node |
+| Navigation | `NavigationRegion2D` | Removed `avoidance_layers`, `constrain_avoidance` properties |
+| Editor | `EditorSceneFormatImporterFBX` | Renamed to `EditorSceneFormatImporterFBX2GLTF` |
+| Animation | AnimationMixer base class | AnimationPlayer and AnimationTree now extend AnimationMixer |

--- a/knowledge/engine/godot-deprecated-apis.md
+++ b/knowledge/engine/godot-deprecated-apis.md
@@ -1,0 +1,58 @@
+---
+name: godot-deprecated-apis
+summary: Deprecated Godot APIs to avoid in CCGS projects with recommended replacements
+category: engine
+confidence: medium
+tags: [game-studios, ccgs, godot, deprecated, api-reference]
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+source_path: docs/engine-reference/godot/deprecated-apis.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Godot — Deprecated APIs
+
+Last verified: 2026-02-12
+
+If an agent suggests any API in the "Deprecated" column, it MUST be replaced
+with the "Use Instead" column.
+
+## Nodes & Classes
+
+| Deprecated | Use Instead | Since | Notes |
+|------------|-------------|-------|-------|
+| `TileMap` | `TileMapLayer` | 4.3 | One node per layer instead of multi-layer node |
+| `VisibilityNotifier2D` | `VisibleOnScreenNotifier2D` | 4.0 | Renamed for clarity |
+| `VisibilityNotifier3D` | `VisibleOnScreenNotifier3D` | 4.0 | Renamed for clarity |
+| `YSort` | `Node2D.y_sort_enabled` | 4.0 | Property on Node2D, not a separate node |
+| `Navigation2D` / `Navigation3D` | `NavigationServer2D` / `NavigationServer3D` | 4.0 | Server-based API |
+| `EditorSceneFormatImporterFBX` | `EditorSceneFormatImporterFBX2GLTF` | 4.3 | Renamed |
+
+## Methods & Properties
+
+| Deprecated | Use Instead | Since | Notes |
+|------------|-------------|-------|-------|
+| `yield()` | `await signal` | 4.0 | GDScript 2.0 coroutine syntax |
+| `connect("signal", obj, "method")` | `signal.connect(callable)` | 4.0 | Callable-based connections |
+| `instance()` | `instantiate()` | 4.0 | Renamed |
+| `PackedScene.instance()` | `PackedScene.instantiate()` | 4.0 | Renamed |
+| `get_world()` | `get_world_3d()` | 4.0 | Explicit 2D/3D split |
+| `OS.get_ticks_msec()` | `Time.get_ticks_msec()` | 4.0 | Time singleton preferred |
+| `duplicate()` for nested resources | `duplicate_deep()` | 4.5 | Explicit deep copy control |
+| `Skeleton3D` signal `bone_pose_updated` | `skeleton_updated` | 4.3 | Renamed |
+| `AnimationPlayer.method_call_mode` | `AnimationMixer.callback_mode_method` | 4.3 | Moved to base class |
+| `AnimationPlayer.playback_active` | `AnimationMixer.active` | 4.3 | Moved to base class |
+
+## Patterns (Not Just APIs)
+
+| Deprecated Pattern | Use Instead | Why |
+|--------------------|-------------|-----|
+| String-based `connect()` | Typed signal connections | Type-safe, refactor-friendly |
+| `$NodePath` in `_process()` | `@onready var` cached reference | Performance: path lookup every frame |
+| Untyped `Array` / `Dictionary` | `Array[Type]`, typed variables | GDScript compiler optimizations |
+| `Texture2D` in shader parameters | `Texture` base type | Changed in 4.4 |
+| Manual post-process viewport chains | `Compositor` + `CompositorEffect` | Structured post-processing (4.3+) |
+| GodotPhysics3D for new projects | Jolt Physics 3D | Default since 4.6; better stability |

--- a/knowledge/engine/godot-input.md
+++ b/knowledge/engine/godot-input.md
@@ -1,0 +1,87 @@
+---
+name: godot-input
+summary: Godot engine reference for the input module — APIs, patterns, and best practices
+category: engine
+confidence: medium
+tags: [game-studios, ccgs, godot, engine-reference, input]
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+source_path: docs/engine-reference/godot/modules/input.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Godot Input — Quick Reference
+
+Last verified: 2026-02-12 | Engine: Godot 4.6
+
+## What Changed Since ~4.3 (LLM Cutoff)
+
+### 4.6 Changes
+- **Dual-focus system**: Mouse/touch focus is now separate from keyboard/gamepad focus
+  - Visual feedback differs by input method
+  - Custom focus implementations may need updating
+- **Select Mode keybind changed**: "Select Mode" is now `v` key; old mode renamed "Transform Mode" (`q` key)
+
+### 4.5 Changes
+- **SDL3 gamepad driver**: Gamepad handling delegated to SDL library for better cross-platform support
+- **Recursive Control disable**: Single property disables mouse/focus for entire node hierarchies
+
+### 4.3 Changes (in training data)
+- **InputEventShortcut**: Dedicated event type for menu shortcuts (optional)
+
+## Current API Patterns
+
+### Input Actions (unchanged)
+```gdscript
+func _physics_process(delta: float) -> void:
+    var input_dir: Vector2 = Input.get_vector(
+        &"move_left", &"move_right", &"move_forward", &"move_back"
+    )
+    if Input.is_action_just_pressed(&"jump"):
+        jump()
+```
+
+### Input Events (unchanged)
+```gdscript
+func _unhandled_input(event: InputEvent) -> void:
+    if event is InputEventMouseButton:
+        if event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+            handle_click(event.position)
+    elif event is InputEventKey:
+        if event.keycode == KEY_ESCAPE and event.pressed:
+            toggle_pause()
+```
+
+### Focus Management (4.6 — CHANGED)
+```gdscript
+# Mouse/touch and keyboard/gamepad focus are now SEPARATE
+# Visual styles may differ depending on which input method is active
+# If you have custom focus drawing, test with both input methods
+
+# Standard approach still works:
+func _ready() -> void:
+    %StartButton.grab_focus()  # Keyboard/gamepad focus
+
+# But be aware: mouse hover focus != keyboard focus in 4.6
+```
+
+### Gamepad (4.5+ — SDL3 backend)
+```gdscript
+# API unchanged, but SDL3 provides:
+# - Better device detection across platforms
+# - Improved rumble support
+# - More consistent button mapping
+
+func _input(event: InputEvent) -> void:
+    if event is InputEventJoypadButton:
+        if event.button_index == JOY_BUTTON_A and event.pressed:
+            confirm_selection()
+```
+
+## Common Mistakes
+- Not testing both mouse and keyboard focus paths (dual-focus in 4.6)
+- Assuming `grab_focus()` affects mouse focus (it only affects keyboard/gamepad in 4.6)
+- Using string literals instead of `StringName` (`&"action"`) for action names in hot paths

--- a/knowledge/engine/godot-navigation.md
+++ b/knowledge/engine/godot-navigation.md
@@ -1,0 +1,116 @@
+---
+name: godot-navigation
+summary: Godot engine reference for the navigation module — APIs, patterns, and best practices
+category: engine
+confidence: medium
+tags: [game-studios, ccgs, godot, engine-reference, navigation]
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+source_path: docs/engine-reference/godot/modules/navigation.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Godot Navigation — Quick Reference
+
+Last verified: 2026-02-12 | Engine: Godot 4.6
+
+## What Changed Since ~4.3 (LLM Cutoff)
+
+### 4.5 Changes
+- **Dedicated 2D navigation server**: No longer a proxy to 3D NavigationServer
+  - Reduces export binary size for 2D-only games
+  - API remains the same for both 2D and 3D
+
+### 4.3 Changes (in training data)
+- **`NavigationRegion2D`**: Removed `avoidance_layers` and `constrain_avoidance` properties
+
+## Current API Patterns
+
+### NavigationAgent3D (Preferred for Most Cases)
+```gdscript
+@onready var nav_agent: NavigationAgent3D = %NavigationAgent3D
+
+func _ready() -> void:
+    nav_agent.path_desired_distance = 0.5
+    nav_agent.target_desired_distance = 1.0
+    nav_agent.velocity_computed.connect(_on_velocity_computed)
+
+func navigate_to(target: Vector3) -> void:
+    nav_agent.target_position = target
+
+func _physics_process(delta: float) -> void:
+    if nav_agent.is_navigation_finished():
+        return
+    var next_pos: Vector3 = nav_agent.get_next_path_position()
+    var direction: Vector3 = global_position.direction_to(next_pos)
+    nav_agent.velocity = direction * move_speed
+
+func _on_velocity_computed(safe_velocity: Vector3) -> void:
+    velocity = safe_velocity
+    move_and_slide()
+```
+
+### NavigationAgent2D
+```gdscript
+@onready var nav_agent: NavigationAgent2D = %NavigationAgent2D
+
+func navigate_to(target: Vector2) -> void:
+    nav_agent.target_position = target
+
+func _physics_process(delta: float) -> void:
+    if nav_agent.is_navigation_finished():
+        return
+    var next_pos: Vector2 = nav_agent.get_next_path_position()
+    var direction: Vector2 = global_position.direction_to(next_pos)
+    velocity = direction * move_speed
+    move_and_slide()
+```
+
+### Low-Level Path Query (3D)
+```gdscript
+# Direct server query for custom pathfinding logic
+var query := NavigationPathQueryParameters3D.new()
+query.map = get_world_3d().navigation_map
+query.start_position = global_position
+query.target_position = target_pos
+query.navigation_layers = navigation_layers
+
+var result := NavigationPathQueryResult3D.new()
+NavigationServer3D.query_path(query, result)
+var path: PackedVector3Array = result.path
+```
+
+### Avoidance
+```gdscript
+# Enable RVO2-based local avoidance
+nav_agent.avoidance_enabled = true
+nav_agent.radius = 0.5
+nav_agent.max_speed = move_speed
+nav_agent.neighbor_distance = 10.0
+
+# Use velocity_computed signal for avoidance-safe movement
+nav_agent.velocity_computed.connect(_on_velocity_computed)
+
+# Set velocity each frame (avoidance needs this)
+nav_agent.velocity = desired_velocity
+```
+
+### Navigation Layers
+```gdscript
+# Use layers to separate walkable areas by agent type
+# Layer 1: Ground units
+# Layer 2: Flying units
+# Layer 3: Swimming units
+nav_agent.navigation_layers = 1  # Ground only
+nav_agent.navigation_layers = 1 | 2  # Ground + Flying
+```
+
+## Common Mistakes
+- Calling `get_next_path_position()` without checking `is_navigation_finished()`
+- Not setting `velocity` on the agent when avoidance is enabled (required for RVO2)
+- Using `NavigationRegion2D.avoidance_layers` (removed in 4.3)
+- Forgetting to bake navigation mesh after modifying geometry
+- Not setting `navigation_layers` (defaults to all layers)

--- a/knowledge/ffi/flutter-rust-bridge-compatibility-matrix.md
+++ b/knowledge/ffi/flutter-rust-bridge-compatibility-matrix.md
@@ -1,0 +1,29 @@
+---
+name: flutter-rust-bridge-compatibility-matrix
+type: knowledge
+category: ffi
+summary: flutter_rust_bridge v1.80 requires Rust edition 2021 and has platform-specific build tweaks for each target.
+confidence: high
+tags: [bridge, compatibility, ffi, flutter, matrix, rust]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: [Cargo.toml, src/flutter_ffi.rs]
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Flutter Rust Bridge Compatibility Matrix
+
+## Fact
+flutter_rust_bridge v1.80 requires Rust edition 2021 and has platform-specific build tweaks for each target.
+
+## Why it matters
+Mismatched FRB versions produce cryptic codegen errors; pin FRB version in Cargo.toml and CI.
+
+## Evidence
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- `Cargo.toml`
+- `src/flutter_ffi.rs`

--- a/knowledge/fp8-quantization/fp8-e4m3-vs-ue8m0-format-differences.md
+++ b/knowledge/fp8-quantization/fp8-e4m3-vs-ue8m0-format-differences.md
@@ -1,0 +1,36 @@
+---
+name: fp8-e4m3-vs-ue8m0-format-differences
+summary: SM90 consumes FP32 scales + E4M3 FP8 values; SM100 expects packed UE8M0 (unsigned-exponent, no mantissa) int32 scales with different range/precision tradeoffs.
+category: fp8-quantization
+tags: [fp8, ue8m0, e4m3, quantization, data-format, hardware-specific]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - README.md
+  - csrc/apis/layout.hpp
+  - csrc/jit_kernels/impls/sm100_fp8_fp4_gemm_1d1d.hpp
+imported_at: 2026-04-18T13:12:58Z
+---
+
+# FP8 E4M3 vs UE8M0 Format Differences
+
+## Summary
+When feeding FP8 block-scaled GEMM, the expected **scale format** depends on the target arch:
+
+- **SM90 (Hopper):** scales are standard **FP32** tensors, shape `[m/gran_m, k/gran_k]`. Element format is **E4M3** (4 exp bits, 3 mantissa). Scales are transformed to MN-major and TMA-aligned at dispatch time.
+- **SM100 (Blackwell):** scales are **packed UE8M0** — 4 FP32 scales compressed into one `int32` via a special 8-bit-unsigned-exponent encoding with zero mantissa. Elements are still FP8 E4M3 (or FP4 E2M1 for weights). DeepGEMM auto-converts FP32→UE8M0 via `get_mn_major_tma_aligned_packed_ue8m0_tensor()` if users pass FP32.
+
+## Why it matters
+- UE8M0 captures a **larger dynamic range** than FP32-scaled E4M3 (unsigned exponent covers 0..255), but has zero mantissa precision — the scale is effectively "a power of two." Block-scaled kernels rely on this because within a block, only the exponent varies meaningfully.
+- Memory bandwidth for scales drops **4×** (4 values per int32).
+- Downstream kernel behavior differs: SM100 uses **tensor memory (TMEM)** to compute SF on-chip; SM90 uses shared memory. Descriptor types match.
+- Saturation and rounding semantics differ — a scale that's representable in FP32 but not in UE8M0 rounds to the nearest representable exponent, which can shift quantization error distributions.
+
+## Practical implications
+- If you integrate DeepGEMM on a mixed cluster (SM90 + SM100), produce FP32 scales once; DeepGEMM repacks per arch at dispatch.
+- Don't hand-code UE8M0 — use the provided packer. The bit layout isn't a trivial float-reinterpret.
+- Validation tolerances differ across archs for the same recipe; account for it in cross-arch regression tests.

--- a/knowledge/git-workflow/git-workflow-issue-version-forensics.md
+++ b/knowledge/git-workflow/git-workflow-issue-version-forensics.md
@@ -1,0 +1,99 @@
+---
+name: git-workflow-issue-version-forensics
+summary: For stale bug reports, verify whether the issue is still present by using `git log --until`/`--after` on the relevant file path and `git show <commit>:path` to view the code at the time the issue was filed — avoids wasting effort on already-fixed bugs.
+category: git-workflow
+tags: [git, debugging, issue-triage, forensics, blame, log, history]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: medium
+---
+
+# Git Workflow: Issue Version Forensics
+
+## Context
+
+In active open-source projects, bug reports accumulate faster than they are
+resolved. When a contributor (human or AI agent) picks up an older issue, there
+is a real risk of:
+- Spending time investigating a bug that was already fixed.
+- Writing a fix that duplicates or conflicts with work already merged.
+- Misdiagnosing a regression as the original bug.
+
+The standard response to a stale issue ("can you still reproduce this?") adds
+round-trip latency. A faster approach uses git history to determine the likely
+state of the code at issue-creation time.
+
+## Observation
+
+Given an issue creation date and the path(s) of relevant files, git can answer
+"what did this file look like when the issue was filed?" in seconds:
+
+```bash
+# Get the issue creation date (from your issue tracker CLI)
+ISSUE_DATE="2025-08-23T08:48:35Z"
+
+# Find the commit just before the issue was created
+git log --oneline --until="$ISSUE_DATE" -1
+# e.g.: abc1234 Fix tray icon selection
+
+# View the file as it was at that commit
+git show abc1234:path/to/relevant-file.sh
+
+# Find all commits to the file AFTER the issue was created
+# (these are candidates that may have fixed the issue)
+git log --oneline --after="$ISSUE_DATE" -- path/to/relevant-file.sh
+```
+
+If the `git log --after` output includes commits with messages like "Fix X" or
+"Add Y support" that match the issue description, the fix is likely already
+merged. Reference the specific commit SHA in the issue comment when closing.
+
+## Why it happens
+
+Bug reports reference behavior that existed at a specific point in time. Active
+projects continuously evolve, so the codebase at `HEAD` may have already
+addressed the issue. Without checking history, you cannot tell whether you are
+looking at the buggy state or the fixed state.
+
+`git log --until` and `--after` are date filters that scope the log to a time
+window. `git show <commit>:path` reads the file content from the object
+database at that commit without touching the working tree.
+
+## Practical implication
+
+Adopt this as a first step in issue triage before diving into root-cause
+analysis:
+
+```bash
+# Step 1: get issue creation timestamp from your project management tool
+CREATED_AT=$(gh issue view $ISSUE_NUMBER --json createdAt -q .createdAt)
+
+# Step 2: find the commit just before that timestamp
+BASELINE=$(git log --oneline --until="$CREATED_AT" -1 --format="%H")
+echo "Baseline commit: $BASELINE"
+
+# Step 3: view the file at baseline
+git show "$BASELINE:scripts/relevant-file.sh" | grep -A5 -B5 "keyword"
+
+# Step 4: check for subsequent commits that touched the same file
+git log --oneline --after="$CREATED_AT" -- scripts/relevant-file.sh
+```
+
+If changes to the file since the issue date address the problem:
+- Close or label the issue with a reference to the fixing commit.
+- If still reproducible, you have the exact baseline state to compare against
+  for root-cause analysis.
+
+This technique is especially valuable for AI-assisted development where an
+agent might otherwise reanalyze and re-implement something already solved.
+
+## Source reference
+
+- `CLAUDE.md`: "Investigating Issues" section — exact bash commands with
+  comments explaining the workflow, presented as a required step before working
+  on older issues.

--- a/knowledge/jit-compilation/fsync-directory-is-mandatory-before-rename.md
+++ b/knowledge/jit-compilation/fsync-directory-is-mandatory-before-rename.md
@@ -1,0 +1,49 @@
+---
+name: fsync-directory-is-mandatory-before-rename
+type: knowledge
+category: pitfall
+confidence: high
+source: DeepGEMM
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - csrc/jit/compiler.hpp
+tags: [fsync, directory, rename, nfs, posix, durability]
+imported_at: 2026-04-18T13:30:00Z
+---
+
+# fsync the Directory Itself Before Renaming Into the Cache
+
+## Fact / Decision
+On NFS and POSIX filesystems, after writing files into a directory and before `rename(old_dir, new_dir)`, you must `fsync` not only every file but also the *directory inode*. Without the directory fsync:
+- File contents are durable, but the directory entries that point to them may still be write-behind in the client cache.
+- Another process doing `ls` or `open` on the freshly-renamed directory can see an empty directory or zero-byte children.
+- A machine crash can leave the renamed path pointing at a directory whose children aren't actually there.
+
+## Why it matters
+NFS and other distributed filesystems use write-behind buffers on the client. `fsync(fd)` tells the server "flush this inode". For a regular file, the fd is the file; for a directory, you must open the directory read-only and fsync that fd.
+
+The sequence for committing a multi-file atomic cache entry:
+1. Write each file, close each ofstream.
+2. For each file: `fd = open(path, O_RDONLY); fsync(fd); close(fd)`.
+3. Open the directory itself: `fd = open(dir_path, O_RDONLY); fsync(fd); close(fd)`.
+4. `rename(tmp_dir, final_dir)`.
+
+DeepGEMM implements this as a bottom-up recursive walk (`fsync_dir`) so that nested subdirectories also get their inodes synced before the parent commits.
+
+## Evidence
+- `csrc/jit/compiler.hpp:70-88`: `fsync_path` and `fsync_dir`. The recursion is bottom-up (children before parent) so that by the time you fsync a directory, all its inodes are durable.
+- `csrc/jit/compiler.hpp:79`: explicit comment:
+  > Recursively fsync a directory: files and subdirectories first (bottom-up), then the directory itself
+  > NOTES: ensures data and directory entries are visible on other nodes in distributed filesystems
+- `csrc/jit/compiler.hpp:129-130`: call site — `fsync_dir(tmp_dir_path)` immediately before the rename.
+
+## Caveats / When this doesn't apply
+- **On local `ext4 / xfs` with `barrier=1`**, `fsync` on a file usually implies the directory inode is also synced — but relying on this is fragile. Be explicit.
+- **Some filesystems treat `O_RDONLY fsync` as a no-op.** Test on the target filesystem — don't assume portability.
+- **The cost adds up.** For a 10-kernel compile burst with 3 files each, you're doing 40 fsync syscalls. On spinning disks this is ~10-20ms each. On SSDs with `data=writeback`, it's microseconds. Budget accordingly.
+- **`std::filesystem::copy` and `std::filesystem::rename`** inside the standard library do not fsync — you must do it yourself. Don't assume any C++17 helper handles durability for you.
+- **If you skip the directory fsync but keep the file fsyncs**, readers may still see empty directories momentarily — classic "I wrote the files, why is the directory empty?" symptom.

--- a/knowledge/linux/flatpak-portals-sandbox-workaround.md
+++ b/knowledge/linux/flatpak-portals-sandbox-workaround.md
@@ -1,0 +1,28 @@
+---
+name: flatpak-portals-sandbox-workaround
+type: knowledge
+category: platform/linux
+summary: Flatpak uses XDG desktop portals for screen capture (screencast-portal) instead of direct X11/Wayland.
+confidence: medium
+tags: [flatpak, linux, platform, portals, sandbox, workaround]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: libs/scrap/src/wayland/
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Flatpak Portals Sandbox Workaround
+
+## Fact
+Flatpak uses XDG desktop portals for screen capture (screencast-portal) instead of direct X11/Wayland.
+
+## Why it matters
+Direct X11 capture is blocked in Flatpak; must go through the portal.
+
+## Evidence
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- `libs/scrap/src/wayland/`

--- a/knowledge/llm-agents/function-schema-generation.md
+++ b/knowledge/llm-agents/function-schema-generation.md
@@ -1,0 +1,76 @@
+---
+name: function-schema-generation
+summary: How @function_tool generates JSON schemas from Python function signatures, docstrings, and Pydantic models for LLM tool calling.
+category: llm-agents
+confidence: high
+tags: [openai-agents, function-tool, json-schema, pydantic, type-hints]
+source_type: extracted-from-git
+source_url: https://github.com/openai/openai-agents-python.git
+source_ref: main
+source_commit: e80d2d2319eb300ac17ec496988b70246a5042d6
+source_project: openai-agents-python
+source_path: src/agents/function_schema.py, src/agents/tool.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Function Schema Generation
+
+## How @function_tool Works
+
+The `@function_tool` decorator (or `function_tool()` function) introspects a Python function to produce:
+1. A JSON schema for the LLM (tool parameters)
+2. A wrapper that parses LLM-provided JSON arguments and calls the function
+
+The schema is derived from:
+- **Type hints** — mapped to JSON Schema types
+- **Docstring** — used as the tool description (Google, NumPy, or reStructuredText style)
+- **`Annotated[type, "description"]`** — per-parameter description
+- **Default values** — mark parameters as optional in schema
+- **Pydantic models** — complex parameter or return types auto-schema-generated
+
+## Type Mapping
+
+| Python type | JSON Schema |
+|---|---|
+| `str` | `{"type": "string"}` |
+| `int` | `{"type": "integer"}` |
+| `float` | `{"type": "number"}` |
+| `bool` | `{"type": "boolean"}` |
+| `list[str]` | `{"type": "array", "items": {"type": "string"}}` |
+| `dict[str, Any]` | `{"type": "object"}` |
+| `BaseModel` | Pydantic's JSON schema |
+| `Literal["a","b"]` | `{"type": "string", "enum": ["a","b"]}` |
+| `Optional[str]` | `{"anyOf": [{"type": "string"}, {"type": "null"}]}` |
+
+## Parameter Description via Annotated
+
+```python
+from typing import Annotated
+from agents import function_tool
+
+@function_tool
+def search(query: Annotated[str, "The search query."], max_results: int = 5) -> str:
+    """Search the knowledge base."""
+    ...
+```
+
+`max_results` is optional in the schema because it has a default value.
+
+## First Parameter Context Detection
+
+If the first parameter is typed as `RunContextWrapper[T]` or `ToolContext`, it is excluded from the JSON schema (the LLM does not provide it; the SDK injects it at call time).
+
+## Strict Schema
+
+By default, the SDK enforces strict JSON schema (`additionalProperties: false`, all required fields listed). This improves reliability with OpenAI models that support strict mode.
+
+To disable: `@function_tool(strict_mode=False)`.
+
+## Async Support
+
+Both sync and async functions work identically with `@function_tool`. The decorator handles the async/sync distinction internally.
+
+## Source paths
+- `src/agents/function_schema.py` — core schema generation logic
+- `src/agents/tool.py` — function_tool decorator, FunctionTool class
+- `src/agents/strict_schema.py` — strict JSON schema enforcement

--- a/knowledge/pitfall/gated-huggingface-hardcoded-config.md
+++ b/knowledge/pitfall/gated-huggingface-hardcoded-config.md
@@ -1,0 +1,49 @@
+---
+name: gated-huggingface-hardcoded-config
+summary: Some ML libraries hardcode the original HF repo id for config lookup; the app breaks when only a community fork (MLX / quantized) is cached.
+type: knowledge
+category: pitfall
+confidence: medium
+tags: [huggingface, caching, mlx, transformers, offline]
+source_type: extracted-from-git
+source_url: https://github.com/jamiepine/voicebox.git
+source_ref: main
+source_commit: 476abe07fc2c1587f4b3e3916134018ebacd143d
+source_project: voicebox
+linked_skills: [force-hf-offline-when-cached]
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Gated HuggingFace hardcoded-config pitfall
+
+## Problem
+A model backend (typically an MLX or quantized port) ships weights in a forked HF repo (`mlx-community/Foo-bf16`, `TheBloke/Foo-GGUF`) but some part of the loader still calls `AutoConfig.from_pretrained("original-org/Foo")` or `AutoTokenizer.from_pretrained("original-org/Foo")`. When the app is offline — or when the user only downloaded the forked repo — the config fetch fails with `LocalEntryNotFoundError` / network error even though the actual weights are on disk.
+
+The specific case in voicebox: `mlx_audio` tries to fetch config from `Qwen/Qwen3-TTS-12Hz-1.7B-Base` when only `mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16` is cached.
+
+## Workaround
+Symlink the expected original-repo cache path to the actual cached fork:
+
+```python
+from huggingface_hub import constants as hf_constants
+from pathlib import Path
+
+cache_dir = Path(hf_constants.HF_HUB_CACHE)
+original = cache_dir / "models--original-org--Foo"
+fork = cache_dir / "models--mlx-community--Foo-bf16"
+
+if not original.exists() and fork.exists():
+    original.symlink_to(fork, target_is_directory=True)
+```
+
+Creates the illusion that the original repo is cached, so the config lookup succeeds without network.
+
+## Caveats
+- Works only when the forked repo is a true drop-in (same `config.json`, same tokenizer files). Verify manually before wiring it up.
+- Windows requires admin or developer-mode for `symlink_to`. If you support Windows, fall back to copying the relevant files.
+- This is a band-aid. Upstream the fix in the loader (accept a `base_repo_id` parameter) if you own the library.
+
+## Related skills
+`force-hf-offline-when-cached` wraps the load call in a `HF_HUB_OFFLINE=1` context and performs this symlink at startup to make the whole setup deterministic.
+
+Source references: `backend/utils/hf_offline_patch.py` (`ensure_original_qwen_config_cached`).

--- a/knowledge/pitfall/git-stale-branch-main-dot-dot-head.md
+++ b/knowledge/pitfall/git-stale-branch-main-dot-dot-head.md
@@ -1,0 +1,58 @@
+---
+name: git-stale-branch-main-dot-dot-head
+summary: On a stale contributor branch, `git diff main..HEAD` shows every main commit as a deletion — a 3-line PR looks like a 700-line revert.
+type: knowledge
+category: pitfall
+confidence: high
+tags: [git, code-review, squash-merge, github, triage]
+source_type: extracted-from-git
+source_url: https://github.com/jamiepine/voicebox.git
+source_ref: main
+source_commit: 476abe07fc2c1587f4b3e3916134018ebacd143d
+source_project: voicebox
+linked_skills: [pre-release-pr-triage-worktree]
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Git stale-branch `main..HEAD` pitfall
+
+## Problem
+When a PR branch has fallen behind `main` (no rebase since being opened), reviewing it via `git diff main..HEAD` is misleading:
+
+- `main..HEAD` is equivalent to `git log HEAD ^main` — commits reachable from HEAD but not from main.
+- On a stale branch, HEAD is missing every commit that landed on main after the branch forked.
+- The diff therefore shows every intervening main commit as a **deletion** from HEAD's perspective.
+
+A 3-line change can look like a 700-line revert. Reviewers assume the PR is destructive, request changes, and waste time.
+
+## Related problem: squash-merging a stale branch
+GitHub's squash-merge computes `diff(PR-head, merge-base)`. The merge-base of a stale branch is old; the squash diff therefore includes reverting every main commit since the fork. The PR appears to "pass" CI (because the branch tip itself compiles) but squashing silently reverts other people's work.
+
+## Fixes
+
+**For reviewing**: always inspect the PR's actual commits, not the diff against main:
+```bash
+git show HEAD                      # the last commit on the PR
+git show --stat HEAD               # files touched + line counts
+git log --oneline main..HEAD       # the PR's commit list (not its cumulative diff)
+gh pr diff <N>                     # GitHub's view, which does rebase the diff view
+```
+
+**For merging**: rebase before the squash-merge:
+```bash
+git fetch origin main
+git rebase origin/main
+# If maintainer edits are allowed:
+git push <author-fork> HEAD:<branch> --force-with-lease
+gh pr merge <N> --squash
+```
+
+Rebasing moves the merge-base to `origin/main`, so GitHub's squash computes a clean diff.
+
+## Why this still catches experienced reviewers
+GitHub's web UI shows a rebased diff when rendering the PR files-changed tab, so the stale-branch illusion doesn't appear there. The trap springs when a reviewer drops to the CLI to inspect the branch and uses `git diff main..HEAD` out of habit — the UI and CLI show different stories.
+
+## Related skills
+`pre-release-pr-triage-worktree` (the triage workflow that centers on reviewing the actual commit and rebasing before squash-merge).
+
+Source references: `.agents/skills/triage-prs/SKILL.md` (see "Do NOT review via `git diff main..HEAD`").

--- a/knowledge/pitfall/go-requires-cgo-onnxruntime.md
+++ b/knowledge/pitfall/go-requires-cgo-onnxruntime.md
@@ -1,0 +1,25 @@
+---
+name: go-requires-cgo-onnxruntime
+type: knowledge
+category: pitfall
+summary: The Go binding requires CGO + an externally installed ONNX Runtime C library.
+confidence: high
+tags: [magika, pitfall]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Go Requires Cgo Onnxruntime
+
+## Fact
+
+The Go library uses ONNX Runtime's C API via CGO, not pure Go. This means: requires a C toolchain, prevents static linking, complicates cross-compilation. Users must install ONNX Runtime separately (microsoft/onnxruntime) and use build tags like `go run -tags onnxruntime -ldflags="-linkmode=external"`.
+
+## Evidence
+
+- `go/README.md:6-25`

--- a/knowledge/reference/file-layout-apps-vs-packages.md
+++ b/knowledge/reference/file-layout-apps-vs-packages.md
@@ -1,0 +1,56 @@
+---
+name: file-layout-apps-vs-packages
+summary: apps/ hold leaf-node deployables (cli, electron, viewer, webui); packages/ hold reusable libraries (core, shared, server-core, server, session-tools-core, session-mcp-server, pi-agent-server, ui) — a crisp boundary between "ships to users" and "imported by ships".
+category: reference
+tags: [monorepo, layout, convention]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: package.json
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# apps/ vs packages/ layout
+
+The monorepo enforces a strict distinction:
+
+### `apps/` — user-facing deployables
+- `apps/cli/` — terminal client (craft-cli). `bun run` entry + `bun link` binary.
+- `apps/electron/` — the desktop GUI. Built with esbuild (main/preload) + Vite (renderer).
+- `apps/viewer/` — read-only session snapshot viewer (shared session URLs). Static Vite build.
+- `apps/webui/` — full-featured browser UI for the headless server. Vite build.
+- (Internal only, OSS excludes: `apps/marketing/`, `apps/online-docs/` via `!apps/online-docs`.)
+
+Characteristics:
+- Has its own `bun run <app>:build` / `<app>:dev` / `<app>:preview` scripts in root `package.json`.
+- Depends on `@craft-agent/shared`, `@craft-agent/ui`, etc.
+- Never imported by other apps.
+- Each has a `package.json` with top-level metadata (appId, version).
+
+### `packages/` — shared libraries
+- `packages/core/` — type-only. Shared TypeScript types used across.
+- `packages/shared/` — business logic (agent, auth, config, credentials, mcp, sessions, sources, skills).
+- `packages/server-core/` — RPC transport, bootstrap, handler utilities.
+- `packages/server/` — standalone Bun server entry that uses server-core + shared.
+- `packages/session-tools-core/` — backend-agnostic session tool handlers.
+- `packages/session-mcp-server/` — stdio MCP server wrapping session-tools-core (for Codex).
+- `packages/pi-agent-server/` — subprocess for Pi SDK sessions.
+- `packages/ui/` — shared React components (used by electron renderer + webui + viewer).
+
+Characteristics:
+- Published via workspace protocol (`"workspace:*"`) — no npm publish needed for internal use.
+- Each exposes a selective `exports` map (see `@craft-agent/shared` — 30+ subpaths).
+- No CLI, no main-binary concept; imported by apps or other packages.
+
+### Why the split matters
+- **Build targeting**: `scripts/build-server.ts` copies only `packages/*` source for the server dist; apps/ (including Electron, which you don't want on a server) are skipped entirely.
+- **Type-checking tiers**: `bun run typecheck:all` runs `tsc` in each package in topological order; apps come last.
+- **Dependency discipline**: packages can only depend on other packages. Apps depend on packages. An app never depends on an app. Enforced by code review + mental model, not tooling.
+
+### Reference
+- `package.json#workspaces`
+- `tsconfig.json` (references to package paths)
+- `scripts/build-server.ts` — SERVER_PACKAGES allowlist mirrors the distinction.

--- a/knowledge/reference/gep-protocol-auditable-assets.md
+++ b/knowledge/reference/gep-protocol-auditable-assets.md
@@ -1,0 +1,84 @@
+---
+name: gep-protocol-auditable-assets
+summary: Genome Evolution Protocol (GEP) represents an autonomous loop's "DNA" as three on-disk artifacts — reusable `Gene` definitions, success `Capsule`s, and an append-only `events.jsonl` — so every autonomous change has a signed, auditable trail.
+category: reference
+confidence: medium
+tags: [gep, evolver, audit, genes, capsules, jsonl, autonomous-agent]
+source_type: extracted-from-git
+source_url: https://github.com/EvoMap/evolver.git
+source_ref: main
+source_commit: 4c51382092f9cb125d3ec55475861ead8d1463a6
+source_project: evolver
+imported_at: 2026-04-18T02:45:00Z
+---
+
+# GEP Protocol — Auditable Evolution Assets
+
+## Purpose
+
+The Genome Evolution Protocol (GEP) exists to answer two questions at audit time:
+
+1. What decision did the autonomous loop make this iteration, and why?
+2. What reusable knowledge did it create or update as a result?
+
+It does that with a small fixed set of artifacts on disk.
+
+## The three files
+
+All under `assets/gep/` in an evolver-managed repo:
+
+| File | Shape | Role |
+|---|---|---|
+| `genes.json` | Array of `Gene` records | Reusable decision templates — "when signal X appears, apply transformation Y, then validate with Z" |
+| `capsules.json` | Array of `Capsule` records | Outcome records of a successful evolution step — inputs, the chosen gene, the patch, the validation result |
+| `events.jsonl` | Append-only JSONL | Every non-trivial action the loop took — gene selection, validation runs, solidify, rollback |
+
+## Gene (reusable decision)
+
+Each `Gene` carries at minimum:
+
+- `id` — stable identifier.
+- `signals` — shape of runtime evidence that makes this Gene applicable (e.g. `log_error:ENOENT`, `perf_bottleneck`).
+- `transformation` — description of what to change (often just a prompt template, not code).
+- `validation` — array of shell commands that must pass before the change is accepted (see the `validation-command-allowlist-gate` skill).
+- `metadata` — provenance: author, created_at, last_used_at.
+
+Genes are **selected, never mutated in place**; an "improved" Gene is a new record with a new ID and a link back.
+
+## Capsule (successful outcome)
+
+Capsules are write-once records emitted after a Gene succeeds end-to-end:
+
+- `gene_id` used.
+- `signals` matched this round.
+- `patch` or `prompt` produced.
+- `validation_output` (the command outputs that passed).
+- `solidify_commit` — git SHA after the change was kept.
+
+They become training/reference material for future gene selection without re-running the work.
+
+## events.jsonl (append-only)
+
+One JSON object per line, append-only, never rewritten. Each record has at minimum:
+
+```json
+{
+  "id": "<uuid-v7>",
+  "ts": "<iso8601>",
+  "kind": "gene_selected" | "validation_ran" | "solidified" | "rolled_back" | ...,
+  "iteration_id": "...",
+  "payload": { ... }
+}
+```
+
+Because it's append-only, you can reconstruct any iteration by replaying a slice of the file. Use UUIDv7 for `id` to keep lines naturally time-ordered.
+
+## Rules to keep the trail trustworthy
+
+- **No silent overwrites.** Promoting an external Gene with the same ID as a local one is rejected, not merged.
+- **Commands in `validation` are audited at promote time**, not just at first use.
+- **Only the DNA emoji** is allowed in GEP-adjacent docs (evolver convention); all other emoji are stripped. This is a canary for accidental re-renders of arbitrary text into the audit stream.
+
+## Source
+
+- Evolver repo, `assets/gep/*` and `src/gep/selector.js`, `src/gep/solidify.js`, `src/gep/assetStore.js`. Core evolution modules are distributed obfuscated in the public tree — the protocol shape is from the SKILL.md / README, not from reading the obfuscated JS.

--- a/knowledge/reference/github-token-env-fallback-chain.md
+++ b/knowledge/reference/github-token-env-fallback-chain.md
@@ -1,0 +1,57 @@
+---
+name: github-token-env-fallback-chain
+summary: When resolving a GitHub token from the environment in a tool that runs under both CI and human-local setups, check `GITHUB_TOKEN` → `GH_TOKEN` → `GITHUB_PAT` in that order, and treat "no token found" as silent-skip (not an error) for optional features like auto-issue reporting and release creation.
+category: reference
+tags: [github-token, env-fallback, ci, gh-cli, graceful-degradation]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/EvoMap/evolver.git
+source_ref: main
+source_commit: 4c51382092f9cb125d3ec55475861ead8d1463a6
+source_project: evolver
+source_paths:
+  - src/gep/issueReporter.js
+  - README.md (Auto GitHub Issue Reporting, Public Release sections)
+imported_at: 2026-04-18T03:00:00Z
+---
+
+# GitHub Token Env Fallback Chain
+
+If your tool optionally authenticates to the GitHub API, resolve the token from **three** env vars in this order:
+
+```js
+function getGithubToken() {
+  return process.env.GITHUB_TOKEN
+      || process.env.GH_TOKEN
+      || process.env.GITHUB_PAT
+      || '';
+}
+```
+
+## Why all three
+
+| Env var | Where it comes from |
+|---|---|
+| `GITHUB_TOKEN` | GitHub Actions injects this automatically; also the canonical name in most docs |
+| `GH_TOKEN` | What the `gh` CLI sets/reads; a developer who has `gh auth login` configured will have this populated |
+| `GITHUB_PAT` | Common personal-access-token name in long-lived shell configs and PaaS dashboards |
+
+Checking only `GITHUB_TOKEN` means a local developer has to re-export their token just to use your tool; checking only `GH_TOKEN` breaks CI. Accepting all three covers every reasonable setup.
+
+## Degrade silently, don't error
+
+If none of the three is set, treat token-dependent features as *skipped*, not *failed*:
+
+```js
+const token = getGithubToken();
+if (!token) {
+  console.log('[IssueReporter] No GitHub token available. Skipping auto-report.');
+  return;
+}
+```
+
+Rationale: auto-issue-reporting and release-creation are optional affordances. A missing token is not an input error — it's a configuration choice. Hard-failing on missing token breaks users who explicitly don't want the feature on.
+
+## Exception: when to *require* a token
+
+If the tool's primary purpose *is* GitHub interaction (a PR linter, a label bot, a release publisher invoked directly), require the token explicitly and fail fast with a message naming all three env var names. The silent-skip rule is for auxiliary features.

--- a/registry.json
+++ b/registry.json
@@ -2409,6 +2409,141 @@
       "category": "build",
       "path": "skills/build/coverage-data-file-under-pytest-cache/SKILL.md",
       "version": "1.0.0"
+    },
+    "file-path-reference-for-heavy-assets": {
+      "category": "mcp",
+      "path": "skills/mcp/file-path-reference-for-heavy-assets/SKILL.md",
+      "version": "1.0.0"
+    },
+    "file-stability-polling-for-fs-flush": {
+      "category": "build",
+      "path": "skills/build/file-stability-polling-for-fs-flush/SKILL.md",
+      "version": "1.0.0"
+    },
+    "filestream-seekable-buffer-fallback": {
+      "category": "python",
+      "path": "skills/python/filestream-seekable-buffer-fallback/SKILL.md",
+      "version": "1.0.0"
+    },
+    "finishing-a-development-branch": {
+      "category": "devops",
+      "path": "skills/devops/finishing-a-development-branch/SKILL.md",
+      "version": "1.0.0"
+    },
+    "first-occurrence-config-print-with-set-memo": {
+      "category": "jit-compilation",
+      "path": "skills/jit-compilation/first-occurrence-config-print-with-set-memo/SKILL.md",
+      "version": "1.0.0"
+    },
+    "flash-attn-optional-import-fallback": {
+      "category": "ml-ops",
+      "path": "skills/ml-ops/flash-attn-optional-import-fallback/SKILL.md",
+      "version": "1.0.0"
+    },
+    "flutter-rust-bridge-stream-sink-pattern": {
+      "category": "ffi",
+      "path": "skills/ffi/flutter-rust-bridge-stream-sink-pattern/SKILL.md",
+      "version": "1.0.0"
+    },
+    "fnv1a-splitmix-hex-digest-for-cache-keys": {
+      "category": "jit-compilation",
+      "path": "skills/jit-compilation/fnv1a-splitmix-hex-digest-for-cache-keys/SKILL.md",
+      "version": "1.0.0"
+    },
+    "force-hf-offline-when-cached": {
+      "category": "ml-ops",
+      "path": "skills/ml-ops/force-hf-offline-when-cached/SKILL.md",
+      "version": "1.0.0"
+    },
+    "forcing-tool-use": {
+      "category": "agents",
+      "path": "skills/agents/forcing-tool-use/SKILL.md",
+      "version": "1.0.0"
+    },
+    "foreground-background-daemon-mode": {
+      "category": "cli",
+      "path": "skills/cli/foreground-background-daemon-mode/SKILL.md",
+      "version": "1.0.0"
+    },
+    "full-stack-isolated-dev-env": {
+      "category": "workflow",
+      "path": "skills/workflow/full-stack-isolated-dev-env/SKILL.md",
+      "version": "1.0.0"
+    },
+    "function-tool-registration": {
+      "category": "agents",
+      "path": "skills/agents/function-tool-registration/SKILL.md",
+      "version": "1.0.0"
+    },
+    "game-design-doc-review": {
+      "category": "design",
+      "path": "skills/design/game-design-doc-review/SKILL.md",
+      "version": "1.0.0"
+    },
+    "gate-check": {
+      "category": "production",
+      "path": "skills/production/gate-check/SKILL.md",
+      "version": "1.0.0"
+    },
+    "generate-cli-from-mcp-tool-list": {
+      "category": "cli",
+      "path": "skills/cli/generate-cli-from-mcp-tool-list/SKILL.md",
+      "version": "1.0.0"
+    },
+    "generate-tool-reference-with-token-counts": {
+      "category": "build-tooling",
+      "path": "skills/build-tooling/generate-tool-reference-with-token-counts/SKILL.md",
+      "version": "1.0.0"
+    },
+    "generated-enum-and-config-code-from-json-schema": {
+      "category": "codegen",
+      "path": "skills/codegen/generated-enum-and-config-code-from-json-schema/SKILL.md",
+      "version": "1.0.0"
+    },
+    "gep-environment-fingerprint": {
+      "category": "architecture",
+      "path": "skills/architecture/gep-environment-fingerprint/SKILL.md",
+      "version": "1.0.0"
+    },
+    "get-package-reactive-bindings": {
+      "category": "flutter",
+      "path": "skills/flutter/get-package-reactive-bindings/SKILL.md",
+      "version": "1.0.0"
+    },
+    "git-rollback-mode-selector": {
+      "category": "operations",
+      "path": "skills/operations/git-rollback-mode-selector/SKILL.md",
+      "version": "1.0.0"
+    },
+    "git-worktree-isolation-per-thread": {
+      "category": "git",
+      "path": "skills/git/git-worktree-isolation-per-thread/SKILL.md",
+      "version": "1.0.0"
+    },
+    "github-actions-parallel-test-matrix": {
+      "category": "ci",
+      "path": "skills/ci/github-actions-parallel-test-matrix/SKILL.md",
+      "version": "1.0.0"
+    },
+    "github-hmac-webhook-verify": {
+      "category": "cli",
+      "path": "skills/cli/github-hmac-webhook-verify/SKILL.md",
+      "version": "1.0.0"
+    },
+    "github-trending-zero-dep-scraper": {
+      "category": "integration",
+      "path": "skills/integration/github-trending-zero-dep-scraper/SKILL.md",
+      "version": "1.0.0"
+    },
+    "go-middleware-context-injection": {
+      "category": "architecture",
+      "path": "skills/architecture/go-middleware-context-injection/SKILL.md",
+      "version": "1.0.0"
+    },
+    "goal-driven-verifiable-success-criteria": {
+      "category": "engineering",
+      "path": "skills/engineering/goal-driven-verifiable-success-criteria/SKILL.md",
+      "version": "1.0.0"
     }
   },
   "knowledge": {
@@ -4427,6 +4562,98 @@
     "craft-cli-command-surface": {
       "category": "reference",
       "path": "knowledge/reference/craft-cli-command-surface.md"
+    },
+    "file-layout-apps-vs-packages": {
+      "category": "reference",
+      "path": "knowledge/reference/file-layout-apps-vs-packages.md"
+    },
+    "flatpak-portals-sandbox-workaround": {
+      "category": "linux",
+      "path": "knowledge/linux/flatpak-portals-sandbox-workaround.md"
+    },
+    "flutter-rust-bridge-compatibility-matrix": {
+      "category": "ffi",
+      "path": "knowledge/ffi/flutter-rust-bridge-compatibility-matrix.md"
+    },
+    "fp8-e4m3-vs-ue8m0-format-differences": {
+      "category": "fp8-quantization",
+      "path": "knowledge/fp8-quantization/fp8-e4m3-vs-ue8m0-format-differences.md"
+    },
+    "fsync-directory-is-mandatory-before-rename": {
+      "category": "jit-compilation",
+      "path": "knowledge/jit-compilation/fsync-directory-is-mandatory-before-rename.md"
+    },
+    "function-schema-generation": {
+      "category": "llm-agents",
+      "path": "knowledge/llm-agents/function-schema-generation.md"
+    },
+    "gated-huggingface-hardcoded-config": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/gated-huggingface-hardcoded-config.md"
+    },
+    "gdi-fallback-screen-capture": {
+      "category": "codecs",
+      "path": "knowledge/codecs/gdi-fallback-screen-capture.md"
+    },
+    "gep-asset-model": {
+      "category": "architecture",
+      "path": "knowledge/architecture/gep-asset-model.md"
+    },
+    "gep-genome-evolution-protocol": {
+      "category": "architecture",
+      "path": "knowledge/architecture/gep-genome-evolution-protocol.md"
+    },
+    "gep-protocol-auditable-assets": {
+      "category": "reference",
+      "path": "knowledge/reference/gep-protocol-auditable-assets.md"
+    },
+    "git-stale-branch-main-dot-dot-head": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/git-stale-branch-main-dot-dot-head.md"
+    },
+    "git-workflow-issue-version-forensics": {
+      "category": "git-workflow",
+      "path": "knowledge/git-workflow/git-workflow-issue-version-forensics.md"
+    },
+    "github-token-env-fallback-chain": {
+      "category": "reference",
+      "path": "knowledge/reference/github-token-env-fallback-chain.md"
+    },
+    "github-variables-version-management": {
+      "category": "ci-cd",
+      "path": "knowledge/ci-cd/github-variables-version-management.md"
+    },
+    "go-requires-cgo-onnxruntime": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/go-requires-cgo-onnxruntime.md"
+    },
+    "godot-animation": {
+      "category": "engine",
+      "path": "knowledge/engine/godot-animation.md"
+    },
+    "godot-audio": {
+      "category": "engine",
+      "path": "knowledge/engine/godot-audio.md"
+    },
+    "godot-best-practices": {
+      "category": "engine",
+      "path": "knowledge/engine/godot-best-practices.md"
+    },
+    "godot-breaking-changes": {
+      "category": "engine",
+      "path": "knowledge/engine/godot-breaking-changes.md"
+    },
+    "godot-deprecated-apis": {
+      "category": "engine",
+      "path": "knowledge/engine/godot-deprecated-apis.md"
+    },
+    "godot-input": {
+      "category": "engine",
+      "path": "knowledge/engine/godot-input.md"
+    },
+    "godot-navigation": {
+      "category": "engine",
+      "path": "knowledge/engine/godot-navigation.md"
     }
   }
 }

--- a/skills/agents/forcing-tool-use/SKILL.md
+++ b/skills/agents/forcing-tool-use/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: forcing-tool-use
+description: Force the model to call a specific tool or any tool on the first turn using tool_choice in ModelSettings.
+category: agents
+version: 1.0.0
+version_origin: extracted
+confidence: medium
+tags: [openai-agents, tool-choice, model-settings, forced-tool, reset-tool-choice]
+source_type: extracted-from-git
+source_url: https://github.com/openai/openai-agents-python.git
+source_ref: main
+source_commit: e80d2d2319eb300ac17ec496988b70246a5042d6
+source_project: openai-agents-python
+source_path: examples/agent_patterns/forcing_tool_use.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# forcing-tool-use
+
+Set `model_settings=ModelSettings(tool_choice="required")` to force the model to call at least one tool. Use `tool_choice={"type": "function", "name": "my_tool"}` to force a specific tool.
+
+## When to apply
+
+When you need the agent to always use a tool on its first turn (e.g., always search before answering, always validate input). Prevents the model from skipping the tool and answering directly.
+
+## Core snippet
+
+```python
+from agents import Agent, ModelSettings, function_tool
+
+@function_tool
+def search_knowledge_base(query: str) -> str:
+    """Search the knowledge base for relevant information."""
+    return f"Results for: {query}"
+
+# Force any tool call
+agent = Agent(
+    name="Research assistant",
+    instructions="Always search before answering.",
+    tools=[search_knowledge_base],
+    model_settings=ModelSettings(tool_choice="required"),
+    reset_tool_choice=True,  # Default: reset after first tool call to avoid loops
+)
+
+# Force a specific tool
+agent_specific = Agent(
+    name="Search assistant",
+    tools=[search_knowledge_base],
+    model_settings=ModelSettings(
+        tool_choice={"type": "function", "name": "search_knowledge_base"}
+    ),
+    reset_tool_choice=True,
+)
+```
+
+## Key notes
+
+- `tool_choice="required"`: model must call at least one tool
+- `tool_choice="auto"`: model decides whether to call a tool (default)
+- `tool_choice="none"`: model cannot call any tool
+- `reset_tool_choice=True` (default): resets `tool_choice` to `"auto"` after the first tool call to avoid infinite tool loops
+- Set `reset_tool_choice=False` if you want every turn to require a tool call

--- a/skills/agents/function-tool-registration/SKILL.md
+++ b/skills/agents/function-tool-registration/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: function-tool-registration
+description: Register a Python function as an agent tool using the @function_tool decorator.
+category: agents
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [openai-agents, tools, function-tool, pydantic]
+source_type: extracted-from-git
+source_url: https://github.com/openai/openai-agents-python.git
+source_ref: main
+source_commit: e80d2d2319eb300ac17ec496988b70246a5042d6
+source_project: openai-agents-python
+source_path: examples/basic/tools.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# function-tool-registration
+
+Wrap any Python function as a callable tool using `@function_tool`. The decorator introspects the function signature and docstring to build the JSON schema automatically. Pydantic models work as return types.
+
+## When to apply
+
+Use when an agent needs to call a local Python function — fetch data, compute a result, call an external API — within a single agent turn.
+
+## Core snippet
+
+```python
+from typing import Annotated
+from pydantic import BaseModel, Field
+from agents import Agent, Runner, function_tool
+
+class Weather(BaseModel):
+    city: str = Field(description="The city name")
+    temperature_range: str
+    conditions: str
+
+@function_tool
+def get_weather(city: Annotated[str, "The city to get the weather for"]) -> Weather:
+    """Get the current weather information for a specified city."""
+    return Weather(city=city, temperature_range="14-20C", conditions="Sunny with wind.")
+
+agent = Agent(
+    name="Hello world",
+    instructions="You are a helpful agent.",
+    tools=[get_weather],
+)
+
+async def main():
+    result = await Runner.run(agent, input="What's the weather in Tokyo?")
+    print(result.final_output)
+```
+
+## Key notes
+
+- Docstring becomes the tool description visible to the LLM
+- `Annotated[type, "description"]` annotates individual parameters
+- Pydantic models are automatically serialized/deserialized
+- Async functions work equally: `async def my_tool(...) -> str:`
+- Access run context via first param: `def my_tool(ctx: RunContextWrapper[MyContext], ...):`

--- a/skills/architecture/gep-environment-fingerprint/SKILL.md
+++ b/skills/architecture/gep-environment-fingerprint/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: gep-environment-fingerprint
+description: Compute and persist environment fingerprint for drift detection and state validation
+category: architecture
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [evolver, architecture, fingerprint, drift-detection]
+source_type: extracted-from-git
+source_url: https://github.com/EvoMap/evolver.git
+source_ref: main
+source_commit: 22773782475cecf43dc9c1af264bf5f9cacc28bc
+source_project: evolver
+source_paths:
+  - src/gep/envFingerprint.js
+  - src/proxy/lifecycle/manager.js
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Environment fingerprint for drift detection
+
+Track the environment (OS, Node version, working directory, git state, etc.) and detect when critical state has drifted. Useful for any agent system needing to validate that persisted evolution / cache / state artifacts still apply to the current environment without silent failures.
+
+## Mechanism
+
+1. At boot, collect a stable subset of environment facts: `process.platform`, `process.version`, repo root path, `git rev-parse HEAD`, branch name, presence of key files.
+2. Hash the tuple (e.g., sha256 over a canonical JSON encoding) → fingerprint.
+3. Persist fingerprint alongside state artifacts.
+4. On each cycle, recompute and compare. If it differs, treat persisted state as invalid: refuse to continue, clear caches, or prompt human review.
+
+## When to reuse
+
+- Agents or daemons with long-lived state that shouldn't be replayed across branches/repos.
+- Caching layers that must invalidate on Node upgrade or path move.
+- Any workflow that applies previously-recorded decisions to the current tree.

--- a/skills/architecture/go-middleware-context-injection/SKILL.md
+++ b/skills/architecture/go-middleware-context-injection/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: go-middleware-context-injection
+description: Chi middleware that resolves workspace membership and injects workspace ID and member record into request.Context(), with typed accessors and shared context keys.
+category: architecture
+version: 1.0.0
+tags: [go, chi, middleware, multi-tenancy, context]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- Go HTTP service with multi-tenant workspaces.
+- You want every workspace-scoped handler to receive a pre-validated workspace ID and member record, not re-resolve them per-route.
+
+## Steps
+
+1. Private context keys to avoid collision with stdlib:
+   ```go
+   type contextKey int
+   const (
+       ctxKeyWorkspaceID contextKey = iota
+       ctxKeyMember
+   )
+   ```
+2. Typed accessors — exported so handlers never read raw context values:
+   ```go
+   func WorkspaceIDFromContext(ctx context.Context) string {
+       id, _ := ctx.Value(ctxKeyWorkspaceID).(string)
+       return id
+   }
+   func MemberFromContext(ctx context.Context) (db.Member, bool) {
+       m, ok := ctx.Value(ctxKeyMember).(db.Member)
+       return m, ok
+   }
+   func SetMemberContext(ctx context.Context, wsID string, m db.Member) context.Context {
+       ctx = context.WithValue(ctx, ctxKeyWorkspaceID, wsID)
+       return context.WithValue(ctx, ctxKeyMember, m)
+   }
+   ```
+3. Resolver extracted from request — supports multiple identifier shapes in priority order. Return three outcomes: success, "no identifier" (400), "invalid identifier" (404):
+   ```go
+   var errWorkspaceNotFound = errors.New("workspace not found")
+   type workspaceResolver func(*http.Request) (string, error)
+
+   func resolveWorkspaceUUID(q *db.Queries) workspaceResolver {
+       return func(r *http.Request) (string, error) {
+           if slug := r.Header.Get("X-Workspace-Slug"); slug != "" {
+               ws, err := q.GetWorkspaceBySlug(r.Context(), slug)
+               if err != nil { return "", errWorkspaceNotFound }
+               return ws.ID.String(), nil
+           }
+           if id := r.Header.Get("X-Workspace-ID"); id != "" { return id, nil }
+           return "", nil
+       }
+   }
+   ```
+4. Middleware factory that optionally enforces role:
+   ```go
+   func RequireWorkspaceMember(q *db.Queries) func(http.Handler) http.Handler {
+       return buildMiddleware(q, resolveWorkspaceUUID(q), nil)
+   }
+   func RequireWorkspaceRole(q *db.Queries, roles ...string) func(http.Handler) http.Handler {
+       return buildMiddleware(q, resolveWorkspaceUUID(q), roles)
+   }
+   func buildMiddleware(q *db.Queries, resolve workspaceResolver, roles []string) func(http.Handler) http.Handler {
+       return func(next http.Handler) http.Handler {
+           return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+               wsID, err := resolve(r)
+               if err != nil { writeError(w, 404, "workspace not found"); return }
+               if wsID == "" { writeError(w, 400, "workspace identifier required"); return }
+               userID := r.Header.Get("X-User-ID")
+               if userID == "" { writeError(w, 401, "not authenticated"); return }
+               m, err := q.GetMemberByUserAndWorkspace(r.Context(), ...)
+               if err != nil { writeError(w, 404, "workspace not found"); return }
+               if len(roles) > 0 && !contains(roles, m.Role) { writeError(w, 403, "forbidden"); return }
+               next.ServeHTTP(w, r.WithContext(SetMemberContext(r.Context(), wsID, m)))
+           })
+       }
+   }
+   ```
+5. Mount with chi:
+   ```go
+   r.Route("/api", func(r chi.Router) {
+       r.Use(auth.RequireAuth)
+       r.Group(func(r chi.Router) {
+           r.Use(middleware.RequireWorkspaceMember(queries))
+           r.Get("/issues", listIssues)
+           r.Post("/issues", createIssue)
+       })
+       r.Group(func(r chi.Router) {
+           r.Use(middleware.RequireWorkspaceRole(queries, "admin", "owner"))
+           r.Delete("/workspace", deleteWorkspace)
+       })
+   })
+   ```
+
+## Example
+
+In a handler:
+```go
+func listIssues(w http.ResponseWriter, r *http.Request) {
+    wsID := middleware.WorkspaceIDFromContext(r.Context())
+    member, _ := middleware.MemberFromContext(r.Context())
+    issues, err := queries.ListIssuesByWorkspace(r.Context(), wsID)
+    // ...
+}
+```
+
+## Caveats
+
+- Keep resolver priority deterministic and document it — frontend uses slug, CLI uses UUID, and a legacy client might send both. Decide which wins and stick to it.
+- "not authenticated" (401) is different from "not a member of this workspace" (404) is different from "member but wrong role" (403). Return the right status or UX is confused.
+- Consider caching slug→UUID lookup (slug is immutable) if it shows up in p99 latency.

--- a/skills/build-tooling/generate-tool-reference-with-token-counts/SKILL.md
+++ b/skills/build-tooling/generate-tool-reference-with-token-counts/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: generate-tool-reference-with-token-counts
+description: Generate your MCP tool reference docs by booting the real server, calling listTools, and including a tiktoken cl100k_base count in the title so you and your users can see the context-budget cost at a glance.
+category: build-tooling
+version: 1.0.0
+version_origin: extracted
+tags: [docs, codegen, tiktoken, tokens, mcp]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/ChromeDevTools/chrome-devtools-mcp.git
+source_ref: main
+source_commit: 0a6aaa52ebacb2db834ffa437863e5844aa3730b
+source_project: chrome-devtools-mcp
+source_path: scripts/generate-docs.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Generate Tool Reference with Token Measurements
+
+## When to use
+
+- You maintain MCP tool docs by hand and they drift from the tool descriptions.
+- You want "how many tokens does my server's tool list cost?" as a first-class number in the docs so adding a verbose description has a visible cost.
+- You want a single source of truth: tool `.describe()` text in code, everything downstream (docs, CLI help, marketing README) derived.
+
+## How it works
+
+- In a `scripts/generate-docs.ts`, spawn the built MCP server via `StdioClientTransport`, call `client.listTools()`, pull JSON-schema `inputSchema` and `description` for each.
+- Count tokens: `tiktoken.get_encoding('cl100k_base').encode(JSON.stringify(tools, null, 2)).length`. That's a decent proxy for GPT-4 / Claude-3.5 context cost.
+- Title the generated markdown like `# Tool Reference (~18,472 cl100k_base tokens)` so the cost shows up prominently in both the file and the auto-TOC.
+- Generate two docs from the same pipeline by passing different startup args: `createTools({slim:true})` produces a slim reference, full mode produces the fat one. Show both token counts.
+- Auto-insert a TOC into your README between `<!-- BEGIN AUTO GENERATED TOOLS -->` and `<!-- END AUTO GENERATED TOOLS -->` markers; idempotent regeneration.
+- Cross-link tool names inside descriptions: when a description mentions another tool by name, wrap it as `[\`tool_name\`](#tool_name)` automatically.
+
+## Example
+
+```ts
+async function measureServer(args: string[]) {
+  const transport = new StdioClientTransport({command: 'node', args: ['./build/src/bin/server.js', ...args]});
+  const client = new Client({name:'measurer', version:'1.0.0'}, {capabilities:{}});
+  await client.connect(transport);
+  const {tools} = await client.listTools();
+  const enc = get_encoding('cl100k_base');
+  const tokens = enc.encode(JSON.stringify(tools, null, 2)).length;
+  enc.free();
+  await client.close();
+  return {tokenCount: tokens, tools};
+}
+
+// inside generateReference:
+let md = `# ${title} (~${(await measureServer(args)).tokenCount} cl100k_base tokens)\n\n`;
+// ...render tool categories, cross-link tool names in descriptions, write to OUTPUT_PATH.
+```
+
+## Gotchas
+
+- `cl100k_base` is approximate for modern Claude/GPT; it's a trend indicator, not the exact billed count. Don't quote it as authoritative — just use it to compare slim vs. full, and to alert on regressions.
+- `enc.free()` is required — tiktoken leaks native memory otherwise and long build scripts bloat.
+- When you spawn your server for codegen, set an env var like `NO_USAGE_STATISTICS=true` so every doc build doesn't generate telemetry noise.
+- Keep the generated file under version control; downstream consumers (site builders, search) shouldn't need to re-run the server to read the reference.
+- If two tools both describe each other, the cross-link regex can double-wrap. Run the replacement on longest names first and skip matches already inside `[...]`.

--- a/skills/build/file-stability-polling-for-fs-flush/SKILL.md
+++ b/skills/build/file-stability-polling-for-fs-flush/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: file-stability-polling-for-fs-flush
+description: Poll stat size every 100ms and only treat a file as "ready" after 3 consecutive unchanged readings — bridges the gap between bundler exit and OS filesystem flush on Windows / network volumes.
+category: build
+version: 1.0.0
+version_origin: extracted
+tags: [filesystem, flush, windows, build-tooling]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: scripts/electron-build-main.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# File-stability polling before consuming a freshly built file
+
+## When to use
+- A build step writes a large output file and immediately another step (launch, verify, archive) reads it.
+- On Windows / SMB / slow disks you see intermittent "file is zero bytes" or "truncated" errors.
+- You can't force-sync from inside the bundler; you control only the caller.
+
+## How it works
+1. Poll `fs.statSync(path).size` every 100ms.
+2. Maintain a `stableCount` - incremented when the size matches the previous reading, reset to 0 when it changes.
+3. Return "ready" only after 3 consecutive unchanged readings (~300ms of silence).
+4. Give up after `timeoutMs` (10s default); caller decides what to do.
+5. Also guard against missing file (bundler may not have created it yet) - keep polling.
+
+## Example
+```ts
+async function waitForFileStable(filePath: string, timeoutMs = 10_000): Promise<boolean> {
+  const start = Date.now();
+  let lastSize = -1, stableCount = 0;
+  while (Date.now() - start < timeoutMs) {
+    if (!existsSync(filePath)) { await Bun.sleep(100); continue; }
+    const size = statSync(filePath).size;
+    if (size === lastSize) {
+      if (++stableCount >= 3) return true;
+    } else {
+      stableCount = 0; lastSize = size;
+    }
+    await Bun.sleep(100);
+  }
+  return false;
+}
+```
+
+## Gotchas
+- 3 consecutive readings is a heuristic - tune for your disk. Some network volumes buffer up to 1s.
+- Doesn't detect *corruption*, only partial writes. Add `node --check`-style validation after stability for defense-in-depth.
+- On Linux with local SSDs this is usually unnecessary - but the paranoid cross-platform build stays this way to avoid flaky CI.
+- If multiple writers target the same file, stability polling is racy; use atomic rename (`tmp` -> `final`) instead.

--- a/skills/ci/github-actions-parallel-test-matrix/SKILL.md
+++ b/skills/ci/github-actions-parallel-test-matrix/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: github-actions-parallel-test-matrix
+description: GitHub Actions workflow uses a strategy.matrix over OS × toolchain to run all tests in parallel, with continue-on-error for nightly so unstable toolchains don't block merges.
+category: ci
+version: 1.0.0
+version_origin: extracted
+confidence: medium
+tags: [magika, ci]
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Github Actions Parallel Test Matrix
+
+**Trigger:** Multi-language project that must validate on Linux + macOS + Windows × stable + nightly without serial CI.
+
+## Steps
+
+- Define strategy.matrix with axes: os = [ubuntu-latest, macos-latest, windows-latest], toolchain = [stable, nightly].
+- Each matrix cell runs the full suite; GitHub spawns them in parallel.
+- Set continue-on-error: true for nightly so experimental compiler regressions don't block PRs.
+- Cache language-specific dirs (Cargo registry, pip wheels, node_modules) keyed by lockfile hash.
+- Name jobs descriptively (test (ubuntu / stable)) so matrix failures are easy to read.
+- Aggregate: require stable cells to pass; let nightly be informational only.
+
+## Counter / Caveats
+
+- Matrix explosion (3 OS × N toolchains) burns CI minutes — macOS and Windows are ~10x more expensive on free tier.
+- Flaky tests can fail on one cell and pass on another; quarantine flaky ones rather than rerunning blindly.
+- Setup time often dominates short test suites; cache aggressively.
+- 5GB artifact cap on free tier means you must clean up after large workflows.
+
+## Source
+
+Extracted from `magika` (https://github.com/google/magika.git @ main).
+
+Files of interest:
+- `.github/workflows/rust-test.yml:1-60`
+- `.github/workflows/python-build-and-release-package.yml:74-120`

--- a/skills/ci/github-actions-parallel-test-matrix/content.md
+++ b/skills/ci/github-actions-parallel-test-matrix/content.md
@@ -1,0 +1,21 @@
+# github-actions-parallel-test-matrix — extended notes
+
+This is an extracted draft from the **magika** project at commit `0a8cb9626b`.
+See `SKILL.md` for the procedure. Use the source references below to study the
+original implementation before adapting the pattern to a new codebase.
+
+## Source references
+
+- `.github/workflows/rust-test.yml:1-60`
+- `.github/workflows/python-build-and-release-package.yml:74-120`
+
+## When this pattern is a fit
+
+Multi-language project that must validate on Linux + macOS + Windows × stable + nightly without serial CI.
+
+## When to walk away
+
+- Matrix explosion (3 OS × N toolchains) burns CI minutes — macOS and Windows are ~10x more expensive on free tier.
+- Flaky tests can fail on one cell and pass on another; quarantine flaky ones rather than rerunning blindly.
+- Setup time often dominates short test suites; cache aggressively.
+- 5GB artifact cap on free tier means you must clean up after large workflows.

--- a/skills/cli/foreground-background-daemon-mode/SKILL.md
+++ b/skills/cli/foreground-background-daemon-mode/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: foreground-background-daemon-mode
+description: CLI-managed daemon with foreground (for debug) and background (default, detached) modes, log-file path convention, and a status-check sub-command.
+category: cli
+version: 1.0.0
+tags: [cli, daemon, background-process, logs, debugging]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: medium
+---
+
+## When to use
+
+- A CLI that spawns a long-lived background process (task runner, sync daemon).
+- Users need a way to start it without a terminal, check on it, tail logs, and stop it cleanly.
+
+## Steps
+
+1. `daemon start` defaults to background (double-fork on Unix, `CREATE_NEW_PROCESS_GROUP` on Windows). Add `--foreground` for interactive debug:
+   ```go
+   startCmd.Flags().Bool("foreground", false, "run daemon in the foreground (for debug)")
+   ```
+2. Log to a canonical path unless the foreground flag is set:
+   ```
+   ~/.myapp/daemon.log                            # default
+   ~/.myapp/profiles/<name>/daemon.log            # per-profile
+   ```
+   In foreground mode, log to stdout/stderr directly.
+3. `daemon status` reads the PID file, verifies the process exists, reports uptime and detected agents:
+   ```go
+   pid := readPIDFile(profile)
+   if pid == 0 || !processAlive(pid) { fmt.Println("not running"); return }
+   // read the daemon's own health endpoint for detailed status
+   status := httpGet(fmt.Sprintf("http://127.0.0.1:%d/status", healthPort(profile)))
+   ```
+4. `daemon logs` tails the log file with `-f`/`-n`:
+   ```go
+   logsCmd.Flags().BoolP("follow", "f", false, "follow log output")
+   logsCmd.Flags().IntP("lines",  "n", 50,    "number of lines to show")
+   ```
+5. `daemon stop` sends SIGTERM (or `TerminateProcess` on Windows), waits up to N seconds, falls back to SIGKILL. Clean up the PID file on exit.
+6. `daemon restart` is stop + start, preserving the profile flag.
+
+## Example
+
+```
+$ mycli daemon start
+Daemon running in background (pid 12345). Logs at ~/.myapp/daemon.log.
+
+$ mycli daemon status
+running (pid 12345, uptime 2h, 3 agents, 5 runtimes)
+
+$ mycli daemon logs -f
+[12:30:01] registered runtime ... (workspace=Engineering, provider=claude)
+[12:31:15] task 492abc claimed
+
+$ mycli daemon stop
+Daemon stopped.
+```
+
+## Caveats
+
+- Double-fork detach is Unix-specific; on Windows use `syscall.CreateProcess` with `DETACHED_PROCESS` + `CREATE_NEW_PROCESS_GROUP`.
+- PID file is not a lock — combine with early port-bind on the daemon's health port to catch stale PID cases atomically.
+- Rotate the log file if it can grow unbounded; users will run the daemon for weeks.

--- a/skills/cli/generate-cli-from-mcp-tool-list/SKILL.md
+++ b/skills/cli/generate-cli-from-mcp-tool-list/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: generate-cli-from-mcp-tool-list
+description: Auto-generate a yargs-based CLI from an MCP server's tool list and JSON schemas so every tool becomes a subcommand with typed positional args for required fields and flags for optional ones.
+category: cli
+version: 1.0.0
+version_origin: extracted
+tags: [cli, yargs, codegen, mcp, json-schema]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/ChromeDevTools/chrome-devtools-mcp.git
+source_ref: main
+source_commit: 0a6aaa52ebacb2db834ffa437863e5844aa3730b
+source_project: chrome-devtools-mcp
+source_path: scripts/generate-cli.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Generate CLI from MCP Tool List
+
+## When to use
+
+- You already have an MCP server with N tools and want a shell CLI that mirrors them without hand-writing N yargs commands.
+- You want the CLI to stay in sync with new/renamed tools automatically when you rebuild.
+- You want required parameters to be positional (`mycli click <uid>`) and optional parameters to be flags (`--fullPage`).
+
+## How it works
+
+- In a `scripts/generate-cli.ts` build step, spin up the real MCP server via `StdioClientTransport`, call `client.listTools()`, and walk each tool's `inputSchema` (standard JSON Schema).
+- Convert each property to a `{name, type, description, required, default, enum}` record. For each tool, emit an entry `{description, category, args}` into a `commands` map.
+- Write that map to a generated TS file (`cliDefinitions.ts`) as a `const` export. Ship it as source — generated, but checked in — so the CLI binary can run without a codegen step.
+- In the CLI entry (`bin/mycli.ts`), read `commands`, and for each entry register a yargs command: required args become `y.positional(name, {type, choices, default})`, optional args become `y.option(name, ...)`. Fallthrough handler calls `sendCommand({method:'invoke_tool', tool:name, args})`.
+- Filter inappropriate tools at generation time (e.g. skip tools whose schema is an array or nested object — shells don't pass JSON well).
+
+## Example
+
+```ts
+// scripts/generate-cli.ts
+const tools = (await client.listTools()).tools.filter(t =>
+  t.name !== 'fill_form' && t.name !== 'wait_for' // skip complex schemas
+);
+const commands = Object.fromEntries(tools.map(t => [t.name, {
+  description: t.description,
+  category: toolNameToCategory.get(t.name),
+  args: schemaToCLIOptions(t.inputSchema), // {name,type,required,default,enum}
+}]));
+fs.writeFileSync(OUTPUT_PATH, `export const commands = ${JSON.stringify(commands, null, 2)} as const;`);
+
+// bin/mycli.ts - at runtime
+for (const [name, def] of Object.entries(commands)) {
+  const required = Object.entries(def.args).filter(([,a]) => a.required);
+  let cmdStr = name + required.map(([n]) => ` <${n}>`).join('');
+  y.command(cmdStr, def.description, y => {
+    for (const [argName, opt] of Object.entries(def.args)) {
+      opt.required ? y.positional(argName, {...}) : y.option(argName, {...});
+    }
+  }, async argv => sendCommand({method:'invoke_tool', tool:name, args: argv}));
+}
+```
+
+## Gotchas
+
+- JSON-Schema `type` can be a union (`["string","null"]`); treat that as the non-null variant or skip the tool. Yargs doesn't model nullable well.
+- Map schema types to yargs types explicitly: `integer|number → number`, `array → array`, everything else → `string`. Don't assume `type: 'object'` tools make sense in a shell.
+- Pass `CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS=true` (or your equivalent) when booting the server for codegen — you don't want to spam telemetry from a build script.
+- Keep an escape hatch in the CLI binary to disable tools that make no sense in a shell (e.g. `fill_form` requiring nested JSON). Filter at generation, not at runtime.
+- Pre-generate at build time, don't call `listTools()` on every CLI invocation — that would defeat a fast daemon-backed CLI.

--- a/skills/cli/github-hmac-webhook-verify/SKILL.md
+++ b/skills/cli/github-hmac-webhook-verify/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: github-hmac-webhook-verify
+description: Verify a GitHub webhook's `X-Hub-Signature-256` using HMAC-SHA-256 over the raw body with `timingSafeEqual`, with a same-length guard, prefix-masked logs on mismatch, and a 200-then-async processing pattern.
+category: cli
+version: 1.0.0
+version_origin: extracted
+tags: [webhook, github, hmac, signature, security]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/coleam00/Archon.git
+source_ref: dev
+source_commit: d89bc767d291f52687beea91c9fcf155459be0d9
+source_project: Archon
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Verify GitHub Webhook HMAC-SHA-256 (with Timing-Safe Compare + Async Processing)
+
+## When to use
+
+- Your service receives `POST /webhooks/github` events (issue comments, PR events, etc.).
+- You have `GITHUB_WEBHOOK_SECRET` configured in GitHub's repo settings and in your server env.
+- You want a compact, hardened verify helper that doesn't leak timing information and handles the common failure modes gracefully.
+
+## Steps
+
+1. **Read the raw body as text, before any JSON parse.** HMAC is over the raw bytes; parsing and re-serializing will not reproduce the same digest. In Hono:
+
+   ```ts
+   const payload = await c.req.text();
+   const signature = c.req.header('X-Hub-Signature-256') ?? '';
+   ```
+
+2. **Compute `sha256=` + hex HMAC using your secret:**
+
+   ```ts
+   import { createHmac, timingSafeEqual } from 'crypto';
+   const hmac = createHmac('sha256', webhookSecret);
+   const digest = 'sha256=' + hmac.update(payload).digest('hex');
+   ```
+
+3. **Guard against length mismatch before `timingSafeEqual`.** `timingSafeEqual` throws on different lengths. A missing/malformed header shouldn't crash your handler — it should just fail verification.
+
+   ```ts
+   const digestBuffer = Buffer.from(digest);
+   const signatureBuffer = Buffer.from(signature);
+   if (digestBuffer.length !== signatureBuffer.length) {
+     log.error({ receivedLength: signatureBuffer.length, computedLength: digestBuffer.length }, 'github.signature_length_mismatch');
+     return false;
+   }
+   const isValid = timingSafeEqual(digestBuffer, signatureBuffer);
+   ```
+
+4. **Log both prefixes (not full values) on mismatch.** Signatures are not secrets, but "compressed" logging gives you a diagnostic hint without bloating the log:
+
+   ```ts
+   if (!isValid) {
+     log.error({
+       receivedPrefix: signature.substring(0, 15) + '...',
+       computedPrefix: digest.substring(0, 15) + '...',
+     }, 'github.signature_mismatch');
+   }
+   ```
+
+5. **Wrap the whole verify in a try/catch** that returns `false` on any thrown error — a malformed signature header shouldn't crash the request handler.
+
+6. **Return 200 immediately, process async.** GitHub retries on non-2xx and has a 10-second timeout. Return 200 as soon as signature + authorization check pass, then do the heavy work (database writes, AI spawning, git operations) in a fire-and-forget path:
+
+   ```ts
+   app.post('/webhooks/github', async c => {
+     const payload = await c.req.text();
+     const signature = c.req.header('X-Hub-Signature-256') ?? '';
+     if (!adapter.verifySignature(payload, signature)) return c.text('', 401);
+     // fire-and-forget — don't await
+     adapter.handleWebhook(payload, signature).catch(err => log.error({ err }, 'github.handle_webhook_failed'));
+     return c.text('', 200);
+   });
+   ```
+
+7. **Add an authorization layer after signature verification.** The HMAC only proves "GitHub sent this with our secret." It doesn't prove the sender is authorized in your application. Archon keeps a whitelist of GitHub usernames and silently rejects unauthorized senders (log with masked username, return success) — no error response (prevents probing).
+
+## Counter / Caveats
+
+- `sha1` (`X-Hub-Signature`) is deprecated. Use `X-Hub-Signature-256` only.
+- The GitHub signature format is `sha256=<hex>`. Don't forget the `sha256=` prefix when comparing.
+- Configure `c.req.text()` before any body-consuming middleware — once Hono parses JSON, re-reading raw bytes is not safe.
+- If you need to re-deliver failed webhooks, persist the **raw payload + signature** for later reprocessing; do not reserialize from parsed JSON.
+- Rotate the webhook secret periodically. Your verify code should accept a list of valid secrets during rotation (match on first success). Archon's current adapter takes a single secret; extend with a list if rotation matters.
+
+## Evidence
+
+- `packages/adapters/src/forge/github/adapter.ts:260-296`: `verifySignature` with length guard, `timingSafeEqual`, prefix-masked logs on mismatch, try/catch returning `false`.
+- `handleWebhook` orchestrator at `adapter.ts:691-725`: verify → parse → authorize (whitelist check with masked username log) → close-event handling, etc.
+- `adapter.test.ts` + `context.test.ts` exercise the signature path with real HMAC computation.
+- Root `CLAUDE.md` lines 800-810: "Return 200 immediately, process async. Verify webhook signatures (GitHub: X-Hub-Signature-256). Use `c.req.text()` for raw webhook body (signature verification)."
+- Commit SHA: d89bc767d291f52687beea91c9fcf155459be0d9.

--- a/skills/codegen/generated-enum-and-config-code-from-json-schema/SKILL.md
+++ b/skills/codegen/generated-enum-and-config-code-from-json-schema/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: generated-enum-and-config-code-from-json-schema
+description: Build-time code generator that reads a JSON content-type knowledge base and emits per-language type-safe enums + const TypeInfo structs (MIME type, group, extensions, is_text).
+category: codegen
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [magika, codegen]
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Generated Enum And Config Code From Json Schema
+
+**Trigger:** You have a large dynamic schema (300+ entries) and need per-language type safety without hand-writing or hand-maintaining enums.
+
+## Steps
+
+- Create a generator binary (Rust here) that reads content_types_kb.min.json and config.min.json.
+- Parse with serde; for each content type emit a const struct with label, mime_type, group, description, extensions, is_text.
+- Generate enum variants per type; map labels to valid identifiers (CamelCase / snake_case, leading-digit prefix).
+- Write generated code under a clearly-marked path (rust/lib/src/content.rs, python types/content_type_label.py) with a 'DO NOT EDIT' header.
+- Use a deterministic ordering (BTreeMap) so regeneration is reproducible.
+- Wire generation into the build pipeline (build.rs, setup.py hook, or dedicated generate.sh) and check generated files into git.
+
+## Counter / Caveats
+
+- Generator output must be deterministic; non-deterministic ordering breaks reproducible builds and noisy diffs.
+- Schema drift (new fields, type changes) causes generator failures; version the schema and validate before generating.
+- Large enums (300+ variants) slow Rust compile times; consider non_exhaustive and feature gates.
+- IDE autocomplete fails until generation runs; document a clone-time setup script.
+
+## Source
+
+Extracted from `magika` (https://github.com/google/magika.git @ main).
+
+Files of interest:
+- `rust/gen/src/main.rs:23-100`
+- `python/src/magika/types/content_type_label.py:19-30`
+- `rust/lib/src/content.rs (generated)`

--- a/skills/codegen/generated-enum-and-config-code-from-json-schema/content.md
+++ b/skills/codegen/generated-enum-and-config-code-from-json-schema/content.md
@@ -1,0 +1,22 @@
+# generated-enum-and-config-code-from-json-schema — extended notes
+
+This is an extracted draft from the **magika** project at commit `0a8cb9626b`.
+See `SKILL.md` for the procedure. Use the source references below to study the
+original implementation before adapting the pattern to a new codebase.
+
+## Source references
+
+- `rust/gen/src/main.rs:23-100`
+- `python/src/magika/types/content_type_label.py:19-30`
+- `rust/lib/src/content.rs (generated)`
+
+## When this pattern is a fit
+
+You have a large dynamic schema (300+ entries) and need per-language type safety without hand-writing or hand-maintaining enums.
+
+## When to walk away
+
+- Generator output must be deterministic; non-deterministic ordering breaks reproducible builds and noisy diffs.
+- Schema drift (new fields, type changes) causes generator failures; version the schema and validate before generating.
+- Large enums (300+ variants) slow Rust compile times; consider non_exhaustive and feature gates.
+- IDE autocomplete fails until generation runs; document a clone-time setup script.

--- a/skills/design/game-design-doc-review/SKILL.md
+++ b/skills/design/game-design-doc-review/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: game-design-doc-review
+description: "Reviews a game design document for completeness, internal consistency, implementability, and adherence to project design standards. Run this before handing a design document to programmers."
+argument-hint: "[path-to-design-doc] [--depth full|lean|solo]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write, Edit, Task, AskUserQuestion
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version: 1.0.0
+version_origin: extracted
+---
+
+## Phase 0: Parse Arguments
+
+Extract `--depth [full|lean|solo]` if present. Default is `full` when no flag is given.
+
+**Note**: `--depth` controls the *analysis depth* of this skill (how many specialist agents are spawned). It is independent of the global review mode in `production/review-mode.txt`, which controls director gate spawning. These are two different concepts — `--depth` is about how thoroughly *this* skill analyses the document.
+
+- **`full`**: Complete review — all phases + specialist agent delegation (Phase 3b)
+- **`lean`**: All phases, no specialist agents — faster, single-session analysis
+- **`solo`**: Phases 1-4 only, no delegation, no Phase 5 next-step prompt — use when called from within another skill
+
+---
+
+## Phase 1: Load Documents
+
+Read the target design document in full. Read CLAUDE.md to understand project context and standards. Read related design documents referenced or implied by the target doc (check `design/gdd/` for related systems).
+
+**Dependency graph validation:** For every system listed in the Dependencies section, use Glob to check whether its GDD file exists in `design/gdd/`. Flag any that don't exist yet — these are broken references that downstream authors will hit.
+
+**Lore/narrative alignment:** If `design/gdd/game-concept.md` or any file in `design/narrative/` exists, read it. Note any mechanical choices in this GDD that contradict established world rules, tone, or design pillars. Pass this context to `game-designer` in Phase 3b.
+
+**Prior review check:** Check whether `design/gdd/reviews/[doc-name]-review-log.md` exists. If it does, read the most recent entry — note what verdict was given and what blocking items were listed. This session is a re-review; track whether prior items were addressed.
+
+---
+
+## Phase 2: Completeness Check
+
+Evaluate against the Design Document Standard checklist:
+
+- [ ] Has Overview section (one-paragraph summary)
+- [ ] Has Player Fantasy section (intended feeling)
+- [ ] Has Detailed Rules section (unambiguous mechanics)
+- [ ] Has Formulas section (all math defined with variables)
+- [ ] Has Edge Cases section (unusual situations handled)
+- [ ] Has Dependencies section (other systems listed)
+- [ ] Has Tuning Knobs section (configurable values identified)
+- [ ] Has Acceptance Criteria section (testable success conditions)
+
+---
+
+## Phase 3: Consistency and Implementability
+
+**Internal consistency:**
+- Do the formulas produce values that match the described behavior?
+- Do edge cases contradict the main rules?
+- Are dependencies bidirectional (does the other system know about this one)?
+
+**Implementability:**
+- Are the rules precise enough for a programmer to implement without guessing?
+- Are there any "hand-wave" sections where details are missing?
+- Are performance implications considered?
+
+**Cross-system consistency:**
+- Does this conflict with any existing mechanic?
+- Does this create unintended interactions with other systems?
+- Is this consistent with the game's established tone and pillars?
+
+---
+
+## Phase 3b: Adversarial Specialist Review (full mode only)
+
+**Skip this phase in `lean` or `solo` mode.**
+
+**This phase is MANDATORY in full mode.** Do not skip it.
+
+**Before spawning any agents**, print this notice:
+> "Full review: spawning specialist agents in parallel. This typically takes 8–15 minutes. Use `--review lean` for faster single-session analysis."
+
+### Step 1 — Identify all domains the GDD touches
+
+Read the GDD and identify every domain present. A GDD can touch multiple domains simultaneously — be thorough. Common signals:
+
+| If the GDD contains... | Spawn these agents |
+|------------------------|-------------------|
+| Costs, prices, drops, rewards, economy | `economy-designer` |
+| Combat stats, damage, health, DPS | `game-designer`, `systems-designer` |
+| AI behaviour, pathfinding, targeting | `ai-programmer` |
+| Level layout, spawning, wave structure | `level-designer` |
+| Player progression, XP, unlocks | `economy-designer`, `game-designer` |
+| UI, HUD, menus, player-facing displays | `ux-designer`, `ui-programmer` |
+| Dialogue, quests, story, lore | `narrative-director` |
+| Animation, feel, timing, juice | `gameplay-programmer` |
+| Multiplayer, sync, replication | `network-programmer` |
+| Audio cues, music triggers | `audio-director` |
+| Performance, draw calls, memory | `performance-analyst` |
+| Engine-specific patterns or APIs | Primary engine specialist (from `.claude/docs/technical-preferences.md`) |
+| Acceptance criteria, test coverage | `qa-lead` |
+| Data schema, resource structure | `systems-designer` |
+| Any gameplay system | `game-designer` (always) |
+
+**Always spawn `game-designer` and `systems-designer` as a baseline minimum.** Every GDD touches their domain.
+
+### Step 2 — Spawn all relevant specialists in parallel
+
+**CRITICAL: Task in this skill spawns a SUBAGENT — a separate independent Claude session
+with its own context window. It is NOT task tracking. Do NOT simulate specialist
+perspectives internally. Do NOT reason through domain views yourself. You MUST issue
+actual Task calls. A simulated review is not a specialist review.**
+
+Issue all Task calls simultaneously. Do NOT spawn one at a time.
+
+**Prompt each specialist adversarially:**
+> "Here is the GDD for [system] and the main review's structural findings so far.
+> Your job is NOT to validate this design — your job is to find problems.
+> Challenge the design choices from your domain expertise. What is wrong,
+> underspecified, likely to cause problems, or missing entirely?
+> Be specific and critical. Disagreement with the main review is welcome."
+
+**Additional instructions per agent type:**
+
+- **`game-designer`**: Anchor your review to the Player Fantasy stated in Section B of this GDD. Does this design actually deliver that fantasy? Would a player feel the intended experience? Flag any rules that serve implementability but undermine the stated feeling.
+
+- **`systems-designer`**: For every formula in the GDD, plug in boundary values (minimum and maximum plausible inputs). Report whether any outputs go degenerate — negative values, division by zero, infinity, or nonsensical results at the extremes.
+
+- **`qa-lead`**: Review every acceptance criterion. Flag any that are not independently testable — phrases like "feels balanced", "works correctly", "performs well" are not ACs. Suggest concrete rewrites for any that fail this test.
+
+### Step 3 — Senior lead review
+
+After all specialists respond, spawn `creative-director` as the **senior reviewer**:
+- Provide: the GDD, all specialist findings, any disagreements between them
+- Ask: "Synthesise these findings. What are the most important issues? Do you agree with the specialists? What is your overall verdict on this design?"
+- The creative-director's synthesis becomes the **final verdict** in Phase 4.
+
+### Step 4 — Surface disagreements
+
+If specialists disagree with each other or with the creative-director, do NOT silently pick one view. Present the disagreement explicitly in Phase 4 so the user can adjudicate.
+
+Mark every finding with its source: `[game-designer]`, `[economy-designer]`, `[creative-director]` etc.
+
+---
+
+## Phase 4: Output Review
+
+```
+## Design Review: [Document Title]
+Specialists consulted: [list agents spawned]
+Re-review: [Yes — prior verdict was X on YYYY-MM-DD / No — first review]
+
+### Completeness: [X/8 sections present]
+[List missing sections]
+
+### Dependency Graph
+[List each declared dependency and whether its GDD file exists on disk]
+- ✓ enemy-definition-data.md — exists
+- ✗ loot-system.md — NOT FOUND (file does not exist yet)
+
+### Required Before Implementation
+[Numbered list — blocking issues only. Each item tagged with source agent.]
+
+### Recommended Revisions
+[Numbered list — important but not blocking. Source-tagged.]
+
+### Specialist Disagreements
+[Any cases where agents disagreed with each other or with the main review.
+Present both sides — do not silently resolve.]
+
+### Nice-to-Have
+[Minor improvements, low priority.]
+
+### Senior Verdict [creative-director]
+[Creative director's synthesis and overall assessment.]
+
+### Scope Signal
+Estimate implementation scope based on: dependency count, formula count,
+systems touched, and whether new ADRs are required.
+- **S** — single system, no formulas, no new ADRs, <3 dependencies
+- **M** — moderate complexity, 1-2 formulas, 3-6 dependencies
+- **L** — multi-system integration, 3+ formulas, may require new ADR
+- **XL** — cross-cutting concern, 5+ dependencies, multiple new ADRs likely
+Label clearly: "Rough scope signal: M (producer should verify before sprint planning)"
+
+### Verdict: [APPROVED / NEEDS REVISION / MAJOR REVISION NEEDED]
+```
+
+This skill is read-only — no files are written during Phase 4.
+
+---
+
+## Phase 5: Next Steps
+
+Use `AskUserQuestion` for ALL closing interactions. Never plain text.
+
+**First widget — what to do next:**
+
+If APPROVED (first-pass, no revision needed), proceed directly to the systems-index widget, review-log widget, then the final closing widget. Do not show a separate "what to do" widget — the final closing widget covers next steps.
+
+If NEEDS REVISION or MAJOR REVISION NEEDED, options:
+- `[A] Revise the GDD now — address blocking items together`
+- `[B] Stop here — revise in a separate session`
+- `[C] Accept as-is and move on (only if all items are advisory)`
+
+**If user selects [A] — Revise now:**
+
+Work through all blocking items, asking for design decisions only where you cannot resolve the issue from the GDD and existing docs alone. Group all design-decision questions into a single multi-tab `AskUserQuestion` before making any edits — do not interrupt mid-revision for each blocker individually.
+
+After all revisions are complete, show a summary table (blocker → fix applied) and use `AskUserQuestion` for a **post-revision closing widget**:
+
+- Prompt: "Revisions complete — [N] blockers resolved. What next?"
+- Note current context usage: if context is above ~50%, add: "(Recommended: /clear before re-review — this session has used X% context. A full re-review runs 5 agents and needs clean context.)"
+- Options:
+  - `[A] Re-review in a new session — run /design-review [doc-path] after /clear`
+  - `[B] Accept revisions and mark Approved — update systems index, skip re-review`
+  - `[C] Move to next system — /design-system [next-system] (#N in design order)`
+  - `[D] Stop here`
+
+Never end the revision flow with plain text. Always close with this widget.
+
+**Second widget — systems index update (always show this separately):**
+
+Use a second `AskUserQuestion`:
+- Prompt: "May I update `design/gdd/systems-index.md` to mark [system] as [In Review / Approved]?"
+- Options: `[A] Yes — update it` / `[B] No — leave it as-is`
+
+**Third widget — review log (always offer):**
+
+Use a third `AskUserQuestion`:
+- Prompt: "May I append this review summary to `design/gdd/reviews/[doc-name]-review-log.md`? This creates a revision history so future re-reviews can track what changed."
+- Options: `[A] Yes — append to review log` / `[B] No — skip`
+
+If yes, append an entry in this format:
+```
+## Review — [YYYY-MM-DD] — Verdict: [APPROVED / NEEDS REVISION / MAJOR REVISION NEEDED]
+Scope signal: [S/M/L/XL]
+Specialists: [list]
+Blocking items: [count] | Recommended: [count]
+Summary: [2-3 sentence summary of key findings from creative-director verdict]
+Prior verdict resolved: [Yes / No / First review]
+```
+
+---
+
+**Final closing widget — always show after all file writes complete:**
+
+Once the systems-index and review-log widgets are answered, check project state and show one final `AskUserQuestion`:
+
+Before building options, read:
+- `design/gdd/systems-index.md` — find any system with Status: In Review or NEEDS REVISION (other than the one just reviewed)
+- Count `.md` files in `design/gdd/` (excluding game-concept.md, systems-index.md) to determine if `/review-all-gdds` is worth offering (≥2 GDDs)
+- Find the next system with Status: Not Started in design order
+
+Build the option list dynamically — only include options that are genuinely next:
+- `[_] Run /design-review [other-gdd-path] — [system name] is still [In Review / NEEDS REVISION]` (include if another GDD needs review)
+- `[_] Run /consistency-check — verify this GDD's values don't conflict with existing GDDs` (always include if ≥1 other GDD exists)
+- `[_] Run /review-all-gdds — holistic design-theory review across all designed systems` (include if ≥2 GDDs exist)
+- `[_] Run /design-system [next-system] — next in design order` (always include, name the actual system)
+- `[_] Stop here`
+
+Assign letters A, B, C… only to included options. Mark the most pipeline-advancing option as `(recommended)`.
+
+Never end the skill with plain text after file writes. Always close with this widget.

--- a/skills/devops/finishing-a-development-branch/SKILL.md
+++ b/skills/devops/finishing-a-development-branch/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: finishing-a-development-branch
+description: Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup
+category: devops
+version: 1.0.0
+version_origin: extracted
+source_type: extracted-from-git
+source_url: https://github.com/obra/superpowers.git
+source_ref: main
+source_commit: b55764852ac78870e65c6565fb585b6cd8b3c5c9
+source_project: superpowers
+imported_at: 2026-04-18T06:36:49Z
+---
+
+# Finishing a Development Branch
+
+## Overview
+
+Guide completion of development work by presenting clear options and handling chosen workflow.
+
+**Core principle:** Verify tests → Present options → Execute choice → Clean up.
+
+**Announce at start:** "I'm using the finishing-a-development-branch skill to complete this work."
+
+## The Process
+
+### Step 1: Verify Tests
+
+**Before presenting options, verify tests pass:**
+
+```bash
+# Run project's test suite
+npm test / cargo test / pytest / go test ./...
+```
+
+**If tests fail:**
+```
+Tests failing (<N> failures). Must fix before completing:
+
+[Show failures]
+
+Cannot proceed with merge/PR until tests pass.
+```
+
+Stop. Don't proceed to Step 2.
+
+**If tests pass:** Continue to Step 2.
+
+### Step 2: Determine Base Branch
+
+```bash
+# Try common base branches
+git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null
+```
+
+Or ask: "This branch split from main - is that correct?"
+
+### Step 3: Present Options
+
+Present exactly these 4 options:
+
+```
+Implementation complete. What would you like to do?
+
+1. Merge back to <base-branch> locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?
+```
+
+**Don't add explanation** - keep options concise.
+
+### Step 4: Execute Choice
+
+#### Option 1: Merge Locally
+
+```bash
+# Switch to base branch
+git checkout <base-branch>
+
+# Pull latest
+git pull
+
+# Merge feature branch
+git merge <feature-branch>
+
+# Verify tests on merged result
+<test command>
+
+# If tests pass
+git branch -d <feature-branch>
+```
+
+Then: Cleanup worktree (Step 5)
+
+#### Option 2: Push and Create PR
+
+```bash
+# Push branch
+git push -u origin <feature-branch>
+
+# Create PR
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+<2-3 bullets of what changed>
+
+## Test Plan
+- [ ] <verification steps>
+EOF
+)"
+```
+
+Then: Cleanup worktree (Step 5)
+
+#### Option 3: Keep As-Is
+
+Report: "Keeping branch <name>. Worktree preserved at <path>."
+
+**Don't cleanup worktree.**
+
+#### Option 4: Discard
+
+**Confirm first:**
+```
+This will permanently delete:
+- Branch <name>
+- All commits: <commit-list>
+- Worktree at <path>
+
+Type 'discard' to confirm.
+```
+
+Wait for exact confirmation.
+
+If confirmed:
+```bash
+git checkout <base-branch>
+git branch -D <feature-branch>
+```
+
+Then: Cleanup worktree (Step 5)
+
+### Step 5: Cleanup Worktree
+
+**For Options 1, 2, 4:**
+
+Check if in worktree:
+```bash
+git worktree list | grep $(git branch --show-current)
+```
+
+If yes:
+```bash
+git worktree remove <worktree-path>
+```
+
+**For Option 3:** Keep worktree.
+
+## Quick Reference
+
+| Option | Merge | Push | Keep Worktree | Cleanup Branch |
+|--------|-------|------|---------------|----------------|
+| 1. Merge locally | ✓ | - | - | ✓ |
+| 2. Create PR | - | ✓ | ✓ | - |
+| 3. Keep as-is | - | - | ✓ | - |
+| 4. Discard | - | - | - | ✓ (force) |
+
+## Common Mistakes
+
+**Skipping test verification**
+- **Problem:** Merge broken code, create failing PR
+- **Fix:** Always verify tests before offering options
+
+**Open-ended questions**
+- **Problem:** "What should I do next?" → ambiguous
+- **Fix:** Present exactly 4 structured options
+
+**Automatic worktree cleanup**
+- **Problem:** Remove worktree when might need it (Option 2, 3)
+- **Fix:** Only cleanup for Options 1 and 4
+
+**No confirmation for discard**
+- **Problem:** Accidentally delete work
+- **Fix:** Require typed "discard" confirmation
+
+## Red Flags
+
+**Never:**
+- Proceed with failing tests
+- Merge without verifying tests on result
+- Delete work without confirmation
+- Force-push without explicit request
+
+**Always:**
+- Verify tests before offering options
+- Present exactly 4 options
+- Get typed confirmation for Option 4
+- Clean up worktree for Options 1 & 4 only
+
+## Integration
+
+**Called by:**
+- **subagent-driven-development** (Step 7) - After all tasks complete
+- **executing-plans** (Step 5) - After all batches complete
+
+**Pairs with:**
+- **using-git-worktrees** - Cleans up worktree created by that skill

--- a/skills/engineering/goal-driven-verifiable-success-criteria/SKILL.md
+++ b/skills/engineering/goal-driven-verifiable-success-criteria/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: goal-driven-verifiable-success-criteria
+description: Transform imperative tasks into verifiable goals. Define success criteria before implementing so the loop can self-terminate. Use for any non-trivial task, especially bug fixes and refactors.
+category: engineering
+version: 1.0.0
+version_origin: extracted
+tags: [tdd, verification, goal-setting, autonomous-loop]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/forrestchang/andrej-karpathy-skills.git
+source_ref: main
+source_commit: c9a44ae835fa2f5765a697216692705761a53f40
+source_project: andrej-karpathy-skills
+source_path: skills/karpathy-guidelines/SKILL.md
+imported_at: 2026-04-18T08:26:22Z
+---
+
+# Goal-Driven Execution — Verifiable Success Criteria
+
+**Define success criteria. Loop until verified.**
+
+Karpathy: *"LLMs are exceptionally good at looping until they meet specific goals... Don't tell it what to do, give it success criteria and watch it go."*
+
+## Transform rule
+| Imperative | Verifiable goal |
+|-----------|-----------------|
+| "Add validation" | "Write tests for invalid inputs, then make them pass" |
+| "Fix the bug" | "Write a test that reproduces it, then make it pass" |
+| "Refactor X" | "Ensure tests pass before and after" |
+| "Make it faster" | "Baseline latency = Xms; target < Yms; bench before/after" |
+
+## Multi-step plan template
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Each step must have an **independent, machine-checkable verification**.
+
+## Example — Rate limiting
+1. Add in-memory limit on one endpoint → *verify:* test 11 requests; #11 returns 429.
+2. Extract to middleware → *verify:* same test on two endpoints; existing tests green.
+3. Swap to Redis backend → *verify:* counter persists across restart; shared across two app instances.
+4. Make rates configurable → *verify:* config file parses; per-endpoint rates enforced.
+
+Each step is independently verifiable AND deployable.
+
+## Why weak criteria fail
+"Make it work" keeps requiring human clarification. "Test X passes" lets the loop self-terminate.

--- a/skills/ffi/flutter-rust-bridge-stream-sink-pattern/SKILL.md
+++ b/skills/ffi/flutter-rust-bridge-stream-sink-pattern/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: flutter-rust-bridge-stream-sink-pattern
+description: StreamSink<String> for async event channeling from Rust to Flutter.
+category: ffi
+version: 1.0.0
+version_origin: extracted
+tags: [bridge, ffi, flutter, pattern, rust, sink]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: src/flutter_ffi.rs
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Flutter Rust Bridge Stream Sink Pattern
+
+## When to use
+StreamSink<String> for async event channeling from Rust to Flutter.
+
+## Source context
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- Demonstrated in: `src/flutter_ffi.rs`
+
+## Why this generalizes
+Core pattern for push notifications over flutter_rust_bridge.
+
+## Next steps before publishing
+- Read the source files above and rewrite this as a product-agnostic `how-to` — keep the pattern, drop rustdesk-specific names.
+- Add a minimal code example in the target language (Rust + Dart / Rust only / etc.).
+- List 2-3 gotchas you hit while reproducing it.

--- a/skills/flutter/get-package-reactive-bindings/SKILL.md
+++ b/skills/flutter/get-package-reactive-bindings/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: get-package-reactive-bindings
+description: GetX library for reactive variable binding (RxList, Rx<T>, onChanged) in Flutter UI.
+category: flutter
+version: 1.0.0
+version_origin: extracted
+tags: [bindings, flutter, get, package, reactive]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: flutter/lib/desktop/pages/remote_tab_page.dart
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Get Package Reactive Bindings
+
+## When to use
+GetX library for reactive variable binding (RxList, Rx<T>, onChanged) in Flutter UI.
+
+## Source context
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- Demonstrated in: `flutter/lib/desktop/pages/remote_tab_page.dart`
+
+## Why this generalizes
+Template for GetX-based reactive UIs.
+
+## Next steps before publishing
+- Read the source files above and rewrite this as a product-agnostic `how-to` — keep the pattern, drop rustdesk-specific names.
+- Add a minimal code example in the target language (Rust + Dart / Rust only / etc.).
+- List 2-3 gotchas you hit while reproducing it.

--- a/skills/git/git-worktree-isolation-per-thread/SKILL.md
+++ b/skills/git/git-worktree-isolation-per-thread/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: git-worktree-isolation-per-thread
+description: Use git worktrees to isolate filesystem state per conversation thread, avoiding conflicts between concurrent edits
+category: git
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [git, worktree, concurrency, isolation]
+source_type: extracted-from-git
+source_url: https://github.com/pingdotgg/t3code.git
+source_ref: main
+source_commit: 9df3c640210fecccb58f7fbc735f81ca0ee011bd
+source_project: t3code
+imported_at: 2026-04-18
+evidence:
+  - apps/server/src/git/Layers/GitCore.ts
+  - .docs/encyclopedia.md
+  - .docs/workspace-layout.md
+---
+
+## When to Apply
+- You manage multiple long-running agent threads in the same repository
+- Threads may edit overlapping files concurrently without blocking each other
+- You want to capture "turn diffs" per thread without conflict resolution complexity
+- You need to snapshot state at checkpoint boundaries and restore old states
+
+## Steps
+1. On thread creation, check if thread should use a worktree (e.g., `worktreePath` in thread contracts)
+2. Create a git worktree: `git worktree add <path> <branch>`
+3. Worktree path is stored in thread state; all thread operations (git, filesystem) use that path
+4. On turn start, capture a checkpoint: save current HEAD as a git ref (hidden, prefixed)
+5. After turn completes, compute diff between checkpoint and current HEAD
+6. On thread delete or reset, clean up worktree: `git worktree remove <path> --force`
+7. Optionally, dedupe worktrees: if two threads reference same commit, share a worktree
+
+## Example
+```typescript
+// Thread creation
+const worktreePath = `${workspaceRoot}/.worktrees/${threadId}`
+yield* GitCore.createWorktree({ path: worktreePath, ref: 'main' })
+thread.worktreePath = worktreePath
+
+// Turn checkpoint
+const checkpointRef = `refs/hidden/checkpoint/${threadId}/${turnId}`
+yield* GitCore.updateRef(checkpointRef, 'HEAD')
+
+// Turn diff
+const diff = yield* GitCore.getDiff(checkpointRef, 'HEAD', { path: worktreePath })
+```
+
+## Counter / Caveats
+- Worktrees consume disk space; each is a separate `.git` directory
+- If worktree is deleted externally, git state is orphaned; add cleanup in startup readiness
+- Worktree can diverge from main tree; branch consistency is caller's responsibility
+- On Windows, worktree paths must not conflict with symlinks in main tree

--- a/skills/integration/github-trending-zero-dep-scraper/SKILL.md
+++ b/skills/integration/github-trending-zero-dep-scraper/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: github-trending-zero-dep-scraper
+description: Scrape https://github.com/trending for the daily/weekly/monthly top repos using only Node's built-in `https` module — no cheerio, no puppeteer, no fetch polyfill. Parse the `<article class="Box-row">` blocks with targeted regex and return a clean list of {owner, repo, language, starsToday}.
+category: integration
+version: 1.0.0
+version_origin: extracted
+confidence: medium
+tags: [github, trending, scraper, html, zero-dep, nodejs, https]
+source_type: extracted-from-project
+source_project: trending-hub-loop
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# GitHub Trending Zero-Dep Scraper
+
+## When to use
+
+You want a periodically-refreshed list of what's trending on GitHub for ingestion into another pipeline (issue triage, codegen corpus, research queue) and you want to keep the dependency surface at zero.
+
+## Why no HTML parser
+
+The GitHub Trending page has **stable, named class attributes** on the structural elements you care about. A few tight regexes on the raw HTML get you past 99% of the problem. Pulling in `cheerio` (250KB) or `jsdom` (10MB+) to find `.Box-row` is overkill and adds a surface for supply-chain drift.
+
+If GitHub ever moves to a fully client-rendered Trending page, this approach breaks — at which point you graduate to the authenticated REST search endpoint (`/search/repositories?q=stars:>N&sort=stars&order=desc`) rather than scraping JS-rendered HTML.
+
+## Request shape
+
+```js
+https.request({
+  host: 'github.com',
+  path: lang ? `/trending/${encodeURIComponent(lang)}?since=${since}` : `/trending?since=${since}`,
+  method: 'GET',
+  headers: {
+    'User-Agent': 'Mozilla/5.0 (your-tool-name; +https://your-url)',
+    'Accept': 'text/html,application/xhtml+xml',
+    'Accept-Language': 'en-US,en;q=0.9',
+  },
+  timeout: 30000,
+}, handler);
+```
+
+- `since` ∈ {`daily`, `weekly`, `monthly`} — the dropdown on the Trending page.
+- `language` is URL-path, not a query param.
+- The `User-Agent` must be non-empty or GitHub 403s. Identify your tool honestly; don't spoof a browser string.
+- Handle `301`/`302` as errors — GitHub redirects to login if you hit it anonymously from some IP ranges.
+
+## Parse shape
+
+```js
+// Each trending repo is wrapped in <article class="Box-row">...</article>.
+const articleRegex = /<article[^>]*class="[^"]*Box-row[^"]*"[^>]*>([\s\S]*?)<\/article>/g;
+
+for (const block of html.matchAll(articleRegex).map(m => m[1])) {
+  // owner/repo from the <h2>…<a href="/owner/repo">
+  const href = block.match(/<h2[^>]*>[\s\S]*?<a[^>]+href="\/([^"\/]+)\/([^"\/]+)"/);
+  // description
+  const desc = block.match(/<p[^>]*class="[^"]*col-9[^"]*"[^>]*>([\s\S]*?)<\/p>/);
+  // language
+  const lang = block.match(/<span itemprop="programmingLanguage">([^<]+)<\/span>/);
+  // stars today
+  const stars = block.match(/<span[^>]*class="[^"]*d-inline-block[^"]*float-sm-right[^"]*"[^>]*>([\s\S]*?)<\/span>/);
+  // ... dedupe by `owner/repo`, strip tags, collapse whitespace
+}
+```
+
+## Rules
+
+- **Always dedupe.** The trending page sometimes lists the same repo twice (featured + category). Keep a `Set` keyed on `owner/repo` and skip dupes.
+- **Strip tags + collapse whitespace on text fields.** Description and stars-today contain nested `<svg>`, `<path>`, and decorative spans. `.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim()` is sufficient.
+- **Treat language as optional.** Not every trending repo has a detectable primary language (Markdown-only repos, multi-lang tools). Default to empty string, don't drop the row.
+- **Set a request timeout.** 30s is a safe default; the page is small but rate-limited paths can hang. Destroy the socket on timeout, don't leak fds.
+- **CLI shape.** `if (require.main === module)` → run with argv so the scraper doubles as a quick smoke-test (`node trending.js python daily`). Keeps the module testable without a test harness.
+- **Export both levels.** Export `fetchTrending` (convenience), `fetchTrendingHtml` (raw HTML for tests), and `parseTrendingRepos` (pure parse for snapshot testing). This layering means you can unit-test the regex against a saved HTML fixture without network.
+
+## Counter / Caveats
+
+- **Class names are GitHub's UI, not an API.** They *have* been stable for years, but any major redesign will invalidate the regexes. Pin a saved HTML fixture to a regression test so you notice on the next run rather than silently getting 0 repos.
+- **Regex on HTML is famously brittle.** This is only OK because the Trending page has no nested `<article>` or `<h2>` inside the Box-row blocks. If you start parsing issue bodies or READMEs, stop and reach for a real parser.
+- **Anonymous scraping has rate limits.** Not rigid for the Trending HTML page, but heavy polling gets you CAPTCHA'd or redirected. Cap at 1 request every few minutes per `since` flavor.
+- **No guarantee of star counts.** The "stars today" string is formatted for humans ("1,234 stars today"). Don't try to parse it as a number unless you really need to — it's already a display string.
+
+## Related
+
+- Knowledge: none direct; this skill is self-contained.
+- Alternative: REST API `/search/repositories?sort=stars&order=desc` with a date filter — authenticated, no rate-limit surprises, but requires a token and misses the "stars today" framing.

--- a/skills/jit-compilation/first-occurrence-config-print-with-set-memo/SKILL.md
+++ b/skills/jit-compilation/first-occurrence-config-print-with-set-memo/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: first-occurrence-config-print-with-set-memo
+description: Print a JIT-selected config the first time a given shape/desc is encountered, memoizing with `std::unordered_set<std::string>` keyed on the stringified descriptor — so each unique workload prints exactly once.
+category: jit-compilation
+version: 1.0.0
+version_origin: extracted
+tags: [diagnostics, logging, jit, memoization, debug]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - csrc/jit_kernels/heuristics/common.hpp
+  - csrc/jit_kernels/heuristics/mega_moe.hpp
+imported_at: 2026-04-18T13:30:00Z
+---
+
+# First-Occurrence Config Print Memoized On Descriptor String
+
+## When to use
+Your JIT picks a config (block size, stages, cluster dims) for each unique GEMM/MoE shape. You want debug visibility — "which config got picked for M=128, N=4096, K=7168?" — without flooding the log with the same line 10,000 times per iteration.
+
+The right cadence is "log once per unique input", keyed on the *full* descriptor string (not just M/N/K — that would miss cases where dtype or layout differs).
+
+## Steps
+1. **Stringify the descriptor via `operator<<`.** Define `friend std::ostream& operator<<(std::ostream&, const Desc&)` on your `Desc` struct so every field is serialized. This makes the key unique per input combination *and* the log line human-readable.
+2. **Inside the config-picking function**, after computing the config:
+   ```cpp
+   if (get_env<int>("DG_JIT_DEBUG") or get_env<int>("DG_PRINT_CONFIGS")) {
+       std::stringstream ss;
+       ss << desc;
+       const auto key = ss.str();
+       static std::unordered_set<std::string> printed;
+       if (printed.count(key) == 0) {
+           std::cout << desc << ": " << gemm_config << ", " << layout_info << std::endl;
+           printed.insert(key);
+       }
+   }
+   ```
+3. **`static` scope** means the memo persists across calls but doesn't leak across processes. That's the right semantics for a dev-debug flag.
+4. **Gate by env var.** `DG_JIT_DEBUG` (uber) or `DG_PRINT_CONFIGS` (targeted). Zero overhead when off — the string build and set lookup are inside the guard.
+5. **Apply the same pattern wherever dispatch happens.** `mega_moe` uses a separate `printed` set with a separate key format (descriptor formatted with `fmt::format`), because the MoE descriptor isn't a struct — it's N separate ints.
+
+## Evidence (from DeepGEMM)
+- `csrc/jit_kernels/heuristics/common.hpp:40-50`: the GEMM-side implementation, using `operator<<` of `GemmDesc`.
+- `csrc/jit_kernels/heuristics/mega_moe.hpp:198-207`: the MoE-side variant, using `fmt::format` to build the key because the inputs don't form a struct.
+
+## Counter / Caveats
+- **Memo grows unbounded.** For long-running inference servers with millions of distinct shapes the set never stops growing. Mitigation: bound the set size (LRU) or gate the print behind a "recent only" policy. In practice, a training run has ~hundreds of distinct shapes, so unbounded is fine.
+- **`static unordered_set` is not thread-safe.** If multiple host threads call the dispatch concurrently, you need a mutex or accept rare duplicate prints. DeepGEMM assumes single-threaded dispatch.
+- **`stringstream ss; ss << desc` happens on *every* call when debug is enabled**, even on a memoized hit. If the `operator<<` is expensive, hash the key separately.

--- a/skills/jit-compilation/fnv1a-splitmix-hex-digest-for-cache-keys/SKILL.md
+++ b/skills/jit-compilation/fnv1a-splitmix-hex-digest-for-cache-keys/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: fnv1a-splitmix-hex-digest-for-cache-keys
+description: Build a 128-bit deterministic hex digest for JIT cache keys using two FNV-1a streams with different seeds, finalized with split-mix64 — 40 lines, header-only, no crypto dependency.
+category: jit-compilation
+version: 1.0.0
+version_origin: extracted
+tags: [hashing, cache-key, fnv1a, splitmix, deterministic, header-only]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - csrc/utils/hash.hpp
+imported_at: 2026-04-18T13:30:00Z
+---
+
+# FNV-1a + SplitMix64 Hex Digest For JIT Cache Keys
+
+## When to use
+Your JIT needs a deterministic, cross-platform, "collision rare enough for a local cache" digest over strings (kernel source, signature, flags). You don't want OpenSSL or `xxhash` as a dependency, and you don't need cryptographic strength. A 32-char hex digest (128 bits) is short enough to be a filesystem directory name and wide enough that birthday collisions on a per-user cache are astronomically small.
+
+## Steps
+1. **Implement FNV-1a in ~10 lines:** initial `h = seed`, loop `h ^= byte; h *= 0x100000001b3ull`.
+2. **Run it twice with two different seeds** — DeepGEMM uses `0xc6a4a7935bd1e995ull` (Murmur) and `0x9e3779b97f4a7c15ull` (golden ratio). Two independent FNV-1a streams act like a double-hashing scheme and cut collision probability roughly in half per bit.
+3. **Finalize each 64-bit state with SplitMix64** (the avalanche mixer from `xoshiro`):
+   ```cpp
+   z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9ull;
+   z = (z ^ (z >> 27)) * 0x94d049bb133111ebull;
+   return z ^ (z >> 31);
+   ```
+   This fixes FNV-1a's weak high-bit diffusion on short inputs.
+4. **Emit as a fixed 32-char hex string** via `std::ostringstream << std::hex << std::setw(16)`. Fixed width matters — your cache directory naming scheme depends on it.
+5. **Offer a `vector<char>` overload and a `string` overload** so callers can hash binary buffers (`.cubin`) or source strings without adaptors.
+6. **Use as the cache-dir name:** `get_hex_digest(name + "$$" + signature + "$$" + flags + "$$" + code)`.
+
+## Evidence (from DeepGEMM)
+- `csrc/utils/hash.hpp:7-15`: FNV-1a in 8 lines.
+- `csrc/utils/hash.hpp:17-33`: two passes with distinct seeds, SplitMix64 finalize, `std::setw(16)` per 64-bit half — 32 hex chars total.
+- `csrc/jit/compiler.hpp:101-102`: use site — `kernel.{name}.{hex_digest}` as the final cache directory name.
+
+## Counter / Caveats
+- **Not cryptographic.** Do not use to authenticate or protect untrusted inputs. The seeds are public; collisions can be forged.
+- **128 bits is plenty for a single-user cache** (~10^18 birthday collision floor), but a shared fleet-wide cache with 10^15 entries has real collision risk. Use BLAKE3 in that regime.
+- **Heavy templating inputs (e.g. FP4/FP8 dtype strings) differ only in short substrings** — one FNV-1a pass alone would cluster; the two-seed trick genuinely helps here.

--- a/skills/mcp/file-path-reference-for-heavy-assets/SKILL.md
+++ b/skills/mcp/file-path-reference-for-heavy-assets/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: file-path-reference-for-heavy-assets
+description: For heavy MCP tool outputs (screenshots, traces, videos, heap snapshots), write the asset to a file and return only its path in the tool response — never inline megabytes of base64 into the response stream.
+category: mcp
+version: 1.0.0
+version_origin: extracted
+tags: [mcp, file-reference, token-budget, design-principle, assets]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/ChromeDevTools/chrome-devtools-mcp.git
+source_ref: main
+source_commit: 0a6aaa52ebacb2db834ffa437863e5844aa3730b
+source_project: chrome-devtools-mcp
+source_path: docs/design-principles.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Reference-Over-Value for Heavy Tool Outputs
+
+## When to use
+
+- Your MCP tool produces artifacts bigger than a few KB: screenshots, performance traces, heap snapshots, recorded videos, generated PDFs.
+- You want every tool result to fit within a small fraction of the agent's context window.
+- Downstream tools (image viewers, trace analyzers) can consume the asset from disk.
+
+## How it works
+
+- Add an optional `filePath` parameter to every asset-producing tool's schema. If the user supplies it, save there. If omitted, save to a temp file and return that path.
+- Expose two helpers on `Context`: `saveTemporaryFile(data, filename)` (OS temp dir, auto-unique name) and `saveFile(data, clientProvidedPath, extension)` (resolves relative paths against CWD, validates the extension against a union type).
+- In the response, append a single line: `"Saved to /path/to/file.ext."`. Put the path in `structuredContent.<toolName>FilePath` too.
+- For MCP image content specifically, you may attach `{type:'image', data, mimeType}` when the client supports inline images — but treat that as an exception, not the rule.
+
+## Example
+
+```ts
+// schema fragment
+schema: {
+  filePath: zod.string().optional().describe('Absolute or CWD-relative path. If omitted, uses a temp file.'),
+}
+
+// handler
+const png = await page.screenshot({type: 'png'});
+if (request.params.filePath) {
+  const {filename} = await context.saveFile(png, request.params.filePath, '.png');
+  response.appendResponseLine(`Saved screenshot to ${filename}.`);
+} else {
+  const {filepath} = await context.saveTemporaryFile(png, 'screenshot.png');
+  response.appendResponseLine(`Saved screenshot to ${filepath}.`);
+}
+```
+
+## Gotchas
+
+- Enforce the extension via a union type (`.png | .jpeg | .webp | .json | .txt | .network-response | ...`). Don't let callers write arbitrary extensions; it's a correctness *and* a security gate.
+- Resolve user-provided paths against `process.cwd()` predictably and warn (but allow) absolute paths. Document the rule.
+- Don't silently overwrite existing files. `saveFile` should fail closed unless the caller opts into overwrite — or attach a short random suffix to avoid it.
+- For traces, support `.gz` via `zlib.gzip` when the user chose `.json.gz` as the extension — a 200MB trace compresses to ~10MB and round-trips via file references.
+- Pair this pattern with a short human-readable summary (LCP, score, request count). Agents shouldn't need to open the file to answer common questions.

--- a/skills/ml-ops/flash-attn-optional-import-fallback/SKILL.md
+++ b/skills/ml-ops/flash-attn-optional-import-fallback/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: flash-attn-optional-import-fallback
+description: Try-import flash_attn and choose HuggingFace attn_implementation accordingly, falling back to torch sdpa with a loud warning that points the user to the fix.
+category: ml-ops
+version: 1.0.0
+version_origin: extracted
+tags: [transformers, attention, flash-attention, optional-dependency, fallback]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/z-lab/dflash.git
+source_ref: main
+source_commit: 1fe684b00efba56490d920d15eeb9ba6e4471751
+source_project: dflash
+source_path: dflash/benchmark.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Flash-Attn Optional Import → attn_implementation
+
+## When to use
+- You load a HuggingFace model that benefits from `attn_implementation="flash_attention_2"` but want the script to run on machines without flash-attn installed (CPU, older GPUs, Apple Silicon, CI).
+- You want the user to know *why* their benchmark is slow, with a copy-pasteable install command.
+
+## Pattern
+
+```python
+def _get_transformers_attn_impl() -> str:
+    try:
+        import flash_attn  # noqa: F401
+        return "flash_attention_2"
+    except ImportError:
+        logger.warning(
+            "flash_attn not installed. Falling back to torch.sdpa. Speedup will be lower. "
+            "For optimal speedup in Transformers backend, please install: "
+            "pip install flash-attn --no-build-isolation"
+        )
+        return "sdpa"
+
+
+attn_impl = _get_transformers_attn_impl()
+model = AutoModelForCausalLM.from_pretrained(
+    name, attn_implementation=attn_impl, dtype=torch.bfloat16,
+).to(device).eval()
+```
+
+## Why this shape
+- A single import check at startup; the `noqa: F401` prevents lint noise for the "unused" module (the import *is* the check).
+- Warn, don't crash — benchmarking a fallback implementation is still useful for correctness, just slower.
+- The warning includes the exact install hint so the user never has to search for "how do I install flash-attn on HF transformers".
+
+## Gotchas
+- `flash_attention_2` requires Ampere or newer + `dtype=torch.bfloat16` / `torch.float16`. If you run FP32 you'll get a clearer error than a silent slowdown.
+- Some HF model classes don't accept `attn_implementation="flash_attention_2"` even when flash-attn is importable (older configs). Catch the `ValueError` at `from_pretrained` time and degrade to `sdpa` there too.
+- `--no-build-isolation` in the install hint is deliberate — flash-attn needs a compatible torch in the build env, which isolation breaks.

--- a/skills/ml-ops/force-hf-offline-when-cached/SKILL.md
+++ b/skills/ml-ops/force-hf-offline-when-cached/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: force-hf-offline-when-cached
+description: Force HF_HUB_OFFLINE=1 while loading a fully-cached model so transformers / mlx_audio don't make network calls on every startup.
+category: ml-ops
+version: 1.0.0
+version_origin: extracted
+tags: [huggingface, offline, caching, desktop-ml, startup-time]
+source_type: extracted-from-git
+source_url: https://github.com/jamiepine/voicebox.git
+source_ref: main
+source_commit: 476abe07fc2c1587f4b3e3916134018ebacd143d
+source_project: voicebox
+confidence: high
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Force HF offline when cached
+
+## When to use
+A desktop or embedded app loads models via `transformers.from_pretrained` / `mlx_audio` / `huggingface_hub.snapshot_download`. Even when the model is fully cached, these libraries make head/etag HEAD requests on every load — slow on bad networks, broken behind corporate proxies, and sometimes breaks completely offline.
+
+## Steps
+1. Before loading, check cache residency yourself: walk `HF_HUB_CACHE/models--<org>--<repo>/` and confirm the expected weight files exist. Consider the model "cached" only when the full file set is present, not just `config.json`.
+2. Wrap the load call with a context manager that sets `os.environ["HF_HUB_OFFLINE"] = "1"` on entry and restores the prior value on exit. This forces the whole HF stack into offline mode for the load.
+3. Also monkey-patch `huggingface_hub.file_download._try_to_load_from_cache` with a wrapper that logs cache hits/misses with the expected path — invaluable for diagnosing "why is it downloading again" bugs in user reports.
+4. When only a MLX/community repo is cached but the library asks for the original upstream repo, create a filesystem symlink from `models--<upstream>--<repo>` → `models--<mlx>--<repo>` so the config lookup succeeds without a network call.
+5. Catch any load exception whose message contains "offline" and retry once **with** network access (i.e. restore the original env, then call again). This handles partial-cache states where one small config file was never fetched.
+6. Gate the entire patch behind an env var (e.g. `VOICEBOX_OFFLINE_PATCH=1`) so users with unusual setups can opt out without a rebuild.
+
+## Counter / Caveats
+- Do not force offline mode globally at process start — only for the specific load call. Other parts of the app (token validation, dataset fetch) may legitimately need network.
+- Never silently swallow the offline-mode retry failure. If both offline and online loads fail, surface the original offline exception — it usually points at the missing file.
+- Symlink trick only works when the cached fork is a true drop-in (same config, same tokenizer). Verify manually before wiring it up.
+- Test the patch path by pointing `HF_HUB_CACHE` at a temp directory that you know is empty; it should cleanly fall through to online mode.
+
+Source references: `backend/utils/hf_offline_patch.py`.

--- a/skills/operations/git-rollback-mode-selector/SKILL.md
+++ b/skills/operations/git-rollback-mode-selector/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: git-rollback-mode-selector
+description: Let operators pick how failed autonomous changes unwind — hard reset, stash-and-continue, or no-op — via one env var. The three modes trade audit-trail preservation against blast-radius containment.
+category: operations
+version: 1.0.0
+version_origin: extracted
+confidence: medium
+tags: [git, rollback, autonomous-agent, recovery, operations]
+source_type: extracted-from-git
+source_url: https://github.com/EvoMap/evolver.git
+source_ref: main
+source_commit: 4c51382092f9cb125d3ec55475861ead8d1463a6
+source_project: evolver
+imported_at: 2026-04-18T02:45:00Z
+---
+
+# Git Rollback Mode Selector
+
+## Context
+
+An autonomous process (codegen agent, evolver, migration runner) writes changes into a git worktree. When its own validation fails, you need to decide what happens to those changes. One env var, three modes:
+
+| Mode | Behavior | Cost |
+|---|---|---|
+| `hard` (default) | `git reset --hard` to pre-change HEAD; discard working tree & index | Fastest clean state; zero artifact of the failed attempt |
+| `stash` | `git stash push --include-untracked` the failed attempt; HEAD returns to pre-change state | Attempt is preserved for human review; stash accumulates if failures repeat |
+| `none` | Leave the tree as-is; log and abort the loop | Lets human inspect the exact failing state in place; next iteration blocked until cleanup |
+
+Env var: `EVOLVER_ROLLBACK_MODE={hard|stash|none}`.
+
+## Rules
+
+- **Record the pre-change ref.** Capture `git rev-parse HEAD` at the start of each iteration; that's the rollback target. Never trust "the previous commit" — the previous iteration may have already moved HEAD.
+- **Include untracked.** `hard` must also `git clean -fd` (scoped to the working dir, not recursively above it) or agents leave orphaned files. `stash` must use `--include-untracked`.
+- **Fail loud on `none`.** When `none` is chosen and rollback is skipped, the loop must refuse to proceed until a human signals resume. Otherwise the next iteration runs on top of broken state.
+- **Never `--force` push automatically.** Rollback is local-only. If the failed attempt was already pushed, open an issue / alert; do not rewrite remote history from an autonomous loop.
+- **Tag the rollback in the audit log.** Emit `{iteration_id, rollback_mode, pre_ref, post_ref, reason}` to the event stream so you can reconstruct what happened even when `hard` erased the working tree.
+
+## Anti-patterns
+
+- Using `git checkout .` as the rollback — leaves untracked files and staged deletions.
+- Using `git stash` with no `--include-untracked` — same leak.
+- Rolling back across iterations (jumping past more than one pre-ref) — that's not rollback, that's revert; different operation, different semantics.

--- a/skills/production/gate-check/SKILL.md
+++ b/skills/production/gate-check/SKILL.md
@@ -1,0 +1,517 @@
+---
+name: gate-check
+description: "Validate readiness to advance between development phases. Produces a PASS/CONCERNS/FAIL verdict with specific blockers and required artifacts. Use when user says 'are we ready to move to X', 'can we advance to production', 'check if we can start the next phase', 'pass the gate'."
+argument-hint: "[target-phase: systems-design | technical-setup | pre-production | production | polish | release] [--review full|lean|solo]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Bash, Write, Task, AskUserQuestion
+model: opus
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version: 1.0.0
+version_origin: extracted
+---
+
+# Phase Gate Validation
+
+This skill validates whether the project is ready to advance to the next development
+phase. It checks for required artifacts, quality standards, and blockers.
+
+**Distinct from `/project-stage-detect`**: That skill is diagnostic ("where are we?").
+This skill is prescriptive ("are we ready to advance?" with a formal verdict).
+
+## Production Stages (7)
+
+The project progresses through these stages:
+
+1. **Concept** — Brainstorming, game concept document
+2. **Systems Design** — Mapping systems, writing GDDs
+3. **Technical Setup** — Engine config, architecture decisions
+4. **Pre-Production** — Prototyping, vertical slice validation
+5. **Production** — Feature development (Epic/Feature/Task tracking active)
+6. **Polish** — Performance, playtesting, bug fixing
+7. **Release** — Launch prep, certification
+
+**When a gate passes**, write the new stage name to `production/stage.txt`
+(single line, e.g. `Production`). This updates the status line immediately.
+
+---
+
+## 1. Parse Arguments
+
+**Target phase:** `$ARGUMENTS[0]` (blank = auto-detect current stage, then validate next transition)
+
+Also resolve the review mode (once, store for all gate spawns this run):
+1. If `--review [full|lean|solo]` was passed → use that
+2. Else read `production/review-mode.txt` → use that value
+3. Else → default to `lean`
+
+Note: in `solo` mode, director spawns (CD-PHASE-GATE, TD-PHASE-GATE, PR-PHASE-GATE, AD-PHASE-GATE) are skipped — gate-check becomes artifact-existence checks only. In `lean` mode, all four directors still run (phase gates are the purpose of lean mode).
+
+- **With argument**: `/gate-check production` — validate readiness for that specific phase
+- **No argument**: Auto-detect current stage using the same heuristics as
+  `/project-stage-detect`, then **confirm with the user before running**:
+
+  Use `AskUserQuestion`:
+  - Prompt: "Detected stage: **[current stage]**. Running gate for [Current] → [Next] transition. Is this correct?"
+  - Options:
+    - `[A] Yes — run this gate`
+    - `[B] No — pick a different gate` (if selected, show a second widget listing all gate options: Concept → Systems Design, Systems Design → Technical Setup, Technical Setup → Pre-Production, Pre-Production → Production, Production → Polish, Polish → Release)
+  
+  Do not skip this confirmation step when no argument is provided.
+
+---
+
+## 2. Phase Gate Definitions
+
+### Gate: Concept → Systems Design
+
+**Required Artifacts:**
+- [ ] `design/gdd/game-concept.md` exists and has content
+- [ ] Game pillars defined (in concept doc or `design/gdd/game-pillars.md`)
+- [ ] Visual Identity Anchor section exists in `design/gdd/game-concept.md` (from brainstorm Phase 4 art-director output)
+
+**Quality Checks:**
+- [ ] Game concept has been reviewed (`/design-review` verdict not MAJOR REVISION NEEDED)
+- [ ] Core loop is described and understood
+- [ ] Target audience is identified
+- [ ] Visual Identity Anchor contains a one-line visual rule and at least 2 supporting visual principles
+
+---
+
+### Gate: Systems Design → Technical Setup
+
+**Required Artifacts:**
+- [ ] Systems index exists at `design/gdd/systems-index.md` with at least MVP systems enumerated
+- [ ] All MVP-tier GDDs exist in `design/gdd/` and individually pass `/design-review`
+- [ ] A cross-GDD review report exists in `design/gdd/` (from `/review-all-gdds`)
+
+**Quality Checks:**
+- [ ] All MVP GDDs pass individual design review (8 required sections, no MAJOR REVISION NEEDED verdict)
+- [ ] `/review-all-gdds` verdict is not FAIL (cross-GDD consistency and design theory checks pass)
+- [ ] All cross-GDD consistency issues flagged by `/review-all-gdds` are resolved or explicitly accepted
+- [ ] System dependencies are mapped in the systems index and are bidirectionally consistent
+- [ ] MVP priority tier is defined
+- [ ] No stale GDD references flagged (older GDDs updated to reflect decisions made in later GDDs)
+
+---
+
+### Gate: Technical Setup → Pre-Production
+
+**Required Artifacts:**
+- [ ] Engine chosen (CLAUDE.md Technology Stack is not `[CHOOSE]`)
+- [ ] Technical preferences configured (`.claude/docs/technical-preferences.md` populated)
+- [ ] Art bible exists at `design/art/art-bible.md` with at least Sections 1–4 (Visual Identity Foundation)
+- [ ] At least 3 Architecture Decision Records in `docs/architecture/` covering
+      Foundation-layer systems (scene management, event architecture, save/load)
+- [ ] Engine reference docs exist in `docs/engine-reference/[engine]/`
+- [ ] Test framework initialized: `tests/unit/` and `tests/integration/` directories exist
+- [ ] CI/CD test workflow exists at `.github/workflows/tests.yml` (or equivalent)
+- [ ] At least one example test file exists to confirm the framework is functional
+- [ ] Master architecture document exists at `docs/architecture/architecture.md`
+- [ ] Architecture traceability index exists at `docs/architecture/architecture-traceability.md`
+- [ ] `/architecture-review` has been run (a review report file exists in `docs/architecture/`)
+- [ ] `design/accessibility-requirements.md` exists with accessibility tier committed
+- [ ] `design/ux/interaction-patterns.md` exists (pattern library initialized, even if minimal)
+
+**Quality Checks:**
+- [ ] Architecture decisions cover core systems (rendering, input, state management)
+- [ ] Technical preferences have naming conventions and performance budgets set
+- [ ] Accessibility tier is defined and documented (even "Basic" is acceptable — undefined is not)
+- [ ] At least one screen's UX spec started (often the main menu or core HUD is designed during Technical Setup)
+- [ ] All ADRs have an **Engine Compatibility section** with engine version stamped
+- [ ] All ADRs have a **GDD Requirements Addressed section** with explicit GDD linkage
+- [ ] No ADR references APIs listed in `docs/engine-reference/[engine]/deprecated-apis.md`
+- [ ] All HIGH RISK engine domains (per VERSION.md) have been explicitly addressed
+      in the architecture document or flagged as open questions
+- [ ] Architecture traceability matrix has **zero Foundation layer gaps**
+      (all Foundation requirements must have ADR coverage before Pre-Production)
+
+**ADR Circular Dependency Check**: For all ADRs in `docs/architecture/`, read each ADR's
+"ADR Dependencies" / "Depends On" section. Build a dependency graph (ADR-A → ADR-B means
+A depends on B). If any cycle is detected (e.g. A→B→A, or A→B→C→A):
+- Flag as **FAIL**: "Circular ADR dependency: [ADR-X] → [ADR-Y] → [ADR-X].
+  Neither can reach Accepted while the cycle exists. Remove one 'Depends On' edge to
+  break the cycle."
+
+**Engine Validation** (read `docs/engine-reference/[engine]/VERSION.md` first):
+- [ ] ADRs that touch post-cutoff engine APIs are flagged with Knowledge Risk: HIGH/MEDIUM
+- [ ] `/architecture-review` engine audit shows no deprecated API usage
+- [ ] All ADRs agree on the same engine version (no stale version references)
+
+---
+
+### Gate: Pre-Production → Production
+
+**Required Artifacts:**
+- [ ] At least 1 prototype in `prototypes/` with a README
+- [ ] First sprint plan exists in `production/sprints/`
+- [ ] Art bible is complete (all 9 sections) and AD-ART-BIBLE sign-off verdict is recorded in `design/art/art-bible.md`
+- [ ] Character visual profiles exist for key characters referenced in narrative docs
+- [ ] All MVP-tier GDDs from systems index are complete
+- [ ] Master architecture document exists at `docs/architecture/architecture.md`
+- [ ] At least 3 ADRs covering Foundation-layer decisions exist in `docs/architecture/`
+- [ ] Control manifest exists at `docs/architecture/control-manifest.md`
+      (generated by `/create-control-manifest` from Accepted ADRs)
+- [ ] Epics defined in `production/epics/` with at least Foundation and Core
+      layer epics present (use `/create-epics layer: foundation` and
+      `/create-epics layer: core` to create them, then `/create-stories [epic-slug]`
+      for each epic)
+- [ ] Vertical Slice build exists and is playable (not just scope-defined)
+- [ ] Vertical Slice has been playtested with at least 3 sessions (internal OK)
+- [ ] Vertical Slice playtest report exists at `production/playtests/` or equivalent
+- [ ] UX specs exist for key screens: main menu, core gameplay HUD (at `design/ux/`), pause menu
+- [ ] HUD design document exists at `design/ux/hud.md` (if game has in-game HUD)
+- [ ] All key screen UX specs have passed `/ux-review` (verdict APPROVED or NEEDS REVISION accepted)
+
+**Quality Checks:**
+- [ ] **Core loop fun is validated** — playtest data confirms the central mechanic is enjoyable, not just functional. Explicitly check the Vertical Slice playtest report.
+- [ ] UX specs cover all UI Requirements sections from MVP-tier GDDs
+- [ ] Interaction pattern library documents patterns used in key screens
+- [ ] Accessibility tier from `design/accessibility-requirements.md` is addressed in all key screen UX specs
+- [ ] Sprint plan references real story file paths from `production/epics/`
+      (not just GDDs — stories must embed GDD req ID + ADR reference)
+- [ ] **Vertical Slice is COMPLETE**, not just scoped — the build demonstrates the full core loop end-to-end. At least one complete [start → challenge → resolution] cycle works.
+- [ ] Architecture document has no unresolved open questions in Foundation or Core layers
+- [ ] All ADRs have Engine Compatibility sections stamped with the engine version
+- [ ] All ADRs have ADR Dependencies sections (even if all fields are "None")
+- [ ] Manual validation confirms GDDs + architecture + epics are coherent
+      (run `/review-all-gdds` and `/architecture-review` if not done recently)
+- [ ] **Core fantasy is delivered** — at least one playtester independently described an experience that matches the Player Fantasy section of the core system GDDs (without being prompted).
+
+**Vertical Slice Validation** (FAIL if any item is NO):
+- [ ] A human has played through the core loop without developer guidance
+- [ ] The game communicates what to do within the first 2 minutes of play
+- [ ] No critical "fun blocker" bugs exist in the Vertical Slice build
+- [ ] The core mechanic feels good to interact with (this is a subjective check — ask the user)
+
+> **Note**: If any Vertical Slice Validation item is FAIL, the verdict is automatically FAIL
+> regardless of other checks. Advancing without a validated Vertical Slice is the #1 cause of
+> production failure in game development (per GDC postmortem data from 155 projects).
+
+---
+
+### Gate: Production → Polish
+
+**Required Artifacts:**
+- [ ] `src/` has active code organized into subsystems
+- [ ] All core mechanics from GDD are implemented (cross-reference `design/gdd/` with `src/`)
+- [ ] Main gameplay path is playable end-to-end
+- [ ] Test files exist in `tests/unit/` and `tests/integration/` covering Logic and Integration stories
+- [ ] All Logic stories from this sprint have corresponding unit test files in `tests/unit/`
+- [ ] Smoke check has been run with a PASS or PASS WITH WARNINGS verdict — report exists in `production/qa/`
+- [ ] QA plan exists in `production/qa/` (generated by `/qa-plan`) covering this sprint or final production sprint
+- [ ] QA sign-off report exists in `production/qa/` (generated by `/team-qa`) with verdict APPROVED or APPROVED WITH CONDITIONS
+- [ ] At least 3 distinct playtest sessions documented in `production/playtests/`
+- [ ] Playtest reports cover: new player experience, mid-game systems, and difficulty curve
+- [ ] Fun hypothesis from Game Concept has been explicitly validated or revised
+
+**Quality Checks:**
+- [ ] Tests are passing (run test suite via Bash)
+- [ ] No critical/blocker bugs in any bug tracker or known issues
+- [ ] Core loop plays as designed (compare to GDD acceptance criteria)
+- [ ] Performance is within budget (check technical-preferences.md targets)
+- [ ] Playtest findings have been reviewed and critical fun issues addressed (not just documented)
+- [ ] No "confusion loops" identified — no point in the game where >50% of playtesters got stuck without knowing why
+- [ ] Difficulty curve matches the Difficulty Curve design doc (if one exists at `design/difficulty-curve.md`)
+- [ ] All implemented screens have corresponding UX specs (no "designed in-code" screens)
+- [ ] Interaction pattern library is up-to-date with all patterns used in implementation
+- [ ] Accessibility compliance verified against committed tier in `design/accessibility-requirements.md`
+
+---
+
+### Gate: Polish → Release
+
+**Required Artifacts:**
+- [ ] All features from milestone plan are implemented
+- [ ] Content is complete (all levels, assets, dialogue referenced in design docs exist)
+- [ ] Localization strings are externalized (no hardcoded player-facing text in `src/`)
+- [ ] QA test plan exists (`/qa-plan` output in `production/qa/`)
+- [ ] QA sign-off report exists (`/team-qa` output — APPROVED or APPROVED WITH CONDITIONS)
+- [ ] All Must Have story test evidence is present (Logic/Integration: test files pass; Visual/Feel/UI: sign-off docs in `production/qa/evidence/`)
+- [ ] Smoke check passes cleanly (PASS verdict) on the release candidate build
+- [ ] No test regressions from previous sprint (test suite passes fully)
+- [ ] Balance data has been reviewed (`/balance-check` run)
+- [ ] Release checklist completed (`/release-checklist` or `/launch-checklist` run)
+- [ ] Store metadata prepared (if applicable)
+- [ ] Changelog / patch notes drafted
+
+**Quality Checks:**
+- [ ] Full QA pass signed off by `qa-lead`
+- [ ] All tests passing
+- [ ] Performance targets met across all target platforms
+- [ ] No known critical, high, or medium-severity bugs
+- [ ] Accessibility basics covered (remapping, text scaling if applicable)
+- [ ] Localization verified for all target languages
+- [ ] Legal requirements met (EULA, privacy policy, age ratings if applicable)
+- [ ] Build compiles and packages cleanly
+
+---
+
+## 3. Run the Gate Check
+
+**Before running artifact checks**, read `docs/consistency-failures.md` if it exists.
+Extract entries whose Domain matches the target phase (e.g., if checking
+Systems Design → Technical Setup, pull entries in Economy, Combat, or any GDD domain;
+if checking Technical Setup → Pre-Production, pull entries in Architecture, Engine).
+Carry these as context — recurring conflict patterns in the target domain warrant
+increased scrutiny on those specific checks.
+
+For each item in the target gate:
+
+### Artifact Checks
+- Use `Glob` and `Read` to verify files exist and have meaningful content
+- Don't just check existence — verify the file has real content (not just a template header)
+- For code checks, verify directory structure and file counts
+
+**Systems Design → Technical Setup gate — cross-GDD review check**:
+Use `Glob('design/gdd/gdd-cross-review-*.md')` to find the `/review-all-gdds` report.
+If no file matches, mark the "cross-GDD review report exists" artifact as **FAIL** and
+surface it prominently: "No `/review-all-gdds` report found in `design/gdd/`. Run
+`/review-all-gdds` before advancing to Technical Setup."
+If a file is found, read it and check the verdict line: a FAIL verdict means the
+cross-GDD consistency check failed and must be resolved before advancing.
+
+### Quality Checks
+- For test checks: Run the test suite via `Bash` if a test runner is configured
+- For design review checks: `Read` the GDD and check for the 8 required sections
+- For performance checks: `Read` technical-preferences.md and compare against any
+  profiling data in `tests/performance/` or recent `/perf-profile` output
+- For localization checks: `Grep` for hardcoded strings in `src/`
+
+### Cross-Reference Checks
+- Compare `design/gdd/` documents against `src/` implementations
+- Check that every system referenced in architecture docs has corresponding code
+- Verify sprint plans reference real work items
+
+---
+
+## 4. Collaborative Assessment
+
+For items that can't be automatically verified, **ask the user**:
+
+- "I can't automatically verify that the core loop plays well. Has it been playtested?"
+- "No playtest report found. Has informal testing been done?"
+- "Performance profiling data isn't available. Would you like to run `/perf-profile`?"
+
+**Never assume PASS for unverifiable items.** Mark them as MANUAL CHECK NEEDED.
+
+---
+
+## 4b. Director Panel Assessment
+
+Before generating the final verdict, spawn all four directors as **parallel subagents** via Task using the parallel gate protocol from `.claude/docs/director-gates.md`. Issue all four Task calls simultaneously — do not wait for one before starting the next.
+
+**Spawn in parallel:**
+
+1. **`creative-director`** — gate **CD-PHASE-GATE** (`.claude/docs/director-gates.md`)
+2. **`technical-director`** — gate **TD-PHASE-GATE** (`.claude/docs/director-gates.md`)
+3. **`producer`** — gate **PR-PHASE-GATE** (`.claude/docs/director-gates.md`)
+4. **`art-director`** — gate **AD-PHASE-GATE** (`.claude/docs/director-gates.md`)
+
+Pass to each: target phase name, list of artifacts present, and the context fields listed in that gate's definition.
+
+**Collect all four responses, then present the Director Panel summary:**
+
+```
+## Director Panel Assessment
+
+Creative Director:  [READY / CONCERNS / NOT READY]
+  [feedback]
+
+Technical Director: [READY / CONCERNS / NOT READY]
+  [feedback]
+
+Producer:           [READY / CONCERNS / NOT READY]
+  [feedback]
+
+Art Director:       [READY / CONCERNS / NOT READY]
+  [feedback]
+```
+
+**Apply to the verdict:**
+- Any director returns NOT READY → verdict is minimum FAIL (user may override with explicit acknowledgement)
+- Any director returns CONCERNS → verdict is minimum CONCERNS
+- All four READY → eligible for PASS (still subject to artifact and quality checks from Section 3)
+
+---
+
+## 5. Output the Verdict
+
+```
+## Gate Check: [Current Phase] → [Target Phase]
+
+**Date**: [date]
+**Checked by**: gate-check skill
+
+### Required Artifacts: [X/Y present]
+- [x] design/gdd/game-concept.md — exists, 2.4KB
+- [ ] docs/architecture/ — MISSING (no ADRs found)
+- [x] production/sprints/ — exists, 1 sprint plan
+
+### Quality Checks: [X/Y passing]
+- [x] GDD has 8/8 required sections
+- [ ] Tests — FAILED (3 failures in tests/unit/)
+- [?] Core loop playtested — MANUAL CHECK NEEDED
+
+### Blockers
+1. **No Architecture Decision Records** — Run `/architecture-decision` to create one
+   covering core system architecture before entering production.
+2. **3 test failures** — Fix failing tests in tests/unit/ before advancing.
+
+### Recommendations
+- [Priority actions to resolve blockers]
+- [Optional improvements that aren't blocking]
+
+### Verdict: [PASS / CONCERNS / FAIL]
+- **PASS**: All required artifacts present, all quality checks passing
+- **CONCERNS**: Minor gaps exist but can be addressed during the next phase
+- **FAIL**: Critical blockers must be resolved before advancing
+```
+
+---
+
+## 5a. Chain-of-Verification
+
+After drafting the verdict in Phase 5, challenge it before finalising.
+
+**Step 1 — Generate 5 challenge questions** designed to disprove the verdict:
+
+For a **PASS** draft:
+- "Which quality checks did I verify by actually reading a file, vs. inferring they passed?"
+- "Are there MANUAL CHECK NEEDED items I marked PASS without user confirmation?"
+- "Did I confirm all listed artifacts have real content, not just empty headers?"
+- "Could any blocker I dismissed as minor actually prevent the phase from succeeding?"
+- "Which single check am I least confident in, and why?"
+
+For a **CONCERNS** draft:
+- "Could any listed CONCERN be elevated to a blocker given the project's current state?"
+- "Is the concern resolvable within the next phase, or does it compound over time?"
+- "Did I soften any FAIL condition into a CONCERN to avoid a harder verdict?"
+- "Are there artifacts I didn't check that could reveal additional blockers?"
+- "Do all the CONCERNS together create a blocking problem even if each is minor alone?"
+
+For a **FAIL** draft:
+- "Have I accurately separated hard blockers from strong recommendations?"
+- "Are there any PASS items I was too lenient about?"
+- "Am I missing any additional blockers the user should know about?"
+- "Can I provide a minimal path to PASS — the specific 3 things that must change?"
+- "Is the fail condition resolvable, or does it indicate a deeper design problem?"
+
+**Step 2 — Answer each question** independently.
+Do NOT reference the draft verdict text — re-check specific files or ask the user.
+
+**Step 3 — Revise if needed:**
+- If any answer reveals a missed blocker → upgrade verdict (PASS→CONCERNS or CONCERNS→FAIL)
+- If any answer reveals an over-stated blocker → downgrade only if citing specific evidence
+- If answers are consistent → confirm verdict unchanged
+
+**Step 4 — Note the verification** in the final report output:
+`Chain-of-Verification: [N] questions checked — verdict [unchanged | revised from X to Y]`
+
+---
+
+## 6. Update Stage on PASS
+
+When the verdict is **PASS** and the user confirms they want to advance:
+
+1. Write the new stage name to `production/stage.txt` (single line, no trailing newline)
+2. This immediately updates the status line for all future sessions
+
+Example: if passing the "Pre-Production → Production" gate:
+```bash
+echo -n "Production" > production/stage.txt
+```
+
+**Always ask before writing**: "Gate passed. May I update `production/stage.txt` to 'Production'?"
+
+---
+
+## 7. Closing Next-Step Widget
+
+After the verdict is presented and any stage.txt update is complete, close with a structured next-step prompt using `AskUserQuestion`.
+
+**Tailor the options to the gate that just ran:**
+
+For **systems-design PASS**:
+```
+Gate passed. What would you like to do next?
+[A] Run /create-architecture — produce your master architecture blueprint and ADR work plan (recommended next step)
+[B] Design more GDDs first — return here when all MVP systems are complete
+[C] Stop here for this session
+```
+
+> **Note for systems-design PASS**: `/create-architecture` is the required next step before writing any ADRs. It produces the master architecture document and a prioritized list of ADRs to write. Running `/architecture-decision` without this step means writing ADRs without a blueprint — skip it at your own risk.
+
+For **technical-setup PASS**:
+```
+Gate passed. What would you like to do next?
+[A] Start Pre-Production — begin prototyping the Vertical Slice
+[B] Write more ADRs first — run /architecture-decision [next-system]
+[C] Stop here for this session
+```
+
+For all other gates, offer the two most logical next steps for that phase plus "Stop here".
+
+---
+
+## 8. Follow-Up Actions
+
+Based on the verdict, suggest specific next steps:
+
+- **No art bible?** → `/art-bible` to create the visual identity specification
+- **Art bible exists but no asset specs?** → `/asset-spec system:[name]` to generate per-asset visual specs and generation prompts from approved GDDs
+- **No game concept?** → `/brainstorm` to create one
+- **No systems index?** → `/map-systems` to decompose the concept into systems
+- **Missing design docs?** → `/reverse-document` or delegate to `game-designer`
+- **Small design change needed?** → `/quick-design` for changes under ~4 hours (bypasses full GDD pipeline)
+- **No UX specs?** → `/ux-design [screen name]` to author specs, or `/team-ui [feature]` for full pipeline
+- **UX specs not reviewed?** → `/ux-review [file]` or `/ux-review all` to validate
+- **No accessibility requirements doc?** → Use `AskUserQuestion` to offer to create it now:
+  - Prompt: "The gate requires `design/accessibility-requirements.md`. Shall I create it from the template?"
+  - Options: `Create it now — I'll choose an accessibility tier`, `I'll create it myself`, `Skip for now`
+  - If "Create it now": use a second `AskUserQuestion` to ask for the tier:
+    - Prompt: "Which accessibility tier fits this project?"
+    - Options: `Basic — remapping + subtitles only (lowest effort)`, `Standard — Basic + colorblind modes + scalable UI`, `Comprehensive — Standard + motor accessibility + full settings menu`, `Exemplary — Comprehensive + external audit + full customization`
+  - Then write `design/accessibility-requirements.md` using the template at `.claude/docs/templates/accessibility-requirements.md`, filling in the chosen tier. Confirm: "May I write `design/accessibility-requirements.md`?"
+- **No interaction pattern library?** → `/ux-design patterns` to initialize it
+- **GDDs not cross-reviewed?** → `/review-all-gdds` (run after all MVP GDDs are individually approved)
+- **Cross-GDD consistency issues?** → fix flagged GDDs, then re-run `/review-all-gdds`
+- **No test framework?** → `/test-setup` to scaffold the framework for your engine
+- **No QA plan for current sprint?** → `/qa-plan sprint` to generate one before implementation begins
+- **Missing ADRs?** → `/architecture-decision` for individual decisions
+- **No master architecture doc?** → `/create-architecture` for the full blueprint
+- **ADRs missing engine compatibility sections?** → Re-run `/architecture-decision`
+  or manually add Engine Compatibility sections to existing ADRs
+- **Missing control manifest?** → `/create-control-manifest` (requires Accepted ADRs)
+- **Missing epics?** → `/create-epics layer: foundation` then `/create-epics layer: core` (requires control manifest)
+- **Missing stories for an epic?** → `/create-stories [epic-slug]` (run after each epic is created)
+- **Stories not implementation-ready?** → `/story-readiness` to validate stories before developers pick them up
+- **Tests failing?** → delegate to `lead-programmer` or `qa-tester`
+- **No playtest data?** → `/playtest-report`
+- **Less than 3 playtest sessions?** → Run more playtests before advancing. Use `/playtest-report` to structure findings.
+- **No Difficulty Curve doc?** → Consider creating one at `design/difficulty-curve.md` before polish
+- **No player journey document?** → create `design/player-journey.md` using the player journey template
+- **Need a quick sprint check?** → `/sprint-status` for current sprint progress snapshot
+- **Performance unknown?** → `/perf-profile`
+- **Not localized?** → `/localize`
+- **Ready for release?** → `/launch-checklist`
+
+---
+
+## Collaborative Protocol
+
+This skill follows the collaborative design principle:
+
+1. **Scan first**: Check all artifacts and quality gates
+2. **Ask about unknowns**: Don't assume PASS for things you can't verify
+3. **Present findings**: Show the full checklist with status
+4. **User decides**: The verdict is a recommendation — the user makes the final call
+5. **Get approval**: "May I write this gate check report to production/gate-checks/?"
+
+**Never** block a user from advancing — the verdict is advisory. Document the risks
+and let the user decide whether to proceed despite concerns.

--- a/skills/python/filestream-seekable-buffer-fallback/SKILL.md
+++ b/skills/python/filestream-seekable-buffer-fallback/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: filestream-seekable-buffer-fallback
+description: If an input stream isn't seekable, slurp it into BytesIO before entering any multi-pass pipeline — lets every downstream consumer use tell()/seek() without worrying whether the source was a pipe, socket, or chunked HTTP body.
+category: python
+version: 1.0.0
+tags: [python, streams, bytesio, seekable, binaryio, ingestion]
+source_type: extracted-from-git
+source_url: https://github.com/microsoft/markitdown.git
+source_ref: main
+source_commit: 604bba13da2f43b756b49122cb65bdedb85b1dff
+source_project: markitdown
+source_path: packages/markitdown/src/markitdown/_markitdown.py
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version_origin: extracted
+---
+
+# Seekable-buffer fallback for unseekable streams
+
+In a pipeline that dispatches to multiple handlers — each of which needs to peek at the stream, then rewind — you need `tell()`/`seek()`. Files are seekable; pipes, sockets, chunked HTTP bodies, and most generators aren't. The idiom: at the very top of the pipeline, check `stream.seekable()` and if not, buffer the whole thing into `BytesIO` once. Every handler downstream now gets a uniform, seekable stream.
+
+## The one-liner
+
+```python
+import io
+
+def _ensure_seekable(stream):
+    if stream.seekable():
+        return stream
+    buf = io.BytesIO()
+    while True:
+        chunk = stream.read(4096)
+        if not chunk:
+            break
+        buf.write(chunk)
+    buf.seek(0)
+    return buf
+```
+
+Call it once at the pipeline entry:
+
+```python
+def convert_stream(self, stream, **kwargs):
+    stream = _ensure_seekable(stream)      # buffer if necessary, no-op if already seekable
+    # ... proceed; every converter's accepts()/convert() can peek freely
+```
+
+## Why you need it
+
+Many format-detection pipelines call `accepts(file_stream, ...)` on many candidate handlers. Each `accepts()` may `read(N)` to peek, then `seek(cur_pos)` to restore. If the stream doesn't support `seek`, the second `accepts()` call gets garbage. The buffer materializes a seekable interface in the one place that needs it.
+
+## Common callers of unseekable streams
+
+| Source | Seekable? | Common fix |
+|---|---|---|
+| `open(path, "rb")` | Yes | — |
+| `subprocess.Popen(stdout=PIPE).stdout` | No | Buffer. |
+| `requests.Response.raw` | No | Use `response.iter_content()` → BytesIO, or pass `stream=True` + buffer. |
+| `urllib.request.urlopen(url)` | No | Buffer. |
+| `socket.makefile("rb")` | No | Buffer. |
+| `io.BytesIO(b)` | Yes | — |
+
+## HTTP-specific variant (requests)
+
+```python
+def response_to_seekable(resp):
+    buf = io.BytesIO()
+    for chunk in resp.iter_content(chunk_size=512):
+        buf.write(chunk)
+    buf.seek(0)
+    return buf
+```
+
+Skip `response.raw`; it's not seekable and has cross-version quirks around decompression. Always buffer from `iter_content`.
+
+## Memory-bounded variant
+
+The blunt version loads the whole stream into memory. For inputs larger than RAM, swap in a spillable temp file:
+
+```python
+import tempfile
+
+def _ensure_seekable_bounded(stream, *, memlimit=100 * 1024 * 1024):
+    if stream.seekable():
+        return stream
+    buf = tempfile.SpooledTemporaryFile(max_size=memlimit)    # spills to disk past memlimit
+    while True:
+        chunk = stream.read(1024 * 1024)
+        if not chunk:
+            break
+        buf.write(chunk)
+    buf.seek(0)
+    return buf
+```
+
+`SpooledTemporaryFile` is `BinaryIO`-compatible and seekable throughout, so handlers don't see a difference.
+
+## When you don't need the buffer
+
+- **Single-pass, no peek.** If every handler reads forward-only to EOF, don't bother — you save the memory.
+- **Very large inputs that would spill to disk.** Prefer to decide the handler from metadata (path, URL, Content-Type) without peeking; keep the stream streaming.
+- **Pipes whose source emits slowly.** Buffering blocks until EOF; breaks interactive streaming.
+
+## Anti-patterns
+
+- **Calling `.seek(0)` without checking `.seekable()`.** Raises on pipes.
+- **`stream.read()` to slurp once, then passing bytes everywhere.** Type mismatch — handlers now have to special-case `BinaryIO` vs `bytes`. The `BytesIO` wrapper avoids that.
+- **Buffering inside each handler.** Every handler pays the I/O cost and the memory. Buffer once at the top.
+- **Not resetting position after buffering.** `BytesIO` starts at `tell() == end-of-buffer` after the fill loop. Always `buf.seek(0)`.
+
+## Variations
+
+- **Async streams.** Use `anyio.BufferedByteReceiveStream` or buffer into `BytesIO` before handing off to sync handlers.
+- **Known-size upper bound.** If your protocol advertises a size (Content-Length), preallocate `BytesIO(b"\0" * size)` and `writeinto`.
+- **Very-large chunked reads.** Tune the chunk size to your I/O pattern; 4KB is fine for typical cases, 1MB is better for large binary uploads.

--- a/skills/workflow/full-stack-isolated-dev-env/SKILL.md
+++ b/skills/workflow/full-stack-isolated-dev-env/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: full-stack-isolated-dev-env
+description: Stand up a fully isolated backend + frontend + daemon dev environment per worktree with scripted auth bootstrap (login + PAT + workspace) for AI/CI workflows.
+category: workflow
+version: 1.0.0
+tags: [dev-env, worktree, isolation, automation, ci]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: medium
+---
+
+## When to use
+
+- AI coding agent or CI workflow that needs a fresh, isolated stack with automated auth (no browser login).
+- Multiple feature branches in parallel, each in its own worktree, each fully isolated from production CLI config.
+
+## Steps
+
+1. Compute deterministic profile name from the worktree path:
+   ```bash
+   WORKTREE_DIR="$(basename "$PWD")"
+   SLUG="$(printf '%s' "$WORKTREE_DIR" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g; s/__*/_/g; s/^_//; s/_$//')"
+   HASH="$(printf '%s' "$PWD" | cksum | awk '{print $1}')"
+   OFFSET=$((HASH % 1000))
+   PROFILE="dev-${SLUG}-${OFFSET}"
+   ```
+   Matches the worktree's port and DB allocation for easy identification.
+2. Start the stack:
+   ```bash
+   make dev
+   PORT=$(grep '^PORT=' .env.worktree 2>/dev/null | cut -d= -f2)
+   PORT=${PORT:-8080}
+   SERVER="http://localhost:${PORT}"
+   # wait for /health
+   for i in $(seq 1 30); do curl -sf "$SERVER/health" >/dev/null && break; sleep 2; done
+   ```
+3. Automated auth — dev master code `888888` in non-production:
+   ```bash
+   curl -s -X POST "$SERVER/auth/send-code" -H "Content-Type: application/json" -d '{"email": "dev@localhost"}'
+   JWT=$(curl -s -X POST "$SERVER/auth/verify-code" -H "Content-Type: application/json" -d '{"email": "dev@localhost", "code": "888888"}' | jq -r .token)
+   PAT=$(curl -s -X POST "$SERVER/api/tokens" -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" -d '{"name": "auto-dev", "expires_in_days": 365}' | jq -r .token)
+   ```
+4. Create a workspace:
+   ```bash
+   WS=$(curl -s -X POST "$SERVER/api/workspaces" -H "Authorization: Bearer $PAT" -H "Content-Type: application/json" -d '{"name": "Dev", "slug": "dev"}' | jq -r .id)
+   ```
+5. Write per-profile config:
+   ```bash
+   CONFIG_DIR="$HOME/.myapp/profiles/$PROFILE"
+   mkdir -p "$CONFIG_DIR"
+   cat > "$CONFIG_DIR/config.json" <<EOF
+   {
+     "server_url": "$SERVER",
+     "app_url": "http://localhost:$FRONTEND_PORT",
+     "token": "$PAT",
+     "workspace_id": "$WS",
+     "watched_workspaces": [{"id": "$WS", "name": "Dev"}]
+   }
+   EOF
+   ```
+6. Start the daemon from source with this profile:
+   ```bash
+   make cli ARGS="daemon start --profile $PROFILE"
+   ```
+7. Teardown script reverses every step (stop daemon → stop services → optionally stop DB → optionally clean workdirs and profile config).
+
+## Example
+
+Use case: an AI agent needs a working stack to test a code change against. Without scripted auth the agent can't get past the login screen. This recipe lets it come up in ~30s, run a test, and tear down without touching the user's production CLI config or daemon.
+
+## Caveats
+
+- `888888` as master code only works when `APP_ENV != "production"`. Self-host defaults to production; set `APP_ENV=development` in the worktree env for this flow.
+- Don't run this recipe against a real server — it creates real users and tokens. Scoped to localhost only.
+- Reuse worktree port allocation rather than random ports so the same worktree always comes up on the same URLs (bookmarks, WebSocket reconnect, etc. all survive across days).


### PR DESCRIPTION
## Batch
- batch 8/24

## Knowledge (23)
- `reference/file-layout-apps-vs-packages`
- `linux/flatpak-portals-sandbox-workaround`
- `ffi/flutter-rust-bridge-compatibility-matrix`
- `fp8-quantization/fp8-e4m3-vs-ue8m0-format-differences`
- `jit-compilation/fsync-directory-is-mandatory-before-rename`
- `llm-agents/function-schema-generation`
- `pitfall/gated-huggingface-hardcoded-config`
- `codecs/gdi-fallback-screen-capture`
- `architecture/gep-asset-model`
- `architecture/gep-genome-evolution-protocol`
- `reference/gep-protocol-auditable-assets`
- `pitfall/git-stale-branch-main-dot-dot-head`
- `git-workflow/git-workflow-issue-version-forensics`
- `reference/github-token-env-fallback-chain`
- `ci-cd/github-variables-version-management`
- `pitfall/go-requires-cgo-onnxruntime`
- `engine/godot-animation`
- `engine/godot-audio`
- `engine/godot-best-practices`
- `engine/godot-breaking-changes`
- _... and 3 more_

## Skills (27)
- `mcp/file-path-reference-for-heavy-assets`
- `build/file-stability-polling-for-fs-flush`
- `python/filestream-seekable-buffer-fallback`
- `devops/finishing-a-development-branch`
- `jit-compilation/first-occurrence-config-print-with-set-memo`
- `ml-ops/flash-attn-optional-import-fallback`
- `ffi/flutter-rust-bridge-stream-sink-pattern`
- `jit-compilation/fnv1a-splitmix-hex-digest-for-cache-keys`
- `ml-ops/force-hf-offline-when-cached`
- `agents/forcing-tool-use`
- `cli/foreground-background-daemon-mode`
- `workflow/full-stack-isolated-dev-env`
- `agents/function-tool-registration`
- `design/game-design-doc-review`
- `production/gate-check`
- `cli/generate-cli-from-mcp-tool-list`
- `build-tooling/generate-tool-reference-with-token-counts`
- `codegen/generated-enum-and-config-code-from-json-schema`
- `architecture/gep-environment-fingerprint`
- `flutter/get-package-reactive-bindings`
- _... and 7 more_

## Source
- project: F:/workspace/tool (bulk extract)
- batch plan: .omc/batch-plan.json

## Post-merge
After squash-merge, run step 7 to re-anchor skill tags at the merge commit.