### PR TITLE
Publish batch 13/24: 22 knowledge + 28 skills

### DIFF
--- a/index.json
+++ b/index.json
@@ -929,6 +929,24 @@
   },
   {
     "kind": "knowledge",
+    "name": "mcp-stdio-child-of-daemon-topology",
+    "slug": "mcp-stdio-child-of-daemon-topology",
+    "category": "arch",
+    "description": "The chrome-devtools-mcp daemon architecture is a 3-process chain — CLI client talks to a daemon over a socket, and the daemon spawns the real MCP stdio server as a child and connects to it with an MCP Client. This keeps \"MCP stdio transport\" as the only server protocol while adding CLI-level persistence.",
+    "tags": [
+      "daemon",
+      "mcp",
+      "stdio",
+      "architecture",
+      "ipc"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/mcp-stdio-child-of-daemon-topology.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "mf-cross-remote-import-forbidden",
     "slug": "mf-cross-remote-import-forbidden",
     "category": "arch",
@@ -978,6 +996,66 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/arch/mf-shared-singleton-config.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "model-api-contract-sync-and-async",
+    "slug": "model-api-contract-sync-and-async",
+    "category": "arch",
+    "description": "Rust API exposes both SyncInput and AsyncInput traits so callers can pick blocking or async without two libraries.",
+    "tags": [
+      "magika",
+      "arch"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/model-api-contract-sync-and-async.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "model-generation-tooling-in-rust-gen",
+    "slug": "model-generation-tooling-in-rust-gen",
+    "category": "arch",
+    "description": "rust/gen/ contains code generators for new model versions — sync.sh and publish.sh automate the propagation.",
+    "tags": [
+      "magika",
+      "arch"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/model-generation-tooling-in-rust-gen.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "model-not-used-for-edge-cases",
+    "slug": "model-not-used-for-edge-cases",
+    "category": "arch",
+    "description": "The deep learning model is intentionally bypassed for empty files, directories, symlinks, and very small files (<8 bytes).",
+    "tags": [
+      "magika",
+      "arch"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/model-not-used-for-edge-cases.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "model-variants-standard-fast-begonly",
+    "slug": "model-variants-standard-fast-begonly",
+    "category": "arch",
+    "description": "Magika ships standard / fast / begonly model variants with different speed-vs-accuracy tradeoffs.",
+    "tags": [
+      "magika",
+      "arch"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/model-variants-standard-fast-begonly.md",
     "has_content": true
   },
   {
@@ -2044,6 +2122,23 @@
   },
   {
     "kind": "knowledge",
+    "name": "mcp-pool-vs-direct-connections",
+    "slug": "mcp-pool-vs-direct-connections",
+    "category": "architecture",
+    "description": "Why Craft Agents centralizes MCP source connections in a McpClientPool exposed as a single Streamable-HTTP endpoint to SDK subprocesses, instead of letting each subprocess connect independently.",
+    "tags": [
+      "mcp",
+      "pool",
+      "subprocess",
+      "streamable-http"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/architecture/mcp-pool-vs-direct-connections.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "ci-gpg-signing-batch-mode-non-interactive",
     "slug": "ci-gpg-signing-batch-mode-non-interactive",
     "category": "ci-cd",
@@ -2114,6 +2209,24 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/clipboard/clipboard-ownership-protocol.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "multi-audio-resampling-backends",
+    "slug": "multi-audio-resampling-backends",
+    "category": "codecs",
+    "description": "Resampling backends: Dasp (pure Rust, slow), Rubato (FFT, faster), SampleRate (libsamplerate, fastest).",
+    "tags": [
+      "audio",
+      "backends",
+      "codecs",
+      "multi",
+      "resampling"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/codecs/multi-audio-resampling-backends.md",
     "has_content": true
   },
   {
@@ -2438,6 +2551,24 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/configuration/config-system-four-tiers.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "memory-graph-adaptive-query-with-recency",
+    "slug": "memory-graph-adaptive-query-with-recency",
+    "category": "data-pipeline",
+    "description": "Query agent memory as a DAG, prioritize recency, cap nodes, merge related events",
+    "tags": [
+      "evolver",
+      "data-pipeline",
+      "memory-graph",
+      "llm-context",
+      "reference"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/data-pipeline/memory-graph-adaptive-query-with-recency.md",
     "has_content": true
   },
   {
@@ -3157,6 +3288,22 @@
   },
   {
     "kind": "knowledge",
+    "name": "monorepo-subpath-exports-over-barrel-index",
+    "slug": "monorepo-subpath-exports-over-barrel-index",
+    "category": "decision",
+    "description": "T3Code uses explicit subpath exports (e.g., `@t3tools/shared/git`) instead of a single `index.ts` to reduce bundle size and improve tree-shaking",
+    "tags": [
+      "monorepo",
+      "design",
+      "exports"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/monorepo-subpath-exports-over-barrel-index.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "node-npm-pin-matches-jenkins",
     "slug": "node-npm-pin-matches-jenkins",
     "category": "decision",
@@ -3771,6 +3918,36 @@
   },
   {
     "kind": "knowledge",
+    "name": "model-output-space-vs-tool-output-space",
+    "slug": "model-output-space-vs-tool-output-space",
+    "category": "domain",
+    "description": "The 'model output space' (216 NN labels in standard_v3_3) is a strict subset of the 'tool output space' (model outputs + 5 generic labels).",
+    "tags": [
+      "magika",
+      "domain"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/domain/model-output-space-vs-tool-output-space.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "model-trained-on-100m-samples",
+    "slug": "model-trained-on-100m-samples",
+    "category": "domain",
+    "description": "Magika's standard models are trained on ~100M files spanning 200+ content types.",
+    "tags": [
+      "magika",
+      "domain"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/domain/model-trained-on-100m-samples.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "mongodb-exclude-system-databases",
     "slug": "mongodb-exclude-system-databases",
     "category": "domain",
@@ -3900,6 +4077,66 @@
   },
   {
     "kind": "knowledge",
+    "name": "menu-bar-visibility-modes-linux-workaround",
+    "slug": "menu-bar-visibility-modes-linux-workaround",
+    "category": "electron-packaging",
+    "description": "Electron's `autoHideMenuBar` on Linux causes layout shifts on Alt keypress in DEs like KDE Plasma; a three-mode env var (`auto`/`visible`/`hidden`) with boolean aliases gives users control, and `hidden` mode suppresses the Alt toggle by re-hiding on every `show` event.",
+    "tags": [
+      "electron",
+      "menu-bar",
+      "linux",
+      "kde",
+      "wayland",
+      "autoHideMenuBar",
+      "ux",
+      "env-var"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/electron-packaging/menu-bar-visibility-modes-linux-workaround.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "minified-electron-regex-patching-gotchas",
+    "slug": "minified-electron-regex-patching-gotchas",
+    "category": "electron-packaging",
+    "description": "Minified variable names in Electron bundles change with every release; patches must use optional-whitespace regexes with the `-E` flag and test against both minified and beautified spacing to remain stable across updates.",
+    "tags": [
+      "electron",
+      "minification",
+      "regex",
+      "sed",
+      "patching",
+      "build"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/electron-packaging/minified-electron-regex-patching-gotchas.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "minified-js-ast-anchor-extraction",
+    "slug": "minified-js-ast-anchor-extraction",
+    "category": "electron-packaging",
+    "description": "When patching minified JavaScript you cannot rely on line numbers or variable names; instead anchor on stable string literals (error messages, log strings, property names) and extract surrounding minified variable names via regex capture groups.",
+    "tags": [
+      "minification",
+      "javascript",
+      "regex",
+      "patching",
+      "anchors",
+      "variable-extraction",
+      "build"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/electron-packaging/minified-js-ast-anchor-extraction.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "condition-based-waiting",
     "slug": "condition-based-waiting",
     "category": "engineering",
@@ -3911,6 +4148,25 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/engineering/condition-based-waiting.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "multi-language-i18n-compile-time-generation",
+    "slug": "multi-language-i18n-compile-time-generation",
+    "category": "i18n",
+    "description": "i18n via compile-time code generation for 47 languages under src/lang/{ar,be,bg,...}.rs.",
+    "tags": [
+      "compile",
+      "generation",
+      "i18n",
+      "language",
+      "multi",
+      "time"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/i18n/multi-language-i18n-compile-time-generation.md",
     "has_content": true
   },
   {
@@ -3988,6 +4244,99 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/llm-agents/agent-runner-loop-semantics.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mcp-integration-guide",
+    "slug": "mcp-integration-guide",
+    "category": "llm-agents",
+    "description": "How to integrate MCP servers with OpenAI Agents SDK — transport options, tool filtering, caching, and hosted vs. local execution.",
+    "tags": [
+      "openai-agents",
+      "mcp",
+      "model-context-protocol",
+      "transport",
+      "hosted",
+      "stdio",
+      "sse"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/llm-agents/mcp-integration-guide.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mlx-kv-cache-trimmability",
+    "slug": "mlx-kv-cache-trimmability",
+    "category": "llm-agents",
+    "description": "Which MLX KV caches support trim() and which don't — attention-based caches are trimmable by slicing; GatedDeltaNet state is not, and speculative decoding on Qwen3.5 MoE has to replay accepted inputs to roll back.",
+    "tags": [
+      "mlx",
+      "kv-cache",
+      "gated-delta",
+      "speculative-decoding",
+      "qwen3"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/llm-agents/mlx-kv-cache-trimmability.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "multi-agent-orchestration-patterns",
+    "slug": "multi-agent-orchestration-patterns",
+    "category": "llm-agents",
+    "description": "Taxonomy of orchestration patterns in the OpenAI Agents SDK — LLM-driven vs. code-driven, with tradeoffs.",
+    "tags": [
+      "openai-agents",
+      "orchestration",
+      "patterns",
+      "multi-agent",
+      "design"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/llm-agents/multi-agent-orchestration-patterns.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "multi-llm-provider-trade-offs",
+    "slug": "multi-llm-provider-trade-offs",
+    "category": "llm-model-routing",
+    "description": "OpenSRE supports 8 LLM providers (Anthropic native, OpenAI, OpenRouter, Gemini, NVIDIA NIM, Minimax, Ollama, Bedrock) by routing through one of three client classes (Anthropic, OpenAI-compatible, Bedrock-via-Anthropic-SDK) — a useful pattern for cross-provider portability with provider-specific quirks contained.",
+    "tags": [
+      "llm",
+      "providers",
+      "anthropic",
+      "openai",
+      "ollama",
+      "bedrock"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/llm-agents/multi-llm-provider-trade-offs.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "mega-moe-imbalance-factor-for-uneven-routing",
+    "slug": "mega-moe-imbalance-factor-for-uneven-routing",
+    "category": "moe-optimization",
+    "description": "Mega MoE sizes per-expert work assuming a 2x token-imbalance factor. If actual routing skew exceeds that, users must override mk_alignment_for_contiguous_layout.",
+    "tags": [
+      "moe",
+      "load-balancing",
+      "kernel-tuning",
+      "top-k",
+      "distributed-systems"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/moe-optimization/mega-moe-imbalance-factor-for-uneven-routing.md",
     "has_content": true
   },
   {
@@ -6824,6 +7173,24 @@
   },
   {
     "kind": "knowledge",
+    "name": "mcp-localhost-bind-default-warn-on-expose",
+    "slug": "mcp-localhost-bind-default-warn-on-expose",
+    "category": "security",
+    "description": "MCP HTTP servers should default to 127.0.0.1, fail fast if --host/--port are used without --http, and emit a loud stderr warning when the operator explicitly binds to a non-localhost interface.",
+    "tags": [
+      "mcp",
+      "security",
+      "network-binding",
+      "unauthenticated",
+      "defaults"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/security/mcp-localhost-bind-default-warn-on-expose.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "agent-qa-tester",
     "slug": "agent-qa-tester",
     "category": "testing",
@@ -6857,6 +7224,21 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/testing/agent-test-spec-template.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "model-version-compatibility-major-version",
+    "slug": "model-version-compatibility-major-version",
+    "category": "version-quirk",
+    "description": "Major model version bumps (v1 → v2 → v3) change the output space and are not transparently backwards-compatible.",
+    "tags": [
+      "magika",
+      "version-quirk"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/version-quirk/model-version-compatibility-major-version.md",
     "has_content": true
   },
   {
@@ -6960,6 +7342,18 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/qa/content-audit",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "milestone-review",
+    "slug": "milestone-review",
+    "category": "",
+    "description": "\"Generates a comprehensive milestone progress review including feature completeness, quality metrics, risk assessment, and go/no-go recommendation. Use at milestone checkpoints or when evaluating readiness for a milestone deadline.\"",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/production/milestone-review",
     "has_content": false
   },
   {
@@ -7082,6 +7476,24 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/agents/coding-agent-cli-backend-interface",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "model-retry-settings",
+    "slug": "model-retry-settings",
+    "category": "agents",
+    "description": "Configure exponential backoff and retry policy for transient model API errors.",
+    "tags": [
+      "openai-agents",
+      "retry",
+      "backoff",
+      "resilience",
+      "model-settings"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/agents/model-retry-settings",
     "has_content": false
   },
   {
@@ -8111,6 +8523,24 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/architecture/accepts-then-convert-two-phase-dispatch",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "ml-model-config-registry-dispatch",
+    "slug": "ml-model-config-registry-dispatch",
+    "category": "architecture",
+    "description": "Centralize per-engine ML model configuration in a declarative registry so route, service, and backend layers stay free of if/elif chains.",
+    "tags": [
+      "architecture",
+      "registry",
+      "ml-models",
+      "dispatch",
+      "configuration"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/architecture/ml-model-config-registry-dispatch",
     "has_content": false
   },
   {
@@ -10256,6 +10686,21 @@
   },
   {
     "kind": "skill",
+    "name": "multi-language-onnx-model-binding",
+    "slug": "multi-language-onnx-model-binding",
+    "category": "bindings",
+    "description": "Expose one ONNX model across Rust (ort), Python (onnxruntime+maturin), JS (TensorFlow.js), and Go (CGO) bindings.",
+    "tags": [
+      "magika",
+      "bindings"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/bindings/multi-language-onnx-model-binding",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
     "name": "coverage-data-file-under-pytest-cache",
     "slug": "coverage-data-file-under-pytest-cache",
     "category": "build",
@@ -10288,6 +10733,23 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/build-system/cmake-cuda-extension-with-git-submodule-vendoring",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "multi-platform-desktop-release-workflow-github-actions",
+    "slug": "multi-platform-desktop-release-workflow-github-actions",
+    "category": "ci",
+    "description": "Build and sign desktop apps (macOS, Windows, Linux) from a single CI workflow with conditional code-signing",
+    "tags": [
+      "ci",
+      "release",
+      "desktop",
+      "github-actions"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/ci/multi-platform-desktop-release-workflow-github-actions",
     "has_content": false
   },
   {
@@ -10851,6 +11313,24 @@
   },
   {
     "kind": "skill",
+    "name": "multi-backend-argparse-dispatcher",
+    "slug": "multi-backend-argparse-dispatcher",
+    "category": "cli",
+    "description": "Single argparse CLI that dispatches to per-backend implementations (transformers / sglang / vllm / mlx) by required --backend choice, with post-parse cross-flag validation.",
+    "tags": [
+      "argparse",
+      "cli",
+      "dispatch",
+      "multi-backend",
+      "validation"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/multi-backend-argparse-dispatcher",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "office-hours",
     "slug": "office-hours",
     "category": "cli",
@@ -11191,6 +11671,25 @@
   },
   {
     "kind": "skill",
+    "name": "multi-llm-provider-router-by-env",
+    "slug": "multi-llm-provider-router-by-env",
+    "category": "configuration",
+    "description": "One factory function dispatches to the right LLM client based on a single LLM_PROVIDER env var, picking provider-specific base URL, env-var name for the API key, model id, and parameter quirks (e.g. max_completion_tokens for o1/gpt-5).",
+    "tags": [
+      "llm",
+      "provider-routing",
+      "anthropic",
+      "openai",
+      "ollama",
+      "bedrock"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/configuration/multi-llm-provider-router-by-env",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "content-type-info-metadata-embedding",
     "slug": "content-type-info-metadata-embedding",
     "category": "data",
@@ -11203,6 +11702,38 @@
     "version": "1.0.0",
     "path": "skills/data/content-type-info-metadata-embedding",
     "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "model-config-min-json-compact-format",
+    "slug": "model-config-min-json-compact-format",
+    "category": "data",
+    "description": "Distribute model config as compact JSON (config.min.json) alongside the .onnx file so package size stays small and parsing is universal.",
+    "tags": [
+      "magika",
+      "data"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/data/model-config-min-json-compact-format",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "memory-fragment-sizing-for-llm-input",
+    "slug": "memory-fragment-sizing-for-llm-input",
+    "category": "data-pipeline",
+    "description": "Chunk memory into fragments respecting LLM token budget, per-file and per-session limits",
+    "tags": [
+      "evolver",
+      "data-pipeline",
+      "llm",
+      "context-budget"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/data-pipeline/memory-fragment-sizing-for-llm-input",
+    "has_content": false
   },
   {
     "kind": "skill",
@@ -12972,6 +13503,43 @@
   },
   {
     "kind": "skill",
+    "name": "multi-instance-electron-dev",
+    "slug": "multi-instance-electron-dev",
+    "category": "electron",
+    "description": "Run multiple independent dev instances of the same Electron app on one machine by deriving port, config dir, app name, and deep-link scheme from a numeric suffix on the project folder name.",
+    "tags": [
+      "electron",
+      "dev",
+      "multi-instance",
+      "deep-links"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/electron/multi-instance-electron-dev",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "minified-js-variable-extraction-dynamic",
+    "slug": "minified-js-variable-extraction-dynamic",
+    "category": "electron-packaging",
+    "description": "Extract minified variable or function names from bundled JavaScript via regex capture groups anchored on stable string literals. Compose per-release sed patches using the extracted names. Handles $ prefixes from minifiers and optional whitespace in both minified and beautified forms.",
+    "tags": [
+      "minified-js",
+      "variable-extraction",
+      "regex",
+      "sed",
+      "electron",
+      "patching",
+      "build"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/electron-packaging/minified-js-variable-extraction-dynamic",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "ag-grid-cell-renderer-pattern",
     "slug": "ag-grid-cell-renderer-pattern",
     "category": "frontend",
@@ -13280,6 +13848,18 @@
   },
   {
     "kind": "skill",
+    "name": "modal-navigation-stack-with-back",
+    "slug": "modal-navigation-stack-with-back",
+    "category": "frontend",
+    "description": "For drill-down UIs reusing a single modal surface, snapshot head/path/body before each open and push to a stack; a Back button / Backspace pops the stack, Esc clears it.",
+    "tags": "",
+    "triggers": "",
+    "version": "1.0.0",
+    "path": "skills/frontend/modal-navigation-stack-with-back",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "module-federation-expose-react-component",
     "slug": "module-federation-expose-react-component",
     "category": "frontend",
@@ -13577,6 +14157,41 @@
   },
   {
     "kind": "skill",
+    "name": "multi-kernel-dispatch-with-shape-driven-selection",
+    "slug": "multi-kernel-dispatch-with-shape-driven-selection",
+    "category": "gpu-kernels",
+    "description": "Hide multiple kernel variants (1D1D vs 1D2D, SM90 vs SM100, packed-vs-unpacked SF) behind a single public API by inspecting tensor metadata to pick the right dispatcher.",
+    "tags": [
+      "kernel-dispatch",
+      "shape-analysis",
+      "polymorphism",
+      "api-design"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/gpu-kernels/multi-kernel-dispatch-with-shape-driven-selection",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "mouse-button-enum-dispatch",
+    "slug": "mouse-button-enum-dispatch",
+    "category": "input",
+    "description": "Enum-based mouse event handling (left, right, wheel, back) with callback routing.",
+    "tags": [
+      "button",
+      "dispatch",
+      "enum",
+      "input",
+      "mouse"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/input/mouse-button-enum-dispatch",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "a2a-protocol-with-hello-publish-decision",
     "slug": "a2a-protocol-with-hello-publish-decision",
     "category": "integration",
@@ -13641,6 +14256,40 @@
   },
   {
     "kind": "skill",
+    "name": "mcp-multi-transport-config-pydantic",
+    "slug": "mcp-multi-transport-config-pydantic",
+    "category": "integration",
+    "description": "Single Pydantic config that supports three MCP transports (stdio, sse, streamable-http) with per-transport required-field validation in a model_validator(after) so users get a clear error when the wrong combination is set.",
+    "tags": [
+      "mcp",
+      "pydantic",
+      "multi-transport",
+      "validation"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/integration/mcp-multi-transport-config-pydantic",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "mcp-streamable-http-detached-httpx-client",
+    "slug": "mcp-streamable-http-detached-httpx-client",
+    "category": "integration",
+    "description": "Inject a caller-owned httpx.AsyncClient into the official MCP streamable_http transport via httpx_client_factory, using a no-op async-context-manager so the transport never closes the underlying client on exit.",
+    "tags": [
+      "mcp",
+      "streamable-http",
+      "httpx",
+      "sdk-shim"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/integration/mcp-streamable-http-detached-httpx-client",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "agent-handoff-routing",
     "slug": "agent-handoff-routing",
     "category": "llm-agents",
@@ -13672,6 +14321,94 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/llm-agents/agents-as-tools",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "mlx-kv-cache-rollback-on-reject",
+    "slug": "mlx-kv-cache-rollback-on-reject",
+    "category": "llm-agents",
+    "description": "Roll back target-model KV cache after rejected speculative tokens, including GatedDeltaNet (non-trimmable) layers, by capturing per-layer inputs and replaying only the accepted prefix.",
+    "tags": [
+      "speculative-decoding",
+      "kv-cache",
+      "mlx",
+      "gated-delta",
+      "state-rollback"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/llm-agents/mlx-kv-cache-rollback-on-reject",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "mcp-pool-http-proxy-for-subprocess-sdks",
+    "slug": "mcp-pool-http-proxy-for-subprocess-sdks",
+    "category": "mcp-integration",
+    "description": "Expose a pool of MCP sources (Linear, GitHub, Notion, ...) to Codex/Copilot SDK subprocesses through a single Streamable-HTTP MCP endpoint, instead of having each subprocess open independent connections.",
+    "tags": [
+      "mcp",
+      "streamable-http",
+      "subprocess",
+      "connection-pool"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/mcp-integration/mcp-pool-http-proxy-for-subprocess-sdks",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "mcp-sse-streamable-http",
+    "slug": "mcp-sse-streamable-http",
+    "category": "mcp-integration",
+    "description": "Connect an agent to a remote MCP server via HTTP+SSE or Streamable HTTP transport.",
+    "tags": [
+      "openai-agents",
+      "mcp",
+      "sse",
+      "streamable-http",
+      "remote-server"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/mcp-integration/mcp-sse-streamable-http",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "mcp-stdio-server",
+    "slug": "mcp-stdio-server",
+    "category": "mcp-integration",
+    "description": "Connect an agent to a local MCP server running as a subprocess over stdio.",
+    "tags": [
+      "openai-agents",
+      "mcp",
+      "stdio",
+      "subprocess",
+      "local-tools"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/mcp-integration/mcp-stdio-server",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "mcp-tool-intent-metadata-injection",
+    "slug": "mcp-tool-intent-metadata-injection",
+    "category": "mcp-integration",
+    "description": "Inject a hidden _intent / _displayName field into every MCP tool schema via a fetch interceptor so large-response summarization and UI rendering have context that the LLM never sees.",
+    "tags": [
+      "mcp",
+      "interceptor",
+      "metadata",
+      "summarization"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/mcp-integration/mcp-tool-intent-metadata-injection",
     "has_content": false
   },
   {
@@ -13790,6 +14527,24 @@
   },
   {
     "kind": "skill",
+    "name": "mega-moe-fusion-with-symmetric-memory",
+    "slug": "mega-moe-fusion-with-symmetric-memory",
+    "category": "moe-optimization",
+    "description": "Fuse EP dispatch, FP8×FP4 GEMM×2, SwiGLU, and EP combine into a single kernel that reads across ranks via symmetric-memory (same VA on every rank) to overlap NVLink collectives with compute.",
+    "tags": [
+      "moe",
+      "kernel-fusion",
+      "symmetric-memory",
+      "nvlink",
+      "communication-compute-overlap"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/moe-optimization/mega-moe-fusion-with-symmetric-memory",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "agent-tracing-spans",
     "slug": "agent-tracing-spans",
     "category": "observability",
@@ -13843,6 +14598,27 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/operations/claude-cli-unattended-wrapper",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "multi-format-native-package-orchestrator",
+    "slug": "multi-format-native-package-orchestrator",
+    "category": "packaging",
+    "description": "Orchestrate building a single Electron app source into .deb, .rpm, AppImage, and Nix outputs from one script. Handles architecture detection, distro-family detection, format-specific build dispatch, and shared staging.",
+    "tags": [
+      "electron",
+      "packaging",
+      "deb",
+      "rpm",
+      "appimage",
+      "nix",
+      "build-orchestration",
+      "linux"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/packaging/multi-format-native-package-orchestrator",
     "has_content": false
   },
   {
@@ -14083,6 +14859,23 @@
   },
   {
     "kind": "skill",
+    "name": "mcp-subprocess-env-filtering",
+    "slug": "mcp-subprocess-env-filtering",
+    "category": "security",
+    "description": "When spawning a stdio MCP server (or any untrusted subprocess), allowlist/denylist environment variables so app-level auth tokens and third-party API keys don't leak into the child process.",
+    "tags": [
+      "mcp",
+      "subprocess",
+      "env-vars",
+      "credential-leakage"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/security/mcp-subprocess-env-filtering",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "oauth-token-env-persistence",
     "slug": "oauth-token-env-persistence",
     "category": "security",
@@ -14320,6 +15113,25 @@
   },
   {
     "kind": "skill",
+    "name": "model-regression-test-with-csv-fixture",
+    "slug": "model-regression-test-with-csv-fixture",
+    "category": "testing",
+    "description": "Lock down a model's deterministic output by committing input+expected-output CSVs and re-running with a generator script when intentionally changing behavior.",
+    "tags": [
+      "regression-test",
+      "pytest",
+      "ml-model-testing",
+      "determinism",
+      "fixtures",
+      "golden-file"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/testing/model-regression-test-with-csv-fixture",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "qa",
     "slug": "qa",
     "category": "testing",
@@ -14403,6 +15215,54 @@
     "version": "1.0.0",
     "path": "skills/testing-gpu/cosine-similarity-diff-for-fp8-numerics",
     "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "minimal-ddp-amp-accelerator-wrapper",
+    "slug": "minimal-ddp-amp-accelerator-wrapper",
+    "category": "training",
+    "description": "Minimal DDP + AMP training wrapper without HuggingFace Accelerate dependency",
+    "tags": [
+      "ddp",
+      "amp",
+      "training",
+      "pytorch",
+      "distributed"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/training/minimal-ddp-amp-accelerator-wrapper",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "model-config-versioning-and-backwards-compat",
+    "slug": "model-config-versioning-and-backwards-compat",
+    "category": "versioning",
+    "description": "Embed major/minor version in model config.min.json; validate at load time; ship multiple model versions side-by-side under assets/models/<version>/ with a CHANGELOG.",
+    "tags": [
+      "magika",
+      "versioning"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/versioning/model-config-versioning-and-backwards-compat",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "model-onnx-file-versioning-and-staging",
+    "slug": "model-onnx-file-versioning-and-staging",
+    "category": "versioning",
+    "description": "Version model assets under assets/models/<name>_v<major>_<minor>/ with per-version README and a top-level CHANGELOG.md, and a 'default' pointer (file or symlink).",
+    "tags": [
+      "magika",
+      "versioning"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/versioning/model-onnx-file-versioning-and-staging",
+    "has_content": true
   },
   {
     "kind": "skill",

--- a/knowledge/arch/mcp-stdio-child-of-daemon-topology.md
+++ b/knowledge/arch/mcp-stdio-child-of-daemon-topology.md
@@ -1,0 +1,44 @@
+---
+name: mcp-stdio-child-of-daemon-topology
+summary: The chrome-devtools-mcp daemon architecture is a 3-process chain — CLI client talks to a daemon over a socket, and the daemon spawns the real MCP stdio server as a child and connects to it with an MCP Client. This keeps "MCP stdio transport" as the only server protocol while adding CLI-level persistence.
+category: arch
+confidence: high
+tags: [daemon, mcp, stdio, architecture, ipc]
+source_type: extracted-from-git
+source_url: https://github.com/ChromeDevTools/chrome-devtools-mcp.git
+source_ref: main
+source_commit: 0a6aaa52ebacb2db834ffa437863e5844aa3730b
+source_project: chrome-devtools-mcp
+source_path: src/daemon/daemon.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# CLI → Daemon → MCP Stdio Server Topology
+
+## Context
+
+MCP servers normally speak stdio to exactly one client. To build a persistent CLI where `mycli foo; mycli bar` reuses state, naïve approaches are tempting: make the CLI re-exec the stdio server every call (slow), or teach the server a second transport (maintenance burden forever). Chrome DevTools MCP picked a third route.
+
+## The fact / decision / pitfall
+
+Three processes:
+
+1. **CLI client** (`chrome-devtools <subcommand>`): opens a local Unix socket / Windows named pipe, sends one JSON request `{method, tool, args}`, reads one response, exits.
+2. **Daemon** (`chrome-devtools-daemon`): long-lived. Listens on the socket. Internally instantiates an MCP `Client` with `StdioClientTransport`, which spawns…
+3. **MCP stdio server** (`chrome-devtools-mcp`): the actual server, completely unaware of the daemon. Speaks stdio MCP as usual.
+
+The daemon forwards `invoke_tool` requests to the MCP client, serializes the response back over the socket, replies to the CLI, closes the socket. Browser/session state lives in the MCP stdio server process — the daemon is a thin forwarder.
+
+## Evidence
+
+- `src/daemon/daemon.ts` creates `StdioClientTransport({command: process.execPath, args: [INDEX_SCRIPT_PATH, ...mcpServerArgs]})` and connects an MCP `Client` to it.
+- `src/daemon/client.ts::sendCommand` opens `net.createConnection({path: socketPath})` with `PipeTransport` and sends `{method:'invoke_tool', tool, args}`.
+- `src/bin/chrome-devtools.ts` is the yargs entry — for every auto-generated command, it ensures the daemon is running then calls `sendCommand`.
+
+## Implications
+
+- The MCP stdio server is zero-change; it doesn't learn about daemons. You could drop in a different MCP server and the daemon still works.
+- Telemetry/opt-out/version-check logic lives in the MCP server, not the daemon. The daemon only sees opaque tool calls.
+- Debugging: `DEBUG=* chrome-devtools foo` turns on logging in the CLI, but the MCP server's own logs only flow if you pass `--log-file` at daemon start.
+- The daemon's startup args are captured at `start` time and sent to every subsequent MCP server spawn — so `chrome-devtools start --headless` changes the daemon's config and a `stop` + `start` is required to change it.
+- If the MCP server crashes, the daemon's `Client` breaks. The daemon should detect and either auto-restart the child or surface the error to the CLI. chrome-devtools-mcp currently surfaces; a resilient daemon could do more.

--- a/knowledge/arch/model-api-contract-sync-and-async.md
+++ b/knowledge/arch/model-api-contract-sync-and-async.md
@@ -1,0 +1,25 @@
+---
+name: model-api-contract-sync-and-async
+type: knowledge
+category: arch
+summary: Rust API exposes both SyncInput and AsyncInput traits so callers can pick blocking or async without two libraries.
+confidence: medium
+tags: [magika, arch]
+linked_skills: [platform-agnostic-file-input-abstraction]
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Model Api Contract Sync And Async
+
+## Fact
+
+SyncInputApi and AsyncInputApi traits cover the two world-views; core inference logic is shared via generics. Lets the same crate serve a sync CLI and an async HTTP server.
+
+## Evidence
+
+- `rust/lib/src/input.rs:31-46`

--- a/knowledge/arch/model-generation-tooling-in-rust-gen.md
+++ b/knowledge/arch/model-generation-tooling-in-rust-gen.md
@@ -1,0 +1,25 @@
+---
+name: model-generation-tooling-in-rust-gen
+type: knowledge
+category: arch
+summary: rust/gen/ contains code generators for new model versions — sync.sh and publish.sh automate the propagation.
+confidence: medium
+tags: [magika, arch]
+linked_skills: [generated-enum-and-config-code-from-json-schema]
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Model Generation Tooling In Rust Gen
+
+## Fact
+
+When a new model lands, rust/gen regenerates Rust bindings (content.rs with thresholds and metadata, model.rs). This guarantees model updates propagate consistently to all language bindings — no hand-editing per binding.
+
+## Evidence
+
+- `rust/README.md:6-11`

--- a/knowledge/arch/model-not-used-for-edge-cases.md
+++ b/knowledge/arch/model-not-used-for-edge-cases.md
@@ -1,0 +1,25 @@
+---
+name: model-not-used-for-edge-cases
+type: knowledge
+category: arch
+summary: The deep learning model is intentionally bypassed for empty files, directories, symlinks, and very small files (<8 bytes).
+confidence: high
+tags: [magika, arch]
+linked_skills: [predict-mode-dispatch-with-fallback-heuristics]
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Model Not Used For Edge Cases
+
+## Fact
+
+These cases use hardcoded labels (empty / directory / symlink / txt / unknown) rather than the model — the model would have no meaningful input. dl.label is set to 'undefined' for these so callers can see the model wasn't consulted.
+
+## Evidence
+
+- `website-ng/src/content/docs/core-concepts/how-magika-works.md:17-21`

--- a/knowledge/arch/model-variants-standard-fast-begonly.md
+++ b/knowledge/arch/model-variants-standard-fast-begonly.md
@@ -1,0 +1,26 @@
+---
+name: model-variants-standard-fast-begonly
+type: knowledge
+category: arch
+summary: Magika ships standard / fast / begonly model variants with different speed-vs-accuracy tradeoffs.
+confidence: high
+tags: [magika, arch]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Model Variants Standard Fast Begonly
+
+## Fact
+
+standard_v3_3 is the full model (~99% accuracy, ~2ms). fast_v2_1 is ~98.5% accuracy and ~4× faster. begonly_v2_1 only reads the file's beginning (cheaper IO). Current bindings ship standard_v3_3 as default, but the variant is a deployment choice that affects both accuracy and latency.
+
+## Evidence
+
+- `assets/models/CHANGELOG.md:39-42`
+- `website-ng/src/content/docs/core-concepts/models-and-content-types.md`

--- a/knowledge/architecture/mcp-pool-vs-direct-connections.md
+++ b/knowledge/architecture/mcp-pool-vs-direct-connections.md
@@ -1,0 +1,46 @@
+---
+name: mcp-pool-vs-direct-connections
+summary: Why Craft Agents centralizes MCP source connections in a McpClientPool exposed as a single Streamable-HTTP endpoint to SDK subprocesses, instead of letting each subprocess connect independently.
+category: architecture
+tags: [mcp, pool, subprocess, streamable-http]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: packages/shared/src/mcp/pool-server.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# MCP pool vs. direct connections
+
+### Problem
+Craft Agents has many MCP sources (Linear, GitHub, Notion, Craft docs, custom). It also spawns SDK subprocesses (Codex, Copilot) that each want to call MCP tools. Naive design: each subprocess opens its own stdio / SSE connection to every source. Consequences:
+- N sources × M subprocesses = N·M connections, all authenticated, all maintaining session state.
+- Credential distribution: every subprocess needs to know every source's token.
+- Connection pooling + heartbeat for each is duplicated work.
+
+### Solution: centralized pool + stateless HTTP façade
+The main process holds a single `McpClientPool` with one `PoolClient` per source (the real MCP connection). It exposes the aggregated tool list over a local HTTP endpoint (`http://127.0.0.1:<rand>/mcp`) using `StreamableHTTPServerTransport({ sessionIdGenerator: undefined })`.
+
+Each SDK subprocess connects to ONLY that local endpoint. Tool names are namespaced `mcp__<source>__<tool>` so there's no ambiguity on dispatch. The main process fans out each call to the right pool client, aggregates the response, returns it.
+
+### Benefits
+- Connections: N + 1 per source (pool has 1, façade serves all subprocesses).
+- Credentials never touch subprocess environments — they stay in the main process's credential manager.
+- Subprocesses see a single MCP endpoint; simpler config, simpler auth.
+- Rate-limit / retry / backoff logic for each real source connection centralized.
+
+### Trade-offs
+- Added hop: subprocess → HTTP façade → real MCP → back. Adds latency for local stdio sources. In practice negligible next to LLM call latency.
+- Stateless mode rules out resource subscriptions / server-initiated notifications (pool façade can't propagate them). For the repo's use case, tools-only is enough.
+- Single point of failure: if the pool dies, all subprocesses lose MCP. Main process crash already loses everything, so this doesn't widen blast radius.
+
+### Where the other approach lives
+Session-scoped MCP servers (e.g. `packages/session-mcp-server`) are STILL stdio and spawned per session. Those expose session-specific tools (`SubmitPlan`, `config_validate`) that need session context baked in. The pool is for CROSS-session tools.
+
+### Reference
+- `packages/shared/src/mcp/pool-server.ts` — HTTP façade.
+- `packages/shared/src/mcp/mcp-pool.ts` — pool + per-source clients.
+- `packages/shared/src/mcp/api-source-pool-client.ts` — shim for REST-API sources as PoolClients.

--- a/knowledge/codecs/multi-audio-resampling-backends.md
+++ b/knowledge/codecs/multi-audio-resampling-backends.md
@@ -1,0 +1,29 @@
+---
+name: multi-audio-resampling-backends
+type: knowledge
+category: codecs
+summary: Resampling backends: Dasp (pure Rust, slow), Rubato (FFT, faster), SampleRate (libsamplerate, fastest).
+confidence: medium
+tags: [audio, backends, codecs, multi, resampling]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: [Cargo.toml, src/server/audio_service.rs]
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Multi Audio Resampling Backends
+
+## Fact
+Resampling backends: Dasp (pure Rust, slow), Rubato (FFT, faster), SampleRate (libsamplerate, fastest).
+
+## Why it matters
+Choose via feature flag; Rubato is a good default outside of no_std.
+
+## Evidence
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- `Cargo.toml`
+- `src/server/audio_service.rs`

--- a/knowledge/data-pipeline/memory-graph-adaptive-query-with-recency.md
+++ b/knowledge/data-pipeline/memory-graph-adaptive-query-with-recency.md
@@ -1,0 +1,34 @@
+---
+name: memory-graph-adaptive-query-with-recency
+summary: Query agent memory as a DAG, prioritize recency, cap nodes, merge related events
+category: data-pipeline
+confidence: high
+tags: [evolver, data-pipeline, memory-graph, llm-context, reference]
+source_type: extracted-from-git
+source_url: https://github.com/EvoMap/evolver.git
+source_ref: main
+source_commit: 22773782475cecf43dc9c1af264bf5f9cacc28bc
+source_project: evolver
+source_paths:
+  - src/gep/memoryGraph.js
+  - src/gep/memoryGraphAdapter.js
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Memory as a causal DAG, queried with recency bias
+
+Store agent memory as a DAG — events are nodes, causality is edges. When querying (for evolution analysis, LLM context, or reporting), traverse with three constraints:
+
+1. **Recency bias** — newer events have higher weight; old siblings are pruned first.
+2. **Hard node cap** — e.g., 1000 nodes returned. Prevents context explosion.
+3. **Similarity merge** — fold near-duplicate events (same error class, same tag) into a single representative node with a count.
+
+## Why a DAG over a flat log
+
+- Preserves causal chains: "error E caused retry R caused fix F".
+- Merging happens only within semantically related siblings, not arbitrarily across time.
+- Enables "explain this failure" traversals (walk ancestors) and "what did this decision unlock" (walk descendants).
+
+## Reuse notes
+
+Any agent memory system. The specific schema doesn't matter; what matters is: edges encode causality, recency drives pruning, merging prevents context bloat.

--- a/knowledge/decision/monorepo-subpath-exports-over-barrel-index.md
+++ b/knowledge/decision/monorepo-subpath-exports-over-barrel-index.md
@@ -1,0 +1,40 @@
+---
+name: monorepo-subpath-exports-over-barrel-index
+summary: T3Code uses explicit subpath exports (e.g., `@t3tools/shared/git`) instead of a single `index.ts` to reduce bundle size and improve tree-shaking
+type: knowledge
+category: decision
+confidence: high
+tags: [monorepo, design, exports]
+source_type: extracted-from-git
+source_url: https://github.com/pingdotgg/t3code.git
+source_ref: main
+source_commit: 9df3c640210fecccb58f7fbc735f81ca0ee011bd
+source_project: t3code
+imported_at: 2026-04-18
+evidence:
+  - package.json
+  - packages/shared/src
+  - .docs/workspace-layout.md
+---
+
+## Fact
+T3Code's shared package does not have a barrel `index.ts`. Instead, `package.json` defines explicit subpath exports like `"./git"` and `"./DrainableWorker"`, each mapping to a separate file. Callers import explicitly: `import { GitCore } from '@t3tools/shared/git'`, not `import { GitCore } from '@t3tools/shared'`.
+
+## Why it matters
+1. **Smaller bundle** — bundlers can tree-shake unused exports because each export is isolated
+2. **Clearer dependencies** — the import statement reveals which module is used; `from '@t3tools/shared'` is opaque
+3. **Reduced startup time** — server startup does not load every utility in shared; only requested modules are imported
+4. **Easier refactoring** — moving or renaming a module is localized; barrel index changes would affect many imports
+5. **Avoids circular imports** — common source of bugs in large shared packages; subpath exports force acyclic dependency graphs
+
+## Evidence
+- `packages/shared/src` has files like `git.ts`, `DrainableWorker.ts`, `KeyedCoalescingWorker.ts` with no barrel `index.ts`
+- Workspace layout doc says: "uses explicit subpath exports (e.g. `@t3tools/shared/git`, `@t3tools/shared/DrainableWorker`) — no barrel index"
+- Package.json defines exports: `{ "./git": "./dist/git.js", ... }`
+
+## How to apply
+- In shared packages, avoid creating `index.ts`
+- Each public module gets one file and one export entry in package.json
+- If a module has sub-modules (e.g., `git/utils.ts`), still export from the parent: `"./git"` points to `git.ts`, not `git/index.ts`
+- Document the public API in a README: list all subpath exports
+- In tests, import from exact paths: `import { GitCore } from '@t3tools/shared/git'`

--- a/knowledge/domain/model-output-space-vs-tool-output-space.md
+++ b/knowledge/domain/model-output-space-vs-tool-output-space.md
@@ -1,0 +1,25 @@
+---
+name: model-output-space-vs-tool-output-space
+type: knowledge
+category: domain
+summary: The 'model output space' (216 NN labels in standard_v3_3) is a strict subset of the 'tool output space' (model outputs + 5 generic labels).
+confidence: high
+tags: [magika, domain]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Model Output Space Vs Tool Output Space
+
+## Fact
+
+The DL model has a fixed label set (e.g. 216 in v3_3). The tool layer adds: empty (zero-byte file), directory, symlink, txt (generic text fallback), unknown (generic binary fallback). API consumers must handle these tool-only labels — they cannot come from the model.
+
+## Evidence
+
+- `assets/models/standard_v3_3/README.md:8-12`

--- a/knowledge/domain/model-trained-on-100m-samples.md
+++ b/knowledge/domain/model-trained-on-100m-samples.md
@@ -1,0 +1,26 @@
+---
+name: model-trained-on-100m-samples
+type: knowledge
+category: domain
+summary: Magika's standard models are trained on ~100M files spanning 200+ content types.
+confidence: high
+tags: [magika, domain]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Model Trained On 100M Samples
+
+## Fact
+
+The training corpus is curated from Google's internal file distributions, which is what underwrites the ~99% average accuracy claim and the broad type coverage (modern JS/TS variants, newer document formats, etc.). Smaller corpora produce noticeably worse coverage on long-tail types.
+
+## Evidence
+
+- `README.md:15`
+- `website-ng/src/content/docs/introduction/overview.md:5`

--- a/knowledge/electron-packaging/menu-bar-visibility-modes-linux-workaround.md
+++ b/knowledge/electron-packaging/menu-bar-visibility-modes-linux-workaround.md
@@ -1,0 +1,125 @@
+---
+name: menu-bar-visibility-modes-linux-workaround
+summary: Electron's `autoHideMenuBar` on Linux causes layout shifts on Alt keypress in DEs like KDE Plasma; a three-mode env var (`auto`/`visible`/`hidden`) with boolean aliases gives users control, and `hidden` mode suppresses the Alt toggle by re-hiding on every `show` event.
+category: electron-packaging
+tags: [electron, menu-bar, linux, kde, wayland, autoHideMenuBar, ux, env-var]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: medium
+---
+
+# Menu Bar Visibility Modes on Linux
+
+## Context
+
+Electron's default `autoHideMenuBar: true` behavior hides the menu bar until
+the user presses Alt, then shows it, then hides it again. On most desktop
+environments this is acceptable. On KDE Plasma (and some other DEs), Alt is
+heavily used for window management (Alt+drag to move, Alt+Tab, Alt+F4). The
+menu bar appearing and disappearing on every Alt keypress causes a visible
+layout shift and is disruptive for users.
+
+Additionally, when the menu bar is hidden and `autoHideMenuBar` is active,
+the `Ctrl+Q` keyboard shortcut from the application menu does not fire because
+Electron does not dispatch menu accelerators when the menu bar is in
+auto-hide state.
+
+## Observation
+
+Three distinct behaviors are useful:
+
+| Mode | Menu visible | Alt toggles | Best for |
+|------|-------------|-------------|---------|
+| `auto` | No (default hidden) | Yes | Most DEs |
+| `visible` | Yes (always) | No | Stable layout, no Alt shift |
+| `hidden` | No (always) | No | Full Alt freedom |
+
+Electron provides `autoHideMenuBar` (boolean) and `setMenuBarVisibility(bool)`,
+but no built-in three-mode system. The `hidden` mode requires actively
+suppressing the Alt toggle that `autoHideMenuBar` would normally allow.
+
+The Alt toggle cannot be disabled via any Electron API directly — it is
+hardcoded in Chromium's input handling when `autoHideMenuBar` is true.
+
+## Why it happens
+
+`autoHideMenuBar: true` tells Chromium to handle the Alt key as a menu
+bar toggle. There is no Electron-level API to say "hide the menu bar but
+do not respond to Alt". The only workaround is to set
+`autoHideMenuBar: false` and manually re-hide the menu bar whenever it
+would become visible.
+
+The `show` event on a `BrowserWindow` fires when the window becomes visible
+(including after an Alt press shows the menu bar). Re-hiding immediately on
+`show` suppresses the visual effect.
+
+## Practical implication
+
+Implement the three-mode system in a preload wrapper:
+
+```js
+const VALID_MODES = ['auto', 'visible', 'hidden'];
+const ALIASES = {
+  '1': 'visible', 'true': 'visible', 'yes': 'visible', 'on': 'visible',
+  '0': 'hidden',  'false': 'hidden', 'no': 'hidden',   'off': 'hidden',
+};
+
+const raw = (process.env.APP_MENU_BAR || 'auto').toLowerCase();
+const mode = ALIASES[raw] || (VALID_MODES.includes(raw) ? raw : 'auto');
+```
+
+Apply at `BrowserWindow` construction (in a patched subclass):
+
+```js
+// 'auto': hidden by default, Alt toggles (Electron's built-in behavior)
+// 'visible'/'hidden': no Alt toggle
+options.autoHideMenuBar = (mode === 'auto');
+```
+
+After construction, force the initial visibility:
+
+```js
+if (mode !== 'visible') {
+  this.setMenuBarVisibility(false);
+}
+
+// For 'hidden' mode: suppress Alt toggle by re-hiding on every show
+if (mode === 'hidden') {
+  this.on('show', () => {
+    this.setMenuBarVisibility(false);
+  });
+}
+```
+
+Also intercept `Menu.setApplicationMenu` to re-hide on every menu update
+(which Electron briefly shows the menu bar for):
+
+```js
+if (mode === 'hidden') {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) win.setMenuBarVisibility(false);
+  }
+}
+```
+
+Register a global `Ctrl+Q` shortcut explicitly to ensure quit works regardless
+of menu bar state:
+
+```js
+electron.globalShortcut.register('CommandOrControl+Q', () => {
+  electron.app.quit();
+});
+```
+
+## Source reference
+
+- `scripts/frame-fix-wrapper.js`: `MENU_BAR_MODE`, `MENU_BAR_ALIASES`,
+  `options.autoHideMenuBar = (MENU_BAR_MODE === 'auto')`,
+  `'hidden'` mode `show` event handler, `patchedSetApplicationMenu`.
+- `docs/CONFIGURATION.md`: "Menu Bar" section — user-facing mode table and
+  env var documentation.

--- a/knowledge/electron-packaging/minified-electron-regex-patching-gotchas.md
+++ b/knowledge/electron-packaging/minified-electron-regex-patching-gotchas.md
@@ -1,0 +1,108 @@
+---
+name: minified-electron-regex-patching-gotchas
+summary: Minified variable names in Electron bundles change with every release; patches must use optional-whitespace regexes with the `-E` flag and test against both minified and beautified spacing to remain stable across updates.
+category: electron-packaging
+tags: [electron, minification, regex, sed, patching, build]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+# Minified Electron Bundle Regex Patching Gotchas
+
+## Context
+
+When redistributing or repackaging an Electron application you do not control,
+you often need to patch the minified JavaScript inside the `.asar` archive:
+remove Windows-only code paths, inject Linux-specific behavior, or alter
+feature flags. The app's JavaScript is built once by the upstream vendor and
+arrives as a single minified bundle (`index.js`, `mainWindow.js`, etc.).
+
+Because you are patching code you do not own, the patches must survive version
+bumps without manual intervention. This is non-trivial when the bundle is
+minified.
+
+## Observation
+
+Three independent failure modes appear when patching minified Electron bundles
+with `sed`:
+
+1. **Variable/function names change per release.** The minifier assigns short
+   identifiers (`oe`, `Ci`, `fz`, `bYe`) non-deterministically. A literal
+   match like `sed 's/oe.nativeTheme/...'` silently fails in the next release.
+
+2. **Spacing differs between minified and beautified source.** When you use a
+   beautified reference copy to understand the code and then write a pattern,
+   the pattern includes spaces that are absent in the minified file:
+   ```
+   # Minified:  oe.nativeTheme.on("updated",()=>{
+   # Beautified: oe.nativeTheme.on("updated", () => {
+   ```
+   A literal match written from the beautified copy will never match the real
+   file.
+
+3. **`sed` defaults to basic regex (BRE) which lacks grouping without `\(`.**
+   Using grouping or alternation requires either `-E` (extended regex, ERE) or
+   explicit `\(` escaping. Forgetting `-E` causes silent no-ops.
+
+## Why it happens
+
+Minifiers (esbuild, terser, rollup) rename identifiers to minimize byte count.
+The mapping is deterministic within one build but changes whenever the upstream
+vendor rebuilds with different source or configuration. There is no stable
+identifier you can rely on across releases.
+
+Beautifiers (prettier, js-beautify) add whitespace back in a normalized form,
+which differs from the minifier's original whitespace choices.
+
+`sed`'s BRE mode is the POSIX default; `-E` switches to ERE, which matches the
+regex dialect most developers intuitively write.
+
+## Practical implication
+
+**Pattern for stable patches:**
+
+1. **Use a unique string anchor, not a variable name.** String literals in the
+   bundle (error messages, log strings, property names) are stable across
+   releases. Example: find the error message `"Unsupported platform"` instead
+   of a variable name.
+
+2. **Extract variable names dynamically via regex capture groups:**
+   ```bash
+   # Extract the minified function name by its structural context
+   TRAY_FUNC=$(grep -oP 'on\("menuBarEnabled",\(\)=>\{\K\w+(?=\(\)\})' app.asar.contents/.vite/build/index.js)
+   # Then use $TRAY_FUNC in the subsequent sed command
+   ```
+
+3. **Use `-E` and handle optional whitespace in all spacing positions:**
+   ```bash
+   # Bad: assumes no spaces
+   sed -i 's/oe.nativeTheme.on("updated",()=>{/replacement/'
+
+   # Good: handles optional whitespace with -E
+   sed -i -E 's/(oe\.nativeTheme\.on\(\s*"updated"\s*,\s*\(\)\s*=>\s*\{)/replacement/'
+   ```
+
+4. **Prefer Node.js inline scripts for complex patches** that involve multiple
+   captures or multi-line context, as shell escaping of minified JS quickly
+   becomes unmaintainable.
+
+5. **Keep a beautified reference copy separate from the live build directory.**
+   Use it only for human comprehension; never copy patterns directly from it
+   into sed commands.
+
+6. **Gate patches with an idempotency check** (e.g., `grep -q 'already-patched-marker'`)
+   so re-running the build script does not double-apply patches.
+
+## Source reference
+
+- `build.sh`: `extract_electron_variable()`, `fix_native_theme_references()`,
+  `patch_tray_menu_handler()`, `patch_cowork_linux()` — all demonstrate dynamic
+  variable extraction and optional-whitespace patterns.
+- `CLAUDE.md`: "Working with Minified JavaScript" section documents all three
+  rules explicitly with before/after examples.

--- a/knowledge/electron-packaging/minified-js-ast-anchor-extraction.md
+++ b/knowledge/electron-packaging/minified-js-ast-anchor-extraction.md
@@ -1,0 +1,110 @@
+---
+name: minified-js-ast-anchor-extraction
+summary: When patching minified JavaScript you cannot rely on line numbers or variable names; instead anchor on stable string literals (error messages, log strings, property names) and extract surrounding minified variable names via regex capture groups.
+category: electron-packaging
+tags: [minification, javascript, regex, patching, anchors, variable-extraction, build]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+# Minified JS AST Anchor Extraction
+
+## Context
+
+Automated patching of third-party minified JavaScript (e.g., inside an Electron
+`.asar` bundle you redistribute) must survive upstream version bumps without
+human intervention. Line numbers are unstable (any upstream edit shifts them),
+and variable/function names are unstable (minifier renames them each build).
+You need a technique that is both precise and durable.
+
+## Observation
+
+String literals embedded in minified code are far more stable across releases
+than identifiers or positions:
+- **Error messages** (`"Unsupported platform"`, `"VM service not running."`)
+  rarely change in wording because they are user-visible or logged.
+- **Log strings** (`"vmClient (TypeScript)"`, `"cowork-vm-service"`) are
+  intentional identifiers chosen by developers.
+- **Object property names** (`"menuBarEnabled"`, `"pop-up-menu"`) map to public
+  APIs or configuration keys that are stable by contract.
+
+The technique is:
+1. Find the stable string anchor with a simple `grep -F` or `indexOf()`.
+2. In the regex that uses the anchor, add a **capture group** that matches the
+   surrounding minified identifier (`\w+` or `\$?\w+` for dollar-prefixed names).
+3. Store that captured identifier in a shell variable or JS variable.
+4. Use the captured identifier in all subsequent patches in the same build
+   session.
+
+## Why it happens
+
+Minifiers assign single-letter or short identifiers based on usage frequency
+and scope. The same source variable (`isWindows`, `trayManager`) gets a
+different short name in each build. The only stable surface is what the
+developer deliberately wrote as a string literal or what is part of a public
+interface (property names, event names, error messages).
+
+Capture groups in regex turn the "find the stable anchor" step and the
+"extract the unstable name next to it" step into one atomic operation.
+
+## Practical implication
+
+**Shell (grep -oP with lookbehind/lookahead):**
+
+```bash
+# Extract the function name that is called when menuBarEnabled changes.
+# Anchor: the string "menuBarEnabled" inside a known structural pattern.
+TRAY_FUNC=$(grep -oP 'on\("menuBarEnabled",\(\)=>\{\K\w+(?=\(\)\})' bundle.js)
+
+# Extract variable name assigned from require("electron")
+ELECTRON_VAR=$(grep -oP '\$?\w+(?=\s*=\s*require\("electron"\))' bundle.js | head -1)
+
+# If primary anchor fails, try a structural fallback
+if [[ -z "$ELECTRON_VAR" ]]; then
+  ELECTRON_VAR=$(grep -oP '(?<=new )\$?\w+(?=\.Tray\b)' bundle.js | head -1)
+fi
+```
+
+**Node.js (for multi-capture or multi-line cases):**
+
+```js
+const code = fs.readFileSync('bundle.js', 'utf8');
+
+// Anchor: known error message string
+const anchorIdx = code.indexOf('"VM service not running."');
+if (anchorIdx === -1) throw new Error('Anchor not found');
+
+// Extract minified variable name in the ~200 chars before the anchor
+const context = code.substring(anchorIdx - 200, anchorIdx);
+const varMatch = context.match(/(\$?\w+)\s*\.\s*connect\s*\(/);
+if (!varMatch) throw new Error('Variable not found near anchor');
+const socketVar = varMatch[1];
+```
+
+**Robustness rules:**
+- Always check that the extracted variable is non-empty and fail the build
+  with a clear error if it is not found, rather than silently producing a
+  broken patch.
+- Prefer `grep -oP` (Perl regex) over basic grep for reliable lookahead/
+  lookbehind.
+- Handle dollar-prefixed identifiers (`\$?\w+`) — some minifiers emit `$e`,
+  `$t`, etc.
+- After applying a patch, verify with a second `grep` that the expected result
+  is present (idempotency check).
+
+## Source reference
+
+- `build.sh`: `extract_electron_variable()` — extracting the electron module
+  variable name via two fallback patterns.
+- `build.sh`: `patch_tray_menu_handler()` — extracting tray function name,
+  tray variable name, and first-const variable name via three chained
+  anchor-based extractions.
+- `build.sh`: `patch_cowork_linux()` — inline Node.js script using
+  `code.indexOf(anchor)` + nearby regex capture pattern.
+- `CLAUDE.md`: "Extract variable names dynamically" guideline with code example.

--- a/knowledge/i18n/multi-language-i18n-compile-time-generation.md
+++ b/knowledge/i18n/multi-language-i18n-compile-time-generation.md
@@ -1,0 +1,28 @@
+---
+name: multi-language-i18n-compile-time-generation
+type: knowledge
+category: i18n
+summary: i18n via compile-time code generation for 47 languages under src/lang/{ar,be,bg,...}.rs.
+confidence: medium
+tags: [compile, generation, i18n, language, multi, time]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: src/lang.rs
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Multi Language I18n Compile Time Generation
+
+## Fact
+i18n via compile-time code generation for 47 languages under src/lang/{ar,be,bg,...}.rs.
+
+## Why it matters
+Zero runtime IO, fast startup, and the compiler catches missing keys.
+
+## Evidence
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- `src/lang.rs`

--- a/knowledge/llm-agents/mcp-integration-guide.md
+++ b/knowledge/llm-agents/mcp-integration-guide.md
@@ -1,0 +1,93 @@
+---
+name: mcp-integration-guide
+summary: How to integrate MCP servers with OpenAI Agents SDK — transport options, tool filtering, caching, and hosted vs. local execution.
+category: llm-agents
+confidence: high
+tags: [openai-agents, mcp, model-context-protocol, transport, hosted, stdio, sse]
+source_type: extracted-from-git
+source_url: https://github.com/openai/openai-agents-python.git
+source_ref: main
+source_commit: e80d2d2319eb300ac17ec496988b70246a5042d6
+source_project: openai-agents-python
+source_path: docs/mcp.md, src/agents/mcp/
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# MCP Integration Guide
+
+## Transport Selection Matrix
+
+| Scenario | Transport | Class |
+|---|---|---|
+| Public MCP server; let OpenAI call it | Hosted | `HostedMCPTool` |
+| Remote server, tool calls in your process | Streamable HTTP | `MCPServerStreamableHttp` |
+| Legacy HTTP+SSE server | SSE | `MCPServerSse` |
+| Local subprocess (stdin/stdout) | stdio | `MCPServerStdio` |
+
+## Hosted MCP (HostedMCPTool)
+
+- OpenAI's Responses API makes tool calls directly to the MCP server
+- Your Python process is NOT involved in individual tool calls
+- Server must be publicly reachable
+- Works only with OpenAI Responses API models
+- Supports `require_approval: "never" | "always"` for tool call gating
+
+## Local MCP Servers (Stdio, SSE, Streamable HTTP)
+
+All three are used as async context managers:
+```python
+async with MCPServerStdio(name="...", params={...}) as server:
+    agent = Agent(mcp_servers=[server], ...)
+```
+
+They share common patterns:
+- `cache_tools_list=True` — cache `list_tools()` result per session
+- `tool_filter=["tool_a", "tool_b"]` — expose only specific tools
+- `failure_error_function` — custom error handling for MCP failures
+- Tracing: MCP list_tools operations appear as `mcp_tools_span`
+
+## Agent-Level MCP Config
+
+```python
+agent = Agent(
+    name="Assistant",
+    mcp_servers=[server],
+    mcp_config={
+        "convert_schemas_to_strict": True,  # Best-effort strict JSON schema
+        "failure_error_function": None,      # None = raise exception on failure
+    },
+)
+```
+
+## MCP Server Prompts
+
+Some MCP servers expose reusable prompts. Access them via:
+```python
+prompts = await server.list_prompts()
+prompt = await server.get_prompt("prompt_name", arguments={...})
+```
+
+## Caching Behavior
+
+`cache_tools_list=True`: The SDK calls `list_tools()` once and caches the result for the lifetime of the `async with` block. Use when the server's tool list is static.
+
+Without caching: `list_tools()` is called at the start of each agent turn (new Runner.run() call).
+
+## Custom Headers and Auth
+
+```python
+async with MCPServerStreamableHttp(
+    name="Authenticated Server",
+    params={
+        "url": "https://api.example.com/mcp",
+        "headers": {"Authorization": "Bearer token"},
+    },
+) as server:
+    ...
+```
+
+## Source paths
+- `src/agents/mcp/` — MCP implementation
+- `src/agents/mcp/server.py` — MCPServerStdio, MCPServerSse, MCPServerStreamableHttp
+- `docs/mcp.md` — comprehensive MCP guide
+- `examples/mcp/` — runnable examples for each transport

--- a/knowledge/llm-agents/mlx-kv-cache-trimmability.md
+++ b/knowledge/llm-agents/mlx-kv-cache-trimmability.md
@@ -1,0 +1,61 @@
+---
+name: mlx-kv-cache-trimmability
+summary: Which MLX KV caches support trim() and which don't — attention-based caches are trimmable by slicing; GatedDeltaNet state is not, and speculative decoding on Qwen3.5 MoE has to replay accepted inputs to roll back.
+category: llm-agents
+tags: [mlx, kv-cache, gated-delta, speculative-decoding, qwen3]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/z-lab/dflash.git
+source_ref: main
+source_commit: 1fe684b00efba56490d920d15eeb9ba6e4471751
+source_project: dflash
+source_path: dflash/model_mlx.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# MLX KV cache: which layers are trimmable?
+
+## The two worlds
+
+MLX `mlx_lm` models use different per-layer cache shapes:
+
+- **Attention layers** (`KVCache`, `RotatingKVCache`) — K and V are stored as contiguous arrays. Trimming `n` tokens is `arr = arr[:, :, :-n, :]` plus an offset decrement. `cache.is_trimmable() == True`.
+- **Gated Delta Net / state-space layers** (Qwen3.5 MoE) — the state is a *recurrent summary*, not a window. You cannot slice off the last `n` tokens' contribution.
+  - `cache.cache[0]` is the 1-D conv prefix (trimmable if you also remember the conv inputs).
+  - `cache.cache[1]` is the SSM state — irreversibly fused; must be recomputed.
+  - `cache.is_trimmable() == False`.
+
+## Speculative decoding implications
+
+If your target model is pure attention (e.g., Qwen3.5-4B, Qwen3.5-27B), `trim_prompt_cache(cache, n)` is all you need on reject.
+
+If your target is Qwen3.5 MoE (`GatedDeltaNet` layers), you must:
+1. Intercept `GatedDeltaNet.__call__` during the verify pass and capture `(q, k, v, a, b, A_log, dt_bias, state_before, mask)` per layer.
+2. On reject (`trim = block_size - accepted - 1 > 0`), replay `gated_delta_update(q[:, :n], ..., state_before)` with `n = accepted + 1` and overwrite `cache.cache[1]` with the resulting state.
+3. Reslice the conv cache `cache.cache[0] = conv_input[:, accepted+1 : accepted+K]`.
+4. Trimmable layers still use `c.trim(trim)`; non-trimmable use the replay.
+
+The DFlash MLX implementation guards against missing `gated_delta` support:
+
+```python
+_target_can_trim = can_trim_prompt_cache(target_cache)
+if not _target_can_trim and not _HAS_GDN:
+    raise RuntimeError(
+        "This MLX model requires gated-delta rollback support, but "
+        "mlx_lm.models.gated_delta is unavailable."
+    )
+```
+
+## Testing your cache classification
+
+```python
+from mlx_lm.models.cache import can_trim_prompt_cache, make_prompt_cache
+cache = make_prompt_cache(model)
+print(can_trim_prompt_cache(cache))   # True → easy path
+for c in cache:
+    print(type(c).__name__, c.is_trimmable())
+```
+
+## Why this is MLX-specific
+- PyTorch `DynamicCache` supports `.crop(n)` and stays trimmable across all layer types because PyTorch ports of Gated-Delta / Mamba typically store per-token states.
+- MLX's `gated_delta` is an optional, fused C++ kernel — the Python wrapper exposes only the fused state, not per-token residuals, so rollback requires the replay pattern above.

--- a/knowledge/llm-agents/multi-agent-orchestration-patterns.md
+++ b/knowledge/llm-agents/multi-agent-orchestration-patterns.md
@@ -1,0 +1,81 @@
+---
+name: multi-agent-orchestration-patterns
+summary: Taxonomy of orchestration patterns in the OpenAI Agents SDK — LLM-driven vs. code-driven, with tradeoffs.
+category: llm-agents
+confidence: high
+tags: [openai-agents, orchestration, patterns, multi-agent, design]
+source_type: extracted-from-git
+source_url: https://github.com/openai/openai-agents-python.git
+source_ref: main
+source_commit: e80d2d2319eb300ac17ec496988b70246a5042d6
+source_project: openai-agents-python
+source_path: docs/multi_agent.md, examples/agent_patterns/
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Multi-Agent Orchestration Patterns
+
+## Two Fundamental Approaches
+
+### 1. LLM-Driven Orchestration
+The model decides what happens next: which tools to call, which agents to hand off to, when to stop.
+- More flexible for open-ended tasks
+- Less predictable cost/latency
+- Requires good prompts describing available tools and handoff targets
+
+### 2. Code-Driven Orchestration
+Your code determines flow: call agent A, inspect output, conditionally call agent B.
+- More deterministic and auditable
+- Easier cost/latency control
+- Requires you to design the pipeline explicitly
+
+You can mix both: code-driven pipeline with LLM-driven specialists.
+
+## Pattern Catalog
+
+### Routing (Triage → Specialist)
+Triage agent receives first message, hands off to the correct specialist.
+- File: `examples/agent_patterns/routing.py`
+- Use: Language routing, department routing, intent classification → specialist
+
+### Agents as Tools (Orchestrator + Specialists)
+Orchestrator calls specialists as tools, retains control, composes final reply.
+- File: `examples/agent_patterns/agents_as_tools.py`
+- Use: Translation fan-out, multi-source research, parallel subtask aggregation
+
+### Parallelization
+Run multiple agent instances simultaneously, pick the best result.
+- File: `examples/agent_patterns/parallelization.py`
+- Use: Best-of-N sampling, independent subtasks, latency reduction
+
+### Deterministic Pipeline (Code-Driven Chain)
+Generate → Check → Conditionally proceed → Refine.
+- File: `examples/agent_patterns/deterministic.py`
+- Use: Multi-step generation with validation gates, ETL pipelines
+
+### LLM as Judge (Feedback Loop)
+Generator → Evaluator → Feedback → Generator (repeat until pass).
+- File: `examples/agent_patterns/llm_as_a_judge.py`
+- Use: Creative writing, code generation, quality-gated output
+
+### Human in the Loop
+Agent pauses for human approval before executing sensitive tools.
+- File: `examples/agent_patterns/human_in_the_loop.py`
+- Use: Email sending, file deletion, external API calls with side effects
+
+### Streaming Guardrails
+Run guardrails concurrently with streaming output, cancel if guardrail trips.
+- File: `examples/agent_patterns/streaming_guardrails.py`
+- Use: Real-time content moderation on streaming output
+
+## Design Principles (from SDK docs)
+
+1. Invest in good prompts; describe tools/handoffs clearly
+2. Have specialized agents rather than one general-purpose agent
+3. Monitor and iterate based on traces
+4. Allow agents to self-critique in loops
+5. Build evals to measure improvement over time
+
+## Source paths
+- `docs/multi_agent.md` — orchestration concepts
+- `examples/agent_patterns/` — all runnable pattern examples

--- a/knowledge/llm-agents/multi-llm-provider-trade-offs.md
+++ b/knowledge/llm-agents/multi-llm-provider-trade-offs.md
@@ -1,0 +1,46 @@
+---
+name: multi-llm-provider-trade-offs
+summary: OpenSRE supports 8 LLM providers (Anthropic native, OpenAI, OpenRouter, Gemini, NVIDIA NIM, Minimax, Ollama, Bedrock) by routing through one of three client classes (Anthropic, OpenAI-compatible, Bedrock-via-Anthropic-SDK) — a useful pattern for cross-provider portability with provider-specific quirks contained.
+category: llm-model-routing
+tags: [llm, providers, anthropic, openai, ollama, bedrock]
+source_type: extracted-from-git
+source_url: https://github.com/Tracer-Cloud/opensre.git
+source_ref: main
+source_commit: fb5ba0a1b4ef511d16c56a80f1f126b1f581d724
+source_project: opensre
+source_path: app/services/llm_client.py
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+---
+
+# Multi-LLM Provider Trade-offs in OpenSRE
+
+## The three client classes
+1. **`LLMClient`** — Anthropic native via `anthropic.Anthropic`. Used by default.
+2. **`OpenAILLMClient`** — `openai.OpenAI` SDK. Powers OpenAI direct, OpenRouter, Gemini, NVIDIA NIM, Minimax, Ollama (all OpenAI-compatible HTTP APIs). Each provider differs only in `base_url`, `api_key_env`, optional `api_key_default` (Ollama), and required temperature (Minimax forces 1.0).
+3. **`BedrockLLMClient`** — `anthropic.AnthropicBedrock` (Claude on AWS Bedrock with IAM auth, no API key).
+
+## Provider selection
+Single env var: `LLM_PROVIDER` ∈ `{anthropic, openai, openrouter, gemini, nvidia, minimax, ollama, bedrock}`. Default: anthropic.
+
+## Reasoning vs tool-call models
+Two model tiers per provider:
+- **Reasoning** (e.g. Claude Opus, GPT-4o) — root cause diagnosis, multi-step analysis, claim validation.
+- **Tool-call** (e.g. Claude Haiku, GPT-4o mini) — tool selection, action planning, lightweight routing.
+
+Two singletons (`_llm`, `_llm_for_tools`) cached per process; `reset_llm_singletons()` for tests.
+
+## Provider-specific quirks
+- **OpenAI o1/o3/o4/gpt-5*** — require `max_completion_tokens` instead of `max_tokens`. Detected by `_uses_max_completion_tokens(model)`.
+- **Bedrock** — IAM via `AWS_REGION`; no API key flow.
+- **Ollama** — needs a placeholder API key (`"ollama"`) because the OpenAI SDK refuses an empty key.
+- **Minimax** — requires `temperature=1.0` because the API errors otherwise.
+
+## API key resolution
+Every provider goes through `resolve_llm_api_key(env_var)`: env first, then OS keychain (via `keyring`), with `<APP>_DISABLE_KEYRING=1` to skip keychain entirely (Docker/CI).
+
+## Trade-offs summary
+- Pro: Users can switch providers with one env var; no code changes.
+- Pro: Different reasoning/toolcall tiers reduce cost; pair Haiku for planning + Opus for diagnosis.
+- Con: Provider quirks (max_completion_tokens, temperature, key default) are scattered through the dispatcher; easy to miss when adding a new provider.
+- Con: Native Anthropic vs OpenAI-compat split means structured-output behaviors differ subtly across providers.

--- a/knowledge/moe-optimization/mega-moe-imbalance-factor-for-uneven-routing.md
+++ b/knowledge/moe-optimization/mega-moe-imbalance-factor-for-uneven-routing.md
@@ -1,0 +1,37 @@
+---
+name: mega-moe-imbalance-factor-for-uneven-routing
+summary: Mega MoE sizes per-expert work assuming a 2x token-imbalance factor. If actual routing skew exceeds that, users must override mk_alignment_for_contiguous_layout.
+category: moe-optimization
+tags: [moe, load-balancing, kernel-tuning, top-k, distributed-systems]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - csrc/jit_kernels/heuristics/mega_moe.hpp
+imported_at: 2026-04-18T13:12:58Z
+---
+
+# Mega MoE Imbalance Factor for Uneven Routing
+
+## Summary
+Top-k routing in MoE rarely produces perfectly balanced expert loads. Mega MoE's kernel pre-allocates per-expert block counts based on an estimate:
+
+```
+expected_tokens_per_expert = (num_tokens × num_topk / num_experts + 1) / kImbalanceFactor
+```
+
+with `kImbalanceFactor = 2`. This gives a conservative under-estimate so the total `experts × m_blocks` fits within `num_sms`. The kernel then enumerates `experts_per_wave` against this budget.
+
+## Why it matters
+- The factor-of-2 is empirical — works for most production routers but isn't a hard guarantee.
+- If your model has a highly skewed router (some experts always winning top-1 by a big margin), the actual tokens-per-top-expert can exceed `2× mean`. The kernel will try to launch more blocks than fit and fail.
+- The imbalance also affects MFU estimation — a "100% scheduled" wave may run at 60% efficiency because half the experts get ~0 work.
+
+## Practical implications
+- Default works for standard top-k=4 to top-k=8 MoE with reasonably balanced aux-loss. Don't touch it.
+- For heavy-skew models or small-batch inference: call `mk_alignment_for_contiguous_layout()` with an explicit larger block count per expert to force the right budget.
+- When debugging a Mega MoE launch failure, first check router skew: `tokens per expert histogram` in your training/inference loop. If max/mean > 2, that's your bug.
+- Consider adaptive: measure imbalance at runtime and re-dispatch with a larger factor if observed skew > threshold.

--- a/knowledge/security/mcp-localhost-bind-default-warn-on-expose.md
+++ b/knowledge/security/mcp-localhost-bind-default-warn-on-expose.md
@@ -1,0 +1,68 @@
+---
+name: mcp-localhost-bind-default-warn-on-expose
+summary: MCP HTTP servers should default to 127.0.0.1, fail fast if --host/--port are used without --http, and emit a loud stderr warning when the operator explicitly binds to a non-localhost interface.
+category: security
+confidence: medium
+tags: [mcp, security, network-binding, unauthenticated, defaults]
+source_type: extracted-from-git
+source_url: https://github.com/microsoft/markitdown.git
+source_ref: main
+source_commit: 604bba13da2f43b756b49122cb65bdedb85b1dff
+source_project: markitdown
+source_path: packages/markitdown-mcp/src/markitdown_mcp/__main__.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# MCP server bind defaults: localhost, with a loud warning if you deviate
+
+A raw MCP server is **unauthenticated** and runs with the launching user's privileges. Any process or user that can reach the bind address can invoke every registered tool — which often means "read any file this user can read" or "call any internet endpoint." Treat a publicly-bound MCP server the same way you'd treat `nc -l -p 80 -e /bin/bash`.
+
+## The three-rule default
+
+1. **Default bind: `127.0.0.1`.** STDIO mode has no network exposure at all — prefer it when the client (Claude Desktop, inspector) launches the server as a subprocess.
+2. **`--host`/`--port` only valid with `--http`.** Refuse at argparse time if the operator passes them without explicitly opting into HTTP — prevents silent "I thought `--port 3001` worked."
+3. **Non-localhost bind triggers a loud warning.** Emit a multi-line banner on stderr whenever the operator passes `--host 0.0.0.0` or any non-`127.0.0.1`/`localhost` host:
+
+   ```
+   WARNING: The server is being bound to a non-localhost interface (0.0.0.0).
+   This exposes the server to other machines on the network or Internet.
+   The server has NO authentication and runs with your user's privileges.
+   Any process or user that can reach this interface can read files and
+   fetch network resources accessible to this user.
+   Only proceed if you understand the security implications.
+   ```
+
+## Rationale (markitdown's stance verbatim)
+
+> The server does not support authentication, and runs with the privileges of the user running it. For this reason, when running in SSE or Streamable HTTP mode, the server binds by default to `localhost`. Even still, it is important to recognize that the server can be accessed by any process or users on the same local machine... If you require additional security, consider running the server in a sandboxed environment, such as a virtual machine or container, and ensure that the user permissions are properly configured to limit access to sensitive files and network segments. Above all, DO NOT bind the server to other interfaces (non-localhost) unless you understand the security implications of doing so.
+
+## When you actually do need remote access
+
+- **VPN** — run the MCP server bound to localhost on a jump host, reach it via VPN (Tailscale, WireGuard). No direct internet exposure.
+- **TLS reverse proxy with auth** — nginx/Caddy terminates TLS, authenticates the request, proxies to `127.0.0.1:3001`. MCP server still binds local.
+- **Dockerized** — container network namespace isolates the bind; map via `-p 127.0.0.1:3001:3001` on the host.
+
+Do **not** build auth into the MCP server itself — it's not the right layer, and it'll drift behind best practices.
+
+## Recommended argparse shape
+
+```python
+parser.add_argument("--http", action="store_true")
+parser.add_argument("--host", default=None)
+parser.add_argument("--port", type=int, default=None)
+args = parser.parse_args()
+
+# Refuse host/port without --http
+if not args.http and (args.host or args.port):
+    parser.error("--host/--port only valid with --http")
+
+# Default to loopback; warn on deviation
+host = args.host or "127.0.0.1"
+if args.host and host not in ("127.0.0.1", "localhost"):
+    sys.stderr.write(WARNING_BANNER)
+```
+
+## Related
+
+- `fastmcp-stdio-http-dual-transport` — the paired skill showing the full server shape with both transports.
+- Any skill on "unauthenticated localhost service" — same playbook applies to Jupyter, Prometheus node_exporter, and redis in dev setups.

--- a/knowledge/version-quirk/model-version-compatibility-major-version.md
+++ b/knowledge/version-quirk/model-version-compatibility-major-version.md
@@ -1,0 +1,26 @@
+---
+name: model-version-compatibility-major-version
+type: knowledge
+category: version-quirk
+summary: Major model version bumps (v1 → v2 → v3) change the output space and are not transparently backwards-compatible.
+confidence: medium
+tags: [magika, version-quirk]
+linked_skills: [model-config-versioning-and-backwards-compat]
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Model Version Compatibility Major Version
+
+## Fact
+
+v1 had ~100 types; v2_1 expanded to 200+. A binding pinned to one model version may not understand new types from a later one. When upgrading bindings, verify which model version they ship with — the output space may have grown.
+
+## Evidence
+
+- `assets/models/CHANGELOG.md:1-50`
+- `website-ng/src/content/docs/core-concepts/models-and-content-types.md:4-17`

--- a/registry.json
+++ b/registry.json
@@ -2409,6 +2409,146 @@
       "category": "build",
       "path": "skills/build/coverage-data-file-under-pytest-cache/SKILL.md",
       "version": "1.0.0"
+    },
+    "mcp-multi-transport-config-pydantic": {
+      "category": "integration",
+      "path": "skills/integration/mcp-multi-transport-config-pydantic/SKILL.md",
+      "version": "1.0.0"
+    },
+    "mcp-pool-http-proxy-for-subprocess-sdks": {
+      "category": "mcp-integration",
+      "path": "skills/mcp-integration/mcp-pool-http-proxy-for-subprocess-sdks/SKILL.md",
+      "version": "1.0.0"
+    },
+    "mcp-sse-streamable-http": {
+      "category": "mcp-integration",
+      "path": "skills/mcp-integration/mcp-sse-streamable-http/SKILL.md",
+      "version": "1.0.0"
+    },
+    "mcp-stdio-server": {
+      "category": "mcp-integration",
+      "path": "skills/mcp-integration/mcp-stdio-server/SKILL.md",
+      "version": "1.0.0"
+    },
+    "mcp-streamable-http-detached-httpx-client": {
+      "category": "integration",
+      "path": "skills/integration/mcp-streamable-http-detached-httpx-client/SKILL.md",
+      "version": "1.0.0"
+    },
+    "mcp-subprocess-env-filtering": {
+      "category": "security",
+      "path": "skills/security/mcp-subprocess-env-filtering/SKILL.md",
+      "version": "1.0.0"
+    },
+    "mcp-tool-intent-metadata-injection": {
+      "category": "mcp-integration",
+      "path": "skills/mcp-integration/mcp-tool-intent-metadata-injection/SKILL.md",
+      "version": "1.0.0"
+    },
+    "mega-moe-fusion-with-symmetric-memory": {
+      "category": "moe-optimization",
+      "path": "skills/moe-optimization/mega-moe-fusion-with-symmetric-memory/SKILL.md",
+      "version": "1.0.0"
+    },
+    "memory-fragment-sizing-for-llm-input": {
+      "category": "data-pipeline",
+      "path": "skills/data-pipeline/memory-fragment-sizing-for-llm-input/SKILL.md",
+      "version": "1.0.0"
+    },
+    "milestone-review": {
+      "category": "production",
+      "path": "skills/production/milestone-review/SKILL.md",
+      "version": "1.0.0"
+    },
+    "minified-js-variable-extraction-dynamic": {
+      "category": "electron-packaging",
+      "path": "skills/electron-packaging/minified-js-variable-extraction-dynamic/SKILL.md",
+      "version": "1.0.0"
+    },
+    "minimal-ddp-amp-accelerator-wrapper": {
+      "category": "training",
+      "path": "skills/training/minimal-ddp-amp-accelerator-wrapper/SKILL.md",
+      "version": "1.0.0"
+    },
+    "ml-model-config-registry-dispatch": {
+      "category": "architecture",
+      "path": "skills/architecture/ml-model-config-registry-dispatch/SKILL.md",
+      "version": "1.0.0"
+    },
+    "mlx-kv-cache-rollback-on-reject": {
+      "category": "llm-agents",
+      "path": "skills/llm-agents/mlx-kv-cache-rollback-on-reject/SKILL.md",
+      "version": "1.0.0"
+    },
+    "modal-navigation-stack-with-back": {
+      "category": "frontend",
+      "path": "skills/frontend/modal-navigation-stack-with-back/SKILL.md",
+      "version": "1.0.0"
+    },
+    "model-config-min-json-compact-format": {
+      "category": "data",
+      "path": "skills/data/model-config-min-json-compact-format/SKILL.md",
+      "version": "1.0.0"
+    },
+    "model-config-versioning-and-backwards-compat": {
+      "category": "versioning",
+      "path": "skills/versioning/model-config-versioning-and-backwards-compat/SKILL.md",
+      "version": "1.0.0"
+    },
+    "model-onnx-file-versioning-and-staging": {
+      "category": "versioning",
+      "path": "skills/versioning/model-onnx-file-versioning-and-staging/SKILL.md",
+      "version": "1.0.0"
+    },
+    "model-regression-test-with-csv-fixture": {
+      "category": "testing",
+      "path": "skills/testing/model-regression-test-with-csv-fixture/SKILL.md",
+      "version": "1.0.0"
+    },
+    "model-retry-settings": {
+      "category": "agents",
+      "path": "skills/agents/model-retry-settings/SKILL.md",
+      "version": "1.0.0"
+    },
+    "mouse-button-enum-dispatch": {
+      "category": "input",
+      "path": "skills/input/mouse-button-enum-dispatch/SKILL.md",
+      "version": "1.0.0"
+    },
+    "multi-backend-argparse-dispatcher": {
+      "category": "cli",
+      "path": "skills/cli/multi-backend-argparse-dispatcher/SKILL.md",
+      "version": "1.0.0"
+    },
+    "multi-format-native-package-orchestrator": {
+      "category": "packaging",
+      "path": "skills/packaging/multi-format-native-package-orchestrator/SKILL.md",
+      "version": "1.0.0"
+    },
+    "multi-instance-electron-dev": {
+      "category": "electron",
+      "path": "skills/electron/multi-instance-electron-dev/SKILL.md",
+      "version": "1.0.0"
+    },
+    "multi-kernel-dispatch-with-shape-driven-selection": {
+      "category": "gpu-kernels",
+      "path": "skills/gpu-kernels/multi-kernel-dispatch-with-shape-driven-selection/SKILL.md",
+      "version": "1.0.0"
+    },
+    "multi-language-onnx-model-binding": {
+      "category": "bindings",
+      "path": "skills/bindings/multi-language-onnx-model-binding/SKILL.md",
+      "version": "1.0.0"
+    },
+    "multi-llm-provider-router-by-env": {
+      "category": "configuration",
+      "path": "skills/configuration/multi-llm-provider-router-by-env/SKILL.md",
+      "version": "1.0.0"
+    },
+    "multi-platform-desktop-release-workflow-github-actions": {
+      "category": "ci",
+      "path": "skills/ci/multi-platform-desktop-release-workflow-github-actions/SKILL.md",
+      "version": "1.0.0"
     }
   },
   "knowledge": {
@@ -4427,6 +4567,94 @@
     "craft-cli-command-surface": {
       "category": "reference",
       "path": "knowledge/reference/craft-cli-command-surface.md"
+    },
+    "mcp-integration-guide": {
+      "category": "llm-agents",
+      "path": "knowledge/llm-agents/mcp-integration-guide.md"
+    },
+    "mcp-localhost-bind-default-warn-on-expose": {
+      "category": "security",
+      "path": "knowledge/security/mcp-localhost-bind-default-warn-on-expose.md"
+    },
+    "mcp-pool-vs-direct-connections": {
+      "category": "architecture",
+      "path": "knowledge/architecture/mcp-pool-vs-direct-connections.md"
+    },
+    "mcp-stdio-child-of-daemon-topology": {
+      "category": "arch",
+      "path": "knowledge/arch/mcp-stdio-child-of-daemon-topology.md"
+    },
+    "mega-moe-imbalance-factor-for-uneven-routing": {
+      "category": "moe-optimization",
+      "path": "knowledge/moe-optimization/mega-moe-imbalance-factor-for-uneven-routing.md"
+    },
+    "memory-graph-adaptive-query-with-recency": {
+      "category": "data-pipeline",
+      "path": "knowledge/data-pipeline/memory-graph-adaptive-query-with-recency.md"
+    },
+    "menu-bar-visibility-modes-linux-workaround": {
+      "category": "electron-packaging",
+      "path": "knowledge/electron-packaging/menu-bar-visibility-modes-linux-workaround.md"
+    },
+    "minified-electron-regex-patching-gotchas": {
+      "category": "electron-packaging",
+      "path": "knowledge/electron-packaging/minified-electron-regex-patching-gotchas.md"
+    },
+    "minified-js-ast-anchor-extraction": {
+      "category": "electron-packaging",
+      "path": "knowledge/electron-packaging/minified-js-ast-anchor-extraction.md"
+    },
+    "mlx-kv-cache-trimmability": {
+      "category": "llm-agents",
+      "path": "knowledge/llm-agents/mlx-kv-cache-trimmability.md"
+    },
+    "model-api-contract-sync-and-async": {
+      "category": "arch",
+      "path": "knowledge/arch/model-api-contract-sync-and-async.md"
+    },
+    "model-generation-tooling-in-rust-gen": {
+      "category": "arch",
+      "path": "knowledge/arch/model-generation-tooling-in-rust-gen.md"
+    },
+    "model-not-used-for-edge-cases": {
+      "category": "arch",
+      "path": "knowledge/arch/model-not-used-for-edge-cases.md"
+    },
+    "model-output-space-vs-tool-output-space": {
+      "category": "domain",
+      "path": "knowledge/domain/model-output-space-vs-tool-output-space.md"
+    },
+    "model-trained-on-100m-samples": {
+      "category": "domain",
+      "path": "knowledge/domain/model-trained-on-100m-samples.md"
+    },
+    "model-variants-standard-fast-begonly": {
+      "category": "arch",
+      "path": "knowledge/arch/model-variants-standard-fast-begonly.md"
+    },
+    "model-version-compatibility-major-version": {
+      "category": "version-quirk",
+      "path": "knowledge/version-quirk/model-version-compatibility-major-version.md"
+    },
+    "monorepo-subpath-exports-over-barrel-index": {
+      "category": "decision",
+      "path": "knowledge/decision/monorepo-subpath-exports-over-barrel-index.md"
+    },
+    "multi-agent-orchestration-patterns": {
+      "category": "llm-agents",
+      "path": "knowledge/llm-agents/multi-agent-orchestration-patterns.md"
+    },
+    "multi-audio-resampling-backends": {
+      "category": "codecs",
+      "path": "knowledge/codecs/multi-audio-resampling-backends.md"
+    },
+    "multi-language-i18n-compile-time-generation": {
+      "category": "i18n",
+      "path": "knowledge/i18n/multi-language-i18n-compile-time-generation.md"
+    },
+    "multi-llm-provider-trade-offs": {
+      "category": "llm-agents",
+      "path": "knowledge/llm-agents/multi-llm-provider-trade-offs.md"
     }
   }
 }

--- a/skills/agents/model-retry-settings/SKILL.md
+++ b/skills/agents/model-retry-settings/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: model-retry-settings
+description: Configure exponential backoff and retry policy for transient model API errors.
+category: agents
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [openai-agents, retry, backoff, resilience, model-settings]
+source_type: extracted-from-git
+source_url: https://github.com/openai/openai-agents-python.git
+source_ref: main
+source_commit: e80d2d2319eb300ac17ec496988b70246a5042d6
+source_project: openai-agents-python
+source_path: examples/basic/retry.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# model-retry-settings
+
+Set `ModelRetrySettings` on `ModelSettings` to configure max retries, backoff strategy, and a custom retry policy. Pass to `RunConfig` for run-wide defaults or per-agent `model_settings`.
+
+## When to apply
+
+When running agents in production where 429/5xx errors are expected. Prevents hard failures on transient rate-limit or server errors.
+
+## Core snippet
+
+```python
+from agents import Agent, ModelRetrySettings, ModelSettings, RetryDecision, RunConfig, Runner, retry_policies
+
+apply_policies = retry_policies.any(
+    retry_policies.provider_suggested(),
+    retry_policies.retry_after(),
+    retry_policies.network_error(),
+    retry_policies.http_status([408, 409, 429, 500, 502, 503, 504]),
+)
+
+retry = ModelRetrySettings(
+    max_retries=4,
+    backoff={
+        "initial_delay": 0.5,
+        "max_delay": 5.0,
+        "multiplier": 2.0,
+        "jitter": True,
+    },
+    policy=apply_policies,
+)
+
+run_config = RunConfig(model_settings=ModelSettings(retry=retry))
+
+agent = Agent(
+    name="Assistant",
+    instructions="You are a concise assistant.",
+    model_settings=ModelSettings(retry=retry),
+)
+
+result = await Runner.run(agent, "Hello!", run_config=run_config)
+```
+
+## Key notes
+
+- `RunConfig.model_settings` sets run-wide defaults; per-agent `model_settings` overrides for overlapping keys
+- `retry_policies.provider_suggested()` respects `x-should-retry` headers from OpenAI
+- `jitter=True` adds randomness to avoid thundering-herd retries
+- Per-agent retry config overrides `RunConfig` when both are set

--- a/skills/architecture/ml-model-config-registry-dispatch/SKILL.md
+++ b/skills/architecture/ml-model-config-registry-dispatch/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: ml-model-config-registry-dispatch
+description: Centralize per-engine ML model configuration in a declarative registry so route, service, and backend layers stay free of if/elif chains.
+category: architecture
+version: 1.0.0
+version_origin: extracted
+tags: [architecture, registry, ml-models, dispatch, configuration]
+source_type: extracted-from-git
+source_url: https://github.com/jamiepine/voicebox.git
+source_ref: main
+source_commit: 476abe07fc2c1587f4b3e3916134018ebacd143d
+source_project: voicebox
+confidence: high
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# ML model config registry dispatch
+
+## When to use
+Your app supports multiple ML engines (TTS/STT/image) with per-engine quirks: different HF repos, size variants, languages, feature flags (instruct support, hallucination trim, etc.). Left unchecked, the same if/elif chain spreads across routes, services, UI selectors, and download screens.
+
+## Steps
+1. Define a `@dataclass ModelConfig` with fields: `model_name` (stable id), `display_name`, `engine`, `hf_repo_id`, `model_size` (default `"default"`), `size_mb`, plus any boolean feature flags relevant to your domain (`needs_trim`, `supports_instruct`, etc.) and a `languages: list[str]`.
+2. Write small generator functions per engine family (`_get_qwen_model_configs()`, `_get_non_qwen_tts_configs()`, etc.) that return `list[ModelConfig]`. Centralize platform branching (CUDA vs MLX repos) inside the generator so callers never see it.
+3. Expose aggregate accessors: `get_all_model_configs()`, `get_tts_model_configs()`, `get_model_config(model_name)`. Downstream code uses these — never hardcodes an engine name.
+4. Route lookups through the registry. Replace `if engine == "qwen": ... elif engine == "chatterbox": ...` with `engine_needs_trim(engine)`, `engine_has_model_sizes(engine)`, `get_tts_backend_for_engine(engine)`, etc. Each is a one-liner over the registry.
+5. Keep a thread-safe factory (`dict + Lock`) that lazily instantiates backend classes on first access and caches them. Double-check-locked to avoid duplicate instantiation under load.
+6. Unify load/unload/check through config-driven helpers (`unload_model_by_config(cfg)`, `check_model_loaded(cfg)`, `get_model_load_func(cfg)`) so the HTTP routes become single-call functions with no engine branching.
+
+## Counter / Caveats
+- Two engines cannot share a `model_name`. Treat `model_name` as the stable public id used by HTTP payloads and DB rows, and never let the display name leak into persistence.
+- When a new feature applies to only one engine (e.g. `supports_instruct` for Qwen CustomVoice), add the flag to `ModelConfig` and set it per-engine rather than branching by engine name downstream.
+- Do not put runtime state (loaded model, weights) on the config. Configs are declarative; the backend instance holds runtime state.
+- Per-engine backend classes still expose their own tiny dispatch for load signatures (`load_model(model_size)` vs `load_model()`) — keep that dispatch in one place (`load_engine_model`) rather than rediscovering it per caller.
+
+Source references: `backend/backends/__init__.py` (the `ModelConfig`, config generators, lookup helpers, `get_tts_backend_for_engine`, `load_engine_model`, `check_model_loaded`, `unload_model_by_config`).

--- a/skills/bindings/multi-language-onnx-model-binding/SKILL.md
+++ b/skills/bindings/multi-language-onnx-model-binding/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: multi-language-onnx-model-binding
+description: Expose one ONNX model across Rust (ort), Python (onnxruntime+maturin), JS (TensorFlow.js), and Go (CGO) bindings.
+category: bindings
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [magika, bindings]
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Multi Language Onnx Model Binding
+
+**Trigger:** Building a portable ML inference library that must support multiple language ecosystems with consistent behavior.
+
+## Steps
+
+- Embed or reference ONNX model file in platform-native binaries (Rust: include_bytes!, Go: linked binary).
+- Use each language's native runtime: Rust ort crate session builder, Python onnxruntime, JS TensorFlow.js, Go CGO to ONNX Runtime C API.
+- Expose identical sync/async input abstraction (SyncInput / AsyncInput in Rust; file/bytes/stream in Python; loadUrl in JS).
+- Coordinate model version across bindings via shared assets/models/ directory + semver tag.
+- Generate per-language type stubs and content_type enums from a single config.min.json source of truth.
+- Add cross-binding inference parity tests that pin reference outputs from one language and verify the others match.
+
+## Counter / Caveats
+
+- Version mismatch across bindings is fragile; requires coordinated cargo-dist + maturin + npm + Go module release pipeline.
+- ONNX Runtime behavior differs subtly across platforms (GPU availability, threading semantics); test on every target OS.
+- TensorFlow.js browser vs Node have different loading paths; detect environment and branch.
+- Go via CGO requires the ONNX Runtime C library installed; consider vendoring or prebuilt binaries.
+
+## Source
+
+Extracted from `magika` (https://github.com/google/magika.git @ main).
+
+Files of interest:
+- `rust/lib/src/model.rs:23-31`
+- `python/pyproject.toml:41-49`
+- `js/src/model.ts:15-29`
+- `go/onnx/onnx_runtime.go:1-25`

--- a/skills/bindings/multi-language-onnx-model-binding/content.md
+++ b/skills/bindings/multi-language-onnx-model-binding/content.md
@@ -1,0 +1,23 @@
+# multi-language-onnx-model-binding — extended notes
+
+This is an extracted draft from the **magika** project at commit `0a8cb9626b`.
+See `SKILL.md` for the procedure. Use the source references below to study the
+original implementation before adapting the pattern to a new codebase.
+
+## Source references
+
+- `rust/lib/src/model.rs:23-31`
+- `python/pyproject.toml:41-49`
+- `js/src/model.ts:15-29`
+- `go/onnx/onnx_runtime.go:1-25`
+
+## When this pattern is a fit
+
+Building a portable ML inference library that must support multiple language ecosystems with consistent behavior.
+
+## When to walk away
+
+- Version mismatch across bindings is fragile; requires coordinated cargo-dist + maturin + npm + Go module release pipeline.
+- ONNX Runtime behavior differs subtly across platforms (GPU availability, threading semantics); test on every target OS.
+- TensorFlow.js browser vs Node have different loading paths; detect environment and branch.
+- Go via CGO requires the ONNX Runtime C library installed; consider vendoring or prebuilt binaries.

--- a/skills/ci/multi-platform-desktop-release-workflow-github-actions/SKILL.md
+++ b/skills/ci/multi-platform-desktop-release-workflow-github-actions/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: multi-platform-desktop-release-workflow-github-actions
+description: Build and sign desktop apps (macOS, Windows, Linux) from a single CI workflow with conditional code-signing
+category: ci
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [ci, release, desktop, github-actions]
+source_type: extracted-from-git
+source_url: https://github.com/pingdotgg/t3code.git
+source_ref: main
+source_commit: 9df3c640210fecccb58f7fbc735f81ca0ee011bd
+source_project: t3code
+imported_at: 2026-04-18
+evidence:
+  - .github/workflows/release.yml
+  - docs/release.md
+  - .docs/scripts.md
+---
+
+## When to Apply
+- You build Electron apps for macOS (arm64 + x64), Windows (x64), and Linux
+- You want a single release workflow triggered by git tags (`v*.*.*`)
+- You need code-signing and notarization for macOS and Windows
+- You support nightly builds on a schedule (e.g., every 3 hours)
+- You want to conditionally enable signing only when secrets are present
+
+## Steps
+1. Add `release.yml` with three trigger types: tag push (`v*.*.*`), schedule (`0 */3 * * *`), and workflow_dispatch
+2. First job: `check_changes` — on schedule, compare HEAD to last nightly tag; skip if no changes
+3. Second job: `preflight` — sets release metadata (version, channel, tag); depends on check_changes
+4. Platform-specific jobs: `build-macos`, `build-windows`, `build-linux` — depend on preflight
+5. Conditionally enable signing with `secrets.APPLE_*` (macOS) and `AZURE_TRUSTED_SIGNING_*` (Windows)
+6. Publish artifacts to GitHub Releases with version/channel metadata
+7. For nightly, use `-nightly` tag suffix and set `is_prerelease: true`
+8. For stable, set `make_latest: true` to mark as latest in GitHub UI
+
+## Example
+```yaml
+on:
+  push:
+    tags: ['v*.*.*']
+  schedule:
+    - cron: '0 */3 * * *'
+
+jobs:
+  preflight:
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    outputs:
+      version: ${{ steps.release_meta.outputs.version }}
+  build-macos:
+    needs: preflight
+    runs-on: macos-latest
+    steps:
+      - run: bun run dist:desktop:dmg:arm64
+      - if: secrets.APPLE_ID
+        run: codesign -s "${{ secrets.APPLE_CERT_ID }}" dist.dmg
+  publish:
+    needs: [build-macos, build-windows, build-linux]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: release/*
+```
+
+## Counter / Caveats
+- Apple notarization can be slow (5-10min); plan CI timeout accordingly
+- Azure Trusted Signing requires service principal setup; test with `--dry-run` first
+- GitHub release secrets are not exposed to pull requests; tag-based releases work, but workflow_dispatch won't sign in PRs
+- Nightly builds consume GitHub Actions minutes; throttle to every 3 hours or longer
+- Unsigned releases are shareable but may trigger OS warnings on first launch

--- a/skills/cli/multi-backend-argparse-dispatcher/SKILL.md
+++ b/skills/cli/multi-backend-argparse-dispatcher/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: multi-backend-argparse-dispatcher
+description: Single argparse CLI that dispatches to per-backend implementations (transformers / sglang / vllm / mlx) by required --backend choice, with post-parse cross-flag validation.
+category: cli
+version: 1.0.0
+version_origin: extracted
+tags: [argparse, cli, dispatch, multi-backend, validation]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/z-lab/dflash.git
+source_ref: main
+source_commit: 1fe684b00efba56490d920d15eeb9ba6e4471751
+source_project: dflash
+source_path: dflash/benchmark.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Multi-Backend argparse Dispatcher
+
+## When to use
+- One CLI (`python -m pkg.benchmark ...`) needs to support several mutually-exclusive backends that each require their own Python deps.
+- Some args are universal (`--model`, `--dataset`) and some only make sense for specific backends (`--draft-model` required for `transformers`/`mlx`; `--base-url` for server backends).
+- You want a flat argparse surface (no subparsers) so `--help` stays readable and users can copy commands between backends.
+
+## Pattern
+
+```python
+def main() -> None:
+    p = argparse.ArgumentParser(description="DFlash benchmark")
+    p.add_argument("--backend", choices=["transformers", "sglang", "vllm", "mlx"], required=True)
+    p.add_argument("--model", type=str, required=True)
+    p.add_argument("--dataset", type=str, required=True)
+    p.add_argument("--max-new-tokens", type=int, default=2048)
+    p.add_argument("--temperature", type=float, default=0.0)
+    p.add_argument("--draft-model", type=str, default=None)    # only used by transformers/mlx
+    p.add_argument("--base-url", type=str, default="http://127.0.0.1:30000")  # server only
+    p.add_argument("--enable-thinking", action="store_true")
+    # ... more shared / server-only args ...
+
+    args = p.parse_args()
+
+    # Post-parse cross-flag guards — errors read like argparse's own output.
+    assert not (args.enable_thinking
+                and any(x in args.model.lower() for x in ["qwen3-4b", "qwen3-8b"])), (
+        "DFlash draft models for Qwen3-4B and Qwen3-8B were not trained with thinking traces."
+    )
+
+    if args.backend == "transformers":
+        if args.draft_model is None:
+            p.error("--draft-model is required for transformers backend")   # argparse-style error
+        _run_transformers(args)
+    elif args.backend == "mlx":
+        if args.draft_model is None:
+            p.error("--draft-model is required for mlx backend")
+        _run_mlx(args)
+    else:
+        _run_server(args)   # sglang / vllm share a server path
+```
+
+## Why this shape, not subparsers
+- You can swap backends in a long shell script by just changing one flag, keeping the rest of the command line identical.
+- `p.error(...)` exits with code 2 and prints the usage — consistent with missing-arg errors.
+- Conditional-required is resolved *after* parsing; argparse's own `required=True` would force `--draft-model` on backends that do not need it.
+
+## Per-backend runner split
+- `_run_transformers(args)` — imports torch / transformers inside the function. Users without those libs can still run `mlx` or `sglang`.
+- `_run_mlx(args)` — imports `mlx_lm`.
+- `_run_server(args)` — handles both `sglang` and `vllm` because they share "POST to a URL" semantics; inside, `is_vllm = args.backend == "vllm"` gates the two request shapes.
+
+## Gotchas
+- Do not import heavy deps (`torch`, `mlx`, `vllm`) at module top; keep them inside the runner functions so `--help` works on a minimal install.
+- When flags are ambiguous across backends (e.g., `--block-size` means something different in MLX vs transformers), keep the name but document the backend-specific meaning in the help text.

--- a/skills/configuration/multi-llm-provider-router-by-env/SKILL.md
+++ b/skills/configuration/multi-llm-provider-router-by-env/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: multi-llm-provider-router-by-env
+description: One factory function dispatches to the right LLM client based on a single LLM_PROVIDER env var, picking provider-specific base URL, env-var name for the API key, model id, and parameter quirks (e.g. max_completion_tokens for o1/gpt-5).
+category: configuration
+version: 1.0.0
+version_origin: extracted
+tags: [llm, provider-routing, anthropic, openai, ollama, bedrock]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/Tracer-Cloud/opensre.git
+source_ref: main
+source_commit: fb5ba0a1b4ef511d16c56a80f1f126b1f581d724
+source_project: opensre
+source_path: app/services/llm_client.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Multi-LLM Provider Router by Env
+
+## When to use
+Your app supports many LLM providers (Anthropic, OpenAI, OpenRouter, Gemini, NVIDIA NIM, Minimax, Ollama, Bedrock) and you want users to switch with a single env var. Reasoning vs tool-call models can be selected independently per provider.
+
+## How it works
+- `LLMSettings.from_env()` reads `LLM_PROVIDER` plus per-provider model envs (`OPENAI_REASONING_MODEL`, `ANTHROPIC_TOOLCALL_MODEL`, ...).
+- `_create_llm_client(model_type)` is a single dispatch that returns a typed client (`LLMClient` for Anthropic native, `OpenAILLMClient` for any OpenAI-compatible HTTP API, `BedrockLLMClient` for Bedrock-via-Anthropic-SDK).
+- OpenAI-compatible providers (OpenRouter, Gemini, NVIDIA, Ollama, Minimax) all reuse `OpenAILLMClient` with a different `base_url` and `api_key_env`.
+- Reasoning models (o1, o3, o4, gpt-5*) need `max_completion_tokens` instead of `max_tokens` — picked via `_uses_max_completion_tokens(model)`.
+- Singletons cached separately for "reasoning" and "tools" so a single process can route different node types to different model tiers.
+
+## Example
+```python
+def _create_llm_client(model_type: str):
+    settings = LLMSettings.from_env()
+    p = settings.provider
+    if p == "openai":
+        return OpenAILLMClient(model=settings.openai_reasoning_model
+                               if model_type == "reasoning"
+                               else settings.openai_toolcall_model,
+                               max_tokens=OPENAI_LLM_CONFIG.max_tokens)
+    elif p == "openrouter":
+        return OpenAILLMClient(model=..., base_url=OPENROUTER_BASE_URL,
+                               api_key_env="OPENROUTER_API_KEY")
+    elif p == "ollama":
+        host = settings.ollama_host.rstrip("/")
+        return OpenAILLMClient(model=settings.ollama_model,
+                               base_url=f"{host}/v1",
+                               api_key_env="OLLAMA_API_KEY",
+                               api_key_default="ollama")
+    elif p == "bedrock":
+        return BedrockLLMClient(model=..., max_tokens=...)
+    else:  # anthropic default
+        return LLMClient(model=settings.anthropic_reasoning_model
+                         if model_type == "reasoning"
+                         else settings.anthropic_toolcall_model)
+
+def _uses_max_completion_tokens(model: str) -> bool:
+    return model.startswith(("o1", "o3", "o4", "gpt-5"))
+
+def get_llm_for_reasoning():
+    global _llm
+    if _llm is None: _llm = _create_llm_client("reasoning")
+    return _llm
+
+def get_llm_for_tools():
+    global _llm_for_tools
+    if _llm_for_tools is None: _llm_for_tools = _create_llm_client("toolcall")
+    return _llm_for_tools
+```
+
+## Gotchas
+- Bedrock uses IAM auth via `AnthropicBedrock` — no API key. Keep it on a separate client class so `resolve_llm_api_key` doesn't get confused.
+- Ollama needs an `api_key_default="ollama"` because the OpenAI SDK refuses an empty key.
+- Always expose `reset_llm_singletons()` for tests/benchmarks that flip env vars between calls.
+- `_ensure_client()` re-resolves the API key on every invocation so a key rotated mid-process is picked up.

--- a/skills/data-pipeline/memory-fragment-sizing-for-llm-input/SKILL.md
+++ b/skills/data-pipeline/memory-fragment-sizing-for-llm-input/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: memory-fragment-sizing-for-llm-input
+description: Chunk memory into fragments respecting LLM token budget, per-file and per-session limits
+category: data-pipeline
+version: 1.0.0
+version_origin: extracted
+confidence: medium
+tags: [evolver, data-pipeline, llm, context-budget]
+source_type: extracted-from-git
+source_url: https://github.com/EvoMap/evolver.git
+source_ref: main
+source_commit: 22773782475cecf43dc9c1af264bf5f9cacc28bc
+source_project: evolver
+source_paths:
+  - src/evolve.js
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Multi-cap memory fragment builder
+
+Feeding agent memory into an LLM requires a *global* context budget and *per-source* caps — without both, one chatty file monopolizes the window.
+
+## Three-cap scheme (config-driven)
+
+- `TARGET_BYTES` — global budget (e.g., 120_000).
+- `PER_FILE_BYTES` — max bytes from any single file (e.g., 20_000).
+- `PER_SESSION_BYTES` — max bytes from any single session (e.g., 20_000).
+
+Sort sources by recency. Greedily include each, trimming to the per-source cap before accounting against the global budget. Stop when the global budget is exhausted.
+
+## Mechanism
+
+```js
+function buildFragments(sources, caps) {
+  const out = [];
+  let used = 0;
+  for (const s of sources.sort(byRecencyDesc)) {
+    const slice = s.body.slice(0, caps.perFile);
+    if (used + slice.length > caps.target) break;
+    out.push({ ref: s.ref, body: slice });
+    used += slice.length;
+  }
+  return out;
+}
+```
+
+## When to reuse
+
+Any RAG or agent pipeline that assembles context from heterogeneous sources and must stay within a hard token/byte cap.

--- a/skills/data/model-config-min-json-compact-format/SKILL.md
+++ b/skills/data/model-config-min-json-compact-format/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: model-config-min-json-compact-format
+description: Distribute model config as compact JSON (config.min.json) alongside the .onnx file so package size stays small and parsing is universal.
+category: data
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [magika, data]
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Model Config Min Json Compact Format
+
+**Trigger:** Distributing an ML model with metadata that must be parsable from every language without a custom binary format.
+
+## Steps
+
+- Author the canonical config in pretty JSON (full whitespace) for readability.
+- Generate config.min.json via jq -c or json.dump(separators=(',', ':')).
+- Ship .min.json next to model.onnx; keep the pretty version in source control for review.
+- Add a config_version field so you can evolve the schema without breaking old loaders.
+- Validate strictly at load time: required fields present, value ranges correct, fail fast on unknown fields if you want strict mode.
+- Test the config parser in every binding to catch JSON quirk drift early.
+
+## Counter / Caveats
+
+- Minified JSON is unreadable for debugging; always keep a pretty source-of-truth.
+- Schema changes need version bumps and migration notes.
+- Threshold arrays of 300+ floats inflate the file; consider a sparse representation.
+- Binary formats (protobuf, msgpack) win on size but lose universal portability.
+
+## Source
+
+Extracted from `magika` (https://github.com/google/magika.git @ main).
+
+Files of interest:
+- `assets/models/standard_v3_3/config.min.json`
+- `rust/lib/src/config.rs`
+- `go/magika/config.go:10-31`

--- a/skills/data/model-config-min-json-compact-format/content.md
+++ b/skills/data/model-config-min-json-compact-format/content.md
@@ -1,0 +1,22 @@
+# model-config-min-json-compact-format — extended notes
+
+This is an extracted draft from the **magika** project at commit `0a8cb9626b`.
+See `SKILL.md` for the procedure. Use the source references below to study the
+original implementation before adapting the pattern to a new codebase.
+
+## Source references
+
+- `assets/models/standard_v3_3/config.min.json`
+- `rust/lib/src/config.rs`
+- `go/magika/config.go:10-31`
+
+## When this pattern is a fit
+
+Distributing an ML model with metadata that must be parsable from every language without a custom binary format.
+
+## When to walk away
+
+- Minified JSON is unreadable for debugging; always keep a pretty source-of-truth.
+- Schema changes need version bumps and migration notes.
+- Threshold arrays of 300+ floats inflate the file; consider a sparse representation.
+- Binary formats (protobuf, msgpack) win on size but lose universal portability.

--- a/skills/electron-packaging/minified-js-variable-extraction-dynamic/SKILL.md
+++ b/skills/electron-packaging/minified-js-variable-extraction-dynamic/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: minified-js-variable-extraction-dynamic
+description: Extract minified variable or function names from bundled JavaScript via regex capture groups anchored on stable string literals. Compose per-release sed patches using the extracted names. Handles $ prefixes from minifiers and optional whitespace in both minified and beautified forms.
+category: electron-packaging
+version: 1.0.0
+tags: [minified-js, variable-extraction, regex, sed, electron, patching, build]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+# Minified JS Variable Extraction (Dynamic)
+
+## When to use
+
+Use this pattern when:
+- You need to apply a surgical patch to a minified JavaScript bundle.
+- Variable and function names are randomized by the minifier and change between upstream releases.
+- There are stable string literals in the code (event names, property names, constructor patterns) that remain unchanged across releases.
+- You want patches that continue to work after the upstream app releases a new version without requiring manual name updates.
+
+## Pattern
+
+### Core technique
+
+```bash
+# grep -oP extracts the match of the capture group (after \K or in lookbehind/lookahead)
+VARIABLE_NAME=$(grep -oP 'stable_literal\K\w+(?=other_stable_literal)' file.js)
+```
+
+### Rule: anchor on string literals, not identifiers
+
+String literals in JavaScript source code (`"event-name"`, `"method-name"`, `require("module-name")`) are preserved verbatim by minifiers. Variable and function names adjacent to these literals can be captured by placing the capture group between two stable anchors.
+
+### Escaping for sed
+
+Variables extracted from minified code may start with `$` (e.g., `$e`, `$t`). Dollar signs must be escaped in sed patterns: `${VAR//\$/\\$}`.
+
+## Minimal example
+
+```bash
+#!/usr/bin/env bash
+JS_FILE="app.asar.contents/.vite/build/index.js"
+
+# 1. Extract the variable that holds the electron module
+#    Stable anchor: the literal string require("electron")
+#    The variable assignment: `VAR = require("electron")` or `$VAR = require("electron")`
+ELECTRON_VAR=$(grep -oP '\$?\w+(?=\s*=\s*require\("electron"\))' "$JS_FILE" | head -1)
+[[ -z $ELECTRON_VAR ]] && { echo "ERROR: electron var not found" >&2; exit 1; }
+ELECTRON_VAR_RE="${ELECTRON_VAR//\$/\\$}"   # escape $ for sed
+echo "Electron var: $ELECTRON_VAR"
+
+# 2. Extract a function name anchored on a unique event string it registers
+#    Pattern: on("menuBarEnabled",()=>{ FUNC_NAME() })
+#    The function is called inside the event handler
+TRAY_FUNC=$(grep -oP 'on\("menuBarEnabled",\(\)=>\{\K\w+(?=\(\)\})' "$JS_FILE")
+[[ -z $TRAY_FUNC ]] && { echo "ERROR: tray func not found" >&2; exit 1; }
+echo "Tray func: $TRAY_FUNC"
+
+# 3. Extract a variable name using a structural pattern
+#    Pattern: });let TRAY_VAR=null;(async|)function TRAY_FUNC(
+TRAY_VAR=$(grep -oP "\}\);let \K\w+(?==null;(?:async )?function ${TRAY_FUNC})" "$JS_FILE")
+[[ -z $TRAY_VAR ]] && { echo "ERROR: tray var not found" >&2; exit 1; }
+echo "Tray var: $TRAY_VAR"
+
+# 4. Extract by unique method call: setAlwaysOnTop(!0,"pop-up-menu")
+POPUP_VAR=$(grep -oP '\w+(?=\.setAlwaysOnTop\(\s*!0\s*,\s*"pop-up-menu"\))' "$JS_FILE" | head -1)
+[[ -z $POPUP_VAR ]] && echo "WARNING: popup var not found (non-fatal)"
+echo "Popup var: ${POPUP_VAR:-<not found>}"
+
+# 5. Extract via const assignment to a known function call
+#    Pattern: const MENU_BAR_VAR = someFunc("menuBarEnabled")
+MENU_BAR_VAR=$(grep -oP 'const \K\w+(?=\s*=\s*\w+\("menuBarEnabled"\))' "$JS_FILE" | head -1)
+[[ -n $MENU_BAR_VAR ]] && echo "Menu bar var: $MENU_BAR_VAR"
+
+# 6. Now apply patches using the extracted names
+#    Make the tray function async
+sed -i "s/function ${TRAY_FUNC}(){/async function ${TRAY_FUNC}(){/g" "$JS_FILE"
+
+#    Fix all wrong nativeTheme references
+WRONG_REFS=$(grep -oP '\$?\w+(?=\.nativeTheme)' "$JS_FILE" | sort -u \
+    | grep -Fxv "$ELECTRON_VAR" || true)
+for REF in $WRONG_REFS; do
+    REF_RE="${REF//\$/\\$}"
+    sed -i -E "s/${REF_RE}\.nativeTheme/${ELECTRON_VAR_RE}.nativeTheme/g" "$JS_FILE"
+done
+
+#    Patch tray icon selection to respect dark mode
+if grep -qP ':\$?\w+="TrayIconTemplate\.png"' "$JS_FILE"; then
+    DARK_CHECK="${ELECTRON_VAR_RE}.nativeTheme.shouldUseDarkColors"
+    sed -i -E \
+        "s/:(\\\$?\w+)=\"TrayIconTemplate\.png\"/:\1=${DARK_CHECK}?\"TrayIconTemplate-Dark.png\":\"TrayIconTemplate.png\"/g" \
+        "$JS_FILE"
+fi
+
+#    Patch menuBarEnabled default (!! → !==false)
+if [[ -n $MENU_BAR_VAR ]] && grep -qP ",\s*!!${MENU_BAR_VAR}\s*\)" "$JS_FILE"; then
+    sed -i -E "s/,\s*!!${MENU_BAR_VAR}\s*\)/,${MENU_BAR_VAR}!==false)/g" "$JS_FILE"
+fi
+```
+
+### Validation before apply
+
+```bash
+# Fail loudly if extraction returns empty — better than silent no-op patch
+require_var() {
+    local name="$1" value="$2"
+    if [[ -z $value ]]; then
+        echo "ERROR: could not extract required variable: $name" >&2
+        echo "  The upstream app may have restructured this code." >&2
+        echo "  Inspect: $JS_FILE" >&2
+        exit 1
+    fi
+}
+require_var "ELECTRON_VAR" "$ELECTRON_VAR"
+require_var "TRAY_FUNC" "$TRAY_FUNC"
+```
+
+## Why this works
+
+### String literals survive minification
+
+JavaScript minifiers rename variables and functions to short identifiers (`a`, `b`, `$e`) to reduce file size. However, they cannot rename string literals used as event names, JSON keys, method call arguments, or module identifiers — changing these would break the program's logic. Patterns like `require("electron")`, `on("menuBarEnabled", ...)`, `"pop-up-menu"`, and `"TrayIconTemplate.png"` are stable across all minification passes.
+
+### `grep -oP` with `\K` and lookahead
+
+`-o` outputs only the matched portion. `-P` enables Perl-compatible regex. `\K` is a zero-width assertion that "keeps" (resets) the match start, effectively acting as a lookbehind without the length constraint. `(?=...)` is a zero-width lookahead. Together, `prefix\K\w+(?=suffix)` extracts the identifier between `prefix` and `suffix` without including either in the output.
+
+### `| head -1` for uniqueness
+
+If the same pattern appears multiple times (e.g., `require("electron")` in multiple modules), `grep -oP ... | head -1` takes the first match. For well-structured single-file bundles, the first match is typically the module-level assignment. Add additional context to the pattern if disambiguation is needed.
+
+### `${VAR//\$/\\$}` — escaping $ for sed
+
+Some minifiers use `$` as a prefix for variable names (e.g., `$e = require("electron")`). Dollar signs have special meaning in sed replacement strings and in regex patterns. `${VAR//\$/\\$}` is a bash parameter expansion that replaces all `$` with `\$` in `$VAR`, producing a sed-safe regex.
+
+### Verify after apply
+
+After applying a patch, verify it took effect:
+```bash
+if grep -qP ',\s*!!${MENU_BAR_VAR}\s*\)' "$JS_FILE"; then
+    echo "ERROR: patch did not apply — pattern still present" >&2; exit 1
+fi
+```
+
+## Pitfalls
+
+- **`-P` (Perl regex) is GNU grep** — not available on BSD grep (macOS). Use `ggrep` or install `grep` via Homebrew when developing on macOS. In Linux build environments, GNU grep is always present.
+- **mapfile vs. array from grep** — use `mapfile -t array < <(grep ...)` to capture multiple matches into an array rather than iterating `$()` output in a for loop (word-splitting issues with filenames containing spaces).
+- **Pattern collision on `head -1`** — if two different variables match the same extraction pattern (e.g., two `require("electron")` at different scopes in a bundled file), `head -1` may return the wrong one. Add more context to the pattern or use a numbered occurrence.
+- **Whitespace in minified code** — minified code has no spaces around operators. But some build pipelines partially format the output. Always use `\s*` around `=`, `,`, `=>`, `{`, `}` in patterns that may encounter either form.
+- **Non-fatal extractions should not block the build** — for variables that are optional (a feature may not be present in all app versions), use a warning instead of `exit 1`. Gate the corresponding patch on `[[ -n $OPTIONAL_VAR ]]`.
+
+## Source reference
+
+`build.sh` — `extract_electron_variable`, `patch_tray_menu_handler`, `patch_tray_icon_selection`, `patch_menu_bar_default` functions; `CLAUDE.md` — "Working with Minified JavaScript" section

--- a/skills/electron/multi-instance-electron-dev/SKILL.md
+++ b/skills/electron/multi-instance-electron-dev/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: multi-instance-electron-dev
+description: Run multiple independent dev instances of the same Electron app on one machine by deriving port, config dir, app name, and deep-link scheme from a numeric suffix on the project folder name.
+category: electron
+version: 1.0.0
+version_origin: extracted
+tags: [electron, dev, multi-instance, deep-links]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: scripts/electron-dev.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Multi-instance Electron dev
+
+## When to use
+- Testing migrations / upgrades where you need "old version" and "new version" running side-by-side.
+- Agent app where you want two independent workspaces without data cross-contamination.
+- Deep links (custom URL scheme) need to route to the right instance.
+
+## How it works
+1. Clone the repo into folders like `craft-agents-1/`, `craft-agents-2/` (or any name ending `-N`).
+2. Dev script parses `basename(ROOT_DIR).match(/-(\d+)$/)`. If matches:
+   - `CRAFT_VITE_PORT = ${N}173` (e.g. `1173`, `2173`).
+   - `CRAFT_CONFIG_DIR = ~/.craft-agent-${N}` - entirely separate config + credentials + sessions.
+   - `CRAFT_APP_NAME = "Craft Agents [${N}]"` - shown in macOS menu bar / dock.
+   - `CRAFT_DEEPLINK_SCHEME = "craftagents${N}"` - `craftagents1://`, `craftagents2://`, etc.
+3. Electron main reads these env vars and uses them for `app.setName()`, config path, and `app.setAsDefaultProtocolClient(scheme)`.
+4. Renderer Vite config binds to `CRAFT_VITE_PORT`; `--strictPort` so it fails rather than silently collides.
+
+## Example
+```ts
+const folderName = basename(ROOT_DIR);
+const match = folderName.match(/-(\d+)$/);
+if (match) {
+  const n = match[1];
+  process.env.CRAFT_INSTANCE_NUMBER = n;
+  process.env.CRAFT_VITE_PORT = `${n}173`;
+  process.env.CRAFT_APP_NAME = `Craft Agents [${n}]`;
+  process.env.CRAFT_CONFIG_DIR = join(process.env.HOME, `.craft-agent-${n}`);
+  process.env.CRAFT_DEEPLINK_SCHEME = `craftagents${n}`;
+}
+```
+
+```ts
+// apps/electron/src/main/index.ts
+app.setName(process.env.CRAFT_APP_NAME || 'Craft Agents');
+const DEEPLINK_SCHEME = process.env.CRAFT_DEEPLINK_SCHEME || 'craftagents';
+app.setAsDefaultProtocolClient(DEEPLINK_SCHEME);
+```
+
+## Gotchas
+- Config dir is the most important isolation - if you share `~/.craft-agent`, two instances will corrupt each other's session files with race writes.
+- Deep link schemes MUST be unique or the OS routes all `craftagents://` URLs to whichever instance claimed it first.
+- Users won't guess the folder-suffix naming - document it. Or use an explicit `CRAFT_INSTANCE=N` env as an alternative path.
+- App name is visible to the user (dock, menu bar); make it scannable at a glance.
+- Bun's `basename()` on Windows uses backslash-aware path parsing - not an issue but worth testing.

--- a/skills/frontend/modal-navigation-stack-with-back/SKILL.md
+++ b/skills/frontend/modal-navigation-stack-with-back/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: modal-navigation-stack-with-back
+description: For drill-down UIs reusing a single modal surface, snapshot head/path/body before each open and push to a stack; a Back button / Backspace pops the stack, Esc clears it.
+category: frontend
+triggers:
+  - modal drill down
+  - single modal multiple views
+  - back button modal
+  - reusable popup
+tags:
+  - ui
+  - vanilla-js
+version: 1.0.0
+---
+
+# modal-navigation-stack-with-back
+
+Reusing one modal for chained drill-downs (e.g., click a chart segment → see a list → click a row → see a detail) silently destroys prior context — closing the innermost view leaves stale content on reopen, and the user has no way back to the list.
+
+## Pattern
+
+Snapshot current modal content before each open. Pop to restore. Clear the stack on close.
+
+```js
+const _stack = [];
+function pushSnapshot() {
+  if (!modal.classList.contains('open')) { _stack.length = 0; return; }
+  _stack.push({ title: $title.innerHTML, path: $path.innerHTML, body: $body.innerHTML });
+  $back.style.display = '';
+}
+function popSnapshot() {
+  const prev = _stack.pop();
+  if (!prev) { $back.style.display = 'none'; return false; }
+  $title.innerHTML = prev.title; $path.innerHTML = prev.path; $body.innerHTML = prev.body;
+  if (_stack.length === 0) $back.style.display = 'none';
+  return true;
+}
+function closeModal() { modal.classList.remove('open'); _stack.length = 0; $back.style.display = 'none'; }
+```
+
+Call `pushSnapshot()` as the very first line of every `openX(...)` function — before mutating title/path/body. The `if modal is open` guard makes the first open a no-op push.
+
+Bind: `×` → closeModal · `←` / Backspace → popSnapshot · backdrop click / Esc → closeModal.
+
+## Why snapshot HTML instead of a data model
+
+Each drill-down has a different shape (list vs. detail vs. list-of-lists). Reconstructing would require per-view serializers. Snapshotting rendered HTML is a flat, view-agnostic restore and costs a few KB per level.
+
+## Guardrail
+
+Backspace handler must early-return if an INPUT/TEXTAREA has focus — otherwise you eat text-editing backspaces.

--- a/skills/gpu-kernels/multi-kernel-dispatch-with-shape-driven-selection/SKILL.md
+++ b/skills/gpu-kernels/multi-kernel-dispatch-with-shape-driven-selection/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: multi-kernel-dispatch-with-shape-driven-selection
+description: Hide multiple kernel variants (1D1D vs 1D2D, SM90 vs SM100, packed-vs-unpacked SF) behind a single public API by inspecting tensor metadata to pick the right dispatcher.
+category: gpu-kernels
+version: 1.0.0
+version_origin: extracted
+tags: [kernel-dispatch, shape-analysis, polymorphism, api-design]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - csrc/apis/gemm.hpp
+imported_at: 2026-04-18T13:12:58Z
+---
+
+# Multi-Kernel Dispatch With Shape-Driven Selection
+
+## What / Why
+Users want one function (`fp8_gemm_nt`) that "just works" regardless of scale granularity, architecture, or packing. Internally there are several kernels optimized for different shape classes. Read the transformed scale factors' metadata (dtype, granularity) to decide which kernel receives the call — the user never picks.
+
+## Procedure
+1. **Normalize inputs.** Transform user-supplied scales into the required layout (`transform_sf_pair_into_required_layout()`). This step also records `gran_n` and dtype as a side effect.
+2. **Branch by arch.** Detect compute capability (SM90 vs SM100) once at init.
+3. **Branch by scale metadata on SM90.**
+   - `sfa/sfb` are FP32 and `gran_n == 1` → dispatch `sm90_fp8_gemm_1d1d_dispatch(...)`.
+   - `sfa/sfb` are FP32 and `gran_n > 1` → dispatch `sm90_fp8_gemm_1d2d_dispatch(...)`.
+4. **Branch by packing on SM100.**
+   - `sfa/sfb` are packed UE8M0 `int32` → `sm100_fp8_fp4_gemm_1d1d_dispatch(...)`.
+   - FP32 scales get auto-packed first, then the same dispatcher runs.
+5. **Precondition check inside each dispatcher.** E.g., 1D1D rejects TMA-split scenarios; bounce back to 1D2D if needed.
+
+## Key design points
+- Keep the dispatch table explicit — a flat `if/else if` chain is easier to audit than a registry of function pointers for a small, fixed number of kernels.
+- Do the transform *before* the dispatch. That way the dispatch sees the kernel-ready form and the dispatch logic is metadata-driven.
+- Assert clearly when no kernel applies: include the shape, dtype, and granularity in the error.
+
+## References
+- `csrc/apis/gemm.hpp` — public `fp8_gemm_nt` with inline dispatch ladder.
+- `csrc/jit_kernels/impls/*` — individual kernel dispatchers.

--- a/skills/input/mouse-button-enum-dispatch/SKILL.md
+++ b/skills/input/mouse-button-enum-dispatch/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: mouse-button-enum-dispatch
+description: Enum-based mouse event handling (left, right, wheel, back) with callback routing.
+category: input
+version: 1.0.0
+version_origin: extracted
+tags: [button, dispatch, enum, input, mouse]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: flutter/lib/models/input_model.dart
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Mouse Button Enum Dispatch
+
+## When to use
+Enum-based mouse event handling (left, right, wheel, back) with callback routing.
+
+## Source context
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- Demonstrated in: `flutter/lib/models/input_model.dart`
+
+## Why this generalizes
+Clean pattern vs. chained if/else for input events.
+
+## Next steps before publishing
+- Read the source files above and rewrite this as a product-agnostic `how-to` — keep the pattern, drop rustdesk-specific names.
+- Add a minimal code example in the target language (Rust + Dart / Rust only / etc.).
+- List 2-3 gotchas you hit while reproducing it.

--- a/skills/integration/mcp-multi-transport-config-pydantic/SKILL.md
+++ b/skills/integration/mcp-multi-transport-config-pydantic/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: mcp-multi-transport-config-pydantic
+description: Single Pydantic config that supports three MCP transports (stdio, sse, streamable-http) with per-transport required-field validation in a model_validator(after) so users get a clear error when the wrong combination is set.
+category: integration
+version: 1.0.0
+version_origin: extracted
+tags: [mcp, pydantic, multi-transport, validation]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/Tracer-Cloud/opensre.git
+source_ref: main
+source_commit: fb5ba0a1b4ef511d16c56a80f1f126b1f581d724
+source_project: opensre
+source_path: app/integrations/openclaw.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Single MCP Config with Per-Transport Required-Field Validation
+
+## When to use
+Your tool/agent integrates with an MCP server that exposes multiple transports (stdio for local dev, sse / streamable-http for hosted). Users give you ONE config dict; you want a single Pydantic model that accepts all transports but enforces the right required fields per `mode`.
+
+## How it works
+- A `mode: Literal["stdio","sse","streamable-http"]` field with a `before`-validator normalizing case.
+- Per-field `before`-validators normalize URLs (`rstrip('/')`), strip whitespace from tokens, and convert `Bearer xxx` to bare tokens.
+- A `model_validator(mode="after")` enforces transport-specific requirements: stdio requires `command`; sse/streamable-http require `url`.
+- All built on a `StrictConfigModel` base so unknown keys are rejected with did-you-mean suggestions.
+
+## Example
+```python
+class OpenClawConfig(StrictConfigModel):
+    url: str = ""
+    mode: Literal["stdio", "sse", "streamable-http"] = DEFAULT_MODE
+    auth_token: str = ""
+    command: str = ""
+    args: tuple[str, ...] = ()
+    headers: dict[str, str] = Field(default_factory=dict)
+    timeout_seconds: float = Field(default=15.0, gt=0)
+    integration_id: str = ""
+
+    @field_validator("url", mode="before")
+    @classmethod
+    def _normalize_url(cls, value):
+        return str(value or "").strip().rstrip("/")
+
+    @field_validator("auth_token", mode="before")
+    @classmethod
+    def _normalize_auth_token(cls, value):
+        token = str(value or "").strip()
+        if token.lower().startswith("bearer "):
+            token = token.split(None, 1)[1].strip()
+        return token
+
+    @model_validator(mode="after")
+    def _validate_transport_requirements(self):
+        if self.mode == "stdio" and not self.command:
+            raise ValueError("OpenClaw stdio mode requires 'command'")
+        if self.mode in ("sse", "streamable-http") and not self.url:
+            raise ValueError(f"OpenClaw {self.mode} mode requires 'url'")
+        return self
+```
+
+## Gotchas
+- Use `Literal[...]` for the mode field so Pydantic emits a clear validation error for unknown transports — and so type checkers narrow downstream code.
+- Strip `Bearer ` from auth tokens automatically; users frequently paste the full Authorization header value.
+- Validate `gt=0` on timeouts directly in `Field(...)` rather than in a custom validator — built-in constraints surface clearer errors.
+- Run normalization in `mode="before"` so the validators see the raw input (e.g. `"  https://x/  "`) before any other field-level processing.

--- a/skills/integration/mcp-streamable-http-detached-httpx-client/SKILL.md
+++ b/skills/integration/mcp-streamable-http-detached-httpx-client/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: mcp-streamable-http-detached-httpx-client
+description: Inject a caller-owned httpx.AsyncClient into the official MCP streamable_http transport via httpx_client_factory, using a no-op async-context-manager so the transport never closes the underlying client on exit.
+category: integration
+version: 1.0.0
+version_origin: extracted
+tags: [mcp, streamable-http, httpx, sdk-shim]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/Tracer-Cloud/opensre.git
+source_ref: main
+source_commit: fb5ba0a1b4ef511d16c56a80f1f126b1f581d724
+source_project: opensre
+source_path: app/integrations/mcp_streamable_http_compat.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# MCP Streamable HTTP with a Detached httpx Client
+
+## When to use
+You want to share one `httpx.AsyncClient` (with custom auth, proxies, retries, connection pool) across many MCP server connections, but `mcp.client.streamable_http.streamablehttp_client` only accepts an `httpx_client_factory` callable that constructs a new client (and that the transport will close on exit). You need a shim that hands back the existing client without taking ownership of its lifecycle.
+
+## How it works
+- `_DetachExitAsyncClientCM` is a tiny `async with` context manager that yields the pre-built `httpx.AsyncClient` on `__aenter__` and does NOTHING on `__aexit__` — no close, no shutdown.
+- `_httpx_factory_for_client(client)` returns the factory function the MCP SDK expects; the factory ignores the SDK's headers/timeout/auth args (they're already configured on the client) and returns the wrapper CM.
+- The public `streamable_http_client` function passes the factory into the official transport, so application code can use one client across many MCP servers.
+
+## Example
+```python
+class _DetachExitAsyncClientCM:
+    __slots__ = ("_client",)
+    def __init__(self, client: httpx.AsyncClient): self._client = client
+    async def __aenter__(self):  return self._client
+    async def __aexit__(self, *_): return None
+
+def _httpx_factory_for_client(http_client):
+    def _factory(headers=None, timeout=None, auth=None):
+        del headers, timeout, auth          # already configured on the shared client
+        return cast(httpx.AsyncClient, _DetachExitAsyncClientCM(http_client))
+    return _factory
+
+@asynccontextmanager
+async def streamable_http_client(url, *, http_client, headers=None,
+                                 timeout=30.0, sse_read_timeout=300.0,
+                                 terminate_on_close=True):
+    async with _streamablehttp_client(
+        url, headers=headers or {}, timeout=timeout,
+        sse_read_timeout=sse_read_timeout, terminate_on_close=terminate_on_close,
+        httpx_client_factory=_httpx_factory_for_client(http_client),
+    ) as triple:
+        yield triple
+```
+
+## Gotchas
+- `cast(httpx.AsyncClient, _DetachExitAsyncClientCM(...))` is a type-checker workaround — the SDK type-hints want an `AsyncClient`, but it actually only uses `async with` semantics on the result.
+- This pattern is a maintenance burden: when the upstream SDK changes its transport contract, this shim must be revisited.
+- Use `__slots__` on the wrapper so it has zero per-instance overhead.
+- Pair with a single `httpx.AsyncClient(timeout=httpx.Timeout(...), limits=httpx.Limits(...))` constructed at app startup so all MCP traffic shares one connection pool.

--- a/skills/llm-agents/mlx-kv-cache-rollback-on-reject/SKILL.md
+++ b/skills/llm-agents/mlx-kv-cache-rollback-on-reject/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: mlx-kv-cache-rollback-on-reject
+description: Roll back target-model KV cache after rejected speculative tokens, including GatedDeltaNet (non-trimmable) layers, by capturing per-layer inputs and replaying only the accepted prefix.
+category: llm-agents
+version: 1.0.0
+version_origin: extracted
+tags: [speculative-decoding, kv-cache, mlx, gated-delta, state-rollback]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/z-lab/dflash.git
+source_ref: main
+source_commit: 1fe684b00efba56490d920d15eeb9ba6e4471751
+source_project: dflash
+source_path: dflash/model_mlx.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Rollback MLX KV Cache After Rejected Specs
+
+## When to use
+- You are doing speculative decoding on an MLX model that mixes standard `KVCache` / `RotatingKVCache` (trimmable) with state-space / linear-attention layers such as GatedDeltaNet (non-trimmable).
+- You need to discard `trim = block_size - accepted - 1` tokens from every cache so the next block starts with a consistent state.
+- Trimming works for attention-based layers, but SSM-like layers have no per-token slice — you must replay the last `accepted + 1` tokens' state update.
+
+## Pattern
+
+Two caches behave differently:
+- **Trimmable** (`c.is_trimmable() == True`): call `trim_prompt_cache(cache, trim)` — cheap O(1) index adjustment.
+- **Non-trimmable** GatedDeltaNet: intercept `__call__` to record `(q, k, v, a, b, A_log, dt_bias, state, mask)` per layer during the verify-forward. On reject, re-run `gated_delta_update` over only the accepted prefix and overwrite `cache.cache[1]`.
+
+```python
+class _GDNStateCapture:
+    """Monkey-patches GatedDeltaNet.__call__ to record inputs, provides rollback()."""
+    def __init__(self):
+        self._gdn_inputs, self.conv_data = [], []
+        _GDN_PATCH_LOCK.acquire()
+        self._patch()          # replace class __call__ with capturing version
+
+    def rollback(self, cache, accepted, trim):
+        n_non_trim = sum(1 for c in cache if not c.is_trimmable())
+        assert n_non_trim == len(self._gdn_inputs)
+        j = 0
+        for c in cache:
+            if c.is_trimmable():
+                c.trim(trim)
+            else:
+                q, k, v, a, b, A_log, dt_bias, init_state, mask = self._gdn_inputs[j]
+                n = accepted + 1
+                _, new_state = _gd_mod.gated_delta_update(
+                    q[:, :n], k[:, :n], v[:, :n], a[:, :n], b[:, :n],
+                    A_log, dt_bias, init_state,
+                    None if mask is None else mask[:, :n],
+                    use_kernel=True,
+                )
+                c.cache[1] = new_state
+                conv_input, K = self.conv_data[j]
+                c.cache[0] = conv_input[:, accepted + 1: accepted + K]
+                j += 1
+
+    def close(self):
+        # Restore GatedDeltaNet.__call__, release the class-level lock.
+        ...
+```
+
+## Driver loop
+
+```python
+_can_trim = can_trim_prompt_cache(target_cache)
+_capture = _GDNStateCapture() if not _can_trim else None
+try:
+    while generating:
+        if _capture is not None:
+            _capture.clear()
+        # ... verify target ...
+        trim = block_size - accepted - 1
+        if trim > 0:
+            if _can_trim:
+                trim_prompt_cache(target_cache, trim)
+            else:
+                _capture.rollback(target_cache, accepted, trim)
+finally:
+    if _capture is not None:
+        _capture.close()
+```
+
+## Gotchas
+- The capture patches a *class method*, so concurrent speculative decoders in the same process would collide. Guard with a module-level `RLock` and always `close()` in `finally`.
+- The convolution 1-D state (`conv_data`) must also be re-sliced — tokens after `accepted + 1` pollute the convolution prefix.
+- Assert `len(self._gdn_inputs) == n_non_trimmable` so a shape mismatch fails loudly rather than silently corrupting state.
+- This is MLX-specific because `cache.cache[0]` / `cache.cache[1]` are the conv + state slots in MLX's GatedDeltaNet cache shape; PyTorch equivalents use different field names.

--- a/skills/mcp-integration/mcp-pool-http-proxy-for-subprocess-sdks/SKILL.md
+++ b/skills/mcp-integration/mcp-pool-http-proxy-for-subprocess-sdks/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: mcp-pool-http-proxy-for-subprocess-sdks
+description: Expose a pool of MCP sources (Linear, GitHub, Notion, ...) to Codex/Copilot SDK subprocesses through a single Streamable-HTTP MCP endpoint, instead of having each subprocess open independent connections.
+category: mcp-integration
+version: 1.0.0
+version_origin: extracted
+tags: [mcp, streamable-http, subprocess, connection-pool]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: packages/shared/src/mcp/pool-server.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# MCP pool HTTP proxy for subprocess SDKs
+
+## When to use
+- Host process already manages MCP connections to many sources (Linear, GitHub, Notion, ...).
+- You spawn LLM SDK subprocesses (Codex, Copilot) that themselves consume MCP tools.
+- You do NOT want each subprocess re-establishing stateful stdio/SSE connections to every source.
+- Want stateless HTTP so multiple subprocesses can share the pool with no session tracking.
+
+## How it works
+1. In the host (e.g. Electron main), keep an `McpClientPool` of `PoolClient` instances — one per source, each holding the real `@modelcontextprotocol/sdk` client.
+2. Stand up a local HTTP server on `127.0.0.1:0` (random port).
+3. Wrap it with `StreamableHTTPServerTransport({ sessionIdGenerator: undefined })` — **stateless mode**, no session affinity.
+4. Connect an `@modelcontextprotocol/sdk/server` `Server` to the transport; register `ListToolsRequestSchema` (fan-out to the pool, namespaced tool names) and `CallToolRequestSchema` (dispatch back).
+5. Route every incoming request at `/mcp` to `transport.handleRequest(req, res)` regardless of HTTP method.
+6. Return the URL `http://127.0.0.1:<port>/mcp` to each spawned SDK subprocess as its MCP endpoint.
+7. Subprocess uses `StreamableHTTPClientTransport(new URL(url))` to talk to the pool.
+
+## Example
+```ts
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+
+this.transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+this.mcpServer = new Server({ name: 'pool', version: '1.0.0' }, { capabilities: { tools: {} } });
+this.mcpServer.setRequestHandler(ListToolsRequestSchema, async () => {
+  const tools = [];
+  for (const [slug, client] of this.pool.entries()) {
+    const list = await client.listTools();
+    tools.push(...list.map(t => ({ ...t, name: `mcp__${slug}__${t.name}` })));
+  }
+  return { tools };
+});
+this.mcpServer.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const [, slug, tool] = req.params.name.split('__');
+  return this.pool.get(slug).callTool(tool, req.params.arguments);
+});
+await this.mcpServer.connect(this.transport);
+http.createServer((req, res) => this.transport.handleRequest(req, res)).listen(0, '127.0.0.1');
+```
+
+## Gotchas
+- Stateless mode means DO NOT use `session/notifications` or resource subscriptions - they all need a session ID.
+- Bind to `127.0.0.1` only - the SDK subprocess shares your localhost so no need to open a port publicly.
+- Namespace tool names aggressively (`mcp__<source>__<tool>`) so collisions between sources don't silently shadow each other.
+- `transport.handleRequest` covers POST, GET, DELETE - route them all to it; don't try to branch on method.

--- a/skills/mcp-integration/mcp-sse-streamable-http/SKILL.md
+++ b/skills/mcp-integration/mcp-sse-streamable-http/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: mcp-sse-streamable-http
+description: Connect an agent to a remote MCP server via HTTP+SSE or Streamable HTTP transport.
+category: mcp-integration
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [openai-agents, mcp, sse, streamable-http, remote-server]
+source_type: extracted-from-git
+source_url: https://github.com/openai/openai-agents-python.git
+source_ref: main
+source_commit: e80d2d2319eb300ac17ec496988b70246a5042d6
+source_project: openai-agents-python
+source_path: examples/mcp/sse_example/main.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# mcp-sse-streamable-http
+
+Use `MCPServerSse` for HTTP+SSE MCP servers or `MCPServerStreamableHttp` for Streamable HTTP servers. Both run tool calls in your Python process, unlike `HostedMCPTool`.
+
+## When to apply
+
+When you run a private MCP server (not exposed to the internet) that your Python process can reach, and you want tool execution to happen locally rather than on OpenAI's infrastructure.
+
+## HTTP+SSE
+
+```python
+from agents import Agent, Runner
+from agents.mcp import MCPServerSse
+
+async def main():
+    async with MCPServerSse(
+        name="SSE Server",
+        params={"url": "http://localhost:8000/sse"},
+        cache_tools_list=True,
+    ) as mcp_server:
+        agent = Agent(
+            name="Assistant",
+            instructions="Use the tools to answer questions.",
+            mcp_servers=[mcp_server],
+        )
+        result = await Runner.run(agent, "What tools do you have?")
+        print(result.final_output)
+```
+
+## Streamable HTTP
+
+```python
+from agents.mcp import MCPServerStreamableHttp
+
+async with MCPServerStreamableHttp(
+    name="Streamable HTTP Server",
+    params={"url": "http://localhost:8000/mcp"},
+) as mcp_server:
+    agent = Agent(name="Assistant", mcp_servers=[mcp_server])
+    result = await Runner.run(agent, "Hello!")
+```
+
+## Key notes
+
+- Both require the server to be running before the agent starts
+- `cache_tools_list=True` caches the tool list to avoid repeated `list_tools()` calls
+- Both support `tool_filter` for exposing only a subset of available tools
+- `MCPServerStreamableHttp` is preferred for new servers; `MCPServerSse` for legacy servers
+- Add `mcp_config={"convert_schemas_to_strict": True}` on the agent for better schema compatibility

--- a/skills/mcp-integration/mcp-stdio-server/SKILL.md
+++ b/skills/mcp-integration/mcp-stdio-server/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: mcp-stdio-server
+description: Connect an agent to a local MCP server running as a subprocess over stdio.
+category: mcp-integration
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [openai-agents, mcp, stdio, subprocess, local-tools]
+source_type: extracted-from-git
+source_url: https://github.com/openai/openai-agents-python.git
+source_ref: main
+source_commit: e80d2d2319eb300ac17ec496988b70246a5042d6
+source_project: openai-agents-python
+source_path: examples/mcp
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# mcp-stdio-server
+
+Use `MCPServerStdio` to launch a local process and communicate over stdin/stdout using the MCP protocol. Add the server to `Agent.mcp_servers`.
+
+## When to apply
+
+When you have an MCP server that runs as a local process (e.g., `npx @modelcontextprotocol/server-filesystem`). Best for development and trusted local environments.
+
+## Core snippet
+
+```python
+import asyncio
+from agents import Agent, Runner
+from agents.mcp import MCPServerStdio
+
+async def main():
+    async with MCPServerStdio(
+        name="Filesystem Server",
+        params={
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+        },
+        # Optional: cache list_tools() result
+        cache_tools_list=True,
+    ) as mcp_server:
+        agent = Agent(
+            name="File assistant",
+            instructions="Use the tools to answer questions about files.",
+            mcp_servers=[mcp_server],
+        )
+        result = await Runner.run(agent, "List the files in /tmp")
+        print(result.final_output)
+
+asyncio.run(main())
+```
+
+## With tool filtering
+
+```python
+async with MCPServerStdio(
+    name="Git Server",
+    params={"command": "uvx", "args": ["mcp-server-git", "--repository", "."]},
+    # Only expose specific tools from the server
+    tool_filter=["git_log", "git_diff"],
+) as mcp_server:
+    agent = Agent(name="Git assistant", mcp_servers=[mcp_server])
+```
+
+## Key notes
+
+- Use as an async context manager to manage the subprocess lifecycle
+- `cache_tools_list=True` avoids repeated `list_tools()` calls per agent turn
+- `tool_filter` accepts a list of tool names or a callable predicate
+- MCP tool failures surface as tool error text by default; customize via `mcp_config`
+- For remote servers, use `MCPServerSse` (HTTP+SSE) or `MCPServerStreamableHttp`

--- a/skills/mcp-integration/mcp-tool-intent-metadata-injection/SKILL.md
+++ b/skills/mcp-integration/mcp-tool-intent-metadata-injection/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: mcp-tool-intent-metadata-injection
+description: Inject a hidden _intent / _displayName field into every MCP tool schema via a fetch interceptor so large-response summarization and UI rendering have context that the LLM never sees.
+category: mcp-integration
+version: 1.0.0
+version_origin: extracted
+tags: [mcp, interceptor, metadata, summarization]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: packages/shared/src/unified-network-interceptor.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# MCP tool intent-metadata injection via fetch interceptor
+
+## When to use
+- Large MCP tool responses (60KB+) need automatic summarization, but summarization needs to know *why* the user called the tool.
+- You have an LLM SDK that owns the fetch loop and you can't modify how tools are defined.
+- Different UI surfaces want different display names for the same underlying tool.
+
+## How it works
+1. Build a shared fetch interceptor as a standalone CJS bundle (e.g. via esbuild) - `interceptor.cjs`.
+2. Inject it into every Node-based SDK subprocess with `--require=/path/to/interceptor.cjs` (or `--preload` under Bun). This patches `globalThis.fetch` BEFORE any SDK captures it.
+3. On outgoing LLM requests, walk the `tools[]` array in the JSON body. For every tool, add two hidden schema fields:
+   - `_intent`: one-liner on why the assistant is calling it.
+   - `_displayName`: override for UI rendering.
+4. The LLM fills them in as normal schema fields. Your host code reads them off the `tool_use` event.
+5. On SSE response streaming, strip these fields back out before handing to the SDK - the SDK will reject unknown fields on Anthropic. For OpenAI, pass them through and let a downstream hook strip later (the two providers differ on strictness).
+6. Store per-call metadata in a `toolMetadataStore` keyed by tool-use ID; re-inject on the next request so the model still sees the history it wrote.
+
+## Example
+```ts
+// interceptor.cjs (preloaded into every SDK subprocess)
+const origFetch = globalThis.fetch;
+globalThis.fetch = async (input, init) => {
+  if (init?.body && isClaudeMessagesRequest(input)) {
+    const body = JSON.parse(init.body);
+    for (const t of body.tools ?? []) {
+      t.input_schema.properties._intent = { type: 'string', description: '1-line why' };
+      t.input_schema.properties._displayName = { type: 'string' };
+    }
+    init = { ...init, body: JSON.stringify(body) };
+  }
+  const res = await origFetch(input, init);
+  return interceptSse(res, /* strip metadata for Anthropic */);
+};
+```
+
+## Gotchas
+- Bundle as CJS with bundled deps - you're `--require`-ing into arbitrary Node processes that don't have your `node_modules`.
+- Anthropic's SSE validation is strict; you MUST strip metadata from streamed deltas before the SDK parses them.
+- Re-injection on follow-up turns is easy to forget. Store metadata by the tool-use-id and walk the `messages[].content` array to rewrite.
+- The LLM will "waste" tokens writing `_intent` values - cap the description with a firm instruction like "one short sentence, <120 chars".

--- a/skills/moe-optimization/mega-moe-fusion-with-symmetric-memory/SKILL.md
+++ b/skills/moe-optimization/mega-moe-fusion-with-symmetric-memory/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: mega-moe-fusion-with-symmetric-memory
+description: Fuse EP dispatch, FP8×FP4 GEMM×2, SwiGLU, and EP combine into a single kernel that reads across ranks via symmetric-memory (same VA on every rank) to overlap NVLink collectives with compute.
+category: moe-optimization
+version: 1.0.0
+version_origin: extracted
+tags: [moe, kernel-fusion, symmetric-memory, nvlink, communication-compute-overlap]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - csrc/jit_kernels/heuristics/mega_moe.hpp
+  - deep_gemm/mega/__init__.py
+  - tests/test_mega_moe.py
+imported_at: 2026-04-18T13:12:58Z
+---
+
+# Mega MoE Fusion With Symmetric Memory
+
+## What / Why
+A classic EP (expert-parallel) MoE step is five discrete ops: allgather tokens, gather-by-expert, GEMM1, SwiGLU, GEMM2, scatter-combine. Each has its own launch + barrier + memory pass. Mega MoE fuses all of them into **one** kernel that reads from *peer-rank* buffers using symmetric memory (same virtual address on every rank, backed by CUDA IPC). Compute on local experts overlaps with NVLink traffic to/from peers — no explicit allgather + compute phase boundaries.
+
+## Procedure
+1. **Require PyTorch ≥ 2.9** for the `torch.cuda.symmetric_memory` API (same VA across ranks via IPC).
+2. **Allocate a symmetric buffer.** `get_symm_buffer_for_mega_moe(group, num_experts, num_max_tokens_per_rank, num_topk, hidden, intermediate_hidden)` returns one `MegaMoEBuffer` per rank, all sharing virtual addresses.
+3. **Layout the buffer** with named regions: `x` (activations FP8), `x_sf` (UE8M0 scales), `topk_idx`, `topk_weights`, `weights` (FP4, read-only), `output`.
+4. **Select kernel config** via `mega_moe.hpp` heuristic: picks `block_m` (tokens per expert), `block_n` (hidden per expert), `block_k`; accounts for a 2× imbalance factor when estimating per-expert token count.
+5. **Kernel pipeline stages.**
+   - Phase 1: warp-group 0 issues cross-rank TMA loads of peer-rank `x` into smem.
+   - Phase 2: warp-groups 1-N run GEMM1 (FP8 × FP4) on already-arrived tiles.
+   - Phase 3: fused SwiGLU (gate × silu(up)).
+   - Phase 4: GEMM2.
+   - Phase 5: cross-rank TMA stores into peer-rank `output` — the EP combine.
+6. **Barrier layout.** Dependency tracking via lightweight mbarriers; no `__syncthreads()` across the whole block.
+
+## Key design points
+- Symmetric memory is the critical enabler — without it, you need host-side gather, which serializes the pipeline.
+- The imbalance factor (2×) is empirical for typical top-k routing. Heavily skewed models should override `mk_alignment_for_contiguous_layout()`.
+- Keep FP8 activations and FP4 weights — no mid-kernel dequantization to FP32. Accumulator stays BF16 / FP32 per tensor-core protocol.
+
+## References
+- `csrc/jit_kernels/heuristics/mega_moe.hpp` — config search with imbalance factor.
+- `deep_gemm/mega/__init__.py` — Python API + symmetric buffer helper.
+- `tests/test_mega_moe.py` — reference correctness check against DeepEP baseline.

--- a/skills/packaging/multi-format-native-package-orchestrator/SKILL.md
+++ b/skills/packaging/multi-format-native-package-orchestrator/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: multi-format-native-package-orchestrator
+description: Orchestrate building a single Electron app source into .deb, .rpm, AppImage, and Nix outputs from one script. Handles architecture detection, distro-family detection, format-specific build dispatch, and shared staging.
+category: packaging
+version: 1.0.0
+tags: [electron, packaging, deb, rpm, appimage, nix, build-orchestration, linux]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+# Multi-Format Native Package Orchestrator
+
+## When to use
+
+Use this pattern when:
+- You need to produce `.deb`, `.rpm`, AppImage, and/or Nix packages from a single Electron (or generic Node.js) application source.
+- The build must run on multiple host distros (Debian-family, Fedora-family, NixOS, or generic) and auto-select the appropriate output format.
+- You want a single entry-point script that handles dependencies, staging, patching, and format-specific sub-scripts with a consistent interface.
+- You want to pass a shared staging directory between stages so each format script does not re-download or re-extract the source.
+
+## Pattern
+
+### Architecture
+
+```
+build.sh (orchestrator)
+  ├── detect_architecture()    → sets $architecture, $download_url, $sha256
+  ├── detect_distro()          → sets $distro_family
+  ├── parse_arguments()        → sets $build_format (override or auto)
+  ├── check_dependencies()     → installs missing tools per distro
+  ├── download_and_extract()   → fills $app_staging_dir
+  ├── patch_app()              → modifies staging dir (shared for all formats)
+  └── dispatch to sub-script:
+        scripts/build-deb-package.sh    $version $arch $work_dir $staging ...
+        scripts/build-rpm-package.sh    $version $arch $work_dir $staging ...
+        scripts/build-appimage.sh       $version $arch $work_dir $staging ...
+        (nix handled inline or via nix derivation)
+```
+
+### Shared staging directory contract
+
+Each format sub-script receives a consistent set of positional arguments:
+```
+$1  version
+$2  architecture   (amd64|arm64)
+$3  work_dir       (top-level build directory)
+$4  app_staging_dir (prepared app files: app.asar, app.asar.unpacked, node_modules/)
+$5  package_name
+$6  maintainer     (for deb; ignored by others)
+$7  description
+```
+
+This contract means the orchestrator patches the app once and every format sub-script consumes the same artifact tree.
+
+## Minimal example
+
+```bash
+#!/usr/bin/env bash
+# Orchestrator skeleton
+
+architecture=''
+distro_family=''
+build_format=''
+work_dir='build'
+app_staging_dir='build/electron-app'
+
+detect_architecture() {
+    local raw_arch
+    raw_arch=$(uname -m)
+    case "$raw_arch" in
+        x86_64)  architecture='amd64' ;;
+        aarch64) architecture='arm64' ;;
+        *) echo "Unsupported arch: $raw_arch" >&2; exit 1 ;;
+    esac
+}
+
+detect_distro() {
+    if   [[ -f /etc/debian_version ]]; then distro_family='debian'
+    elif [[ -f /etc/fedora-release  ]]; then distro_family='rpm'
+    elif [[ -f /etc/NIXOS           ]]; then distro_family='nix'
+    else                                     distro_family='unknown'
+    fi
+}
+
+parse_arguments() {
+    # Default format from distro; override with --build flag
+    case "$distro_family" in
+        debian)  build_format='deb'      ;;
+        rpm)     build_format='rpm'      ;;
+        nix)     build_format='nix'      ;;
+        *)       build_format='appimage' ;;
+    esac
+
+    while (( $# > 0 )); do
+        case "$1" in
+            -b|--build) build_format="$2"; shift 2 ;;
+            *) echo "Unknown flag: $1" >&2; exit 1 ;;
+        esac
+    done
+}
+
+prepare_staging() {
+    mkdir -p "$app_staging_dir"
+    # ... download, extract, patch into $app_staging_dir
+}
+
+dispatch() {
+    local pkg_name='my-electron-app'
+    local maintainer='Maintainers <maintainers@example.com>'
+    local description='My Electron app for Linux'
+
+    case "$build_format" in
+        deb)
+            bash scripts/build-deb-package.sh \
+                "$version" "$architecture" "$work_dir" "$app_staging_dir" \
+                "$pkg_name" "$maintainer" "$description"
+            ;;
+        rpm)
+            bash scripts/build-rpm-package.sh \
+                "$version" "$architecture" "$work_dir" "$app_staging_dir" \
+                "$pkg_name" "$maintainer" "$description"
+            ;;
+        appimage)
+            bash scripts/build-appimage.sh \
+                "$version" "$architecture" "$work_dir" "$app_staging_dir" \
+                "$pkg_name"
+            ;;
+        nix)
+            echo "Nix builds are handled by the flake; run: nix build .#my-app"
+            ;;
+    esac
+}
+
+detect_architecture
+detect_distro
+parse_arguments "$@"
+prepare_staging
+dispatch
+```
+
+## Why this works
+
+### Single staging pass, multiple format outputs
+
+Patching the app once into a shared staging directory means every format sub-script consumes an identical, pre-validated artifact. This eliminates format-specific drift where, for example, the deb package gets a patch that the AppImage doesn't.
+
+### Auto-detection + override
+
+Defaulting the build format to the detected distro family means CI on Debian builds `.deb` automatically, while still allowing `--build appimage` for explicit cross-format builds on any host. The `--build` flag is the escape hatch.
+
+### Positional argument contract for sub-scripts
+
+Using a fixed positional argument order (version, arch, work_dir, staging_dir, package_name, maintainer, description) means sub-scripts are independently testable: you can call `bash scripts/build-deb-package.sh 1.0.0 amd64 /tmp/build /tmp/staging my-app "Me" "App"` without the orchestrator.
+
+### Architecture mapping at the boundary
+
+Architecture names differ by ecosystem: `amd64`/`arm64` (Debian), `x86_64`/`aarch64` (RPM/kernel), `x64`/`arm64` (Node.js). Convert at the outermost layer (detect_architecture produces `amd64`/`arm64`) and let each sub-script remap to its own convention. Never pass raw `uname -m` output to sub-scripts.
+
+## Pitfalls
+
+- **Do not call sub-scripts with `source`** — they use `exit 1` for error handling. A sourced sub-script that exits kills the orchestrator's shell. Use `bash subscript.sh` or invoke as a subprocess.
+- **Work directory must be absolute** — sub-scripts `cd` into various locations; relative paths become invalid. Use `realpath` or `$(pwd)/build`.
+- **Format-specific tool availability** — `dpkg-deb` is only on Debian, `rpmbuild` only on Fedora. Validate tool availability before dispatch, or install via the dependency check step.
+- **Nix builds cannot use the same staging** — Nix derivations run in a sandbox and must fetch sources via `fetchurl`. The orchestrator's downloaded-and-extracted staging dir is not accessible inside the Nix sandbox. Pass source via `--exe` flag or a Nix flake input instead.
+- **Version strings with hyphens break RPM** — RPM's `Version:` field forbids hyphens. If your version is `1.0.0-2.3.4`, the orchestrator must split it into `rpm_version=1.0.0` and `rpm_release=2.3.4` before invoking the RPM sub-script.
+
+## Source reference
+
+`build.sh` — functions `detect_architecture`, `detect_distro`, `parse_arguments`, and the final dispatch block near end of file

--- a/skills/production/milestone-review/SKILL.md
+++ b/skills/production/milestone-review/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: milestone-review
+description: "Generates a comprehensive milestone progress review including feature completeness, quality metrics, risk assessment, and go/no-go recommendation. Use at milestone checkpoints or when evaluating readiness for a milestone deadline."
+argument-hint: "[milestone-name|current] [--review full|lean|solo]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write, Task, AskUserQuestion
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version: 1.0.0
+version_origin: extracted
+---
+
+## Phase 0: Parse Arguments
+
+Extract the milestone name (`current` or a specific name) and resolve the review mode (once, store for all gate spawns this run):
+1. If `--review [full|lean|solo]` was passed → use that
+2. Else read `production/review-mode.txt` → use that value
+3. Else → default to `lean`
+
+See `.claude/docs/director-gates.md` for the full check pattern.
+
+---
+
+## Phase 1: Load Milestone Data
+
+Read the milestone definition from `production/milestones/`. If the argument is `current`, use the most recently modified milestone file.
+
+Read all sprint reports for sprints within this milestone from `production/sprints/`.
+
+---
+
+## Phase 2: Scan Codebase Health
+
+- Scan for `TODO`, `FIXME`, `HACK` markers that indicate incomplete work
+- Check the risk register at `production/risk-register/`
+
+---
+
+## Phase 3: Generate the Milestone Review
+
+```markdown
+# Milestone Review: [Milestone Name]
+
+## Overview
+- **Target Date**: [Date]
+- **Current Date**: [Today]
+- **Days Remaining**: [N]
+- **Sprints Completed**: [X/Y]
+
+## Feature Completeness
+
+### Fully Complete
+| Feature | Acceptance Criteria | Test Status |
+|---------|-------------------|-------------|
+
+### Partially Complete
+| Feature | % Done | Remaining Work | Risk to Milestone |
+|---------|--------|---------------|------------------|
+
+### Not Started
+| Feature | Priority | Can Cut? | Impact of Cutting |
+|---------|----------|----------|------------------|
+
+## Quality Metrics
+- **Open S1 Bugs**: [N] -- [List]
+- **Open S2 Bugs**: [N]
+- **Open S3 Bugs**: [N]
+- **Test Coverage**: [X%]
+- **Performance**: [Within budget? Details]
+
+## Code Health
+- **TODO count**: [N across codebase]
+- **FIXME count**: [N]
+- **HACK count**: [N]
+- **Technical debt items**: [List critical ones]
+
+## Risk Assessment
+| Risk | Status | Impact if Realized | Mitigation Status |
+|------|--------|-------------------|------------------|
+
+## Velocity Analysis
+- **Planned vs Completed** (across all sprints): [X/Y tasks = Z%]
+- **Trend**: [Improving / Stable / Declining]
+- **Adjusted estimate for remaining work**: [Days needed at current velocity]
+
+## Scope Recommendations
+### Protect (Must ship with milestone)
+- [Feature and why]
+
+### At Risk (May need to cut or simplify)
+- [Feature and risk]
+
+### Cut Candidates (Can defer without compromising milestone)
+- [Feature and impact of cutting]
+
+## Go/No-Go Assessment
+
+**Recommendation**: [GO / CONDITIONAL GO / NO-GO]
+
+**Conditions** (if conditional):
+- [Condition 1 that must be met]
+- [Condition 2 that must be met]
+
+**Rationale**: [Explanation of the recommendation]
+
+## Action Items
+| # | Action | Owner | Deadline |
+|---|--------|-------|----------|
+```
+
+---
+
+## Phase 3b: Producer Risk Assessment
+
+**Review mode check** — apply before spawning PR-MILESTONE:
+- `solo` → skip. Note: "PR-MILESTONE skipped — Solo mode." Present the Go/No-Go section without a producer verdict.
+- `lean` → skip (not a PHASE-GATE). Note: "PR-MILESTONE skipped — Lean mode." Present the Go/No-Go section without a producer verdict.
+- `full` → spawn as normal.
+
+Before generating the Go/No-Go recommendation, spawn `producer` via Task using gate **PR-MILESTONE** (`.claude/docs/director-gates.md`).
+
+Pass: milestone name and target date, current completion percentage, blocked story count, velocity data from sprint reports (if available), list of cut candidates.
+
+Present the producer's assessment inline within the Go/No-Go section. The producer's verdict (ON TRACK / AT RISK / OFF TRACK) informs the overall recommendation — do not issue a GO against an OFF TRACK producer verdict without explicit user acknowledgement.
+
+---
+
+## Phase 4: Save Review
+
+Present the review to the user.
+
+Ask: "May I write this to `production/milestones/[milestone-name]-review.md`?"
+
+If yes, write the file, creating the directory if needed. Verdict: **COMPLETE** — milestone review saved.
+
+If no, stop here. Verdict: **BLOCKED** — user declined write.
+
+---
+
+## Phase 5: Next Steps
+
+- Run `/gate-check` for a formal phase gate verdict if this milestone marks a development phase boundary.
+- Run `/sprint-plan` to adjust the next sprint based on the scope recommendations above.

--- a/skills/security/mcp-subprocess-env-filtering/SKILL.md
+++ b/skills/security/mcp-subprocess-env-filtering/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: mcp-subprocess-env-filtering
+description: When spawning a stdio MCP server (or any untrusted subprocess), allowlist/denylist environment variables so app-level auth tokens and third-party API keys don't leak into the child process.
+category: security
+version: 1.0.0
+version_origin: extracted
+tags: [mcp, subprocess, env-vars, credential-leakage]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: packages/shared/src/mcp/client.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Filter env vars to MCP subprocesses
+
+## When to use
+- Spawning a stdio MCP server / any third-party subprocess.
+- Host process holds credentials the subprocess does not need (ANTHROPIC_API_KEY, GITHUB_TOKEN, AWS_*).
+- Users add arbitrary MCP servers - you can't audit every `npx some-random-mcp`.
+
+## How it works
+1. Maintain a `BLOCKED_ENV_VARS` denylist of well-known secret names:
+   - App auth: `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`
+   - Cloud: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`
+   - Common tokens: `GITHUB_TOKEN`, `GH_TOKEN`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `STRIPE_SECRET_KEY`, `NPM_TOKEN`.
+2. When building the subprocess env, start from `process.env`, drop every key in the denylist.
+3. Allow the MCP source config to explicitly opt back in via a per-server `env: { FOO: '...' }` field — the source owner has to know what they're passing.
+4. Mirror the list in any secondary spawn site (e.g. `session-tools-core`'s `transform_data`) - the repo calls this out in a comment so the two lists don't drift.
+
+## Example
+```ts
+const BLOCKED_ENV_VARS = [
+  'ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN',
+  'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN',
+  'GITHUB_TOKEN', 'GH_TOKEN', 'OPENAI_API_KEY', 'GOOGLE_API_KEY',
+  'STRIPE_SECRET_KEY', 'NPM_TOKEN',
+];
+const childEnv = { ...process.env, ...sourceConfig.env };
+for (const k of BLOCKED_ENV_VARS) delete childEnv[k];
+spawn(cmd, args, { env: childEnv });
+```
+
+## Gotchas
+- A denylist is inherently incomplete - prefer an allowlist for truly untrusted processes.
+- Don't forget to scrub from the user's shell env (`.zshrc` exports) too - loading their shell env into your app first (see `shell-env.ts` in craft-agents) can pull in MORE secrets.
+- Document the list in one canonical place and reference it from every spawn site; drift is the #1 failure mode.
+- The README of the project lists these publicly - treating the list as "security through documentation" is fine because the real control is the code filter, not the secret of the list.

--- a/skills/testing/model-regression-test-with-csv-fixture/SKILL.md
+++ b/skills/testing/model-regression-test-with-csv-fixture/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: model-regression-test-with-csv-fixture
+description: Lock down a model's deterministic output by committing input+expected-output CSVs and re-running with a generator script when intentionally changing behavior.
+category: testing
+tags: [regression-test, pytest, ml-model-testing, determinism, fixtures, golden-file]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/shiyu-coder/Kronos.git
+source_ref: master
+source_commit: 67b630e67f6a18c9e9be918d9b4337c960db1e9a
+source_project: Kronos
+source_paths: [tests/test_kronos_regression.py, tests/data/generate_regression_output.py]
+version: 1.0.0
+version_origin: extracted
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# CSV golden-file regression test for a non-trivial model
+
+## When to use
+- Your model has deterministic (or seedable) output that is easy to serialize as a small table.
+- You want CI to fail any time a refactor accidentally changes predictions, even slightly.
+- You want a single script (committed alongside the fixture) that re-generates the "expected" file when changes are intentional — so the update process is one command, not a manual copy-paste.
+
+## Pattern
+Commit three artifacts: `regression_input.csv` (realistic but small), one `regression_output_<config>.csv` per parametrization, and a `generate_regression_output.py` that recreates every `regression_output_*.csv` from the input. The test pins model+tokenizer by commit hash, re-seeds every RNG the library touches, and asserts `np.allclose` with a small `rtol`. Parametrize over the meaningful dimensions (here, context length). A second test checks a secondary metric (MSE over random slices) with a very tight tolerance to catch even subtle numeric drift.
+
+```python
+# tests/test_kronos_regression.py
+MODEL_REVISION     = "901c26c1332695a2a8f243eb2f37243a37bea320"
+TOKENIZER_REVISION = "0e0117387f39004a9016484a186a908917e22426"
+REL_TOLERANCE      = 1e-5
+
+def set_seed(seed):
+    random.seed(seed); np.random.seed(seed); torch.manual_seed(seed)
+    if torch.backends.cudnn.is_available():
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark     = False
+
+@pytest.mark.parametrize("context_len", [512, 256])
+def test_kronos_predictor_regression(context_len):
+    set_seed(123)
+    df          = pd.read_csv(TEST_DATA_ROOT / "regression_input.csv", parse_dates=["timestamps"])
+    expected_df = pd.read_csv(TEST_DATA_ROOT / f"regression_output_{context_len}.csv")
+    expected    = expected_df[FEATURE_NAMES].values.astype(np.float32)
+
+    tokenizer = KronosTokenizer.from_pretrained("NeoQuasar/Kronos-Tokenizer-base", revision=TOKENIZER_REVISION)
+    model     = Kronos.from_pretrained("NeoQuasar/Kronos-small",            revision=MODEL_REVISION)
+    predictor = KronosPredictor(model, tokenizer, device="cpu", max_context=512)
+
+    with torch.no_grad():
+        pred_df = predictor.predict(df=context_df[FEATURE_NAMES], ...,
+                                    T=1.0, top_k=1, top_p=1.0, sample_count=1)
+    np.testing.assert_allclose(pred_df[FEATURE_NAMES].to_numpy(np.float32),
+                               expected, rtol=REL_TOLERANCE)
+```
+
+The companion script regenerates fixtures when behavior changes intentionally:
+
+```python
+# tests/data/generate_regression_output.py — mirrors the test config so updates are one command
+for ctx_len in [512, 256]:
+    generate_output(ctx_len)        # writes regression_output_<ctx_len>.csv
+```
+
+## Why it works / tradeoffs
+Pinning the model commit + CPU device + full seeding makes the test bit-reproducible across machines. Storing expected outputs as CSV makes diffs reviewable in PRs (unlike `.npy`). The separate generator script avoids the anti-pattern of "test has a --update-expected flag" — the regenerate step is deliberate and explicit. Cost: CSV round-tripping through float32 limits `rtol` to about `1e-6`. For stochastic components, choose a deterministic sampling config (`top_k=1, top_p=1.0`) — see the sibling skill on temperature/top-k/top-p filter.
+
+## References
+- `tests/test_kronos_regression.py` in Kronos — main test, parametrized over context length
+- `tests/data/generate_regression_output.py` — fixture regenerator
+- `tests/data/regression_input.csv` and `regression_output_{256,512}.csv` — committed fixtures

--- a/skills/training/minimal-ddp-amp-accelerator-wrapper/SKILL.md
+++ b/skills/training/minimal-ddp-amp-accelerator-wrapper/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: minimal-ddp-amp-accelerator-wrapper
+description: Minimal DDP + AMP training wrapper without HuggingFace Accelerate dependency
+category: training
+version: 1.0.0
+tags: [ddp, amp, training, pytorch, distributed]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/OpenBMB/VoxCPM.git
+source_ref: main
+source_commit: 13605c5a0e6b99d6d3527a43bd1a4e0e69c8800e
+source_project: VoxCPM
+source_paths:
+  - src/voxcpm/training/accelerator.py
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+---
+
+# Minimal DDP + AMP wrapper without HF Accelerate dependency
+
+## When to use
+Use this pattern when you want distributed training (DDP) and mixed-precision (AMP) without pulling in the full HuggingFace Accelerate stack. This is appropriate for research codebases where you control the training loop completely and want to minimize dependencies or customize gradient scaling behavior.
+
+## Pattern
+
+### Detect distributed environment
+```python
+import os
+import torch
+import torch.distributed as dist
+
+def is_distributed() -> bool:
+    return int(os.environ.get("WORLD_SIZE", "1")) > 1
+
+def local_rank() -> int:
+    return int(os.environ.get("LOCAL_RANK", "0"))
+
+def global_rank() -> int:
+    return int(os.environ.get("RANK", "0"))
+
+def world_size() -> int:
+    return int(os.environ.get("WORLD_SIZE", "1"))
+```
+
+### Accelerator class
+```python
+class Accelerator:
+    def __init__(self, use_amp: bool = True):
+        self.use_amp = use_amp
+        self._distributed = is_distributed()
+
+        if self._distributed:
+            torch.cuda.set_device(local_rank())
+            dist.init_process_group(backend="nccl")
+
+        if use_amp:
+            self.scaler = torch.amp.GradScaler("cuda")
+        else:
+            self.scaler = _DummyScaler()
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", local_rank()) if torch.cuda.is_available() \
+               else torch.device("cpu")
+
+    @property
+    def is_main_process(self) -> bool:
+        return global_rank() == 0
+
+    def prepare_model(self, model: torch.nn.Module) -> torch.nn.Module:
+        model = model.to(self.device)
+        if self._distributed:
+            model = torch.nn.parallel.DistributedDataParallel(
+                model, device_ids=[local_rank()]
+            )
+        return model
+
+    def backward(self, loss: torch.Tensor):
+        self.scaler.scale(loss).backward()
+
+    def step(self, optimizer):
+        self.scaler.step(optimizer)
+        self.scaler.update()
+        optimizer.zero_grad()
+
+    def barrier(self):
+        if self._distributed:
+            dist.barrier()
+
+    def all_reduce(self, tensor: torch.Tensor, op=dist.ReduceOp.SUM) -> torch.Tensor:
+        if self._distributed:
+            dist.all_reduce(tensor, op=op)
+        return tensor
+
+    def __enter__(self):
+        torch.cuda.set_device(local_rank())
+        return self
+
+    def __exit__(self, *args):
+        if self._distributed:
+            dist.destroy_process_group()
+```
+
+### Dummy scaler for non-AMP
+```python
+class _DummyScaler:
+    """No-op scaler used when AMP is disabled."""
+    def scale(self, loss):
+        return loss
+    def step(self, optimizer):
+        optimizer.step()
+    def update(self):
+        pass
+    def unscale_(self, optimizer):
+        pass
+```
+
+### Training loop usage
+```python
+with Accelerator(use_amp=True) as acc:
+    model = acc.prepare_model(MyModel())
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)
+
+    for batch in dataloader:
+        with torch.amp.autocast("cuda"):
+            loss = model(batch)
+        acc.backward(loss)
+        acc.step(optimizer)
+
+    acc.barrier()
+    if acc.is_main_process:
+        torch.save(model.state_dict(), "checkpoint.pt")
+```
+
+## Source reference
+- Upstream: `OpenBMB/VoxCPM` @ `main` / `13605c5a`
+- Key files:
+  - `src/voxcpm/training/accelerator.py:1-80` — full Accelerator implementation with DDP init, AMP scaler, barrier, and all_reduce
+
+## Notes
+- Launch with `torchrun --nproc_per_node=N train.py` — it sets `WORLD_SIZE`, `RANK`, `LOCAL_RANK` automatically.
+- The `DummyScaler` makes single-GPU code identical to multi-GPU code — no `if distributed:` branches in the loop.
+- Do not mix this with HF Accelerate in the same process; they both call `dist.init_process_group` and will conflict.

--- a/skills/versioning/model-config-versioning-and-backwards-compat/SKILL.md
+++ b/skills/versioning/model-config-versioning-and-backwards-compat/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: model-config-versioning-and-backwards-compat
+description: Embed major/minor version in model config.min.json; validate at load time; ship multiple model versions side-by-side under assets/models/<version>/ with a CHANGELOG.
+category: versioning
+version: 1.0.0
+version_origin: extracted
+confidence: medium
+tags: [magika, versioning]
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Model Config Versioning And Backwards Compat
+
+**Trigger:** An ML pipeline that must continue serving older models while you ship new ones — and must reject configs whose schema you can't speak.
+
+## Steps
+
+- Add version_major (int) and version_minor (int) fields to model config JSON.
+- At load time, compare model version against the runtime's supported range; raise on unsupported.
+- Keep multiple model versions in assets/models/ (standard_v3_3/, standard_v3_2/) with one symlink/pointer to the default.
+- Document each version in a CHANGELOG with accuracy deltas, dataset changes, breaking changes.
+- When the input schema changes (e.g. beg_size), bump major and refuse to load old runtimes against new models.
+- Log model version in CLI --version output and in every result envelope.
+
+## Counter / Caveats
+
+- Multiple model versions on disk grow your package; consider optional download or external hosting.
+- Feature dependencies (does the model require beg/mid/end offsets?) must be explicit in config — implicit assumptions break.
+- Backwards-compat coverage requires running the regression suite against every supported model.
+- Parameter changes (feature size, padding token) cannot be silently auto-migrated.
+
+## Source
+
+Extracted from `magika` (https://github.com/google/magika.git @ main).
+
+Files of interest:
+- `assets/models/standard_v3_3/config.min.json`
+- `rust/lib/src/content.rs (MODEL_MAJOR_VERSION)`
+- `python/src/magika/magika.py:47-48`
+- `assets/models/CHANGELOG.md`

--- a/skills/versioning/model-config-versioning-and-backwards-compat/content.md
+++ b/skills/versioning/model-config-versioning-and-backwards-compat/content.md
@@ -1,0 +1,23 @@
+# model-config-versioning-and-backwards-compat — extended notes
+
+This is an extracted draft from the **magika** project at commit `0a8cb9626b`.
+See `SKILL.md` for the procedure. Use the source references below to study the
+original implementation before adapting the pattern to a new codebase.
+
+## Source references
+
+- `assets/models/standard_v3_3/config.min.json`
+- `rust/lib/src/content.rs (MODEL_MAJOR_VERSION)`
+- `python/src/magika/magika.py:47-48`
+- `assets/models/CHANGELOG.md`
+
+## When this pattern is a fit
+
+An ML pipeline that must continue serving older models while you ship new ones — and must reject configs whose schema you can't speak.
+
+## When to walk away
+
+- Multiple model versions on disk grow your package; consider optional download or external hosting.
+- Feature dependencies (does the model require beg/mid/end offsets?) must be explicit in config — implicit assumptions break.
+- Backwards-compat coverage requires running the regression suite against every supported model.
+- Parameter changes (feature size, padding token) cannot be silently auto-migrated.

--- a/skills/versioning/model-onnx-file-versioning-and-staging/SKILL.md
+++ b/skills/versioning/model-onnx-file-versioning-and-staging/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: model-onnx-file-versioning-and-staging
+description: Version model assets under assets/models/<name>_v<major>_<minor>/ with per-version README and a top-level CHANGELOG.md, and a 'default' pointer (file or symlink).
+category: versioning
+version: 1.0.0
+version_origin: extracted
+confidence: medium
+tags: [magika, versioning]
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Model Onnx File Versioning And Staging
+
+**Trigger:** Iterating on ML models where you must keep older versions reachable for debugging, A/B testing, and backwards compatibility.
+
+## Steps
+
+- Adopt a naming convention: <family>_v<major>_<minor>/ (standard_v3_3, fast_v2_1).
+- Each model dir contains: model.onnx, config.min.json, metadata.json, README.md.
+- Maintain a single assets/models/CHANGELOG.md with one section per version: dataset changes, accuracy deltas, breaking changes.
+- Pick a default with a pointer file or a symlink — but on Windows prefer a text pointer because symlinks need admin rights.
+- Test new models against the full tests_data/ corpus before promoting to default.
+- Archive old binaries even after promotion — they're needed for reproducing old predictions.
+
+## Counter / Caveats
+
+- .onnx files are large (10–100MB); consider git-lfs or external storage if total size grows.
+- Symlinks don't work on Windows without admin or developer mode; prefer text pointers.
+- Multi-model test matrices multiply CI cost; gate non-default-model tests behind a flag.
+- Running old models is the only way to debug old predictions; don't delete them.
+
+## Source
+
+Extracted from `magika` (https://github.com/google/magika.git @ main).
+
+Files of interest:
+- `assets/models/ (9 versions)`
+- `assets/models/CHANGELOG.md`
+- `rust/gen/src/main.rs:26-27`

--- a/skills/versioning/model-onnx-file-versioning-and-staging/content.md
+++ b/skills/versioning/model-onnx-file-versioning-and-staging/content.md
@@ -1,0 +1,22 @@
+# model-onnx-file-versioning-and-staging — extended notes
+
+This is an extracted draft from the **magika** project at commit `0a8cb9626b`.
+See `SKILL.md` for the procedure. Use the source references below to study the
+original implementation before adapting the pattern to a new codebase.
+
+## Source references
+
+- `assets/models/ (9 versions)`
+- `assets/models/CHANGELOG.md`
+- `rust/gen/src/main.rs:26-27`
+
+## When this pattern is a fit
+
+Iterating on ML models where you must keep older versions reachable for debugging, A/B testing, and backwards compatibility.
+
+## When to walk away
+
+- .onnx files are large (10–100MB); consider git-lfs or external storage if total size grows.
+- Symlinks don't work on Windows without admin or developer mode; prefer text pointers.
+- Multi-model test matrices multiply CI cost; gate non-default-model tests behind a flag.
+- Running old models is the only way to debug old predictions; don't delete them.


### PR DESCRIPTION
## Batch
- batch 13/24

## Knowledge (22)
- `llm-agents/mcp-integration-guide`
- `security/mcp-localhost-bind-default-warn-on-expose`
- `architecture/mcp-pool-vs-direct-connections`
- `arch/mcp-stdio-child-of-daemon-topology`
- `moe-optimization/mega-moe-imbalance-factor-for-uneven-routing`
- `data-pipeline/memory-graph-adaptive-query-with-recency`
- `electron-packaging/menu-bar-visibility-modes-linux-workaround`
- `electron-packaging/minified-electron-regex-patching-gotchas`
- `electron-packaging/minified-js-ast-anchor-extraction`
- `llm-agents/mlx-kv-cache-trimmability`
- `arch/model-api-contract-sync-and-async`
- `arch/model-generation-tooling-in-rust-gen`
- `arch/model-not-used-for-edge-cases`
- `domain/model-output-space-vs-tool-output-space`
- `domain/model-trained-on-100m-samples`
- `arch/model-variants-standard-fast-begonly`
- `version-quirk/model-version-compatibility-major-version`
- `decision/monorepo-subpath-exports-over-barrel-index`
- `llm-agents/multi-agent-orchestration-patterns`
- `codecs/multi-audio-resampling-backends`
- _... and 2 more_

## Skills (28)
- `integration/mcp-multi-transport-config-pydantic`
- `mcp-integration/mcp-pool-http-proxy-for-subprocess-sdks`
- `mcp-integration/mcp-sse-streamable-http`
- `mcp-integration/mcp-stdio-server`
- `integration/mcp-streamable-http-detached-httpx-client`
- `security/mcp-subprocess-env-filtering`
- `mcp-integration/mcp-tool-intent-metadata-injection`
- `moe-optimization/mega-moe-fusion-with-symmetric-memory`
- `data-pipeline/memory-fragment-sizing-for-llm-input`
- `production/milestone-review`
- `electron-packaging/minified-js-variable-extraction-dynamic`
- `training/minimal-ddp-amp-accelerator-wrapper`
- `architecture/ml-model-config-registry-dispatch`
- `llm-agents/mlx-kv-cache-rollback-on-reject`
- `frontend/modal-navigation-stack-with-back`
- `data/model-config-min-json-compact-format`
- `versioning/model-config-versioning-and-backwards-compat`
- `versioning/model-onnx-file-versioning-and-staging`
- `testing/model-regression-test-with-csv-fixture`
- `agents/model-retry-settings`
- _... and 8 more_

## Source
- project: F:/workspace/tool (bulk extract)
- batch plan: .omc/batch-plan.json

## Post-merge
After squash-merge, run step 7 to re-anchor skill tags at the merge commit.