### PR TITLE
Publish batch 14/24: 29 knowledge + 21 skills

### DIFF
--- a/index.json
+++ b/index.json
@@ -243,6 +243,21 @@
   },
   {
     "kind": "knowledge",
+    "name": "no-dereference-option-symlinks",
+    "slug": "no-dereference-option-symlinks",
+    "category": "api",
+    "description": "no_dereference=True (--no-dereference in CLI) treats symlinks as type 'symlink' instead of following them.",
+    "tags": [
+      "magika",
+      "api"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/api/no-dereference-option-symlinks.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "stomp-heartbeat-10s-bidirectional",
     "slug": "stomp-heartbeat-10s-bidirectional",
     "category": "api",
@@ -1068,6 +1083,24 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/arch/nfs-backed-volumes-for-docker-swarm.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "no-autonomous-lifecycle-mutation",
+    "slug": "no-autonomous-lifecycle-mutation",
+    "category": "arch",
+    "description": "A process that cannot reliably distinguish \"actively running elsewhere\" from \"orphaned by a crash\" must not autonomously mark work as failed/cancelled/abandoned based on a timer or staleness guess.",
+    "tags": [
+      "architecture",
+      "lifecycle",
+      "cross-process",
+      "principle",
+      "concurrency"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/no-autonomous-lifecycle-mutation.md",
     "has_content": true
   },
   {
@@ -3157,6 +3190,22 @@
   },
   {
     "kind": "knowledge",
+    "name": "no-backwards-compat-pre-launch",
+    "slug": "no-backwards-compat-pre-launch",
+    "category": "decision",
+    "description": "Before a product is live, prefer removing old code paths over preserving old-plus-new behavior — avoid compat layers, dual-write logic, legacy adapters, and temporary shims.",
+    "tags": [
+      "coding-rules",
+      "refactor",
+      "tech-debt"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/no-backwards-compat-pre-launch.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "node-npm-pin-matches-jenkins",
     "slug": "node-npm-pin-matches-jenkins",
     "category": "decision",
@@ -3172,6 +3221,69 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/decision/node-npm-pin-matches-jenkins.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "non-destructive-curation-for-llm-drafts",
+    "slug": "non-destructive-curation-for-llm-drafts",
+    "category": "decision",
+    "description": "For pipelines that auto-generate hundreds of LLM drafts, prefer reversible ratings (👍/⭐/👎) with persistent state over immediate deletion; expose a single explicit \"Delete 👎\" batch action for destructive cleanup.",
+    "tags": "",
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/non-destructive-curation-for-llm-drafts.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "num-waves-1-is-multicast-veto",
+    "slug": "num-waves-1-is-multicast-veto",
+    "category": "decision",
+    "description": "",
+    "tags": [
+      "multicast",
+      "waves",
+      "cluster",
+      "heuristic",
+      "amortization"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/gpu-kernels/num-waves-1-is-multicast-veto.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "numpy-unpinned-no-workaround",
+    "slug": "numpy-unpinned-no-workaround",
+    "category": "decision",
+    "description": "Magika unpinned numpy because pip's resolver already handles Python-version compatibility automatically.",
+    "tags": [
+      "magika",
+      "decision"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/numpy-unpinned-no-workaround.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "nvcc-12-9-auto-ffma-interleaving",
+    "slug": "nvcc-12-9-auto-ffma-interleaving",
+    "category": "decision",
+    "description": "",
+    "tags": [
+      "nvcc",
+      "ffma",
+      "post-optimization",
+      "compiler-version",
+      "sass"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/performance-modeling/nvcc-12-9-auto-ffma-interleaving.md",
     "has_content": true
   },
   {
@@ -3684,6 +3796,24 @@
   },
   {
     "kind": "knowledge",
+    "name": "no-formatting-only-changes-rule",
+    "slug": "no-formatting-only-changes-rule",
+    "category": "development",
+    "description": "No automatic code formatters on merge; keep diffs semantic-only unless explicit reformat is requested.",
+    "tags": [
+      "changes",
+      "development",
+      "formatting",
+      "only",
+      "rule"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/development/no-formatting-only-changes-rule.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "a11y-uid-tool-targeting-over-selectors",
     "slug": "a11y-uid-tool-targeting-over-selectors",
     "category": "domain",
@@ -3933,6 +4063,42 @@
   },
   {
     "kind": "knowledge",
+    "name": "multi-source-alert-routing-rationale",
+    "slug": "multi-source-alert-routing-rationale",
+    "category": "integration",
+    "description": "OpenSRE's detect_sources() function illustrates a robust pattern for routing alerts across heterogeneous observability backends — accept many alias spellings, gate each backend on alert-source provenance, and merge nested-vs-top-level annotations so LLM-extracted enrichments fill gaps.",
+    "tags": [
+      "alert-routing",
+      "observability",
+      "multi-source",
+      "normalization"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/integration/multi-source-alert-routing-rationale.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "nvcc-vs-nvrtc-compilation-tradeoff",
+    "slug": "nvcc-vs-nvrtc-compilation-tradeoff",
+    "category": "jit-compilation",
+    "description": "NVRTC compiles 10x faster in-process but loses 5-10% perf on some kernels vs NVCC's offline optimization; use NVRTC for iteration (DG_JIT_USE_NVRTC=1), NVCC for production.",
+    "tags": [
+      "nvcc",
+      "nvrtc",
+      "jit",
+      "cuda-compiler",
+      "performance",
+      "build-system"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/jit-compilation/nvcc-vs-nvrtc-compilation-tradeoff.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "cowork-backend-auto-detection-priority",
     "slug": "cowork-backend-auto-detection-priority",
     "category": "linux-sandbox",
@@ -3992,6 +4158,63 @@
   },
   {
     "kind": "knowledge",
+    "name": "multimodal-llm-architectures",
+    "slug": "multimodal-llm-architectures",
+    "category": "llm-agents",
+    "description": "Multimodal LLMs (MLLMs) integrate vision, audio, and text modalities.",
+    "tags": [
+      "mllm",
+      "multimodal",
+      "vision-language",
+      "architecture"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/llm-agents/multimodal-llm-architectures.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "multi-provider-llm-client-config",
+    "slug": "multi-provider-llm-client-config",
+    "category": "llm-model-routing",
+    "description": "Tiered LLM client registry (mini / medium / high / large / persona / gemini) across OpenAI + Anthropic + OpenRouter, with prompt-cache retention and a shared usage-tracking callback for cost accounting.",
+    "tags": [
+      "langchain",
+      "llm-routing",
+      "prompt-caching",
+      "openai",
+      "anthropic",
+      "openrouter",
+      "usage-tracking"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/llm-model-routing/multi-provider-llm-client-config.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "native-module-stub-layered-fallback",
+    "slug": "native-module-stub-layered-fallback",
+    "category": "native-modules",
+    "description": "When stubbing a missing native module for a different OS, use a layered fallback strategy: route to the framework equivalent where one exists (e.g., `BrowserWindow.isMaximized()`), no-op for OS-specific features with no equivalent, and an explicit stub for auth flows that signals unavailability without crashing.",
+    "tags": [
+      "native-modules",
+      "stub",
+      "electron",
+      "linux",
+      "platform-compatibility",
+      "node-gyp",
+      "fallback"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/native-modules/native-module-stub-layered-fallback.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "connection-type-enum-design",
     "slug": "connection-type-enum-design",
     "category": "networking",
@@ -4006,6 +4229,105 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/networking/connection-type-enum-design.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "nat-type-detection-stun-pattern",
+    "slug": "nat-type-detection-stun-pattern",
+    "category": "networking",
+    "description": "NAT type detected via stunclient; drives relay-vs-direct decision at session setup.",
+    "tags": [
+      "detection",
+      "nat",
+      "networking",
+      "pattern",
+      "stun",
+      "type"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/networking/nat-type-detection-stun-pattern.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "nix-npm-lock-fsevents-macos-exclusion",
+    "slug": "nix-npm-lock-fsevents-macos-exclusion",
+    "category": "nix",
+    "description": "Nix's `buildNpmPackage` npm-lock fetcher is stricter than `npm ci` and rejects macOS-only `optionalDependencies` like `fsevents` because it attempts to hash them on Linux; strip the reference from `package-lock.json` in `postPatch` to restore determinism.",
+    "tags": [
+      "nix",
+      "npm",
+      "buildNpmPackage",
+      "fsevents",
+      "macos",
+      "optionalDependencies",
+      "package-lock",
+      "postPatch"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/nix/nix-npm-lock-fsevents-macos-exclusion.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "nix-stock-electron-wrapper-reuse",
+    "slug": "nix-stock-electron-wrapper-reuse",
+    "category": "nix",
+    "description": "The nixpkgs `electron` package is a `makeWrapper` bash script that sets `GIO_EXTRA_MODULES`, `GDK_PIXBUF_MODULE_FILE`, `XDG_DATA_DIRS`, and `CHROME_DEVEL_SANDBOX`; when building a custom Electron tree, reuse its env setup by copying all but the final `exec` line and appending your own exec.",
+    "tags": [
+      "nix",
+      "nixos",
+      "electron",
+      "wrapper",
+      "makeWrapper",
+      "GIO",
+      "GDK_PIXBUF",
+      "environment"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/nix/nix-stock-electron-wrapper-reuse.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "nix-store-resource-path-immutability",
+    "slug": "nix-store-resource-path-immutability",
+    "category": "nix",
+    "description": "The Nix store is read-only and `/proc/self/exe` resolves through symlinks to the real binary location, so Electron's `process.resourcesPath` points at the wrong tree when the binary and application resources live in different store paths.",
+    "tags": [
+      "nix",
+      "nixos",
+      "electron",
+      "resource-path",
+      "proc-self-exe",
+      "symlink",
+      "store"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/nix/nix-store-resource-path-immutability.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "narrative-memory-event-storytelling",
+    "slug": "narrative-memory-event-storytelling",
+    "category": "observability",
+    "description": "Build narrative memory by linking events into causal stories for better recall and reflection",
+    "tags": [
+      "evolver",
+      "observability",
+      "narrative",
+      "memory",
+      "reference"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/observability/narrative-memory-event-storytelling.md",
     "has_content": true
   },
   {
@@ -5653,6 +5975,140 @@
   },
   {
     "kind": "knowledge",
+    "name": "mutation-onsuccess-side-effect-races",
+    "slug": "mutation-onsuccess-side-effect-races",
+    "category": "pitfall",
+    "description": "Putting both state-switch and navigate() in a mutation's onSuccess causes flash-and-jump races; let the UI layer own the side-effect sequence in one microtask.",
+    "tags": [
+      "react-query",
+      "mutations",
+      "side-effects",
+      "race-condition",
+      "ux"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/mutation-onsuccess-side-effect-races.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "navigate-about-blank-before-trace-start",
+    "slug": "navigate-about-blank-before-trace-start",
+    "category": "pitfall",
+    "description": "Before starting a reload-based performance trace, first navigate the page to `about:blank` with `waitUntil: 'networkidle0'` to flush previous-page state; otherwise the trace captures residual activity from the outgoing page and pollutes the insights.",
+    "tags": [
+      "performance",
+      "tracing",
+      "about-blank",
+      "puppeteer"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/navigate-about-blank-before-trace-start.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "nested-claude-code-session-deadlock",
+    "slug": "nested-claude-code-session-deadlock",
+    "category": "pitfall",
+    "description": "Spawning a Claude Code subprocess from inside a Claude Code session deadlocks silently because the Agent SDK leaks `process.env` into the child regardless of the `env` option, so `CLAUDECODE=1` and `CLAUDE_CODE_*` markers propagate.",
+    "tags": [
+      "claude-code",
+      "subprocess",
+      "deadlock",
+      "env-leak",
+      "agent-sdk"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/nested-claude-code-session-deadlock.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "network-collector-preserves-navigation-request",
+    "slug": "network-collector-preserves-navigation-request",
+    "category": "pitfall",
+    "description": "A network-request collector that splits storage at `framenavigated` must migrate the tail of in-flight requests (from the navigation request forward) into the new navigation's bucket; otherwise the nav request and early same-nav requests get orphaned in the previous bucket.",
+    "tags": [
+      "puppeteer",
+      "network",
+      "navigation",
+      "event-collection"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/network-collector-preserves-navigation-request.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "next-cross-component-state-update",
+    "slug": "next-cross-component-state-update",
+    "category": "pitfall",
+    "description": "React 19 forbids setState during render of a different component; defer zustand persist rehydrate calls and cross-component notifications to queueMicrotask.",
+    "tags": [
+      "react-19",
+      "zustand",
+      "setstate",
+      "render",
+      "microtask"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/next-cross-component-state-update.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "no-finer-grained-metadata",
+    "slug": "no-finer-grained-metadata",
+    "category": "pitfall",
+    "description": "Magika returns broad content-type labels — no finer-grained metadata (e.g. ELF static-vs-dynamic, PDF version).",
+    "tags": [
+      "magika",
+      "pitfall"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/no-finer-grained-metadata.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "node-modules-auto-exclude-electron-builder",
+    "slug": "node-modules-auto-exclude-electron-builder",
+    "category": "pitfall",
+    "description": "electron-builder v20.15.2+ auto-excludes directories named \"node_modules\" from the package — work around with explicit extraResources from/to paths to ship your SDK.",
+    "tags": [
+      "electron-builder",
+      "node_modules",
+      "packaging"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/node-modules-auto-exclude-electron-builder.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "not-polyglot-detection-capable",
+    "slug": "not-polyglot-detection-capable",
+    "category": "pitfall",
+    "description": "Magika does NOT detect polyglot files (files valid as multiple types simultaneously, e.g. ZIP-in-JPEG).",
+    "tags": [
+      "magika",
+      "pitfall"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/not-polyglot-detection-capable.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "oauth-implementation-pitfall",
     "slug": "oauth-implementation-pitfall",
     "category": "pitfall",
@@ -6861,6 +7317,62 @@
   },
   {
     "kind": "knowledge",
+    "name": "multimodal-loss-mask-strategy",
+    "slug": "multimodal-loss-mask-strategy",
+    "category": "training",
+    "description": "VoxCPM training masks out loss on text and reference audio regions; only target audio patches contribute to the gradient",
+    "tags": [
+      "training",
+      "loss-mask",
+      "multimodal",
+      "tts",
+      "fine-tuning"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/training/multimodal-loss-mask-strategy.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "oauth-token-cache-corruption-workaround",
+    "slug": "oauth-token-cache-corruption-workaround",
+    "category": "troubleshooting",
+    "description": "Some OAuth implementations leave a corrupted `oauth:tokenCache` key in the app's JSON config after periods of inactivity, causing persistent 401 errors; the workaround is to remove the offending key from the config file and re-authenticate.",
+    "tags": [
+      "oauth",
+      "token-cache",
+      "401",
+      "authentication",
+      "config-corruption",
+      "json",
+      "workaround"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/troubleshooting/oauth-token-cache-corruption-workaround.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "nvrtc-pch-requires-cuda-12-8",
+    "slug": "nvrtc-pch-requires-cuda-12-8",
+    "category": "version-quirk",
+    "description": "",
+    "tags": [
+      "nvrtc",
+      "pch",
+      "precompiled-headers",
+      "cuda-version",
+      "compile-speed"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/jit-compilation/nvrtc-pch-requires-cuda-12-8.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "accept-header-prefer-markdown-over-html",
     "slug": "accept-header-prefer-markdown-over-html",
     "category": "web",
@@ -6960,6 +7472,18 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/qa/content-audit",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "onboard",
+    "slug": "onboard",
+    "category": "",
+    "description": "\"Generates a contextual onboarding document for a new contributor or agent joining the project. Summarizes project state, architecture, conventions, and current priorities relevant to the specified role or area.\"",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/meta/onboard",
     "has_content": false
   },
   {
@@ -7082,6 +7606,24 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/agents/coding-agent-cli-backend-interface",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "new-ml-backend-dependency-audit",
+    "slug": "new-ml-backend-dependency-audit",
+    "category": "agents",
+    "description": "Run a Phase-0 dependency audit on a candidate ML library before writing any integration code, so PyInstaller and runtime surprises are caught early.",
+    "tags": [
+      "ml-ops",
+      "dependencies",
+      "pyinstaller",
+      "audit",
+      "integration"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/agents/new-ml-backend-dependency-audit",
     "has_content": false
   },
   {
@@ -8111,6 +8653,25 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/architecture/accepts-then-convert-two-phase-dispatch",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "navigation-adapter-cross-platform",
+    "slug": "navigation-adapter-cross-platform",
+    "category": "architecture",
+    "description": "NavigationAdapter in each app's platform layer lets shared view code call useNavigation().push() without importing next/navigation or react-router-dom.",
+    "tags": [
+      "routing",
+      "navigation",
+      "cross-platform",
+      "nextjs",
+      "react-router",
+      "electron"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/architecture/navigation-adapter-cross-platform",
     "has_content": false
   },
   {
@@ -10867,6 +11428,24 @@
   },
   {
     "kind": "skill",
+    "name": "one-command-setup-flow",
+    "slug": "one-command-setup-flow",
+    "category": "cli",
+    "description": "Bundle CLI configure + authenticate + daemon start into one `cli setup` command, with per-environment profiles (cloud vs self-host) and custom-port overrides.",
+    "tags": [
+      "cli",
+      "setup",
+      "onboarding",
+      "profiles",
+      "cobra"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/one-command-setup-flow",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "open-gstack-browser",
     "slug": "open-gstack-browser",
     "category": "cli",
@@ -12761,6 +13340,24 @@
   },
   {
     "kind": "skill",
+    "name": "nextjs-docker-standalone-build",
+    "slug": "nextjs-docker-standalone-build",
+    "category": "devops",
+    "description": "Three-stage Docker build for a Next.js app with pnpm workspaces — deps / builder / runner stages, standalone output for a minimal production image.",
+    "tags": [
+      "docker",
+      "nextjs",
+      "pnpm",
+      "monorepo",
+      "standalone"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/nextjs-docker-standalone-build",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "playwright-java-dockerfile",
     "slug": "playwright-java-dockerfile",
     "category": "devops",
@@ -12968,6 +13565,42 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "skills/docs/ubiquitous-language",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "oauth-define-at-buildtime",
+    "slug": "oauth-define-at-buildtime",
+    "category": "electron",
+    "description": "Bake OAuth client IDs/secrets into the main-process bundle at build time via esbuild --define:process.env.X=... so they ship with the app, while user-provided secrets (Google) stay out of the build.",
+    "tags": [
+      "electron",
+      "oauth",
+      "esbuild",
+      "buildtime",
+      "secrets"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/electron/oauth-define-at-buildtime",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "multi-window-parameter-passing",
+    "slug": "multi-window-parameter-passing",
+    "category": "flutter",
+    "description": "Window parameter serialization via Map<String, dynamic> for multi-window session state.",
+    "tags": [
+      "flutter",
+      "multi",
+      "parameter",
+      "passing",
+      "window"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/flutter/multi-window-parameter-passing",
     "has_content": false
   },
   {
@@ -13577,6 +14210,24 @@
   },
   {
     "kind": "skill",
+    "name": "multi-platform-input-dispatch-abstraction",
+    "slug": "multi-platform-input-dispatch-abstraction",
+    "category": "input",
+    "description": "Unified keyboard/mouse input via Windows SendInput, macOS CGEvent, Linux xdo/uinput under one trait.",
+    "tags": [
+      "abstraction",
+      "dispatch",
+      "input",
+      "multi",
+      "platform"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/input/multi-platform-input-dispatch-abstraction",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "a2a-protocol-with-hello-publish-decision",
     "slug": "a2a-protocol-with-hello-publish-decision",
     "category": "integration",
@@ -13641,6 +14292,24 @@
   },
   {
     "kind": "skill",
+    "name": "multi-stage-heuristic-selection-with-comparators",
+    "slug": "multi-stage-heuristic-selection-with-comparators",
+    "category": "kernel-heuristics",
+    "description": "Enumerate all legal kernel configs under hardware constraints, score each with an arch-specific cost model (cycles / wave efficiency), and pick the winner via a comparator.",
+    "tags": [
+      "heuristics",
+      "gpu-optimization",
+      "config-search",
+      "performance-modeling",
+      "comparator"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/kernel-heuristics/multi-stage-heuristic-selection-with-comparators",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "agent-handoff-routing",
     "slug": "agent-handoff-routing",
     "category": "llm-agents",
@@ -13672,6 +14341,24 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/llm-agents/agents-as-tools",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "multi-turn-conversation-history",
+    "slug": "multi-turn-conversation-history",
+    "category": "llm-agents",
+    "description": "Chain multiple agent turns by converting run results to input lists for the next call.",
+    "tags": [
+      "openai-agents",
+      "conversation",
+      "multi-turn",
+      "to-input-list",
+      "history"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/llm-agents/multi-turn-conversation-history",
     "has_content": false
   },
   {
@@ -13790,6 +14477,84 @@
   },
   {
     "kind": "skill",
+    "name": "num-experts-per-wave-by-sm-occupancy",
+    "slug": "num-experts-per-wave-by-sm-occupancy",
+    "category": "moe-optimization",
+    "description": "Pick the number of experts processed per persistent-kernel wave so that total blocks (discounted by a 2x imbalance factor) just saturate all SMs, rounded to a divisor of the expert count.",
+    "tags": [
+      "moe",
+      "persistent-kernel",
+      "occupancy",
+      "sm-utilization",
+      "waves",
+      "scheduler"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/moe-optimization/num-experts-per-wave-by-sm-occupancy",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "native-module-stub-with-electron-fallback",
+    "slug": "native-module-stub-with-electron-fallback",
+    "category": "native-modules",
+    "description": "Stub a missing platform-specific native addon by routing supported methods to Electron equivalents (flashFrame, setProgressBar) and providing safe no-ops for unsupported ones. Enables a Windows-targeted Electron app to run on Linux without the native binary.",
+    "tags": [
+      "electron",
+      "native-module",
+      "stub",
+      "linux",
+      "node-addon",
+      "compatibility"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/native-modules/native-module-stub-with-electron-fallback",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "nix-electron-resource-path-copy",
+    "slug": "nix-electron-resource-path-copy",
+    "category": "nix",
+    "description": "Copy the Electron ELF binary (not symlink) into a custom derivation tree so /proc/self/exe resolves to your tree. Merge app resources and Electron resources into one resources/ directory. Preserve the stock Electron wrapper for environment setup.",
+    "tags": [
+      "nix",
+      "nixos",
+      "electron",
+      "resourcesPath",
+      "proc-self-exe",
+      "packaging",
+      "flake"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/nix/nix-electron-resource-path-copy",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "node-pty-native-module-rebuild-nix",
+    "slug": "node-pty-native-module-rebuild-nix",
+    "category": "nix",
+    "description": "Rebuild a node-gyp native addon (e.g., node-pty) in a Nix derivation using buildNpmPackage. Handle the fsevents macOS-only optional dep by stripping it from package-lock.json in postPatch. Explicitly copy the native build/ directory in postInstall since npmInstallHook skips it.",
+    "tags": [
+      "nix",
+      "node-gyp",
+      "native-addon",
+      "node-pty",
+      "npm",
+      "fsevents",
+      "nixos"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/nix/node-pty-native-module-rebuild-nix",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "agent-tracing-spans",
     "slug": "agent-tracing-spans",
     "category": "observability",
@@ -13847,6 +14612,44 @@
   },
   {
     "kind": "skill",
+    "name": "multi-tenant-session-isolation",
+    "slug": "multi-tenant-session-isolation",
+    "category": "patterns",
+    "description": "Per-peer state isolation using HashMap<SessionKey, Session> with Mutex synchronization.",
+    "tags": [
+      "isolation",
+      "multi",
+      "patterns",
+      "session",
+      "tenant"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/patterns/multi-tenant-session-isolation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "multi-signal-mime-detection-stream-info",
+    "slug": "multi-signal-mime-detection-stream-info",
+    "category": "preprocessing",
+    "description": "Combine extension, HTTP headers, content-disposition, mimetypes.guess_type(), magika content sniffing, and charset_normalizer into an ordered list of StreamInfo guesses that converters try in turn.",
+    "tags": [
+      "preprocessing",
+      "mime",
+      "file-type",
+      "detection",
+      "magika",
+      "charset",
+      "python"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/preprocessing/multi-signal-mime-detection-stream-info",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "a11y-tree-snapshot-with-uids",
     "slug": "a11y-tree-snapshot-with-uids",
     "category": "puppeteer",
@@ -13861,6 +14664,42 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/puppeteer/a11y-tree-snapshot-with-uids",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "multi-source-browser-connection",
+    "slug": "multi-source-browser-connection",
+    "category": "puppeteer",
+    "description": "Build one `ensureBrowserConnected` entry point that accepts any of browserURL, wsEndpoint, release channel, or userDataDir and resolves the right Puppeteer connect options, so callers never branch on \"how do I connect\".",
+    "tags": [
+      "puppeteer",
+      "cdp",
+      "browser-connection",
+      "configuration",
+      "api-design"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/puppeteer/multi-source-browser-connection",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "navigation-aware-event-collector",
+    "slug": "navigation-aware-event-collector",
+    "category": "puppeteer",
+    "description": "Store browser events (network requests, console messages, issues) in per-page WeakMaps split by main-frame navigation so tools can ask for \"requests since the last navigation\" vs. \"requests across the last N navigations\" without leaking memory.",
+    "tags": [
+      "puppeteer",
+      "cdp",
+      "weakmap",
+      "event-collection",
+      "navigation"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/puppeteer/navigation-aware-event-collector",
     "has_content": false
   },
   {
@@ -13950,6 +14789,25 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/reverse-engineering/androidmanifest-to-network-call-flow-tracing",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "obfuscated-jvm-string-anchor-navigation",
+    "slug": "obfuscated-jvm-string-anchor-navigation",
+    "category": "reverse-engineering",
+    "description": "Navigate ProGuard/R8-obfuscated JVM bytecode by anchoring on artifacts that the obfuscator cannot rename — string literals, Android framework classes, library public APIs, and manifest entries — then walking outward through call-site greps to recover logical class names one hop at a time.",
+    "tags": [
+      "android",
+      "reverse-engineering",
+      "obfuscation",
+      "proguard",
+      "r8",
+      "deobfuscation"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/reverse-engineering/obfuscated-jvm-string-anchor-navigation",
     "has_content": false
   },
   {
@@ -14402,6 +15260,24 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/testing-gpu/cosine-similarity-diff-for-fp8-numerics",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "multilingual-tts-text-normalize-and-split",
+    "slug": "multilingual-tts-text-normalize-and-split",
+    "category": "text-normalization",
+    "description": "Multilingual TTS text normalization via wetext + inflect with budget-aware paragraph splitting",
+    "tags": [
+      "text-normalization",
+      "tts",
+      "multilingual",
+      "chinese",
+      "nlp"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/text-normalization/multilingual-tts-text-normalize-and-split",
     "has_content": false
   },
   {
@@ -15425,6 +16301,25 @@
     "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/message-queue-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "multi-turn-repl-chatbot",
+    "slug": "multi-turn-repl-chatbot",
+    "category": "workflow",
+    "description": "Build an interactive CLI chatbot with a while loop that preserves conversation history across turns.",
+    "tags": [
+      "openai-agents",
+      "chatbot",
+      "repl",
+      "cli",
+      "conversation",
+      "multi-turn"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/multi-turn-repl-chatbot",
     "has_content": false
   },
   {

--- a/knowledge/api/no-dereference-option-symlinks.md
+++ b/knowledge/api/no-dereference-option-symlinks.md
@@ -1,0 +1,26 @@
+---
+name: no-dereference-option-symlinks
+type: knowledge
+category: api
+summary: no_dereference=True (--no-dereference in CLI) treats symlinks as type 'symlink' instead of following them.
+confidence: medium
+tags: [magika, api]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# No Dereference Option Symlinks
+
+## Fact
+
+Default behavior follows symlinks and reports the linked file's type. Setting no_dereference inspects the symlink itself. Useful when you care about filesystem metadata (e.g. detecting suspicious symlinks during forensics).
+
+## Evidence
+
+- `python/src/magika/magika.py:57-61`
+- `python/README.md:122-124`

--- a/knowledge/arch/no-autonomous-lifecycle-mutation.md
+++ b/knowledge/arch/no-autonomous-lifecycle-mutation.md
@@ -1,0 +1,52 @@
+---
+name: no-autonomous-lifecycle-mutation
+summary: A process that cannot reliably distinguish "actively running elsewhere" from "orphaned by a crash" must not autonomously mark work as failed/cancelled/abandoned based on a timer or staleness guess.
+category: arch
+confidence: high
+tags: [architecture, lifecycle, cross-process, principle, concurrency]
+source_type: extracted-from-git
+source_url: https://github.com/coleam00/Archon.git
+source_ref: dev
+source_commit: d89bc767d291f52687beea91c9fcf155459be0d9
+source_project: Archon
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# No Autonomous Lifecycle Mutation Across Process Boundaries
+
+## Fact / Decision
+
+In systems where work is initiated and tracked across process boundaries (CLI → DB; webhook → server → DB; cron → shared queue), a process cannot reliably distinguish two states:
+
+1. **"Actively running elsewhere"** — another process is working on this row right now.
+2. **"Orphaned by a crash"** — the originating process died without writing a terminal status.
+
+Any timer-or-staleness-based heuristic to auto-mark non-terminal work as `failed` / `cancelled` / `abandoned` **will** sometimes destroy active work. Therefore:
+
+- **Do not autonomously mutate non-terminal lifecycle state** that was started by a process you can't introspect.
+- Surface the ambiguous state to the user with a one-click resolution ("This run appears stuck — mark as abandoned? Resume?").
+- Keep this rule separate from heuristics for *recoverable* operations: retry backoff, subprocess timeouts that **you** started, hygiene cleanup of rows that are already in terminal status (MERGED, ABANDONED, DELETED). The rule is specifically about destructive mutation of **non-terminal** state owned by an unknowable other party.
+
+## Why
+
+A startup-time "clean up orphans older than N minutes" pass seems helpful. In practice it races against:
+
+- Users who left the CLI open in a backgrounded terminal for hours.
+- Long-running workflows that legitimately span days.
+- Multi-process deployments where `archon serve` restarts while `archon workflow run` is still going.
+
+When the cleanup wrongly marks these as failed, users see their work vanish with no indication why. Support burden spikes. The "orphan cleanup" feature is almost always the wrong abstraction; the right one is user-visible ambiguous-state handling.
+
+## Counter / Caveats
+
+- **Retry / timeout for work I started in-process** is fine — you can observe your own subprocesses.
+- **Hygiene cleanup of terminal rows** is fine — a row that's `merged` or `cancelled` is safe to delete after N days.
+- **Best-effort advisory display** ("This run was last updated 7 days ago") is fine — it's information, not mutation.
+- If you have a heartbeat protocol where the owning process writes a liveness timestamp every N seconds, you can reliably detect crash-vs-alive. Absent that, default to no-op.
+
+## Evidence
+
+- Root `CLAUDE.md` lines 80-84 — the principle is codified word-for-word as "No Autonomous Lifecycle Mutation Across Process Boundaries" with issue reference and CLI orphan-cleanup precedent at `packages/cli/src/cli.ts:256-258`.
+- Archon issue #1216 (referenced inline in CLAUDE.md) is the precedent case.
+- The principle is cited repeatedly in the codebase's fail-fast error handling, which prefers "throw with a clear error" over "silent fallback" for exactly this class of ambiguity.
+- Commit SHA: d89bc767d291f52687beea91c9fcf155459be0d9.

--- a/knowledge/decision/no-backwards-compat-pre-launch.md
+++ b/knowledge/decision/no-backwards-compat-pre-launch.md
@@ -1,0 +1,27 @@
+---
+name: no-backwards-compat-pre-launch
+summary: Before a product is live, prefer removing old code paths over preserving old-plus-new behavior — avoid compat layers, dual-write logic, legacy adapters, and temporary shims.
+category: decision
+tags: [coding-rules, refactor, tech-debt]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: CLAUDE.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+Explicit rule: unless the user asks for backwards compatibility, do not add compatibility layers, fallback paths, dual-write logic, legacy adapters, or temporary shims. If a flow or API is being replaced and the product is not yet live, remove the old path instead of preserving both.
+
+## Why
+
+Shims and fallbacks accumulate; each one adds a branch that must be tested, documented, and eventually removed. Pre-launch, there are no external users to protect, so the cost of "keeping the old one" is paid forever while the benefit is zero. This rule also applies to broad refactors — don't do them unless the task requires it.
+
+Concrete manifestation in the repo: when the auth flow moved from localStorage token to HttpOnly cookie, the old path was removed, not kept as a fallback. When workspace identity moved to URL, the `multica_workspace_id` localStorage key was deleted.
+
+## Evidence
+
+- CLAUDE.md, "Coding Rules" — explicit rule.
+- `docs/workspace-url-refactor-proposal.md:88-91` — "唯一的硬中断点：现有的 /issues 等 URL 在重构后会 404" (old routes just 404 after refactor, no redirect).

--- a/knowledge/decision/non-destructive-curation-for-llm-drafts.md
+++ b/knowledge/decision/non-destructive-curation-for-llm-drafts.md
@@ -1,0 +1,40 @@
+---
+name: non-destructive-curation-for-llm-drafts
+description: For pipelines that auto-generate hundreds of LLM drafts, prefer reversible ratings (👍/⭐/👎) with persistent state over immediate deletion; expose a single explicit "Delete 👎" batch action for destructive cleanup.
+category: decision
+tags:
+  - ux
+  - curation
+  - llm
+  - pipeline
+---
+
+# non-destructive-curation-for-llm-drafts
+
+## Context
+
+The trending-hub-loop auto-imports GitHub trending repos and produces 20–70 skill/knowledge drafts per cycle. After a few days there were 500+ drafts — too many to review in one sitting, with mixed quality. The question: how should the reviewer mark a bad draft?
+
+## Options considered
+
+1. **Immediate delete on 👎.** Simple, obvious. Rejected: a reviewer who misclicks loses the draft permanently, and re-reading later can't change their mind.
+2. **Move to a hidden `_rejected/` folder.** Less destructive. Rejected: hides the judgment from future curation, and adds a fourth state (draft / published / starred / rejected) to the filesystem that other commands must know about.
+3. **In-memory ratings with a separate `.curation.json`.** Chosen.
+
+## Decision
+
+- Ratings live in `.curation.json` as `${kind}::${category}::${name} → -1|1|2`.
+- Tiles show visual state (green/amber/red border) based on rating.
+- Filters (`👍 / ⭐ / 👎 / Unrated`) compose with category tabs for triage.
+- **Delete** is a separate, explicit batch action (`🗑 Delete 👎` button with confirm). Only runs when the reviewer asks — never implicit.
+
+## Why this works
+
+- **Reversible by default.** A 👎 click costs nothing; un-click restores.
+- **History preserved.** Even after `Delete 👎`, the curation file remembers what was rejected so re-runs don't re-stage identical drafts under the same name.
+- **Batch action surface.** Cleaning up is one button, not 50 individual deletes.
+- **Data model matches the mental model.** "I think this is bad / great / meh" is a judgment, not a filesystem operation.
+
+## Applies when
+
+Any pipeline that produces a large queue of items where quality is known only by human review: LLM outputs, scraped leads, PR candidates, generated tests. If the item count is small and quality is binary, delete-on-click is fine.

--- a/knowledge/decision/numpy-unpinned-no-workaround.md
+++ b/knowledge/decision/numpy-unpinned-no-workaround.md
@@ -1,0 +1,26 @@
+---
+name: numpy-unpinned-no-workaround
+type: knowledge
+category: decision
+summary: Magika unpinned numpy because pip's resolver already handles Python-version compatibility automatically.
+confidence: high
+tags: [magika, decision]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Numpy Unpinned No Workaround
+
+## Fact
+
+An earlier version pinned numpy to support Python 3.8, but the constraint was redundant — numpy declares python_requires in its metadata and pip discards incompatible versions on its own. The unpin reduces maintenance burden with no functional regression.
+
+## Evidence
+
+- `commit 2e6742c`
+- `https://iscinumpy.dev/post/bound-version-constraints/`

--- a/knowledge/development/no-formatting-only-changes-rule.md
+++ b/knowledge/development/no-formatting-only-changes-rule.md
@@ -1,0 +1,28 @@
+---
+name: no-formatting-only-changes-rule
+type: knowledge
+category: development
+summary: No automatic code formatters on merge; keep diffs semantic-only unless explicit reformat is requested.
+confidence: medium
+tags: [changes, development, formatting, only, rule]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: CLAUDE.md
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# No Formatting Only Changes Rule
+
+## Fact
+No automatic code formatters on merge; keep diffs semantic-only unless explicit reformat is requested.
+
+## Why it matters
+Prevents review fatigue from churning whitespace diffs.
+
+## Evidence
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- `CLAUDE.md`

--- a/knowledge/gpu-kernels/num-waves-1-is-multicast-veto.md
+++ b/knowledge/gpu-kernels/num-waves-1-is-multicast-veto.md
@@ -1,0 +1,53 @@
+---
+name: num-waves-1-is-multicast-veto
+type: knowledge
+category: decision
+confidence: high
+source: DeepGEMM
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - csrc/jit_kernels/heuristics/sm90.hpp
+tags: [multicast, waves, cluster, heuristic, amortization]
+imported_at: 2026-04-18T13:30:00Z
+---
+
+# Single-Wave Work Size Vetoes Cluster Multicast
+
+## Fact / Decision
+On SM90, if a candidate layout results in exactly one wave of work across the SMs (`num_waves ≤ 1`), DeepGEMM explicitly vetoes multicast by setting its modeled cycle count to `INT64_MAX`. Single-wave jobs end before the cluster synchronization overhead can be amortized, so clustering is strictly worse than running each SM independently.
+
+```cpp
+if (layout.cluster_n * layout.cluster_m > 1 and num_waves <= 1)
+    num_cycles = std::numeric_limits<int64_t>::max();
+```
+
+## Why it matters
+- Cluster-enabled launches on Hopper require inter-block synchronization at a cluster-barrier. The cost is typically ~10-50 cycles per barrier.
+- For a one-wave job, the barrier pays only once, *but* one-wave jobs are by definition small (block-count ≤ SM count). The barrier latency becomes a larger fraction of the total runtime.
+- The cost model without this rule picks the wrong layout in small-N decoding cases, where the apparent L2 bandwidth savings from multicast look great but are measured against a pessimistic non-multicast baseline.
+- The rule is a hard veto rather than a tiebreaker because multicast's cost is step-function (fixed barrier) while its benefit scales with re-use; below one-wave, re-use ≈ 0.
+
+## Evidence
+- `csrc/jit_kernels/heuristics/sm90.hpp:233-236`:
+  ```cpp
+  // Disable multicasting if only one wave exists
+  if (layout.cluster_n * layout.cluster_m > 1 and num_waves <= 1)
+      num_cycles = std::numeric_limits<int64_t>::max();
+  ```
+  The comment is direct.
+- Context: SM90 comparator is `a.num_cycles < b.num_cycles`, so setting `num_cycles = MAX` ensures no single-wave multicast candidate ever wins.
+
+## Caveats / When this doesn't apply
+- **SM100 heuristic uses a different comparator** — not cycle-based. The SM100 comparator explicitly prefers larger cluster sizes as a tiebreaker *unless* single-wave is cleaner:
+  ```cpp
+  if ((a.num_waves == 1 or b.num_waves == 1) and a.num_waves != b.num_waves)
+      return a.num_waves < b.num_waves;
+  ```
+  Different mechanism, same intuition: single-wave wins, and clustering is not free.
+- **Wave count is computed on `expected_*` shapes**, not actual shapes, if the user supplies expected hints. A user who sets `expected_m=4096` for a dispatcher that sometimes runs m=32 pays the multicast overhead on the small cases.
+- **The rule assumes symmetric cluster costs.** If you profile a specific cluster config that has asymmetric costs (e.g. cluster_n=2 with strong L2 reuse but cluster_m=2 with only barrier cost), a binary veto is too blunt; scale the penalty instead.
+- **Masked grouped GEMM** has an even tighter constraint: the heuristic further requires `ceil_div(n, block_n) % (cluster_m * cluster_n) == 0` for multicast legality, on top of the wave-count veto.

--- a/knowledge/integration/multi-source-alert-routing-rationale.md
+++ b/knowledge/integration/multi-source-alert-routing-rationale.md
@@ -1,0 +1,38 @@
+---
+name: multi-source-alert-routing-rationale
+summary: OpenSRE's detect_sources() function illustrates a robust pattern for routing alerts across heterogeneous observability backends — accept many alias spellings, gate each backend on alert-source provenance, and merge nested-vs-top-level annotations so LLM-extracted enrichments fill gaps.
+category: integration
+tags: [alert-routing, observability, multi-source, normalization]
+source_type: extracted-from-git
+source_url: https://github.com/Tracer-Cloud/opensre.git
+source_ref: main
+source_commit: fb5ba0a1b4ef511d16c56a80f1f126b1f581d724
+source_project: opensre
+source_path: app/nodes/plan_actions/detect_sources.py
+imported_at: 2026-04-18T00:00:00Z
+confidence: high
+---
+
+# Multi-Source Alert Routing — Rationale
+
+## The challenge
+A single agent must respond to alerts coming from Grafana, Datadog, Honeycomb, Coralogix, CloudWatch, EKS, PagerDuty, and Slack — each with its own JSON schema and field-naming conventions. The planner needs to know which observability backends to query for *this specific alert* without firing all of them blindly.
+
+## The solution shape
+`detect_sources(raw_alert, context, resolved_integrations)` returns a `dict[str, dict]` keyed by backend name. Each backend entry contains the parameters needed to query it (endpoint, region, namespace, log_query, etc.). The planner then sees `available_sources` and selects tools that match.
+
+## Three rules that make it work
+1. **Alias-tolerance per resource**: `cloudwatch_log_group OR log_group OR cloudwatchLogGroup OR lambda_log_group` — pick whichever exists. Same pattern repeats for s3_bucket, lambda_function, eks_cluster, db_instance, etc.
+2. **Provenance gating**: Each backend integration is only included when `alert_source` matches it OR is unknown. `if grafana_int and not (alert_source in ("grafana", "")): grafana_int = None`. Prevents spurious cross-platform queries.
+3. **Top-level + nested merge**: `{**nested_annotations, **{k:v for k,v in raw_alert.items() if v and k not in nested}}` — LLM-extracted enrichments at top level fill gaps without overriding original annotations.
+
+## Why structural URL detection is needed
+When `alert_source` isn't explicitly set, fall back to inspecting `externalURL`/`generatorURL`. A Grafana Alertmanager webhook always has `externalURL` pointing to Grafana. This catches alerts where the user didn't configure the source field.
+
+## Backend coverage in OpenSRE
+Currently detected: cloudwatch, s3, s3_audit, s3_processed, local_file, lambda, tracer_web, aws_metadata, grafana, datadog, honeycomb, coralogix, eks, github, openclaw, gitlab, vercel, sentry, mongodb, postgresql, mongodb_atlas, mariadb, opsgenie, jira, mysql.
+
+## Trade-offs
+- Pro: Adding a new backend is local — one new block in `detect_sources` plus a new tool module.
+- Con: 950+ lines of imperative parsing in one file. Could be modularized (per-backend extractors) but the current shape keeps the routing logic visible in one place.
+- Con: Hard-codes alias lists. A new alert source with a novel field name needs a code change. Mitigated by the LLM extraction step (`extract_alert`) which flattens common variants up to the top level.

--- a/knowledge/jit-compilation/nvcc-vs-nvrtc-compilation-tradeoff.md
+++ b/knowledge/jit-compilation/nvcc-vs-nvrtc-compilation-tradeoff.md
@@ -1,0 +1,38 @@
+---
+name: nvcc-vs-nvrtc-compilation-tradeoff
+summary: NVRTC compiles 10x faster in-process but loses 5-10% perf on some kernels vs NVCC's offline optimization; use NVRTC for iteration (DG_JIT_USE_NVRTC=1), NVCC for production.
+category: jit-compilation
+tags: [nvcc, nvrtc, jit, cuda-compiler, performance, build-system]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - README.md
+  - csrc/jit/compiler.hpp
+  - csrc/jit/handle.hpp
+imported_at: 2026-04-18T13:12:58Z
+---
+
+# NVCC vs NVRTC Compilation Tradeoff
+
+## Summary
+Two CUDA compilation paths, both supported by DeepGEMM's JIT layer:
+
+- **NVCC (default):** spawns an external `nvcc` process per kernel. Writes source to temp, reads back CUBIN. Slow (seconds per kernel) but produces the reference-quality binary.
+- **NVRTC (`DG_JIT_USE_NVRTC=1`):** in-process compilation via `nvrtcCompileProgram()`. ~10× faster. Supports precompiled headers on CUDA 12.8+.
+
+Same `--ptxas-options=--register-usage-level=10`, same CUTLASS includes, same lazy-loaded CUDA driver calls.
+
+## Why it matters
+- NVCC runs post-compilation SASS passes (e.g., FFMA interleaving) that NVRTC skips. On some kernels this costs 5-10%.
+- **CUDA 12.9+ narrows the gap** — FFMA interleaving moved into the front-end, so NVRTC gets most of it "for free." DeepGEMM removed the post-compilation optimization flag path entirely once 12.9 landed.
+- NVRTC's PCH (Precompiled Headers) in 12.8+ makes incremental iteration much faster — reload time of the DeepGEMM test suite drops dramatically.
+
+## Practical implications
+- **Production:** stick with NVCC. The 5-10% matters on hot GEMMs.
+- **Rapid iteration / prototyping:** `export DG_JIT_USE_NVRTC=1`. Kernel cache misses become bearable.
+- **Cross-version:** if you target a CUDA ≥ 12.9 minimum, NVRTC is probably the better default — the perf gap is basically gone.
+- Both paths share the same cache directory and hash keys, so switching between them invalidates cached CUBINs (different tool chain → different hash).

--- a/knowledge/jit-compilation/nvrtc-pch-requires-cuda-12-8.md
+++ b/knowledge/jit-compilation/nvrtc-pch-requires-cuda-12-8.md
@@ -1,0 +1,52 @@
+---
+name: nvrtc-pch-requires-cuda-12-8
+type: knowledge
+category: version-quirk
+confidence: high
+source: DeepGEMM
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - csrc/jit/compiler.hpp
+tags: [nvrtc, pch, precompiled-headers, cuda-version, compile-speed]
+imported_at: 2026-04-18T13:30:00Z
+---
+
+# NVRTC PCH (precompiled headers) Requires CUDA 12.8+
+
+## Fact / Decision
+NVRTC got precompiled-header support in CUDA 12.8. For a JIT that compiles many small kernels differing only in template parameters, turning on `--pch` is a "vital" compile-speed win (DeepGEMM's own word) — roughly a 10× speedup on kernel-after-kernel iteration where system + CUTLASS headers dominate.
+
+But the flag must be gated: passing `--pch` to NVRTC ≤ 12.7 makes compilation silently slow (best case) or errors out (worst case).
+
+## Why it matters
+A JIT that loads a fresh kernel for every unique shape re-parses CUTLASS/cute headers on every miss. With PCH, the first compile caches the parse state; subsequent kernels skip 80% of the front-end work.
+
+The CUDA version matrix to remember:
+- **NVCC**: no user-level PCH flag — caching of PTX/fatbin happens internally.
+- **NVRTC ≥ 12.8**: supports `--pch` and `--pch-verbose=true` (diagnostic).
+- **NVRTC ≤ 12.7**: no PCH. Each compile is from scratch.
+- **NVRTC 12.9+**: gains `--gpu-architecture=sm_100f` (arch-family suffix) — separate feature, similar version-gating discipline.
+
+## Evidence
+- `csrc/jit/compiler.hpp:270-275`: the NVRTC compiler's init gates PCH on the runtime-detected version:
+  ```cpp
+  std::string pch_flags;
+  if (major > 12 or minor >= 8) {
+      pch_flags = "--pch ";
+      if (get_env<int>("DG_JIT_DEBUG", 0))
+          pch_flags += "--pch-verbose=true ";
+  }
+  ```
+  with the explicit comment:
+  > // NOTES: PCH is vital for compilation speed
+- `csrc/jit/compiler.hpp:261`: the minimum NVRTC version asserted is 12.3 — so the ecosystem spans 12.3 to 12.8+ and PCH is a per-version capability.
+
+## Caveats / When this doesn't apply
+- **PCH invalidates aggressively.** Changing any preprocessor define between compiles invalidates the PCH, so if your code generates lots of `-DKERNEL_SPECIFIC_FOO=bar` flags, PCH helps less than you'd hope. DeepGEMM encodes those via template parameters in the source, not preprocessor flags, specifically to preserve PCH reuse.
+- **`--pch-verbose=true` output is noisy** — only enable alongside `DG_JIT_DEBUG`.
+- **NVRTC's PCH is not compatible with NVCC's PCH** (different layout). If you switch compiler backends mid-run, you're throwing away the cache.
+- **PCH files live in NVRTC's temp dir**, not your JIT cache. They're re-materialized per process.

--- a/knowledge/llm-agents/multimodal-llm-architectures.md
+++ b/knowledge/llm-agents/multimodal-llm-architectures.md
@@ -1,0 +1,43 @@
+---
+name: multimodal-llm-architectures
+summary: Multimodal LLMs (MLLMs) integrate vision, audio, and text modalities.
+category: llm-agents
+tags: [mllm, multimodal, vision-language, architecture]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/Lordog/dive-into-llms.git
+source_ref: main
+source_commit: f84c04268794ef94f8949808bbc14ab8636763a0
+source_project: dive-into-llms
+source_path: documents/chapter8/README.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Multimodal LLM Architectures
+
+## Overview
+
+Multimodal LLMs (MLLMs) integrate vision, audio, and text modalities. Two dominant architectural paradigms: LLM-as-Scheduler and Encoder-LLM-Decoder.
+
+## Key Facts
+
+- LLM-as-Scheduler: the LLM is the central controller that calls external modality-specific tools and integrates their outputs.
+- Encoder-LLM-Decoder: unified model that jointly encodes all modalities via separate encoders and decodes via the LLM backbone. End-to-end trainable.
+- Visual grounding (locating objects with bounding boxes) is a key MLLM capability distinct from pure VQA.
+- GUI agents are an emerging MLLM application: model takes screenshot and outputs action (click, type, scroll).
+- Qwen2-VL, InternVL, LLaVA, and CogVLM are common open-source MLLMs for research.
+- MLLMs are evaluated on benchmarks like MMBench, MME, SEED-Bench, and ScienceQA.
+
+## Taxonomy
+
+By architecture:
+- LLM-as-Scheduler: modular, each modality is a tool called by the LLM
+- Encoder-LLM-Decoder: unified forward pass, joint training
+
+By modality scope:
+- Vision-Language: image/video + text (most common)
+- Audio-Language: speech/audio + text
+- Any-to-Any: all modalities
+
+## References
+- https://github.com/Lordog/dive-into-llms/tree/main/documents/chapter8

--- a/knowledge/llm-model-routing/multi-provider-llm-client-config.md
+++ b/knowledge/llm-model-routing/multi-provider-llm-client-config.md
@@ -1,0 +1,61 @@
+---
+name: multi-provider-llm-client-config
+summary: Tiered LLM client registry (mini / medium / high / large / persona / gemini) across OpenAI + Anthropic + OpenRouter, with prompt-cache retention and a shared usage-tracking callback for cost accounting.
+category: llm-model-routing
+confidence: high
+tags: [langchain, llm-routing, prompt-caching, openai, anthropic, openrouter, usage-tracking]
+source_type: extracted-from-git
+source_url: https://github.com/BasedHardware/omi.git
+source_ref: main
+source_commit: 1c310f7fc4c37acf7e1bedb014e3a4adfd56546e
+source_project: omi
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Multi-Provider LLM Client Registry
+
+Architecture for routing different workloads to different LLM tiers without scattering model names throughout the codebase. Everything lives in a single `clients.py` module, and the rest of the backend imports named handles (`llm_mini`, `llm_agent`, `llm_persona_medium_stream`, …).
+
+## The tier table
+
+| Handle                        | Model                               | Use-case                                   |
+|-------------------------------|-------------------------------------|--------------------------------------------|
+| `llm_mini` / `llm_mini_stream`| `gpt-4.1-mini`                      | Light tasks: classification, routing       |
+| `llm_medium`                  | `gpt-5.2`                           | Default conversation processing            |
+| `llm_high`                    | `o4-mini`                           | Reasoning-heavy tasks                      |
+| `llm_large`                   | `o1-preview`                        | Hardest tasks, cost-tolerant               |
+| `llm_agent` / `_stream`       | `gpt-5.1` + cache-retention 24h     | Agent loops (repeated prefix)              |
+| `llm_persona_mini_stream`     | `google/gemini-flash-1.5-8b` via OpenRouter | Cheap persona chat      |
+| `llm_persona_medium_stream`   | `anthropic/claude-3.5-sonnet` via OpenRouter | Higher-quality persona chat |
+| `llm_gemini_flash`            | `google/gemini-3-flash-preview` via OpenRouter | Long-context summarisation |
+| `anthropic_client`            | `claude-sonnet-4-6` direct SDK      | Tool-use agents                            |
+
+## Patterns worth copying
+
+1. **Name the handle, not the model.** Callers say `llm_agent.invoke(...)` — swapping `gpt-5.1 → gpt-5.3` is a one-line change.
+2. **Streaming pair.** Every non-streaming handle has a `_stream` twin with `streaming=True, stream_options={"include_usage": True}`. Pick at the callsite.
+3. **Prompt cache key** — `model_kwargs={"prompt_cache_key": "omi-agent-v1"}` pins agent calls to the same cache-machine for high prefix hit rates. Bump the suffix (`-v2`) when the system prompt changes materially.
+4. **Cache retention hint** — `extra_body={"prompt_cache_retention": "24h"}` requests 24 h retention instead of the default 5 min; critical for agent loops that reuse the same 20 k-token prelude.
+5. **OpenRouter as Anthropic/Gemini gateway** — set `base_url=https://openrouter.ai/api/v1` + `X-Title` header, keep the `ChatOpenAI` client class. Enables trying multiple Anthropic / Google models without new SDKs.
+6. **Shared usage callback** — `_usage_callback = get_usage_callback()` injected into every client. Every call logs tokens → your usage store; no caller has to remember.
+7. **Tiktoken for budget math** — `encoding_for_model('gpt-4')` is shared; `num_tokens_from_string(s)` lets routing logic count before dispatching.
+8. **Embeddings + parser globals** — `embeddings = OpenAIEmbeddings("text-embedding-3-large")`, `parser = PydanticOutputParser(pydantic_object=Structured)` live here too; one place to swap embed model.
+
+## When to pick which tier
+
+- Folder assignment, news-check triage, first-pass tagging → `llm_mini`.
+- Conversation summarisation, action-item extraction → `llm_medium`.
+- Reasoning-chain inference, deep synthesis → `llm_high` / `llm_large`.
+- Anything that re-sends the same long system prompt (agents, MCP tools) → `llm_agent` with cache.
+- User-facing chat with personas → persona handles (via OpenRouter for Anthropic models).
+- Wrapped / long-context batch jobs → `llm_gemini_flash`.
+
+## Evidence in source
+
+- `backend/utils/llm/clients.py` — full registry
+- `backend/utils/llm/conversation_processing.py` — picks `llm_mini` for cheap classification
+- `backend/tests/unit/test_prompt_cache_integration.py` — cache retention validation
+
+## Reusability
+
+Any app with mixed-workload LLM usage benefits from pinning model choices in one module. Pattern is framework-neutral (swap LangChain for native SDKs and the structure still holds). Keep the cache key + usage callback + streaming-twin conventions — they compound as the product grows.

--- a/knowledge/native-modules/native-module-stub-layered-fallback.md
+++ b/knowledge/native-modules/native-module-stub-layered-fallback.md
@@ -1,0 +1,121 @@
+---
+name: native-module-stub-layered-fallback
+summary: When stubbing a missing native module for a different OS, use a layered fallback strategy: route to the framework equivalent where one exists (e.g., `BrowserWindow.isMaximized()`), no-op for OS-specific features with no equivalent, and an explicit stub for auth flows that signals unavailability without crashing.
+category: native-modules
+tags: [native-modules, stub, electron, linux, platform-compatibility, node-gyp, fallback]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: medium
+---
+
+# Native Module Stub: Layered Fallback Strategy
+
+## Context
+
+Electron apps may ship a Windows/macOS native module (`@scope/native-addon`)
+that wraps OS-level APIs (window effects, system authentication dialogs,
+taskbar progress, attention flashing). When redistributing such an app for
+Linux, the native module either does not compile or does not make sense for
+Linux. A stub module is needed that satisfies the app's `require()` without
+crashing.
+
+The naive approach — stub every function as `() => {}` — causes subtle bugs:
+functions that should return values return `undefined`, calls that should
+trigger real behavior (like flashing a taskbar icon) silently do nothing, and
+auth flows that should display a browser window just hang.
+
+## Observation
+
+A better approach has three layers:
+
+**Layer 1: Framework equivalent** — for functions where the Electron API
+provides the same functionality on Linux, delegate to it:
+
+```js
+// getIsMaximized: Electron's BrowserWindow.isMaximized() works on Linux
+getIsMaximized: () => {
+  const win = BrowserWindow.getFocusedWindow()
+    || BrowserWindow.getAllWindows().find(w => !w.isDestroyed());
+  return win ? win.isMaximized() : false;
+},
+
+// flashFrame: natively supported on Linux (Unity, KDE, GNOME taskbar)
+flashFrame: (flash) => {
+  const win = getWindow();
+  if (win) win.flashFrame(typeof flash === 'boolean' ? flash : true);
+},
+
+// setProgressBar: natively supported on Linux (Unity launcher API)
+setProgressBar: (progress) => {
+  const win = getWindow();
+  if (win) win.setProgressBar(Math.max(0, Math.min(1, progress)));
+},
+```
+
+**Layer 2: No-op** — for functions whose behavior is purely cosmetic and
+platform-specific with no equivalent:
+
+```js
+setWindowEffect: () => {},    // Windows Mica/Acrylic glass effect
+removeWindowEffect: () => {}, // same
+setOverlayIcon: () => {},     // Windows taskbar overlay icon (no equivalent)
+showNotification: () => {},   // may have an equivalent but low priority
+```
+
+**Layer 3: Explicit stub signaling unavailability** — for auth/security flows
+where "silently succeed" would be wrong (e.g., an OS-level auth dialog):
+
+```js
+class AuthRequest {
+  static isAvailable() {
+    return false;  // tells the caller to use a fallback path
+  }
+
+  async start(url, scheme, windowHandle) {
+    throw new Error('AuthRequest not available on Linux');
+  }
+
+  cancel() {}  // no-op is safe here
+}
+```
+
+The `isAvailable()` pattern is critical: the app can check it before attempting
+to use the feature, rather than discovering unavailability via an exception.
+
+## Why it happens
+
+OS-specific native modules wrap platform APIs that have varying degrees of
+equivalence on Linux:
+- Window effects (Mica, Acrylic): no Linux equivalent.
+- Taskbar progress: equivalent exists (Unity launcher API, exposed via Electron).
+- Attention flashing: equivalent exists (`flashFrame` in Electron).
+- OS-level auth dialogs (Windows Hello, macOS TouchID): no Linux equivalent
+  in Electron (requires OS credential manager).
+
+Treating all three cases the same (all no-ops or all throws) leads to either
+silent failures or unnecessary crashes.
+
+## Practical implication
+
+When writing a native module stub:
+1. Inventory all exported symbols.
+2. For each symbol, determine: (a) does an Electron/Node.js API provide
+   equivalent behavior on Linux? (b) is a no-op safe, or will the caller
+   break without a real return value? (c) does a missing feature need to be
+   explicitly signaled?
+3. Use lazy `require('electron')` inside stub functions to avoid circular
+   dependency issues at module load time.
+4. Filter destroyed windows in `getWindow()` helper to prevent errors from
+   `flashFrame()` or `isMaximized()` on destroyed windows.
+
+## Source reference
+
+- `scripts/claude-native-stub.js`: complete implementation showing all three
+  layers — `getIsMaximized`, `flashFrame`, `setProgressBar` (functional via
+  Electron); `setWindowEffect`, `setOverlayIcon`, `showNotification` (no-ops);
+  `AuthRequest` class with `isAvailable() { return false }` (explicit stub).

--- a/knowledge/networking/nat-type-detection-stun-pattern.md
+++ b/knowledge/networking/nat-type-detection-stun-pattern.md
@@ -1,0 +1,28 @@
+---
+name: nat-type-detection-stun-pattern
+type: knowledge
+category: networking
+summary: NAT type detected via stunclient; drives relay-vs-direct decision at session setup.
+confidence: medium
+tags: [detection, nat, networking, pattern, stun, type]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: src/common.rs
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Nat Type Detection Stun Pattern
+
+## Fact
+NAT type detected via stunclient; drives relay-vs-direct decision at session setup.
+
+## Why it matters
+Detect once at connect and cache; don't re-probe per session.
+
+## Evidence
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- `src/common.rs`

--- a/knowledge/nix/nix-npm-lock-fsevents-macos-exclusion.md
+++ b/knowledge/nix/nix-npm-lock-fsevents-macos-exclusion.md
@@ -1,0 +1,94 @@
+---
+name: nix-npm-lock-fsevents-macos-exclusion
+summary: Nix's `buildNpmPackage` npm-lock fetcher is stricter than `npm ci` and rejects macOS-only `optionalDependencies` like `fsevents` because it attempts to hash them on Linux; strip the reference from `package-lock.json` in `postPatch` to restore determinism.
+category: nix
+tags: [nix, npm, buildNpmPackage, fsevents, macos, optionalDependencies, package-lock, postPatch]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: medium
+---
+
+# Nix npm Lock fsevents macOS Exclusion
+
+## Context
+
+When packaging a Node.js package for NixOS using `buildNpmPackage`, Nix
+attempts to pre-fetch all dependencies listed in `package-lock.json` to
+populate the Nix store. This includes `optionalDependencies`.
+
+The `fsevents` package is a macOS-only native module (Apple FSEvents API for
+file system change notifications). It is listed as an `optionalDependency` in
+many packages (including `chokidar`, which is used by build tools). On non-macOS
+systems, `npm ci` silently skips `fsevents` because optional dependencies are
+allowed to fail installation.
+
+## Observation
+
+Nix's `buildNpmPackage` npm-lock fetcher does not apply the same "optional
+means skippable" logic. It tries to fetch and hash `fsevents` because it
+appears in the lock file. On Linux:
+
+1. The fetch may fail because `fsevents` is a macOS-binary-only package with no
+   Linux tarball.
+2. Even if it fetches, the hash stored in `npmDepsHash` will not match what
+   the macOS version would produce, causing a hash mismatch.
+3. The lock file / package.json inconsistency check fails because Nix sees an
+   entry in the lock that cannot be resolved on the current platform.
+
+The result is a build failure that does not happen with a plain `npm ci` on
+Linux.
+
+## Why it happens
+
+Nix is designed for bit-for-bit reproducibility. Its npm lock integration
+treats the lock file as a definitive manifest of what must be fetched, with
+no platform-conditional logic. Optional dependencies are part of the lock file
+and are therefore part of the manifest Nix tries to satisfy.
+
+`npm ci` on Linux respects the `os: ['darwin']` field in `fsevents`'s
+`package.json` and skips it as an unsatisfied optional dependency. Nix's
+fetcher does not implement this platform check.
+
+## Practical implication
+
+Use `postPatch` in the derivation to strip `fsevents` references from
+`package-lock.json` before Nix's fetcher reads it:
+
+```nix
+buildNpmPackage rec {
+  pname = "my-node-package";
+  version = "1.1.0";
+
+  # ... src, npmDepsHash, etc.
+
+  postPatch = ''
+    # Remove macOS-only fsevents from the lock file.
+    # Nix's npm fetcher doesn't handle platform-conditional optional deps
+    # the way "npm ci" does, and attempts to fetch fsevents on Linux fail.
+    sed -i '/"fsevents"/d' package-lock.json
+  '';
+}
+```
+
+This is safe because:
+- `fsevents` is only used on macOS.
+- Removing it from the lock file does not affect Linux builds.
+- The resulting build is still deterministic (the lock file, minus the
+  macOS-only entry, is fully resolved on Linux).
+
+After modifying `postPatch`, you will need to update `npmDepsHash` because the
+effective set of fetched dependencies changes. Run `nix build` with a dummy
+hash, note the actual hash from the error, and update.
+
+## Source reference
+
+- `nix/node-pty.nix`: `postPatch` — exact one-liner `sed -i '/"fsevents"/d'
+  package-lock.json` with the comment "chokidar (dev dep) has an optional dep
+  on fsevents (macOS-only). The Nix npm deps fetcher excludes it, so npm ci
+  sees a lock/json mismatch. Strip the reference from the lock file to fix the
+  sync."

--- a/knowledge/nix/nix-stock-electron-wrapper-reuse.md
+++ b/knowledge/nix/nix-stock-electron-wrapper-reuse.md
@@ -1,0 +1,97 @@
+---
+name: nix-stock-electron-wrapper-reuse
+summary: The nixpkgs `electron` package is a `makeWrapper` bash script that sets `GIO_EXTRA_MODULES`, `GDK_PIXBUF_MODULE_FILE`, `XDG_DATA_DIRS`, and `CHROME_DEVEL_SANDBOX`; when building a custom Electron tree, reuse its env setup by copying all but the final `exec` line and appending your own exec.
+category: nix
+tags: [nix, nixos, electron, wrapper, makeWrapper, GIO, GDK_PIXBUF, environment]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: medium
+---
+
+# Nix Stock Electron Wrapper Reuse
+
+## Context
+
+On NixOS, the `electron` package in nixpkgs is not the raw ELF binary. It is a
+`makeWrapper`-generated bash script that:
+1. Sets environment variables required for GTK/GIO integration.
+2. Resolves paths to GLib IO modules, GDK pixbuf loaders, and XDG data dirs
+   from the Nix store.
+3. Executes the real `electron` ELF binary as its final action.
+
+When you need to package an Electron app with a custom binary tree (e.g., to
+fix `process.resourcesPath` — see `nix-store-resource-path-immutability`),
+you create your own launcher script. If you skip the env setup from the stock
+wrapper, GTK rendering breaks, icons fail to load, and theming is absent.
+
+## Observation
+
+The nixpkgs electron wrapper sets at minimum:
+- `GIO_EXTRA_MODULES` — path to GLib I/O modules (needed for network stack,
+  GVFS, etc.)
+- `GDK_PIXBUF_MODULE_FILE` — path to the GDK pixbuf loaders cache (needed for
+  image loading in GTK widgets)
+- `XDG_DATA_DIRS` — merged list of data directories for icon themes, MIME types
+- `CHROME_DEVEL_SANDBOX` — path to the `chrome-sandbox` binary (Electron reads
+  this env var to locate the sandbox)
+
+These paths are all Nix store paths that change with each nixpkgs revision.
+Hard-coding them in your derivation would require updating them on every
+nixpkgs update.
+
+## Why it happens
+
+NixOS does not have a global `/usr/lib` or `/usr/share`. Every library and
+data file lives in a content-addressed store path. The `makeWrapper` tool
+generates a shell script that embeds the current store paths as env vars
+that the wrapped binary reads at startup.
+
+The stock electron wrapper's env setup is the canonical source of these paths
+for a given nixpkgs revision. Reusing it ensures your app gets the same
+GTK/GIO configuration as any other Electron app on that system.
+
+## Practical implication
+
+Copy the stock wrapper's content minus its last line, then append your own
+`exec` line pointing at your custom binary:
+
+```bash
+# In installPhase — after creating $electron_tree:
+
+# Extract everything except the final exec line from the stock wrapper
+head -n -1 ${electron}/bin/electron > $electron_tree/electron-wrapper
+
+# Append our own exec pointing at our custom binary (not the stock ELF)
+echo "exec \"$electron_tree/electron\" \"\$@\"" >> $electron_tree/electron-wrapper
+chmod +x $electron_tree/electron-wrapper
+```
+
+Then fix the `CHROME_DEVEL_SANDBOX` path (the stock wrapper points it at the
+stock electron binary; ours lives in a different path):
+
+```bash
+substituteInPlace $electron_tree/electron-wrapper \
+  --replace-quiet "${electron}/libexec/electron/chrome-sandbox" \
+    "$electron_tree/chrome-sandbox"
+```
+
+Use `electron-wrapper` as the exec target in the launcher script, not
+`$electron_tree/electron` directly. This preserves all GTK/GIO env setup
+from the nixpkgs wrapper while redirecting the final exec to your binary.
+
+This approach is robust across nixpkgs updates: as long as the stock wrapper
+exists and ends with a single `exec` line, the `head -n -1` trick works.
+If the wrapper format ever changes, the error will be obvious (missing env
+vars or broken exec).
+
+## Source reference
+
+- `nix/claude-desktop.nix`: `installPhase` — `head -n -1 ${electron}/bin/electron`
+  pattern with the `CHROME_DEVEL_SANDBOX` substituteInPlace step.
+- Comment in that section: "replicates the env setup from the stock electron
+  wrapper (GIO, GTK, GDK_PIXBUF, XDG_DATA_DIRS) but execs our custom binary."

--- a/knowledge/nix/nix-store-resource-path-immutability.md
+++ b/knowledge/nix/nix-store-resource-path-immutability.md
@@ -1,0 +1,109 @@
+---
+name: nix-store-resource-path-immutability
+summary: The Nix store is read-only and `/proc/self/exe` resolves through symlinks to the real binary location, so Electron's `process.resourcesPath` points at the wrong tree when the binary and application resources live in different store paths.
+category: nix
+tags: [nix, nixos, electron, resource-path, proc-self-exe, symlink, store]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+# Nix Store Resource Path Immutability
+
+## Context
+
+Packaging an Electron application for NixOS typically reuses the system-level
+`electron` derivation rather than bundling a private copy. The `electron`
+package lives in the Nix store at its own content-addressed path (e.g.,
+`/nix/store/<hash>-electron-<version>/`). The packaged app's resources
+(`.asar`, tray icons, locale JSON files) live in a separate derivation output
+at a different path.
+
+This is the correct Nix way to avoid duplication, but it creates a subtle
+runtime problem.
+
+## Observation
+
+Electron computes `process.resourcesPath` at startup by resolving
+`/proc/self/exe`, walking any symlinks to the real ELF binary, and returning
+the `resources/` subdirectory of that binary's parent directory.
+
+On NixOS, the binary launcher wrapper is a bash script that `exec`s the real
+ELF. The ELF lives in the `electron-unwrapped` store path. So
+`process.resourcesPath` always resolves to
+`/nix/store/<hash>-electron-unwrapped-<version>/libexec/electron/resources/`,
+which contains only Electron's own built-in `default_app.asar` — not the
+application's `app.asar`, locale JSON files, or tray icons.
+
+Trying to correct this with a symlink from the Electron resources directory to
+the app's resources also fails: the Nix store is globally read-only, and
+`ln -s` into an existing store path is impossible at install or activation time.
+
+Additionally, when `ELECTRON_FORCE_IS_PACKAGED=true` is set, the app reads
+locale JSON (`en-US.json`) from `resourcesPath` at module-load time — before
+any JavaScript preload wrapper has a chance to correct the path — resulting in
+an `ENOENT` crash.
+
+## Why it happens
+
+Linux's `/proc/self/exe` returns the real path of the executable after
+resolving all symlinks (via `readlink -f` semantics). Wrapper scripts that
+`exec` a binary do not change the identity of the resulting process's
+`/proc/self/exe`; that still points at the ELF the kernel actually mapped.
+
+The Nix store is implemented as a content-addressed, append-only tree mounted
+read-only. Once a derivation is built and registered, nothing can be written
+into its paths. This prevents both runtime mutation and post-build symlinking
+into existing store paths.
+
+## Practical implication
+
+The solution is to **copy the Electron ELF binary into your own derivation
+output tree** and symlink everything else from the upstream Electron package.
+This one real copy changes what `/proc/self/exe` resolves to, making
+`process.resourcesPath` point at your tree where you can place all app
+resources:
+
+```nix
+# In the installPhase of your derivation:
+electron_tree=$out/lib/my-app/electron
+
+# MUST be a real copy — not a symlink — so /proc/self/exe resolves here
+cp ${electronDir}/electron $electron_tree/electron
+
+# Symlink everything else to avoid duplicating hundreds of MB
+for item in ${electronDir}/*; do
+  name=$(basename "$item")
+  [[ "$name" = "electron" ]] && continue
+  [[ "$name" = "resources" ]] && continue
+  ln -s "$item" "$electron_tree/$name"
+done
+
+# Merge Electron's resources/ and your app's resources/
+for item in ${electronDir}/resources/*; do
+  ln -s "$item" "$electron_tree/resources/$(basename "$item")"
+done
+cp my-app.asar $electron_tree/resources/
+cp -r my-app.asar.unpacked $electron_tree/resources/
+```
+
+Then create a launcher wrapper that replicates the upstream `electron` wrapper's
+env setup (GIO modules, GDK pixbuf, XDG data dirs, chrome-sandbox path) but
+`exec`s `$electron_tree/electron` as the final step.
+
+A JavaScript preload wrapper (`__dirname`-based fallback) can also correct
+`process.resourcesPath` at runtime for cases where resources are loaded lazily,
+as a belt-and-suspenders measure.
+
+## Source reference
+
+- `nix/claude-desktop.nix`: `installPhase` — explicit comment "MUST be a real
+  copy (not symlink) so that /proc/self/exe resolves to our tree" with the
+  full copy+symlink pattern.
+- `scripts/frame-fix-wrapper.js`: `derivedResourcesPath = path.dirname(__dirname)`
+  — runtime correction as belt-and-suspenders.

--- a/knowledge/observability/narrative-memory-event-storytelling.md
+++ b/knowledge/observability/narrative-memory-event-storytelling.md
@@ -1,0 +1,38 @@
+---
+name: narrative-memory-event-storytelling
+summary: Build narrative memory by linking events into causal stories for better recall and reflection
+category: observability
+confidence: medium
+tags: [evolver, observability, narrative, memory, reference]
+source_type: extracted-from-git
+source_url: https://github.com/EvoMap/evolver.git
+source_ref: main
+source_commit: 22773782475cecf43dc9c1af264bf5f9cacc28bc
+source_project: evolver
+source_paths:
+  - src/gep/narrativeMemory.js
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Narrative memory over flat event logs
+
+LLMs reason better about coherent stories than about flat event lists. Narrative memory groups events into causal "stories":
+
+> "User asked X → agent tried approach A → failed with error E → learned lesson L → retried with approach B → succeeded."
+
+## Representation
+
+Each narrative is a linked list of event nodes with:
+- `caused_by` edges for causality
+- `resolved_by` edges for recovery
+- shared `topic` tag so related narratives can be joined
+
+## Why
+
+- Retrieval becomes targeted (pull one narrative instead of 20 raw events).
+- Reflection prompts have better hooks ("you failed twice on X because…").
+- Downstream summarization gets a stable unit to operate on.
+
+## Reuse notes
+
+The hard part is deciding when a narrative ends. Heuristics that work: explicit resolution (success event following a failure chain), topic drift (new tag family), or inactivity (≥N minutes without related events).

--- a/knowledge/performance-modeling/nvcc-12-9-auto-ffma-interleaving.md
+++ b/knowledge/performance-modeling/nvcc-12-9-auto-ffma-interleaving.md
@@ -1,0 +1,52 @@
+---
+name: nvcc-12-9-auto-ffma-interleaving
+type: knowledge
+category: decision
+confidence: high
+source: DeepGEMM
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - README.md
+  - csrc/jit/compiler.hpp
+tags: [nvcc, ffma, post-optimization, compiler-version, sass]
+imported_at: 2026-04-18T13:30:00Z
+---
+
+# NVCC 12.9 Auto-Interleaves FFMA Instructions (Obsoleting Post-Optimization)
+
+## Fact / Decision
+Earlier DeepGEMM versions shipped a SASS-level post-optimizer that interleaved `FFMA` instructions in the compiled cubin to hide pipeline latency. Starting with NVCC 12.9, the compiler does this automatically. DeepGEMM has *removed* its post-optimizer and recommends NVCC 12.9+ as the best path for SM90 performance.
+
+## Why it matters
+- **If you're on NVCC ≤ 12.8, you're leaving a measurable amount of performance on the table** on SM90 GEMMs — roughly 5-10% on compute-bound shapes where FFMA throughput matters.
+- **DIY SASS post-optimizers are high-maintenance.** They break on each CUDA version because SASS encoding changes. Handing the optimization to NVCC is a clean exit.
+- **The README's guidance is prescriptive:** CUDA 12.3+ works, but "we highly recommend 12.9 or higher for the best performance." For SM100 it's *required* (12.9 added `sm_100f` family suffix too).
+
+The 12.9 compiler also adds:
+- Auto arch-family suffix (`sm_100f`) for forward-compat with future compute caps.
+- Better handling of CUTLASS 4.x templates.
+- Relaxed `--expt-extended-lambda` constexpr requirements.
+
+## Evidence
+- `README.md:16-22`: the release note:
+  > 2025.07.20: ... NVRTC and post-compilation SASS optimization are all disabled. ... As NVCC 12.9 will automatically do the FFMA interleaving, all post optimizations will be no longer supported.
+- `README.md:33-34`: requirements state CUDA 12.3 minimum, with 12.9+ recommended for performance.
+- `csrc/jit/compiler.hpp:185-190`: the NVCC version check warns on < 12.9:
+  ```cpp
+  if (major == 12 and minor < 9)
+      printf("Warning: please use at least NVCC 12.9 for the best DeepGEMM performance\n");
+  ```
+- `csrc/jit/compiler.hpp:203-205`: arch-family suffix is only enabled for NVCC > 12 or ≥ 12.9:
+  ```cpp
+  const auto arch = device_runtime->get_arch(false, nvcc_major > 12 or nvcc_minor >= 9);
+  ```
+
+## Caveats / When this doesn't apply
+- **Auto-interleaving is heuristic.** For extremely hand-tuned kernels you might still beat NVCC manually — but the gap shrank from ~10% to < 1%, and maintaining hand-tuned SASS is a full-time job.
+- **Non-FFMA instructions (FP64, integer) are not reordered** by this pass. If your kernel is bottlenecked on integer ALU, version doesn't help.
+- **NVRTC doesn't get the same treatment on older CUDA** — NVRTC's instruction selector is slightly different. The DeepGEMM README warns that NVRTC "may have performance loss with some cases."
+- **Downstream tools like Nsight Compute read the cubin** — if you had a post-optimizer dumping hand-rewritten cubin, profiler views change after removing it. Expect different hotspot lines.

--- a/knowledge/pitfall/mutation-onsuccess-side-effect-races.md
+++ b/knowledge/pitfall/mutation-onsuccess-side-effect-races.md
@@ -1,0 +1,42 @@
+---
+name: mutation-onsuccess-side-effect-races
+summary: Putting both state-switch and navigate() in a mutation's onSuccess causes flash-and-jump races; let the UI layer own the side-effect sequence in one microtask.
+category: pitfall
+tags: [react-query, mutations, side-effects, race-condition, ux]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: HANDOFF_ARCHITECTURE_AUDIT.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+Symptom: after "Create Workspace" completes, the app flashes `/issues` for one frame before jumping to `/onboarding`. Root cause: two `onSuccess` callbacks race:
+- `useCreateWorkspace.onSuccess` → `switchWorkspace(newWs)` → Zustand updates → `/issues` route renders once.
+- Modal's own `onSuccess` → `router.push("/onboarding")` → async-schedule navigation.
+
+The first is synchronous state update; the second is async navigation. `/issues` always wins one render before `/onboarding` pushes.
+
+## Why
+
+Fix by pulling side effects out of the mutation into the UI layer so they execute in the same microtask:
+
+```tsx
+function CreateWorkspaceModal() {
+  const createWs = useCreateWorkspace();
+  return <Button onClick={async () => {
+    const ws = await createWs.mutateAsync({ name, slug });
+    switchWorkspace(ws);
+    navigate.push('/onboarding');    // same microtask, no flash
+  }} />;
+}
+```
+
+Same class of bug shows up on workspace delete (no auto-nav after delete) and accept-invite (two acceptance paths, one missing the switch). Root cure is the URL-based workspace identity refactor — switching becomes pure `<Link>` navigation, no `switchWorkspace` function exists, no race possible.
+
+## Evidence
+
+- `HANDOFF_ARCHITECTURE_AUDIT.md` Task 4 — three specific bugs tied to this pattern.
+- `packages/core/workspace/mutations.ts` — cleaned-up mutation without side effects.

--- a/knowledge/pitfall/navigate-about-blank-before-trace-start.md
+++ b/knowledge/pitfall/navigate-about-blank-before-trace-start.md
@@ -1,0 +1,48 @@
+---
+name: navigate-about-blank-before-trace-start
+summary: Before starting a reload-based performance trace, first navigate the page to `about:blank` with `waitUntil: 'networkidle0'` to flush previous-page state; otherwise the trace captures residual activity from the outgoing page and pollutes the insights.
+category: pitfall
+confidence: medium
+tags: [performance, tracing, about-blank, puppeteer]
+source_type: extracted-from-git
+source_url: https://github.com/ChromeDevTools/chrome-devtools-mcp.git
+source_ref: main
+source_commit: 0a6aaa52ebacb2db834ffa437863e5844aa3730b
+source_project: chrome-devtools-mcp
+source_path: src/tools/performance.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Flush to about:blank Before Trace Start
+
+## Context
+
+Starting `page.tracing.start` on a live page means the trace picks up whatever's already in flight — pending idle-callbacks, deferred loads, long-running timers. When you then trigger a reload, the trace spans the tail of the old navigation and the start of the new one, and insights like "DocumentLatency" or "LCPBreakdown" become confused.
+
+## The fact / decision / pitfall
+
+Fix: if the user asked for `reload: true`, navigate to `about:blank` first and wait for network idle:
+
+```ts
+if (request.params.reload) {
+  await page.pptrPage.goto('about:blank', {waitUntil: ['networkidle0']});
+}
+const categories = [/* ... */];
+await page.pptrPage.tracing.start({categories});
+if (request.params.reload) {
+  await page.pptrPage.goto(pageUrlForTracing, {waitUntil: ['load']});
+}
+```
+
+`about:blank` resets the page context. `networkidle0` guarantees no stray pending requests from the previous page leak into the trace window.
+
+## Evidence
+
+- `src/tools/performance.ts::startTrace` — the exact sequence.
+
+## Implications
+
+- This applies any time you need a clean trace baseline: memory snapshots, performance marks, lighthouse snapshots. `about:blank` is the universal reset.
+- Don't use `goto('about:blank')` on the user-initiated navigation path — it visibly flashes the browser. This is a tracing-only optimization.
+- If `reload: false` (user wants to trace the current state), skip the `about:blank` dance — the trace has a different purpose.
+- For repeated trace runs in a loop, always about:blank between runs. Compounded residue across runs shows up as steadily growing LCP numbers that aren't real.

--- a/knowledge/pitfall/nested-claude-code-session-deadlock.md
+++ b/knowledge/pitfall/nested-claude-code-session-deadlock.md
@@ -1,0 +1,61 @@
+---
+name: nested-claude-code-session-deadlock
+summary: Spawning a Claude Code subprocess from inside a Claude Code session deadlocks silently because the Agent SDK leaks `process.env` into the child regardless of the `env` option, so `CLAUDECODE=1` and `CLAUDE_CODE_*` markers propagate.
+category: pitfall
+confidence: high
+tags: [claude-code, subprocess, deadlock, env-leak, agent-sdk]
+source_type: extracted-from-git
+source_url: https://github.com/coleam00/Archon.git
+source_ref: dev
+source_commit: d89bc767d291f52687beea91c9fcf155459be0d9
+source_project: Archon
+imported_at: 2026-04-18T00:00:00Z
+linked_skills: [strip-cwd-env-boot]
+---
+
+# Nested Claude Code Sessions Deadlock Silently
+
+## Fact / Decision
+
+When the Claude Code SDK spawns a subprocess, the child **inherits the parent's full `process.env`** regardless of the explicit `env` option passed to the SDK's `query({ env: ... })` call (confirmed in Archon's notes: coleam00/Archon#1097).
+
+If the parent process is running inside a Claude Code terminal session, that parent's env contains `CLAUDECODE=1` plus a set of `CLAUDE_CODE_*` markers that Claude Code uses internally to detect "I'm already in a session." When the child inherits those markers, Claude Code's internal state machine becomes confused and the nested session **hangs silently** — no error, no crash, just an unresponsive subprocess.
+
+The only reliable workaround is to **strip the markers from `process.env` of the parent before any Agent-SDK call**. The four keys to strip:
+
+1. `CLAUDECODE`
+2. Any `CLAUDE_CODE_*` key **except** auth-related ones (`CLAUDE_CODE_OAUTH_TOKEN`, `CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_USE_VERTEX`).
+
+Archon additionally strips `NODE_OPTIONS` and `VSCODE_INSPECTOR_OPTIONS` which can crash Claude Code subprocesses (anthropics/claude-code#4619).
+
+Emit a stderr warning when `CLAUDECODE=1` is detected, **before** you delete the marker (otherwise downstream code never sees the signal). Give the user a workaround and a suppression env var:
+
+```
+⚠ Detected CLAUDECODE=1 — running inside a Claude Code session.
+   If workflows hang silently, this is a known class of issue.
+   Workaround: run `archon serve` from a regular shell.
+   Suppress: set ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING=1
+   Details: https://github.com/coleam00/Archon/issues/1067
+```
+
+## Why
+
+The env-inheritance leak comes from Node.js's child-process default behavior: `spawn(cmd, args)` without an explicit `env` option inherits the parent env. The Agent SDK's `env` option filters through that default, but internal implementation paths (e.g. spawning helper processes for MCP, skills, hooks) may bypass the explicit option.
+
+Rather than wait for the SDK to fix it, the fix in user code is to make the parent env clean before any call.
+
+## Counter / Caveats
+
+- The auth markers (`CLAUDE_CODE_OAUTH_TOKEN` etc.) **must be kept** — they're how the SDK authenticates. Curate the strip list carefully.
+- If you run inside a Claude Code session *intentionally* (e.g. debugging a reproducer), setting `ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING=1` lets you silence the warning while still getting the env scrub.
+- The pattern generalizes: any "child process inherits markers that the parent set for itself" class of bug can deadlock. When integrating with a host tool, audit which env vars the host sets on itself and strip them before spawning siblings of the host.
+- This is specifically Claude Code behavior — it may be fixed in future SDK versions. Verify each SDK upgrade whether the strip is still necessary.
+
+## Evidence
+
+- `packages/paths/src/strip-cwd-env.ts:68-93`: the full CLAUDE_CODE_* scrub pass, auth-var allowlist at lines 30-34.
+- Stderr warning at `strip-cwd-env.ts:72-80` with suppression env var.
+- `packages/paths/src/strip-cwd-env.ts:17-22` design comment names coleam00/Archon#1097 (SDK env leak) and coleam00/Archon#1067 (nested session warning PR).
+- anthropics/claude-code#4619 referenced at `strip-cwd-env.ts:91-92` for NODE_OPTIONS / VSCODE_INSPECTOR_OPTIONS strip.
+- Boot-time invocation at `packages/paths/src/strip-cwd-env-boot.ts` (imported as the first line of every CLI entry point).
+- Commit SHA: d89bc767d291f52687beea91c9fcf155459be0d9.

--- a/knowledge/pitfall/network-collector-preserves-navigation-request.md
+++ b/knowledge/pitfall/network-collector-preserves-navigation-request.md
@@ -1,0 +1,55 @@
+---
+name: network-collector-preserves-navigation-request
+summary: A network-request collector that splits storage at `framenavigated` must migrate the tail of in-flight requests (from the navigation request forward) into the new navigation's bucket; otherwise the nav request and early same-nav requests get orphaned in the previous bucket.
+category: pitfall
+confidence: medium
+tags: [puppeteer, network, navigation, event-collection]
+source_type: extracted-from-git
+source_url: https://github.com/ChromeDevTools/chrome-devtools-mcp.git
+source_ref: main
+source_commit: 0a6aaa52ebacb2db834ffa437863e5844aa3730b
+source_project: chrome-devtools-mcp
+source_path: src/PageCollector.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Network Collector Must Migrate Nav Request on Split
+
+## Context
+
+The `PageCollector` pattern stores events in per-navigation buckets and rotates at `framenavigated`. For console messages or issues, a simple `unshift([])` works — the new bucket starts empty. For *network requests*, that's wrong.
+
+## The fact / decision / pitfall
+
+`framenavigated` fires on the *new* URL. By the time it fires, the navigation request itself has already been collected and lives at the tail of the previous bucket. If you simply prepend an empty bucket, the navigation request — arguably the single most important request of the new page — is orphaned in "previous navigation" history.
+
+Fix: override `splitAfterNavigation` for the network collector specifically to find the last navigation request (filtered by `frame === page.mainFrame() && request.isNavigationRequest()`) and migrate from that index forward into the new bucket:
+
+```ts
+override splitAfterNavigation(page: Page) {
+  const navigations = this.storage.get(page) ?? [];
+  const requests = navigations[0];
+  const lastNavIdx = requests.findLastIndex(r =>
+    r.frame() === page.mainFrame() && r.isNavigationRequest()
+  );
+  if (lastNavIdx !== -1) {
+    const fromCurrentNav = requests.splice(lastNavIdx);
+    navigations.unshift(fromCurrentNav);
+  } else {
+    navigations.unshift([]);
+  }
+  navigations.splice(this.maxNavigationSaved);
+}
+```
+
+## Evidence
+
+- `src/PageCollector.ts::NetworkCollector.splitAfterNavigation` — exactly this logic, with comment: "Keep all requests since the last navigation request including that navigation request itself."
+- The superclass `PageCollector.splitAfterNavigation` does the simple unshift that works for consoles.
+
+## Implications
+
+- Any "event type X since the last navigation" query that depends on ordering needs to understand whether the splitting event is *before* or *after* the events it emits.
+- For redirect chains, the navigation request has a redirect chain of its own — make sure the formatter walks `request.redirectChain()` rather than losing intermediate hops.
+- If you paginate or filter in a way that displays "current" vs "previous" buckets, explicitly test the first-page case (immediately after navigation) — the off-by-one shows up there.
+- DevTools itself also applies similar preservation logic on "Preserve log" mode; copy its semantics rather than inventing new ones.

--- a/knowledge/pitfall/next-cross-component-state-update.md
+++ b/knowledge/pitfall/next-cross-component-state-update.md
@@ -1,0 +1,46 @@
+---
+name: next-cross-component-state-update
+summary: React 19 forbids setState during render of a different component; defer zustand persist rehydrate calls and cross-component notifications to queueMicrotask.
+category: pitfall
+tags: [react-19, zustand, setstate, render, microtask]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: packages/core/platform/workspace-storage.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+React 19 strict mode throws a warning ("Cross-component updates during render") when component A's render calls `setState` on component B's store. This happens accidentally when:
+
+- A global setter (e.g. `setCurrentWorkspace(slug, id)`) is invoked during a component's render.
+- The setter synchronously calls `store.persist.rehydrate()` which internally calls `setState` on another store.
+
+Fix: defer the side effect to `queueMicrotask`, batching multiple calls in the same render cycle into one microtask:
+
+```ts
+let _pendingRehydrate = false;
+export function setCurrentWorkspace(slug, wsId) {
+  if (_currentSlug === slug) return;
+  _currentSlug = slug;
+  if (!_pendingRehydrate) {
+    _pendingRehydrate = true;
+    queueMicrotask(() => {
+      _pendingRehydrate = false;
+      for (const fn of _rehydrateFns) fn();
+    });
+  }
+}
+```
+
+## Why
+
+Microtask runs after the current render commits but before the browser paints — effectively batching updates without user-visible delay. Repeat calls with the same slug are no-ops so rapid desktop tab re-mounts (N tabs each calling setCurrentWorkspace on mount) coalesce to one microtask.
+
+Without deferring, tests pass (they often bypass the render cycle) but the dev console warning is always there, and occasionally the deferred work clobbers state that the in-render setState was about to set.
+
+## Evidence
+
+- `packages/core/platform/workspace-storage.ts:30-64` — explicit microtask comment.

--- a/knowledge/pitfall/no-finer-grained-metadata.md
+++ b/knowledge/pitfall/no-finer-grained-metadata.md
@@ -1,0 +1,25 @@
+---
+name: no-finer-grained-metadata
+type: knowledge
+category: pitfall
+summary: Magika returns broad content-type labels — no finer-grained metadata (e.g. ELF static-vs-dynamic, PDF version).
+confidence: medium
+tags: [magika, pitfall]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# No Finer Grained Metadata
+
+## Fact
+
+All ELF binaries → 'elf'. All PDFs → 'pdf'. By design — Magika is a high-level filter for security pipelines, not a detailed analyzer. If you need finer detail, run a specialized parser after Magika triages.
+
+## Evidence
+
+- `website-ng/src/content/docs/additional-resources/faq.md:70-78`

--- a/knowledge/pitfall/node-modules-auto-exclude-electron-builder.md
+++ b/knowledge/pitfall/node-modules-auto-exclude-electron-builder.md
@@ -1,0 +1,54 @@
+---
+name: node-modules-auto-exclude-electron-builder
+summary: electron-builder v20.15.2+ auto-excludes directories named "node_modules" from the package — work around with explicit extraResources from/to paths to ship your SDK.
+category: pitfall
+tags: [electron-builder, node_modules, packaging]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: apps/electron/electron-builder.yml
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# electron-builder silently strips `node_modules`
+
+### The footgun
+Since electron-builder v20.15.2, directories named `node_modules` are automatically excluded from packaging EVEN if you try to include them via the `files:` glob. Reported upstream at electron-builder#3104, not fixed — considered "intentional".
+
+If your app packages a SDK (or any library you've pre-bundled) from `node_modules/@somebody/foo`, it silently won't ship. Symptoms: packaged app crashes at runtime with `Cannot find module '@somebody/foo'`. Dev build works fine.
+
+### The workaround
+Use `extraResources` with explicit `from` / `to` pairs — this path bypasses the `node_modules` auto-exclusion:
+
+```yaml
+# apps/electron/electron-builder.yml
+mac:
+  extraResources:
+    - from: node_modules/@anthropic-ai/claude-agent-sdk
+      to: app/node_modules/@anthropic-ai/claude-agent-sdk
+      filter:
+        - "**/*"
+        - "!vendor/ripgrep/arm64-linux/**"
+        - "!vendor/ripgrep/x64-linux/**"
+        - "!vendor/ripgrep/x64-win32/**"
+```
+
+Note the `filter:` subfield lets you do per-platform strip of unwanted binaries INSIDE the extraResource.
+
+### Implications
+- Anything your app imports at runtime that's pulled via a normal `require` from `node_modules/` must be in `extraResources`, not rely on `files:`.
+- Works best if you keep a small explicit list of deps (SDKs with native binaries). Trying to extraResource ALL of `node_modules` defeats the purpose.
+- Pre-bundling via esbuild + `--bundle` (inlines everything) is an alternative: then you don't need node_modules at runtime. The craft-agents repo uses that for `main.cjs` and the interceptor. It still uses extraResources for the SDK because the SDK internally spawns subprocesses that resolve to its `vendor/ripgrep`.
+
+### Symptoms if you miss it
+- `electron-builder` succeeds with no warnings.
+- `pnpm dist` / `bun run electron:dist` produces an app.
+- Running the packaged app, first SDK call: `Error: Cannot find module '@anthropic-ai/claude-agent-sdk'`.
+- Debugging "it works in dev" wastes hours.
+
+### Reference
+- `apps/electron/electron-builder.yml` (every platform has the same extraResources block).
+- Upstream: https://github.com/electron-userland/electron-builder/issues/3104

--- a/knowledge/pitfall/not-polyglot-detection-capable.md
+++ b/knowledge/pitfall/not-polyglot-detection-capable.md
@@ -1,0 +1,25 @@
+---
+name: not-polyglot-detection-capable
+type: knowledge
+category: pitfall
+summary: Magika does NOT detect polyglot files (files valid as multiple types simultaneously, e.g. ZIP-in-JPEG).
+confidence: high
+tags: [magika, pitfall]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Not Polyglot Detection Capable
+
+## Fact
+
+Polyglots are intentionally crafted to be valid in multiple formats. Magika detects only the dominant type via byte sampling. The team explicitly does not target polyglot detection as a first-release goal and invites adversarial examples to drive future improvements.
+
+## Evidence
+
+- `website-ng/src/content/docs/contributing/known-limitations.md:7`

--- a/knowledge/training/multimodal-loss-mask-strategy.md
+++ b/knowledge/training/multimodal-loss-mask-strategy.md
@@ -1,0 +1,31 @@
+---
+name: multimodal-loss-mask-strategy
+summary: VoxCPM training masks out loss on text and reference audio regions; only target audio patches contribute to the gradient
+category: training
+tags: [training, loss-mask, multimodal, tts, fine-tuning]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/OpenBMB/VoxCPM.git
+source_ref: main
+source_commit: 13605c5a0e6b99d6d3527a43bd1a4e0e69c8800e
+source_project: VoxCPM
+source_paths:
+  - src/voxcpm/training/packers.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Loss mask zeroes text and ref_audio regions; only target audio contributes to loss
+
+VoxCPM's training pipeline builds a flat sequence containing text tokens, reference audio patches, and target audio patches. A critical detail is the loss mask applied during gradient computation: only the target audio region has `loss_mask=1`; all other positions (text tokens, boundary special tokens, reference audio patches) are masked to 0.
+
+The mask is computed in `packers.py` as a float tensor of shape `[seq_len]`. During the loss computation: `loss = (loss_per_token * loss_mask).sum() / loss_mask.sum()`. This ensures the model learns only to predict target audio — not to reconstruct the input text or the reference audio it was given as context.
+
+Incorrect masking is a common and silent training failure mode. If the reference audio region is accidentally set to `loss_mask=1`, the model will learn to "reconstruct" reference audio it already has access to in context, a form of shortcut learning that leads to a model that can only clone voices it memorized in training rather than generalizing to new speakers.
+
+## Why it matters
+When writing a custom packer or data loader for VoxCPM fine-tuning, verify the loss mask independently — log `loss_mask.sum()` per sample and ensure it equals exactly `len(target_audio_patches)`. Any deviation indicates a masking bug that will silently corrupt training.
+
+## Source reference
+- Upstream: `OpenBMB/VoxCPM` @ `main` / `13605c5a`
+- Key files:
+  - `src/voxcpm/training/packers.py:73-150+` — `loss_mask` construction showing the zeroing of text and ref_audio regions and the setting of target audio to 1.0

--- a/knowledge/troubleshooting/oauth-token-cache-corruption-workaround.md
+++ b/knowledge/troubleshooting/oauth-token-cache-corruption-workaround.md
@@ -1,0 +1,100 @@
+---
+name: oauth-token-cache-corruption-workaround
+summary: Some OAuth implementations leave a corrupted `oauth:tokenCache` key in the app's JSON config after periods of inactivity, causing persistent 401 errors; the workaround is to remove the offending key from the config file and re-authenticate.
+category: troubleshooting
+tags: [oauth, token-cache, 401, authentication, config-corruption, json, workaround]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: low
+---
+
+# OAuth Token Cache Corruption Workaround
+
+## Context
+
+Electron apps that store OAuth tokens in a JSON configuration file
+(`~/.config/AppName/config.json`) sometimes write a cached token object
+(`oauth:tokenCache` or similar) during authentication. This cache speeds up
+subsequent requests by avoiding re-authentication on startup.
+
+After extended periods of inactivity (days to weeks), this cache can become
+corrupted or stale in ways that cause every API request to return 401
+Unauthorized, even after the app has been restarted.
+
+## Observation
+
+The symptom is recurring "API Error: 401" messages appearing in the app UI
+after a period of inactivity. The error persists across normal app restarts.
+
+The corrupted entry has a key matching a pattern like `"oauth:tokenCache"` in
+the app's JSON config file. Removing this specific key (and re-authenticating
+once) resolves the issue.
+
+The `config.json` is a JSON file with various settings. Care must be taken to
+maintain valid JSON after removal (trailing commas can invalidate the file).
+
+Manual fix procedure:
+1. Close the application completely (not just minimize).
+2. Open `~/.config/AppName/config.json` in a text editor.
+3. Find and remove the line containing `"oauth:tokenCache"` and any associated
+   trailing comma from the previous line.
+4. Verify the file is still valid JSON.
+5. Save and restart the application.
+6. Re-authenticate when prompted.
+
+## Why it happens
+
+OAuth token caches typically store access tokens with expiry timestamps. If
+the cache corruption involves:
+- A mismatched token/secret pair.
+- An expired refresh token that the app does not handle gracefully.
+- A serialization bug that writes an invalid token object.
+
+...then the app may silently use the cached (invalid) token without attempting
+a re-authentication flow, resulting in perpetual 401 responses.
+
+The specific mechanism (upstream application behavior) may change across
+versions. This is documented as an upstream issue rather than a packaging-level
+bug.
+
+## Practical implication
+
+For any Electron app that stores OAuth state in a JSON config:
+
+**Diagnostic**: If a user reports persistent 401 errors after a period of
+inactivity, check the config file for a token cache key before suggesting
+more invasive fixes (clearing all config, reinstalling).
+
+**Scripted workaround** (Python example):
+```python
+import json
+import re
+from pathlib import Path
+
+config_path = Path.home() / '.config' / 'AppName' / 'config.json'
+with open(config_path) as f:
+    config = json.load(f)
+
+if 'oauth:tokenCache' in config:
+    del config['oauth:tokenCache']
+    with open(config_path, 'w') as f:
+        json.dump(config, f, indent=2)
+    print('Removed oauth:tokenCache — restart the app and re-authenticate')
+else:
+    print('No oauth:tokenCache found')
+```
+
+**`--doctor` check** (preventive): Include a check that reads the config file,
+parses it as JSON, and warns if a token cache key is present that is obviously
+stale (e.g., expired timestamp in the token payload).
+
+## Source reference
+
+- `docs/TROUBLESHOOTING.md`: "Authentication Errors (401)" section — manual
+  steps, credit to the contributor who identified the fix, link to the scripted
+  solution in the GitHub issue thread.

--- a/registry.json
+++ b/registry.json
@@ -2409,6 +2409,111 @@
       "category": "build",
       "path": "skills/build/coverage-data-file-under-pytest-cache/SKILL.md",
       "version": "1.0.0"
+    },
+    "multi-platform-input-dispatch-abstraction": {
+      "category": "input",
+      "path": "skills/input/multi-platform-input-dispatch-abstraction/SKILL.md",
+      "version": "1.0.0"
+    },
+    "multi-signal-mime-detection-stream-info": {
+      "category": "preprocessing",
+      "path": "skills/preprocessing/multi-signal-mime-detection-stream-info/SKILL.md",
+      "version": "1.0.0"
+    },
+    "multi-source-browser-connection": {
+      "category": "puppeteer",
+      "path": "skills/puppeteer/multi-source-browser-connection/SKILL.md",
+      "version": "1.0.0"
+    },
+    "multi-stage-heuristic-selection-with-comparators": {
+      "category": "kernel-heuristics",
+      "path": "skills/kernel-heuristics/multi-stage-heuristic-selection-with-comparators/SKILL.md",
+      "version": "1.0.0"
+    },
+    "multi-tenant-session-isolation": {
+      "category": "patterns",
+      "path": "skills/patterns/multi-tenant-session-isolation/SKILL.md",
+      "version": "1.0.0"
+    },
+    "multi-turn-conversation-history": {
+      "category": "llm-agents",
+      "path": "skills/llm-agents/multi-turn-conversation-history/SKILL.md",
+      "version": "1.0.0"
+    },
+    "multi-turn-repl-chatbot": {
+      "category": "workflow",
+      "path": "skills/workflow/multi-turn-repl-chatbot/SKILL.md",
+      "version": "1.0.0"
+    },
+    "multi-window-parameter-passing": {
+      "category": "flutter",
+      "path": "skills/flutter/multi-window-parameter-passing/SKILL.md",
+      "version": "1.0.0"
+    },
+    "multilingual-tts-text-normalize-and-split": {
+      "category": "text-normalization",
+      "path": "skills/text-normalization/multilingual-tts-text-normalize-and-split/SKILL.md",
+      "version": "1.0.0"
+    },
+    "native-module-stub-with-electron-fallback": {
+      "category": "native-modules",
+      "path": "skills/native-modules/native-module-stub-with-electron-fallback/SKILL.md",
+      "version": "1.0.0"
+    },
+    "navigation-adapter-cross-platform": {
+      "category": "architecture",
+      "path": "skills/architecture/navigation-adapter-cross-platform/SKILL.md",
+      "version": "1.0.0"
+    },
+    "navigation-aware-event-collector": {
+      "category": "puppeteer",
+      "path": "skills/puppeteer/navigation-aware-event-collector/SKILL.md",
+      "version": "1.0.0"
+    },
+    "new-ml-backend-dependency-audit": {
+      "category": "agents",
+      "path": "skills/agents/new-ml-backend-dependency-audit/SKILL.md",
+      "version": "1.0.0"
+    },
+    "nextjs-docker-standalone-build": {
+      "category": "devops",
+      "path": "skills/devops/nextjs-docker-standalone-build/SKILL.md",
+      "version": "1.0.0"
+    },
+    "nix-electron-resource-path-copy": {
+      "category": "nix",
+      "path": "skills/nix/nix-electron-resource-path-copy/SKILL.md",
+      "version": "1.0.0"
+    },
+    "node-pty-native-module-rebuild-nix": {
+      "category": "nix",
+      "path": "skills/nix/node-pty-native-module-rebuild-nix/SKILL.md",
+      "version": "1.0.0"
+    },
+    "num-experts-per-wave-by-sm-occupancy": {
+      "category": "moe-optimization",
+      "path": "skills/moe-optimization/num-experts-per-wave-by-sm-occupancy/SKILL.md",
+      "version": "1.0.0"
+    },
+    "oauth-define-at-buildtime": {
+      "category": "electron",
+      "path": "skills/electron/oauth-define-at-buildtime/SKILL.md",
+      "version": "1.0.0"
+    },
+    "obfuscated-jvm-string-anchor-navigation": {
+      "category": "reverse-engineering",
+      "path": "skills/reverse-engineering/obfuscated-jvm-string-anchor-navigation/SKILL.md",
+      "version": "1.0.0"
+    },
+    "onboard": {
+      "category": "meta",
+      "path": "skills/meta/onboard/SKILL.md",
+      "version": "1.0.0"
+    },
+    "one-command-setup-flow": {
+      "category": "cli",
+      "path": "skills/cli/one-command-setup-flow/SKILL.md",
+      "version": "1.0.0"
     }
   },
   "knowledge": {
@@ -4427,6 +4532,122 @@
     "craft-cli-command-surface": {
       "category": "reference",
       "path": "knowledge/reference/craft-cli-command-surface.md"
+    },
+    "multi-provider-llm-client-config": {
+      "category": "llm-model-routing",
+      "path": "knowledge/llm-model-routing/multi-provider-llm-client-config.md"
+    },
+    "multi-source-alert-routing-rationale": {
+      "category": "integration",
+      "path": "knowledge/integration/multi-source-alert-routing-rationale.md"
+    },
+    "multimodal-llm-architectures": {
+      "category": "llm-agents",
+      "path": "knowledge/llm-agents/multimodal-llm-architectures.md"
+    },
+    "multimodal-loss-mask-strategy": {
+      "category": "training",
+      "path": "knowledge/training/multimodal-loss-mask-strategy.md"
+    },
+    "mutation-onsuccess-side-effect-races": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/mutation-onsuccess-side-effect-races.md"
+    },
+    "narrative-memory-event-storytelling": {
+      "category": "observability",
+      "path": "knowledge/observability/narrative-memory-event-storytelling.md"
+    },
+    "nat-type-detection-stun-pattern": {
+      "category": "networking",
+      "path": "knowledge/networking/nat-type-detection-stun-pattern.md"
+    },
+    "native-module-stub-layered-fallback": {
+      "category": "native-modules",
+      "path": "knowledge/native-modules/native-module-stub-layered-fallback.md"
+    },
+    "navigate-about-blank-before-trace-start": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/navigate-about-blank-before-trace-start.md"
+    },
+    "nested-claude-code-session-deadlock": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/nested-claude-code-session-deadlock.md"
+    },
+    "network-collector-preserves-navigation-request": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/network-collector-preserves-navigation-request.md"
+    },
+    "next-cross-component-state-update": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/next-cross-component-state-update.md"
+    },
+    "nix-npm-lock-fsevents-macos-exclusion": {
+      "category": "nix",
+      "path": "knowledge/nix/nix-npm-lock-fsevents-macos-exclusion.md"
+    },
+    "nix-stock-electron-wrapper-reuse": {
+      "category": "nix",
+      "path": "knowledge/nix/nix-stock-electron-wrapper-reuse.md"
+    },
+    "nix-store-resource-path-immutability": {
+      "category": "nix",
+      "path": "knowledge/nix/nix-store-resource-path-immutability.md"
+    },
+    "no-autonomous-lifecycle-mutation": {
+      "category": "arch",
+      "path": "knowledge/arch/no-autonomous-lifecycle-mutation.md"
+    },
+    "no-backwards-compat-pre-launch": {
+      "category": "decision",
+      "path": "knowledge/decision/no-backwards-compat-pre-launch.md"
+    },
+    "no-dereference-option-symlinks": {
+      "category": "api",
+      "path": "knowledge/api/no-dereference-option-symlinks.md"
+    },
+    "no-finer-grained-metadata": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/no-finer-grained-metadata.md"
+    },
+    "no-formatting-only-changes-rule": {
+      "category": "development",
+      "path": "knowledge/development/no-formatting-only-changes-rule.md"
+    },
+    "node-modules-auto-exclude-electron-builder": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/node-modules-auto-exclude-electron-builder.md"
+    },
+    "non-destructive-curation-for-llm-drafts": {
+      "category": "decision",
+      "path": "knowledge/decision/non-destructive-curation-for-llm-drafts.md"
+    },
+    "not-polyglot-detection-capable": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/not-polyglot-detection-capable.md"
+    },
+    "num-waves-1-is-multicast-veto": {
+      "category": "gpu-kernels",
+      "path": "knowledge/gpu-kernels/num-waves-1-is-multicast-veto.md"
+    },
+    "numpy-unpinned-no-workaround": {
+      "category": "decision",
+      "path": "knowledge/decision/numpy-unpinned-no-workaround.md"
+    },
+    "nvcc-12-9-auto-ffma-interleaving": {
+      "category": "performance-modeling",
+      "path": "knowledge/performance-modeling/nvcc-12-9-auto-ffma-interleaving.md"
+    },
+    "nvcc-vs-nvrtc-compilation-tradeoff": {
+      "category": "jit-compilation",
+      "path": "knowledge/jit-compilation/nvcc-vs-nvrtc-compilation-tradeoff.md"
+    },
+    "nvrtc-pch-requires-cuda-12-8": {
+      "category": "jit-compilation",
+      "path": "knowledge/jit-compilation/nvrtc-pch-requires-cuda-12-8.md"
+    },
+    "oauth-token-cache-corruption-workaround": {
+      "category": "troubleshooting",
+      "path": "knowledge/troubleshooting/oauth-token-cache-corruption-workaround.md"
     }
   }
 }

--- a/skills/agents/new-ml-backend-dependency-audit/SKILL.md
+++ b/skills/agents/new-ml-backend-dependency-audit/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: new-ml-backend-dependency-audit
+description: Run a Phase-0 dependency audit on a candidate ML library before writing any integration code, so PyInstaller and runtime surprises are caught early.
+category: agents
+version: 1.0.0
+version_origin: extracted
+tags: [ml-ops, dependencies, pyinstaller, audit, integration]
+source_type: extracted-from-git
+source_url: https://github.com/jamiepine/voicebox.git
+source_ref: main
+source_commit: 476abe07fc2c1587f4b3e3916134018ebacd143d
+source_project: voicebox
+confidence: high
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# New ML backend dependency audit
+
+## When to use
+You are about to add a new ML model/library (TTS, STT, image, anything torch-based) to an app that ships as a PyInstaller binary. Skipping the audit reliably produces 3+ patch releases chasing frozen-build breakage (typechecked decorators, missing data files, hardcoded system paths).
+
+## Steps
+1. Clone the model library into a throwaway directory (`/tmp/engine-research`). Do NOT install it into the main venv yet.
+2. Grep the clone (and its transitive dependencies) for every pattern that breaks frozen builds:
+   - `@typechecked` / `inspect.getsource` / `torch.jit.script` — forces `--collect-all <pkg>` because `.pyc` fails source reads.
+   - `importlib.metadata.version(` / `pkg_resources.get_distribution(` — forces `--copy-metadata <dist-name>`.
+   - `lazy_loader.attach` / `.pyi` stubs — forces `--collect-all` for the stubs.
+   - Hardcoded `/usr/share/...` / `data_path = Path(__file__).parent / "data"` — forces env var fallback in the frozen entrypoint.
+   - `torch.load(...)` without `map_location=` — forces a monkey-patch when CPU build loads CUDA-tensor checkpoints.
+   - `token=True` in HF calls — forces `snapshot_download(token=None)` + `from_local()` so users without an HF login can run the app.
+3. Produce a written audit covering:
+   a. PyPI vs git-only dependencies.
+   b. PyInstaller flags needed (`--collect-all`, `--copy-metadata`, `--hidden-import`).
+   c. Runtime data files (`.pth.tar`, `.yaml`, `.json`, G2P dictionaries) that must be bundled.
+   d. Native libraries with hardcoded paths (espeak-ng, piper_phonemize, misaki) and the env vars needed to redirect them.
+   e. Monkey-patches (`torch.load`, float64 casts, MPS workarounds).
+   f. Sample rate expected by the model and any sample-rate-conversion needs.
+   g. Model download method (`from_pretrained` vs `snapshot_download + from_local`) and whether it respects `HF_HUB_OFFLINE`.
+4. Build and test model load + a single inference in the throwaway venv on CPU. Only then start the real integration.
+5. Test again with a **clean HuggingFace cache** so you catch download-path bugs that a warm cache hides.
+
+## Counter / Caveats
+- Do NOT skip this audit "because the library is small" — the smallest lib can pull in 400 MB of descript-audiotools transitives.
+- Upstream pretrained weights can move between HF repos; pin the exact `revision=` in the download call to make cache behavior reproducible.
+- Nightly PyTorch is not shippable for releases (non-deterministic, regressions between runs). If a library requires nightly, prefer `TORCH_CUDA_ARCH_LIST=...+PTX` or wait for a stable support window.
+- Keep the audit doc in the repo (e.g. `docs/engine-audits/<engine>.md`) — it becomes the next maintainer's starting point and makes version upgrades routine.
+
+Source references: `.agents/skills/add-tts-engine/SKILL.md` (Phase 0 / the lessons table from v0.2.3).

--- a/skills/architecture/navigation-adapter-cross-platform/SKILL.md
+++ b/skills/architecture/navigation-adapter-cross-platform/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: navigation-adapter-cross-platform
+description: NavigationAdapter in each app's platform layer lets shared view code call useNavigation().push() without importing next/navigation or react-router-dom.
+category: architecture
+version: 1.0.0
+tags: [routing, navigation, cross-platform, nextjs, react-router, electron]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- Monorepo with ≥2 frontend apps (web Next.js + desktop Electron, say) sharing view packages.
+- You want shared views to call `useNavigation().push('/issues')` without knowing which framework is on the other side.
+
+## Steps
+
+1. Define the contract in a shared package (core or views):
+   ```ts
+   // packages/core/navigation/context.ts
+   export interface NavigationAPI {
+     push(path: string): void;
+     replace(path: string): void;
+     back(): void;
+     pathname(): string;
+   }
+   const NavigationContext = createContext<NavigationAPI | null>(null);
+   export function NavigationProvider({ value, children }: { value: NavigationAPI; children: ReactNode }) {
+     return <NavigationContext.Provider value={value}>{children}</NavigationContext.Provider>;
+   }
+   export function useNavigation(): NavigationAPI {
+     const ctx = useContext(NavigationContext);
+     if (!ctx) throw new Error("useNavigation must be inside NavigationProvider");
+     return ctx;
+   }
+   ```
+2. Web app implements the adapter using Next.js APIs:
+   ```ts
+   // apps/web/platform/navigation.tsx
+   import { useRouter, usePathname } from "next/navigation";
+   export function WebNavigationAdapter({ children }: { children: ReactNode }) {
+     const router = useRouter();
+     const pathname = usePathname();
+     const value: NavigationAPI = useMemo(() => ({
+       push: (p) => router.push(p),
+       replace: (p) => router.replace(p),
+       back: () => router.back(),
+       pathname: () => pathname,
+     }), [router, pathname]);
+     return <NavigationProvider value={value}>{children}</NavigationProvider>;
+   }
+   ```
+3. Desktop app implements using react-router-dom:
+   ```ts
+   // apps/desktop/src/renderer/src/platform/navigation.tsx
+   import { useNavigate, useLocation } from "react-router-dom";
+   export function DesktopNavigationAdapter({ children }: { children: ReactNode }) {
+     const nav = useNavigate();
+     const loc = useLocation();
+     const value = useMemo(() => ({
+       push: nav,
+       replace: (p: string) => nav(p, { replace: true }),
+       back: () => nav(-1),
+       pathname: () => loc.pathname,
+     }), [nav, loc]);
+     return <NavigationProvider value={value}>{children}</NavigationProvider>;
+   }
+   ```
+4. Wrap each app's root with its adapter. Shared views consume `useNavigation()` and never import `next/*` or `react-router-dom`.
+5. For workspace-aware routing, the adapter is the right place to auto-prepend the current slug:
+   ```ts
+   push: (p) => router.push(p.startsWith('/') ? `/${currentSlug}${p}` : p),
+   ```
+
+## Example
+
+```tsx
+// packages/views/issues/IssueRow.tsx — framework-agnostic
+function IssueRow({ issue }) {
+  const nav = useNavigation();
+  return <button onClick={() => nav.push(`/issues/${issue.id}`)}>{issue.title}</button>;
+}
+```
+
+## Caveats
+
+- The adapter contract should stay small. If you find yourself adding framework-specific primitives (`searchParams`, SSR-only helpers), push them into the app layer instead.
+- Desktop adapter should detect "cross-workspace push" (path starts with a different slug) and translate into open-new-tab or switch-workspace semantics, rather than a plain navigate in the current tab.
+- Don't bypass the adapter with ad-hoc `window.history.pushState` — cross-platform invariants break silently.

--- a/skills/cli/one-command-setup-flow/SKILL.md
+++ b/skills/cli/one-command-setup-flow/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: one-command-setup-flow
+description: Bundle CLI configure + authenticate + daemon start into one `cli setup` command, with per-environment profiles (cloud vs self-host) and custom-port overrides.
+category: cli
+version: 1.0.0
+tags: [cli, setup, onboarding, profiles, cobra]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- A CLI where first-time setup has always required 3-5 manual steps (config set, login, start daemon).
+- You want a single command to onboard users, with sensible defaults for cloud and self-host.
+
+## Steps
+
+1. Define a `setup` command with two modes:
+   ```go
+   setup := &cobra.Command{
+     Use:   "setup",
+     Short: "Configure, authenticate, and start the daemon",
+   }
+   setup.AddCommand(selfHostCmd()) // mycli setup self-host
+   rootCmd.AddCommand(setup)
+   ```
+   Default `setup` uses cloud endpoints; `setup self-host` targets localhost with overridable flags.
+2. `setup self-host` flags let users override defaults without editing config:
+   ```go
+   cmd.Flags().StringVar(&serverURL, "server-url", "http://localhost:8080", "")
+   cmd.Flags().StringVar(&appURL,    "app-url",    "http://localhost:3000", "")
+   cmd.Flags().Int(   "port",          8080, "backend port (sets server-url)")
+   cmd.Flags().Int(   "frontend-port", 3000, "frontend port (sets app-url)")
+   cmd.Flags().String("profile",       "",   "profile name (default: derived from URL)")
+   ```
+3. Implementation is a sequence of small, idempotent steps, each recoverable:
+   ```
+   1. Resolve server/app URL from flags or defaults
+   2. Write to profile config (~/.mycli/profiles/<name>/config.json)
+   3. Open browser to {appURL}/auth/cli-callback?port=<local listener>
+   4. Wait for callback with token on localhost
+   5. Save token to profile config
+   6. Fetch workspace list with the token
+   7. Start daemon in the background with this profile
+   8. Poll daemon health endpoint until ready
+   9. Print success banner + "what next" hints
+   ```
+4. Each step can be re-run independently:
+   - `mycli login` repeats steps 3-5.
+   - `mycli config set server_url ...` repeats step 2.
+   - `mycli daemon start` repeats steps 7-8.
+5. Prompt before overwriting an existing profile config (don't clobber silently).
+
+## Example
+
+```
+$ mycli setup self-host --port 9090 --frontend-port 4000
+==> Writing config to ~/.mycli/profiles/localhost-9090/config.json
+==> Opening browser for authentication...
+    (paste token if browser doesn't open: http://localhost:4000/auth/cli)
+✓ Authenticated as alice@example.com
+==> Discovered 2 workspaces: "Engineering", "Marketing"
+==> Starting daemon (profile: localhost-9090)...
+✓ Daemon running (PID 12345)
+
+Next: assign an issue to an agent from http://localhost:4000
+```
+
+## Caveats
+
+- Browser-less environments (CI, VM without X): flag `--token` path that reads a PAT from stdin or env; don't force browser auth.
+- Daemon start + healthcheck poll with a 60s timeout; if it fails, print the log path and exit non-zero.
+- Profile name derivation must be deterministic (by URL or worktree), so re-running `setup` targets the same profile.

--- a/skills/devops/nextjs-docker-standalone-build/SKILL.md
+++ b/skills/devops/nextjs-docker-standalone-build/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: nextjs-docker-standalone-build
+description: Three-stage Docker build for a Next.js app with pnpm workspaces — deps / builder / runner stages, standalone output for a minimal production image.
+category: devops
+version: 1.0.0
+tags: [docker, nextjs, pnpm, monorepo, standalone]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- Deploying a Next.js app that lives inside a pnpm workspace with shared packages.
+- You want the production image to contain only the traced node_modules, not the full monorepo.
+- You need a deterministic reproducible build with `pnpm install --frozen-lockfile`.
+
+## Steps
+
+1. **Deps stage** — resolve dependencies from the full workspace but without copying source. This gets cached unless package.jsons change:
+   ```dockerfile
+   FROM node:22-alpine AS deps
+   RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
+   WORKDIR /app
+   COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json .npmrc ./
+   COPY apps/web/package.json apps/web/
+   COPY packages/core/package.json packages/core/
+   COPY packages/ui/package.json packages/ui/
+   COPY packages/views/package.json packages/views/
+   COPY packages/tsconfig/package.json packages/tsconfig/
+   RUN pnpm install --frozen-lockfile
+   ```
+2. **Builder stage** — overlay the source, re-link pnpm symlinks, build:
+   ```dockerfile
+   FROM node:22-alpine AS builder
+   RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
+   WORKDIR /app
+   COPY --from=deps /app ./
+   COPY package.json turbo.json pnpm-workspace.yaml ./
+   COPY apps/web/ apps/web/
+   COPY packages/ packages/
+   RUN pnpm install --frozen-lockfile --offline
+   ARG REMOTE_API_URL=http://backend:8080
+   ENV REMOTE_API_URL=$REMOTE_API_URL
+   ENV STANDALONE=true
+   RUN pnpm --filter @org/web build
+   ```
+   The second install with `--offline` re-creates symlinks the COPY overwrote.
+3. In `apps/web/next.config.ts`, enable standalone output:
+   ```ts
+   export default {
+     output: process.env.STANDALONE ? "standalone" : undefined,
+     transpilePackages: ["@org/core", "@org/ui", "@org/views"],
+   };
+   ```
+4. **Runner stage** — copy only the standalone output + static + public:
+   ```dockerfile
+   FROM node:22-alpine AS runner
+   WORKDIR /app
+   ENV NODE_ENV=production
+   RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
+   COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
+   COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
+   COPY --from=builder --chown=nextjs:nodejs /app/apps/web/public ./apps/web/public
+   USER nextjs
+   EXPOSE 3000
+   ENV PORT=3000 HOSTNAME=0.0.0.0
+   CMD ["node", "apps/web/server.js"]
+   ```
+
+## Example
+
+Image size: ~150-250 MB runner vs 1 GB+ for "copy the whole repo and run `pnpm start`". Build time: first ~3 min, subsequent ~45 s once deps stage caches.
+
+## Caveats
+
+- If you add or remove a shared package, update the deps-stage `COPY` list.
+- Standalone output traces only what's imported from the app entrypoint — dynamic `require()` or runtime-loaded files may be missing and need explicit `outputFileTracingIncludes` config.
+- The re-install in the builder is `--offline`; it fails if deps aren't already in the pnpm store from the deps stage.

--- a/skills/electron/oauth-define-at-buildtime/SKILL.md
+++ b/skills/electron/oauth-define-at-buildtime/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: oauth-define-at-buildtime
+description: Bake OAuth client IDs/secrets into the main-process bundle at build time via esbuild --define:process.env.X=... so they ship with the app, while user-provided secrets (Google) stay out of the build.
+category: electron
+version: 1.0.0
+version_origin: extracted
+tags: [electron, oauth, esbuild, buildtime, secrets]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: scripts/electron-build-main.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Bake OAuth config at build time
+
+## When to use
+- Your Electron app integrates with OAuth providers (Slack, Microsoft, Sentry) that require a client ID/secret baked into the app at distribution time.
+- Some providers (Google) forbid embedding credentials in public code; users must supply their own.
+- You want `process.env.SLACK_OAUTH_CLIENT_ID` to resolve to the literal value in the packaged bundle without leaking in the repo.
+
+## How it works
+1. `.env.example` lists the variables; `.env` (gitignored) holds real values, or CI provides them as secrets.
+2. Build script reads `.env` into `process.env`.
+3. Enumerate the variables to define:
+   ```ts
+   const definedVars = ['SLACK_OAUTH_CLIENT_ID', 'SLACK_OAUTH_CLIENT_SECRET',
+     'MICROSOFT_OAUTH_CLIENT_ID', 'MICROSOFT_OAUTH_CLIENT_SECRET',
+     'SENTRY_ELECTRON_INGEST_URL'];
+   ```
+4. Build `esbuild --define:process.env.X="value"` flags from those vars:
+   ```ts
+   const defines = definedVars.map(v => `--define:process.env.${v}="${process.env[v] ?? ''}"`);
+   ```
+5. Pass through `spawn(['bun', 'run', 'esbuild', ..., ...defines])` when bundling `main.cjs`.
+6. At runtime in packaged code, `process.env.SLACK_OAUTH_CLIENT_ID` is a literal string the minifier already inlined.
+7. **Explicitly document** that Google OAuth is NOT baked in - users fill it in via source config. Provide a setup guide.
+8. For local `electron:dev` development, `.env` is loaded at runtime so devs can iterate without rebuilding.
+
+## Example
+```ts
+// Build script
+function loadEnvFile() {
+  const content = readFileSync(join(ROOT, '.env'), 'utf8');
+  for (const line of content.split('\n')) {
+    if (line.startsWith('#') || !line.includes('=')) continue;
+    const [k, ...rest] = line.split('='); process.env[k] = rest.join('=').trim();
+  }
+}
+loadEnvFile();
+const defines = ['SLACK_OAUTH_CLIENT_ID','SLACK_OAUTH_CLIENT_SECRET','MICROSOFT_OAUTH_CLIENT_ID']
+  .map(v => `--define:process.env.${v}="${process.env[v] ?? ''}"`);
+spawn({ cmd: ['bun', 'run', 'esbuild', 'src/main/index.ts', '--bundle', ...defines], /*...*/ });
+```
+
+## Gotchas
+- Anything in a public build is in the hands of every user - don't bake admin-level secrets. Client IDs + OAuth secrets are fine per OAuth RFCs for desktop clients.
+- Use `""` not `undefined` for missing values - an unquoted `undefined` is invalid JS and will crash the bundle.
+- CI builds need the same env vars as local; use GitHub Actions `secrets.SLACK_OAUTH_CLIENT_ID` -> `env: SLACK_OAUTH_CLIENT_ID: ${{ secrets.X }}`.
+- Google specifically refuses to let third-party apps embed their client secret. Surface this to users early.
+- esbuild's `--define` substitutes literal text; wrap the value in quotes so it's a JS string, not an identifier.

--- a/skills/flutter/multi-window-parameter-passing/SKILL.md
+++ b/skills/flutter/multi-window-parameter-passing/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: multi-window-parameter-passing
+description: Window parameter serialization via Map<String, dynamic> for multi-window session state.
+category: flutter
+version: 1.0.0
+version_origin: extracted
+tags: [flutter, multi, parameter, passing, window]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: flutter/lib/desktop/pages/remote_tab_page.dart
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Multi Window Parameter Passing
+
+## When to use
+Window parameter serialization via Map<String, dynamic> for multi-window session state.
+
+## Source context
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- Demonstrated in: `flutter/lib/desktop/pages/remote_tab_page.dart`
+
+## Why this generalizes
+Reusable for desktop_multi_window-based apps.
+
+## Next steps before publishing
+- Read the source files above and rewrite this as a product-agnostic `how-to` — keep the pattern, drop rustdesk-specific names.
+- Add a minimal code example in the target language (Rust + Dart / Rust only / etc.).
+- List 2-3 gotchas you hit while reproducing it.

--- a/skills/input/multi-platform-input-dispatch-abstraction/SKILL.md
+++ b/skills/input/multi-platform-input-dispatch-abstraction/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: multi-platform-input-dispatch-abstraction
+description: Unified keyboard/mouse input via Windows SendInput, macOS CGEvent, Linux xdo/uinput under one trait.
+category: input
+version: 1.0.0
+version_origin: extracted
+tags: [abstraction, dispatch, input, multi, platform]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: [libs/enigo/src/win/, libs/enigo/src/macos/, libs/enigo/src/linux/]
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Multi Platform Input Dispatch Abstraction
+
+## When to use
+Unified keyboard/mouse input via Windows SendInput, macOS CGEvent, Linux xdo/uinput under one trait.
+
+## Source context
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- Demonstrated in: `libs/enigo/src/win/`, `libs/enigo/src/macos/`, `libs/enigo/src/linux/`
+
+## Why this generalizes
+Any cross-platform input-injection library faces the same divergence.
+
+## Next steps before publishing
+- Read the source files above and rewrite this as a product-agnostic `how-to` — keep the pattern, drop rustdesk-specific names.
+- Add a minimal code example in the target language (Rust + Dart / Rust only / etc.).
+- List 2-3 gotchas you hit while reproducing it.

--- a/skills/kernel-heuristics/multi-stage-heuristic-selection-with-comparators/SKILL.md
+++ b/skills/kernel-heuristics/multi-stage-heuristic-selection-with-comparators/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: multi-stage-heuristic-selection-with-comparators
+description: Enumerate all legal kernel configs under hardware constraints, score each with an arch-specific cost model (cycles / wave efficiency), and pick the winner via a comparator.
+category: kernel-heuristics
+version: 1.0.0
+version_origin: extracted
+tags: [heuristics, gpu-optimization, config-search, performance-modeling, comparator]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - csrc/jit_kernels/heuristics/sm90.hpp
+  - csrc/jit_kernels/heuristics/sm100.hpp
+  - csrc/jit_kernels/heuristics/config.hpp
+imported_at: 2026-04-18T13:12:58Z
+---
+
+# Multi-Stage Heuristic Selection With Comparators
+
+## What / Why
+Avoid manual tuning of GPU kernels across thousands of shapes. Instead, generate the full space of legal `(block_m, block_n, block_k, cluster_m, cluster_n, num_stages, swizzle)` tuples for a given matrix shape + hardware, score each tuple, and pick the best. The cost model is specific to the architecture — SM90 uses cycle estimates, SM100 uses wave efficiency plus multicast preference.
+
+## Procedure
+1. **Enumerate block candidates.** Iterate block_m over `{16,32,64,128,256}` (bounded by `m`), block_n over arch-specific step sizes, block_k over a narrow set (typically 64 or 128 for FP8).
+2. **Apply fast rejections.**
+   - `block_m > 128 && block_n > 128` → reject (register pressure).
+   - Swizzle mode of A/B must be ≥ 64B — reject 32B swizzle (≈ 50% perf loss).
+   - cluster size must divide num_sms; certain kernels require `ceil_div(n, block_n) % cluster_dim == 0`.
+3. **Compute storage & stage count.** Determine swizzle modes from `lcm(16, inner_dim × elem_size)`, compute per-stage smem, derive `num_stages = (smem_total − fixed_overhead) / per_stage_size`.
+4. **Reject under-pipelined candidates.** `num_stages < 3` (or `<4` for small matrices) cannot hide TMA latency — drop.
+5. **Score.** Pass remaining candidates through arch comparator:
+   - SM90: estimate L1/L2 cycles and compute cycles, account for wave efficiency (how full the last wave is), pick min cycles.
+   - SM100: prefer configs with higher wave efficiency and multicast enabled when beneficial.
+6. **Return winner** or warn if no candidate passed all legality gates.
+
+## Key design points
+- Keep the enumerator declarative — a pure function from shape → vector of candidates. Makes it testable without a GPU.
+- Split the comparator per arch rather than a single mega-heuristic — the performance cliffs differ.
+- Store the loss function constants (64B L2 throughput, barrier overhead, etc.) as named constexprs for easy tuning.
+
+## References
+- `csrc/jit_kernels/heuristics/sm90.hpp` — `get_best_configs()` style selection.
+- `csrc/jit_kernels/heuristics/sm100.hpp` — SM100 variant with different score function.
+- `csrc/jit_kernels/heuristics/config.hpp` — shared config struct + validation helpers.

--- a/skills/llm-agents/multi-turn-conversation-history/SKILL.md
+++ b/skills/llm-agents/multi-turn-conversation-history/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: multi-turn-conversation-history
+description: Chain multiple agent turns by converting run results to input lists for the next call.
+category: llm-agents
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [openai-agents, conversation, multi-turn, to-input-list, history]
+source_type: extracted-from-git
+source_url: https://github.com/openai/openai-agents-python.git
+source_ref: main
+source_commit: e80d2d2319eb300ac17ec496988b70246a5042d6
+source_project: openai-agents-python
+source_path: docs/running_agents.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# multi-turn-conversation-history
+
+Use `result.to_input_list()` to build the conversation history from a previous turn, then append a new user message and pass it to the next `Runner.run()` call.
+
+## When to apply
+
+Stateless conversation loops (e.g., CLI chatbots) where you manage history explicitly instead of using a `Session` object. Also needed when you want to inspect or modify the history between turns.
+
+## Core snippet
+
+```python
+import asyncio
+from agents import Agent, Runner, TResponseInputItem
+
+agent = Agent(name="Assistant", instructions="Be concise.")
+
+async def main():
+    inputs: list[TResponseInputItem] = []
+    
+    while True:
+        user_input = input("You: ")
+        if user_input.lower() == "quit":
+            break
+        
+        # Append new user message to history
+        inputs.append({"role": "user", "content": user_input})
+        
+        result = await Runner.run(agent, inputs)
+        print(f"Agent: {result.final_output}")
+        
+        # Carry the full conversation (including agent responses) to next turn
+        inputs = result.to_input_list()
+
+asyncio.run(main())
+```
+
+## With tracing across turns
+
+```python
+import uuid
+from agents import trace
+
+conversation_id = str(uuid.uuid4().hex[:16])
+
+async def run_turn(agent, inputs, user_msg):
+    with trace("Chat turn", group_id=conversation_id):
+        inputs.append({"role": "user", "content": user_msg})
+        result = await Runner.run(agent, inputs)
+        return result.final_output, result.to_input_list()
+```
+
+## Key notes
+
+- `result.to_input_list()` returns a list of `TResponseInputItem` dicts (OpenAI Responses API format)
+- The list includes prior inputs AND all new items (model responses, tool calls, outputs)
+- For automatic history management, prefer `Session` objects instead
+- `result.to_input_list(mode="normalized")` normalizes items for continuation after cancellation

--- a/skills/meta/onboard/SKILL.md
+++ b/skills/meta/onboard/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: onboard
+description: "Generates a contextual onboarding document for a new contributor or agent joining the project. Summarizes project state, architecture, conventions, and current priorities relevant to the specified role or area."
+argument-hint: "[role|area]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write
+model: haiku
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version: 1.0.0
+version_origin: extracted
+---
+
+## Phase 1: Load Project Context
+
+Read CLAUDE.md for project overview and standards.
+
+Read the relevant agent definition from `.claude/agents/` if a specific role is specified.
+
+---
+
+## Phase 2: Scan Relevant Area
+
+- For programmers: scan `src/` for architecture, patterns, key files
+- For designers: scan `design/` for existing design documents
+- For narrative: scan `design/narrative/` for world-building and story docs
+- For QA: scan `tests/` for existing test coverage
+- For production: scan `production/` for current sprint and milestone
+
+Read recent changes (git log if available) to understand current momentum.
+
+---
+
+## Phase 3: Generate Onboarding Document
+
+```markdown
+# Onboarding: [Role/Area]
+
+## Project Summary
+[2-3 sentence summary of what this game is and its current state]
+
+## Your Role
+[What this role does on this project, key responsibilities, who you report to]
+
+## Project Architecture
+[Relevant architectural overview for this role]
+
+### Key Directories
+| Directory | Contents | Your Interaction |
+|-----------|----------|-----------------|
+
+### Key Files
+| File | Purpose | Read Priority |
+|------|---------|--------------|
+
+## Current Standards and Conventions
+[Summary of conventions relevant to this role from CLAUDE.md and agent definition]
+
+## Current State of Your Area
+[What has been built, what is in progress, what is planned next]
+
+## Current Sprint Context
+[What the team is working on now and what is expected of this role]
+
+## Key Dependencies
+[What other roles/systems this role interacts with most]
+
+## Common Pitfalls
+[Things that trip up new contributors in this area]
+
+## First Tasks
+[Suggested first tasks to get oriented and productive]
+
+1. [Read these documents first]
+2. [Review this code/content]
+3. [Start with this small task]
+
+## Questions to Ask
+[Questions the new contributor should ask to get fully oriented]
+```
+
+---
+
+## Phase 4: Save Document
+
+Present the onboarding document to the user.
+
+Ask: "May I write this to `production/onboarding/onboard-[role]-[date].md`?"
+
+If yes, write the file, creating the directory if needed.
+
+---
+
+## Phase 5: Next Steps
+
+Verdict: **COMPLETE** — onboarding document generated.
+
+- Share the onboarding doc with the new contributor before their first session.
+- Run `/sprint-status` to show the new contributor current progress.
+- Run `/help` if the contributor needs guidance on what to work on next.

--- a/skills/moe-optimization/num-experts-per-wave-by-sm-occupancy/SKILL.md
+++ b/skills/moe-optimization/num-experts-per-wave-by-sm-occupancy/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: num-experts-per-wave-by-sm-occupancy
+description: Pick the number of experts processed per persistent-kernel wave so that total blocks (discounted by a 2x imbalance factor) just saturate all SMs, rounded to a divisor of the expert count.
+category: moe-optimization
+version: 1.0.0
+version_origin: extracted
+tags: [moe, persistent-kernel, occupancy, sm-utilization, waves, scheduler]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - csrc/jit_kernels/heuristics/mega_moe.hpp
+imported_at: 2026-04-18T13:30:00Z
+---
+
+# Choose Experts Per Wave By SM Occupancy And Divisibility
+
+## When to use
+You're running a fused MoE kernel in persistent-scheduler form: each SM processes a fixed batch of (expert, token) blocks before finishing. You need to decide how many experts to stuff into one wave. Too few → SMs idle at the end. Too many → shared-memory / tmem pressure blocks you from multicasting. And routing is never perfectly balanced, so reserving some slack matters.
+
+## Steps
+1. **Cap at the hardware-friendly maximum.** DeepGEMM caps at 32 experts per wave and requires that the number *divides* `num_experts_per_rank`:
+   ```cpp
+   int max = std::min(32, num_experts_per_rank);
+   while (max > 1 and num_experts_per_rank % max != 0) --max;
+   ```
+   The divisor constraint ensures every wave handles the same count — no tail wave with 2 experts while the rest had 8.
+2. **Estimate blocks-per-expert** under the assumption of uniform routing:
+   ```cpp
+   expected_tokens_per_expert = num_tokens * num_topk / num_experts_per_rank + 1
+   num_m_blocks = ceil_div(expected_tokens_per_expert, block_m)
+   num_n_blocks = intermediate_hidden / block_n
+   num_l1_blocks_per_expert = num_m_blocks * num_n_blocks
+   ```
+3. **Apply an imbalance factor.** MoE routing never hits the uniform expectation — some experts get 2x the average. DeepGEMM uses `kImbalanceFactor = 2` and solves for experts-per-wave that still keeps SMs busy under that worst-case:
+   ```cpp
+   num_experts_per_wave = ceil_div(kImbalanceFactor * num_sms, num_l1_blocks_per_expert);
+   num_experts_per_wave = min(num_experts_per_wave, max);
+   ```
+   Intuition: "make sure that even if half the experts send 2x their share, we still have enough blocks to fill all SMs in one wave."
+4. **Round up to the nearest divisor of the expert count.** Otherwise the last wave underflows:
+   ```cpp
+   while (num_experts_per_wave < max and num_experts_per_rank % num_experts_per_wave != 0)
+       ++num_experts_per_wave;
+   ```
+5. **Never go below 1.** Guard with `num_l1_blocks_per_expert > 0 ? ... : 1` since `intermediate_hidden / block_n` can be zero for pathologically small configs.
+
+## Evidence (from DeepGEMM)
+- `csrc/jit_kernels/heuristics/mega_moe.hpp:64-93`: `get_num_experts_per_wave_for_mega_moe`, with the explicit comment: "Reduce per-expert block count by this factor since uneven routing leaves some experts with fewer tokens."
+- `csrc/jit_kernels/heuristics/mega_moe.hpp:68-74`: the "find the largest divisor of `num_experts_per_rank` that fits in 32" loop.
+- `csrc/jit_kernels/heuristics/mega_moe.hpp:82-90`: the imbalance-aware lower bound followed by the round-up-to-divisor step.
+
+## Counter / Caveats
+- **`kImbalanceFactor = 2` is a magic number.** It works for DeepSeek's observed routing distribution. If your router is more skewed (top-1 with softmax temperature tricks), bump it to 3 or 4.
+- **The 32-cap is hardware-driven** — some SM100 buffer indexing assumes ≤ 32 experts per wave. Lifting it needs kernel changes, not just heuristic changes.
+- **Rounding up can produce a value of `max`** even when `max * num_l1_blocks_per_expert >> num_sms`. That over-schedules, which costs shared memory. If you see SMs idling on shared-mem waits, check whether the divisor rounding jumped you past the sweet spot.

--- a/skills/native-modules/native-module-stub-with-electron-fallback/SKILL.md
+++ b/skills/native-modules/native-module-stub-with-electron-fallback/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: native-module-stub-with-electron-fallback
+description: Stub a missing platform-specific native addon by routing supported methods to Electron equivalents (flashFrame, setProgressBar) and providing safe no-ops for unsupported ones. Enables a Windows-targeted Electron app to run on Linux without the native binary.
+category: native-modules
+version: 1.0.0
+tags: [electron, native-module, stub, linux, node-addon, compatibility]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+# Native Module Stub with Electron Fallback
+
+## When to use
+
+Use this pattern when:
+- A third-party Electron app includes a platform-specific native addon (`.node` file) that does not exist or cannot be compiled for your target platform.
+- The app `require`s the addon unconditionally and will crash at startup if it is not found.
+- Some of the addon's exported functions have equivalents in Electron's built-in APIs (e.g., `flashFrame`, `setProgressBar`, window state queries).
+- Other exported functions are genuinely unsupported on the target platform and should be safe no-ops.
+
+## Pattern
+
+1. Identify the module path the app uses (e.g., `@vendor/app-native`).
+2. Create a stub `index.js` at that path inside the app's `node_modules`.
+3. In the stub, implement each exported function:
+   - **Functional**: delegate to the equivalent Electron API.
+   - **No-op**: return `undefined` or a sensible default (`false`, `''`).
+   - **Unavailable**: return `false` from `isAvailable()` static methods to trigger the app's own fallback logic.
+4. Use lazy `require('electron')` inside each function to avoid circular dependency issues at module init time.
+5. Export a `KeyboardKey` frozen enum if the native module exports one — it is typically pure data and does not need platform-specific behavior.
+
+## Minimal example
+
+```javascript
+// node_modules/@vendor/app-native/index.js
+// Stub implementation for Linux (replaces Windows-only native addon)
+
+// Keyboard key enum — pure data, no platform dependency
+const KeyboardKey = Object.freeze({
+    Backspace: 43,
+    Tab: 280,
+    Enter: 261,
+    Escape: 85,
+    Space: 276,
+    // ... add keys as needed
+});
+
+// Helper: get focused or first non-destroyed BrowserWindow
+// Lazy-loaded to avoid circular dependency with Electron's module system.
+function getWindow() {
+    try {
+        const { BrowserWindow } = require('electron');
+        const focused = BrowserWindow.getFocusedWindow();
+        if (focused) return focused;
+        return BrowserWindow.getAllWindows().find(w => !w.isDestroyed()) || null;
+    } catch (e) {
+        return null;
+    }
+}
+
+// Unavailable feature: return false from isAvailable() so the app falls
+// back to its own alternative flow (e.g., system browser for OAuth).
+class NativeAuthRequest {
+    static isAvailable() { return false; }
+    async start(url, scheme, windowHandle) {
+        throw new Error('NativeAuthRequest not available on this platform');
+    }
+    cancel() {}
+}
+
+module.exports = {
+    // Platform version stub (app may check this string)
+    getWindowsVersion: () => '10.0.0',
+
+    // Functional: Electron natively supports flash frame on Linux
+    flashFrame: (flash) => {
+        const win = getWindow();
+        if (win) win.flashFrame(typeof flash === 'boolean' ? flash : true);
+    },
+    clearFlashFrame: () => {
+        const win = getWindow();
+        if (win) win.flashFrame(false);
+    },
+
+    // Functional: Electron natively supports task bar progress on Linux
+    setProgressBar: (progress) => {
+        const win = getWindow();
+        if (win && typeof progress === 'number') {
+            win.setProgressBar(Math.max(0, Math.min(1, progress)));
+        }
+    },
+    clearProgressBar: () => {
+        const win = getWindow();
+        if (win) win.setProgressBar(-1);
+    },
+
+    // Functional: window state query
+    getIsMaximized: () => {
+        const win = getWindow();
+        return win ? win.isMaximized() : false;
+    },
+
+    // No-ops: Windows-specific visual effects not supported
+    setWindowEffect: () => {},
+    removeWindowEffect: () => {},
+
+    // No-ops: Windows overlay icon (taskbar badge) not supported
+    setOverlayIcon: () => {},
+    clearOverlayIcon: () => {},
+
+    // No-ops: Desktop notifications handled elsewhere
+    showNotification: () => {},
+
+    // Enum: pure data
+    KeyboardKey,
+
+    // Unavailable class
+    NativeAuthRequest,
+};
+```
+
+To inject the stub during the build:
+```bash
+# Place the stub at the addon's expected module path inside the asar
+STUB_DIR="app.asar.contents/node_modules/@vendor/app-native"
+mkdir -p "$STUB_DIR"
+cp scripts/app-native-stub.js "$STUB_DIR/index.js"
+
+# Also create a minimal package.json so require() resolves correctly
+cat > "$STUB_DIR/package.json" << 'EOF'
+{ "name": "@vendor/app-native", "version": "0.0.0", "main": "index.js" }
+EOF
+```
+
+## Why this works
+
+### Lazy `require('electron')` avoids circular initialization
+
+If you `require('electron')` at the top of the stub module, and the stub is loaded before Electron's main process is fully initialized (which can happen in preload scripts), you get an empty or partial module object. Wrapping the require inside each function delays it until the first call, by which time Electron's module is fully initialized.
+
+### `isAvailable() → false` triggers app-side fallbacks
+
+Well-designed Electron apps check `NativeModule.isAvailable()` before using platform-specific features and fall back to a cross-platform alternative (e.g., opening the system browser for OAuth). By returning `false` from a static `isAvailable()` method, you activate the app's own fallback logic without any patching of the app's code.
+
+### `getWindow()` fallback chain
+
+`getFocusedWindow()` returns `null` when no window has focus (app is in background, minimized, etc.). The fallback to `getAllWindows().find(w => !w.isDestroyed())` ensures operations like `flashFrame` and `setProgressBar` still work when the window is minimized or backgrounded, which is the primary use case for both of those features.
+
+### `setProgressBar(-1)` clears the bar
+
+Electron's `setProgressBar(-1)` removes the progress indicator from the taskbar (Unity, KDE, GNOME). This maps directly to the expected behavior of `clearProgressBar()`.
+
+## Pitfalls
+
+- **Stub must be inside the `.asar` at the exact module path** — if the app uses `require('@vendor/app-native')` and you place the stub outside the asar, Node.js will not find it (the asar is the root of the app's require path).
+- **Do not stub with the `.node` extension** — place an `index.js` stub, not a stub with `.node` extension. Requiring a `.node` file goes through Node's native addon loader, not the JS loader.
+- **`getWindow()` may return a popup** — the fallback `getAllWindows().find(...)` may return a popup or quick-entry window instead of the main window. Operations like `getIsMaximized()` can behave unexpectedly on popups. Document this limitation and callers should be aware.
+- **KeyboardKey enum must be frozen** — the app may compare entries by identity or use it in switch statements. `Object.freeze()` prevents accidental mutation.
+- **`setProgressBar` clamp to `[0, 1]`** — Electron's `setProgressBar` on Linux accepts values 0-1. Some apps pass values like 0.5 correctly, but some may pass raw byte counts. Clamp defensively.
+
+## Source reference
+
+`scripts/claude-native-stub.js` — full implementation

--- a/skills/nix/nix-electron-resource-path-copy/SKILL.md
+++ b/skills/nix/nix-electron-resource-path-copy/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: nix-electron-resource-path-copy
+description: Copy the Electron ELF binary (not symlink) into a custom derivation tree so /proc/self/exe resolves to your tree. Merge app resources and Electron resources into one resources/ directory. Preserve the stock Electron wrapper for environment setup.
+category: nix
+version: 1.0.0
+tags: [nix, nixos, electron, resourcesPath, proc-self-exe, packaging, flake]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+# Nix Electron Resource Path Copy
+
+## When to use
+
+Use this pattern when packaging an Electron application as a Nix derivation and:
+- The app reads files from `process.resourcesPath` at module init time (before any wrapper code can correct it).
+- You are using the nixpkgs `electron` package as a separate input (not bundled into the derivation).
+- Simple `makeWrapper electron --add-flags app.asar` approaches do not work because `process.resourcesPath` resolves to the wrong store path.
+
+## Pattern
+
+### Why the problem occurs
+
+On NixOS, `electron` and your app live in separate Nix store paths. Chromium computes `process.resourcesPath` from `/proc/self/exe`, which resolves symlinks to the actual ELF binary in `electron-unwrapped`'s store path. So `process.resourcesPath` always points to the Electron package's `resources/` directory — not your app's resources.
+
+**`/proc/self/exe` follows symlinks.** `symlinkJoin`, `wrapProgram`, and similar approaches do not work because the kernel resolves the chain to the real ELF. The only solution is a real copy of the ELF binary into your derivation's tree.
+
+### Solution: custom Electron tree
+
+```
+$out/lib/my-app/electron/
+  electron            ← real ELF copy (makes /proc/self/exe resolve here)
+  electron-wrapper    ← adapted from stock wrapper (keeps GIO/GTK env setup)
+  chrome-sandbox      ← symlink to electron-unwrapped
+  *.pak, locales/     ← symlinks to electron-unwrapped
+  resources/
+    default_app.asar  ← symlink from electron-unwrapped/resources/
+    app.asar          ← copied from your build
+    app.asar.unpacked/← copied from your build
+    *.png, *.json     ← app-specific resources
+```
+
+## Minimal example
+
+```nix
+# nix/my-app.nix
+{ lib, stdenvNoCC, fetchurl, electron, nodejs, asar, p7zip, ... }:
+let
+  electronUnwrapped = electron.passthru.unwrapped or electron;
+  electronDir = "${electronUnwrapped}/libexec/electron";
+in
+stdenvNoCC.mkDerivation {
+  pname = "my-electron-app";
+  version = "1.0.0";
+
+  # ... src, nativeBuildInputs, buildPhase ...
+
+  installPhase = ''
+    runHook preInstall
+
+    #=======================================================
+    # Build a custom Electron tree so /proc/self/exe resolves here
+    #=======================================================
+    electron_tree=$out/lib/my-app/electron
+
+    mkdir -p $electron_tree/resources
+
+    # MUST be a real copy — symlink would resolve to electron-unwrapped
+    cp ${electronDir}/electron $electron_tree/electron
+
+    # Symlink everything else (pak files, locales, chrome-sandbox, etc.)
+    for item in ${electronDir}/*; do
+      name=$(basename "$item")
+      [[ "$name" = "electron" ]] && continue   # already copied
+      [[ "$name" = "resources" ]] && continue  # handled below
+      ln -s "$item" "$electron_tree/$name"
+    done
+
+    # Populate resources/ — start with Electron's own resources
+    for item in ${electronDir}/resources/*; do
+      ln -s "$item" "$electron_tree/resources/$(basename "$item")"
+    done
+
+    # Install app resources into the merged tree
+    cp build/electron-app/app.asar                $electron_tree/resources/
+    cp -r build/electron-app/app.asar.unpacked    $electron_tree/resources/
+    # Copy any additional app-specific resources
+    for res in build/electron-app/extra-resources/*; do
+      [[ -f "$res" ]] && cp "$res" $electron_tree/resources/
+    done
+
+    # Build a custom electron-wrapper that points at our tree.
+    # Copy all lines EXCEPT the final exec from the stock wrapper,
+    # then append our own exec line.
+    head -n -1 ${electron}/bin/electron > $electron_tree/electron-wrapper
+    echo "exec \"$electron_tree/electron\" \"\$@\"" >> $electron_tree/electron-wrapper
+    chmod +x $electron_tree/electron-wrapper
+
+    # Fix CHROME_DEVEL_SANDBOX path to point to our tree
+    substituteInPlace $electron_tree/electron-wrapper \
+      --replace-quiet "${electron}/libexec/electron/chrome-sandbox" \
+                      "$electron_tree/chrome-sandbox"
+
+    #=======================================================
+    # Standard install: launcher, icons, desktop file
+    #=======================================================
+    mkdir -p $out/bin
+    cat > $out/bin/my-app << LAUNCHER
+#!/usr/bin/env bash
+electron_exec="$electron_tree/electron-wrapper"
+app_path="$electron_tree/resources/app.asar"
+exec "\$electron_exec" "\$app_path" "\$@"
+LAUNCHER
+    chmod +x $out/bin/my-app
+
+    runHook postInstall
+  '';
+}
+```
+
+## Why this works
+
+### `/proc/self/exe` resolves symlinks at the kernel level
+
+The Linux kernel resolves `/proc/self/exe` to the real path of the executing ELF binary by following all symlinks. There is no way to intercept this from userspace. The only way to make `process.resourcesPath` point to your derivation is to place the actual ELF binary in your derivation's directory tree.
+
+### `symlinkJoin` and `wrapProgram` do not work
+
+`symlinkJoin` creates symlinks; `wrapProgram` creates a wrapper script that calls the original binary. In both cases, `/proc/self/exe` resolves to the electron-unwrapped ELF in its original store path, so `resourcesPath` still points there.
+
+### Reuse the stock wrapper for environment setup
+
+The nixpkgs `electron` wrapper sets up GIO plugin paths, GTK pixel buffer module files, XDG data directories, and `CHROME_DEVEL_SANDBOX`. These environment variables are required for correct rendering and sandbox operation. Copying all lines except the final `exec` line preserves this setup. The `CHROME_DEVEL_SANDBOX` path must be updated to point to your tree's `chrome-sandbox` (which is symlinked to electron-unwrapped, so it still gets the correct binary).
+
+### Symlink non-ELF files to avoid duplication
+
+`.pak` files, `locales/`, and `chrome-sandbox` can be symlinked because they are referenced by path at runtime. Only the main ELF binary needs to be a real copy for `/proc/self/exe` purposes.
+
+### `resources/` merge: Electron's + app's
+
+The merged `resources/` directory must contain both Electron's own files (like `default_app.asar`, which Electron reads at startup) and your app's files (`app.asar`, locale JSONs, tray icons). Starting with symlinks from Electron's resources and then copying app-specific files achieves this without duplication.
+
+## Pitfalls
+
+- **`electron.passthru.unwrapped` may not exist in all nixpkgs versions** — use `electron.passthru.unwrapped or electron` to fall back gracefully. Test with the specific nixpkgs version you pin.
+- **`electronDir` path varies by nixpkgs architecture** — on `x86_64-linux`, it is typically `/nix/store/.../libexec/electron`. Always derive from `${electronUnwrapped}/libexec/electron` rather than hardcoding.
+- **`substituteInPlace` requires `--replace-quiet` for optional replacements** — if the string to replace is not found, `substituteInPlace` fails without `--replace-quiet`. Use `--replace-fail` only when you are certain the pattern is present.
+- **`head -n -1` portability** — `head -n -1` prints all but the last line on GNU coreutils. On BSD/macOS `head`, use `head -n $(( $(wc -l < file) - 1 )) file`. In a Nix derivation, GNU coreutils is always available.
+- **Nix store is read-only after build** — you cannot modify the derivation output at runtime. All file layout decisions must happen in `installPhase`. Plan the resource directory structure carefully before building.
+
+## Source reference
+
+`nix/claude-desktop.nix` — `installPhase` electron_tree construction; `docs/learnings/nix.md` — root cause analysis and rationale

--- a/skills/nix/node-pty-native-module-rebuild-nix/SKILL.md
+++ b/skills/nix/node-pty-native-module-rebuild-nix/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: node-pty-native-module-rebuild-nix
+description: Rebuild a node-gyp native addon (e.g., node-pty) in a Nix derivation using buildNpmPackage. Handle the fsevents macOS-only optional dep by stripping it from package-lock.json in postPatch. Explicitly copy the native build/ directory in postInstall since npmInstallHook skips it.
+category: nix
+version: 1.0.0
+tags: [nix, node-gyp, native-addon, node-pty, npm, fsevents, nixos]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+# Node-gyp Native Addon Rebuild in Nix (node-pty Pattern)
+
+## When to use
+
+Use this pattern when:
+- You need to package a Node.js native addon (`.node` file built via `node-gyp`) in a Nix derivation.
+- The addon's `package-lock.json` references macOS-only optional dependencies (like `fsevents`) that cause `npm ci` to fail in a Linux Nix sandbox.
+- The npm package's `prepublish` or `build` script runs TypeScript compilation but does NOT run `node-gyp rebuild` — you must invoke it separately.
+- The standard `npmInstallHook` does not copy the `build/` directory containing the compiled `.node` file.
+
+## Pattern
+
+### Key issues to address
+
+1. `fsevents` is in the lock file as an optional dep but only exists on macOS. Remove it from `package-lock.json` in `postPatch` so `npm ci` does not fail on Linux.
+2. The `buildPhase` must run both `npm run build` (TypeScript) and `node-gyp rebuild` (native addon). The default `npmBuildHook` only runs `npm run build`.
+3. `npmInstallHook` copies the package but NOT the `build/` directory containing the compiled `.node` file. Copy it explicitly in `postInstall`.
+
+## Minimal example
+
+```nix
+# nix/my-native-addon.nix
+{ lib, buildNpmPackage, fetchFromGitHub, python3, node-gyp }:
+
+buildNpmPackage rec {
+  pname = "my-native-addon";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "org";
+    repo = "my-native-addon";
+    rev = "v${version}";
+    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+
+  npmDepsHash = "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
+
+  # python3 and node-gyp are needed for native compilation
+  nativeBuildInputs = [ python3 node-gyp ];
+
+  # Remove macOS-only optional dependency from lock file.
+  # Without this, npm ci on Linux fails with a lock/json mismatch
+  # because fsevents is in the lock file but excluded by the npm
+  # deps fetcher (it's macOS-only).
+  postPatch = ''
+    sed -i '/"fsevents"/d' package-lock.json
+  '';
+
+  # Run both the TypeScript build AND native addon build.
+  # The default npmBuildHook only runs "npm run build" (tsc).
+  buildPhase = ''
+    runHook preBuild
+    npm run build         # TypeScript compilation
+    node-gyp rebuild      # Native addon (.node file)
+    runHook postBuild
+  '';
+
+  # npmInstallHook copies the npm package contents but NOT build/
+  # The compiled .node file lives in build/Release/ and must be
+  # copied manually.
+  postInstall = ''
+    cp -r build $out/lib/node_modules/${pname}/
+  '';
+
+  meta = with lib; {
+    description = "My native Node.js addon";
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}
+```
+
+### Using the derivation from the main app
+
+```nix
+# In flake.nix or the main derivation:
+{ node-pty, ... }:
+stdenvNoCC.mkDerivation {
+  # Pass node-pty's lib dir to build.sh so it can skip npm install
+  buildPhase = ''
+    bash build.sh \
+      --node-pty-dir "${node-pty}/lib/node_modules/my-native-addon" \
+      ...
+  '';
+  # build.sh copies node_modules/my-native-addon from --node-pty-dir
+  # instead of running npm install (which would fail in the Nix sandbox)
+}
+```
+
+## Why this works
+
+### `fsevents` in `package-lock.json` on Linux
+
+`npm ci` validates that the lock file matches `package.json`. On macOS, `fsevents` is an optional dependency that npm includes in the lock file. On Linux, it is excluded. The lock file is committed with the macOS-generated entry present, so `npm ci` on Linux sees a mismatch and fails. `sed -i '/"fsevents"/d' package-lock.json` in `postPatch` removes all lines containing `"fsevents"` from the lock file, restoring consistency.
+
+### Separate `npm run build` and `node-gyp rebuild`
+
+Most native addon packages separate TypeScript compilation (`npm run build`) from native addon compilation (`node-gyp rebuild`). The `npm run build` script typically produces `.js` files in `lib/`. The native addon requires running `node-gyp rebuild` explicitly. In a Nix derivation, both must be invoked explicitly in `buildPhase` because the default hook only knows about the npm script.
+
+### `postInstall` to copy `build/`
+
+`npmInstallHook` calls `npm install --ignore-scripts --no-package-lock` to produce the output. This copies the package's source and TypeScript output but NOT the `build/` directory, which is in `.gitignore` and is a build artifact. The compiled `.node` file (e.g., `build/Release/pty.node`) lives in `build/` and must be copied explicitly in `postInstall` so downstream consumers can find it.
+
+### `--node-pty-dir` flag in build script
+
+Rather than running `npm install` inside the Nix sandbox (which has no network access), the main derivation's `buildPhase` passes the pre-built addon directory to the build script via a flag. The build script copies the pre-built `node_modules/my-native-addon` into the staging directory instead of fetching it from npm.
+
+## Pitfalls
+
+- **`npmDepsHash` must match the modified lock file** — if you run `sed` in `postPatch`, the `npmDepsHash` in the derivation must be computed from the MODIFIED lock file (as Nix sees it after patching). Recompute with `nix-prefetch-github` or `nix hash path` after testing the derivation.
+- **`node-gyp` version compatibility** — `node-gyp` requires a matching Python version. Pass `python3` (not `python`) in `nativeBuildInputs`; `python` is Python 2 in some nixpkgs versions.
+- **`node-gyp rebuild` uses the Node.js version from nixpkgs** — ensure the Node.js version in `nativeBuildInputs` matches the version the addon targets. Version mismatches produce binaries that fail to load with `NODE_MODULE_VERSION` errors.
+- **ABI mismatch with the app's bundled Electron** — if the main app bundles its own Electron, native addons must be compiled against the Electron Node.js ABI version, not the system Node.js. Use `electron.headers` or a similar mechanism for electron-native addons. `node-pty` is typically not electron-specific, but check the addon's documentation.
+- **`platforms = platforms.linux`** — native addons built in this pattern are Linux-only. Add appropriate `platforms` metadata to prevent accidental use on macOS or other systems.
+
+## Source reference
+
+`nix/node-pty.nix` — full derivation for node-pty native addon

--- a/skills/patterns/multi-tenant-session-isolation/SKILL.md
+++ b/skills/patterns/multi-tenant-session-isolation/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: multi-tenant-session-isolation
+description: Per-peer state isolation using HashMap<SessionKey, Session> with Mutex synchronization.
+category: patterns
+version: 1.0.0
+version_origin: extracted
+tags: [isolation, multi, patterns, session, tenant]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: src/server/connection.rs
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Multi Tenant Session Isolation
+
+## When to use
+Per-peer state isolation using HashMap<SessionKey, Session> with Mutex synchronization.
+
+## Source context
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- Demonstrated in: `src/server/connection.rs`
+
+## Why this generalizes
+Template for multi-tenant async servers.
+
+## Next steps before publishing
+- Read the source files above and rewrite this as a product-agnostic `how-to` — keep the pattern, drop rustdesk-specific names.
+- Add a minimal code example in the target language (Rust + Dart / Rust only / etc.).
+- List 2-3 gotchas you hit while reproducing it.

--- a/skills/preprocessing/multi-signal-mime-detection-stream-info/SKILL.md
+++ b/skills/preprocessing/multi-signal-mime-detection-stream-info/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: multi-signal-mime-detection-stream-info
+description: Combine extension, HTTP headers, content-disposition, mimetypes.guess_type(), magika content sniffing, and charset_normalizer into an ordered list of StreamInfo guesses that converters try in turn.
+category: preprocessing
+version: 1.0.0
+tags: [preprocessing, mime, file-type, detection, magika, charset, python]
+source_type: extracted-from-git
+source_url: https://github.com/microsoft/markitdown.git
+source_ref: main
+source_commit: 604bba13da2f43b756b49122cb65bdedb85b1dff
+source_project: markitdown
+source_path: packages/markitdown/src/markitdown/_markitdown.py
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version_origin: extracted
+---
+
+# Multi-signal MIME + charset detection → list of StreamInfo guesses
+
+Don't trust a single source of truth for "what is this file." Merge extension, HTTP `Content-Type`, `Content-Disposition`, `mimetypes.guess_type()`, a content-sniffing classifier (Google's `magika`), and `charset_normalizer` into a small `StreamInfo` dataclass, then produce an **ordered list of guesses** that converters iterate through. If the caller's signal and the sniffed signal disagree, emit both — and let the dispatcher try both in sequence.
+
+## The dataclass
+
+```python
+from dataclasses import dataclass, asdict
+
+@dataclass(kw_only=True, frozen=True)
+class StreamInfo:
+    mimetype:   Optional[str] = None
+    extension:  Optional[str] = None   # with leading "."
+    charset:    Optional[str] = None
+    filename:   Optional[str] = None   # from path, URL, or Content-Disposition
+    local_path: Optional[str] = None
+    url:        Optional[str] = None
+
+    def copy_and_update(self, *others, **kwargs):
+        new = asdict(self)
+        for si in others:
+            new.update({k: v for k, v in asdict(si).items() if v is not None})
+        new.update(kwargs)
+        return StreamInfo(**new)
+```
+
+Frozen + kw_only so guesses are immutable and construction is self-documenting. `copy_and_update` merges two partial views without the caller caring which keys were None.
+
+## Signal sources
+
+| Source | Gives you | Gotcha |
+|---|---|---|
+| File path | `local_path`, `extension`, `filename` | Extensions lie |
+| URL | `url`, sometimes `extension`, `filename` | Query strings, `/foo` with no extension |
+| HTTP `Content-Type` | `mimetype`, `charset` | Servers lie, `application/octet-stream` is common |
+| HTTP `Content-Disposition` | `filename`, sometimes `extension` | URL-encoded, quoted, optional |
+| `mimetypes.guess_type(path)` | `mimetype` from `extension` | Only canonical extensions |
+| `magika.identify_stream()` | `mimetype`, `extension`, `is_text` | Stream position changes — restore it |
+| `charset_normalizer` on a 4KB peek | `charset` for text files | Costly if stream is huge |
+
+## The pipeline
+
+```python
+def _get_stream_info_guesses(file_stream, base_guess: StreamInfo) -> List[StreamInfo]:
+    guesses = []
+
+    # Step 1 — fill in extension↔mimetype from stdlib, where one is missing.
+    enhanced = base_guess.copy_and_update()
+    if base_guess.mimetype is None and base_guess.extension is not None:
+        m, _ = mimetypes.guess_type("placeholder" + base_guess.extension, strict=False)
+        if m: enhanced = enhanced.copy_and_update(mimetype=m)
+    if base_guess.mimetype is not None and base_guess.extension is None:
+        exts = mimetypes.guess_all_extensions(base_guess.mimetype, strict=False)
+        if exts: enhanced = enhanced.copy_and_update(extension=exts[0])
+
+    # Step 2 — sniff the bytes. MUST restore stream position.
+    cur = file_stream.tell()
+    try:
+        result = magika.Magika().identify_stream(file_stream)
+        if result.status == "ok" and result.prediction.output.label != "unknown":
+            sniffed_mime = result.prediction.output.mime_type
+            sniffed_ext  = "." + result.prediction.output.extensions[0] if result.prediction.output.extensions else None
+            sniffed_charset = None
+            if result.prediction.output.is_text:
+                file_stream.seek(cur)
+                page = file_stream.read(4096)
+                cr = charset_normalizer.from_bytes(page).best()
+                if cr: sniffed_charset = codecs.lookup(cr.encoding).name
+
+            # Compatibility check — if caller told us a different mimetype/extension,
+            # emit both guesses instead of overriding.
+            compatible = (
+                (base_guess.mimetype  is None or base_guess.mimetype == sniffed_mime) and
+                (base_guess.extension is None or base_guess.extension.lstrip(".") in result.prediction.output.extensions) and
+                (base_guess.charset   is None or base_guess.charset == sniffed_charset)
+            )
+            if compatible:
+                guesses.append(StreamInfo(
+                    mimetype=base_guess.mimetype or sniffed_mime,
+                    extension=base_guess.extension or sniffed_ext,
+                    charset=base_guess.charset or sniffed_charset,
+                    filename=base_guess.filename, local_path=base_guess.local_path, url=base_guess.url,
+                ))
+            else:
+                # Incompatible — try both
+                guesses.append(enhanced)
+                guesses.append(StreamInfo(
+                    mimetype=sniffed_mime, extension=sniffed_ext, charset=sniffed_charset,
+                    filename=base_guess.filename, local_path=base_guess.local_path, url=base_guess.url,
+                ))
+        else:
+            guesses.append(enhanced)   # sniffer said "unknown"; fall back
+    finally:
+        file_stream.seek(cur)          # INVARIANT: caller sees stream unchanged
+
+    return guesses
+```
+
+## How the dispatcher uses the list
+
+```python
+for si in guesses + [StreamInfo()]:            # try an empty guess as last resort
+    for reg in sorted_converters:
+        if reg.converter.accepts(file_stream, si, **kwargs):
+            return reg.converter.convert(file_stream, si, **kwargs)
+raise UnsupportedFormatException
+```
+
+The extra empty `StreamInfo()` at the end is a "null" guess — lets a catch-all converter try without any metadata at all.
+
+## Why not just pick one signal?
+
+- **Extension-only**: misses content-sniffable files (no extension) and is wrong when the extension lies (e.g., `.txt` holding JSON).
+- **Magika-only**: strong classifier, but if the file is a format it wasn't trained on it returns "unknown."
+- **HTTP-Content-Type-only**: many servers return `application/octet-stream` or wrong types; need to corroborate.
+
+Emitting multiple guesses lets downstream converters disagree with the ambiguity without the detector having to resolve it prematurely.
+
+## Anti-patterns
+
+- **Mutating the stream position without restoring.** Every consumer must save/restore `tell()`.
+- **Returning a single "best guess" from the detector.** Collapses disagreement; drops the correct answer when the majority vote is wrong.
+- **Guessing charset without peeking content.** HTTP charset is often missing or wrong; always read a page and let `charset_normalizer` decide.
+- **Trusting `Content-Disposition`'s filename verbatim.** Strip quotes, URL-decode, and parse only the `filename=` token.
+
+## Variations
+
+- **Async streams**: same pattern with `aiofiles` or `anyio` byte streams; save/restore becomes `await stream.tell()`/`await stream.seek(...)`.
+- **Very large files**: skip `magika` and fall back to extension+mime only above a size threshold.
+- **Strict mode**: for security-sensitive ingest, require caller-provided mimetype + magika agreement; refuse incompatible.

--- a/skills/puppeteer/multi-source-browser-connection/SKILL.md
+++ b/skills/puppeteer/multi-source-browser-connection/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: multi-source-browser-connection
+description: Build one `ensureBrowserConnected` entry point that accepts any of browserURL, wsEndpoint, release channel, or userDataDir and resolves the right Puppeteer connect options, so callers never branch on "how do I connect".
+category: puppeteer
+version: 1.0.0
+version_origin: extracted
+tags: [puppeteer, cdp, browser-connection, configuration, api-design]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/ChromeDevTools/chrome-devtools-mcp.git
+source_ref: main
+source_commit: 0a6aaa52ebacb2db834ffa437863e5844aa3730b
+source_project: chrome-devtools-mcp
+source_path: src/browser.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Multi-Source Browser Connection
+
+## When to use
+
+- Your tool supports several ways users can bring a Chrome to the party: HTTP debug endpoint (`--remote-debugging-port`), WS endpoint, existing user-data-dir, or "just start Chrome with release channel X".
+- You don't want each caller to know the ordering rules and fallbacks.
+
+## How it works
+
+- Define one exported `ensureBrowserConnected(options)` that takes the full union: `{browserURL?, wsEndpoint?, wsHeaders?, channel?, userDataDir?, devtools, enableExtensions?}`.
+- Resolve in strict precedence: `wsEndpoint` wins, then `browserURL`, then `userDataDir` (read `DevToolsActivePort` from it to construct `ws://127.0.0.1:${port}${path}`), then `channel`. Throw a descriptive error if none is provided.
+- Cache the connected `Browser` at module scope; re-entering `ensureBrowserConnected` while `browser?.connected` is truthy reuses it. This makes the function idempotent.
+- Wrap `puppeteer.connect` in a try/catch that produces a user-facing message that tells the user what to do next ("Check if Chrome is running and remote debugging is enabled at chrome://inspect/#remote-debugging").
+- Provide a matching `ensureBrowserLaunched(options)` for the launch path with its own option shape (userDataDir, headless, isolated, viewport, chromeArgs), same caching rule.
+
+## Example
+
+```ts
+export async function ensureBrowserConnected(options) {
+  if (browser?.connected) return browser;
+  const connectOptions = {targetFilter: makeTargetFilter(options.enableExtensions), defaultViewport: null};
+  if (options.wsEndpoint) {
+    connectOptions.browserWSEndpoint = options.wsEndpoint;
+    if (options.wsHeaders) connectOptions.headers = options.wsHeaders;
+  } else if (options.browserURL) {
+    connectOptions.browserURL = options.browserURL;
+  } else if (options.userDataDir) {
+    const {port, path} = await readDevToolsActivePort(options.userDataDir);
+    connectOptions.browserWSEndpoint = `ws://127.0.0.1:${port}${path}`;
+  } else if (options.channel) {
+    connectOptions.channel = options.channel === 'stable' ? 'chrome' : `chrome-${options.channel}`;
+  } else {
+    throw new Error('Either browserURL, wsEndpoint, channel or userDataDir must be provided');
+  }
+  try { browser = await puppeteer.connect(connectOptions); }
+  catch (err) { throw new Error('Could not connect to Chrome. ...', {cause: err}); }
+  return browser;
+}
+```
+
+## Gotchas
+
+- `DevToolsActivePort` file format is two lines: port number, then the path (e.g. `/devtools/browser/<uuid>`). Handle both missing file and invalid content. The port can be out of 1..65535 if the file is corrupt.
+- `targetFilter` must exclude `chrome://` and `chrome-untrusted://` schemes so your tool doesn't try to operate on the DevTools UI itself. Make extensions opt-in so the filter stays tight by default.
+- Cache is process-scoped; if you fork workers, each gets its own browser handle. Don't try to share a `Browser` across processes.
+- On Windows, if `channel` is requested and Chrome isn't installed, Puppeteer's error is opaque — wrap with context that tells the user to install Chrome or pass `--executablePath`.

--- a/skills/puppeteer/navigation-aware-event-collector/SKILL.md
+++ b/skills/puppeteer/navigation-aware-event-collector/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: navigation-aware-event-collector
+description: Store browser events (network requests, console messages, issues) in per-page WeakMaps split by main-frame navigation so tools can ask for "requests since the last navigation" vs. "requests across the last N navigations" without leaking memory.
+category: puppeteer
+version: 1.0.0
+version_origin: extracted
+tags: [puppeteer, cdp, weakmap, event-collection, navigation]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/ChromeDevTools/chrome-devtools-mcp.git
+source_ref: main
+source_commit: 0a6aaa52ebacb2db834ffa437863e5844aa3730b
+source_project: chrome-devtools-mcp
+source_path: src/PageCollector.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Navigation-Aware Event Collector
+
+## When to use
+
+- Your tool exposes "show me all console messages" or "list network requests" for a long-lived browser.
+- Users expect the default query to scope to the current navigation (like DevTools panels do), with an optional "include preserved" for history.
+- You need stable, short numeric IDs (`reqid=42`) for each event that survive across tool calls but aren't globally unique forever.
+
+## How it works
+
+- Store events in `WeakMap<Page, Array<Array<Event>>>`. Outer array is a per-navigation list, newest first; inner array is the events collected during that navigation.
+- On `framenavigated` (main frame only!) unshift a new empty sub-array and slice to `maxNavigationSaved` (e.g. 3) to cap memory.
+- Tag each event with a monotonic `stableIdSymbol` via a per-page id generator so you can say `getById(page, 42)` even after sub-arrays rotate.
+- Default `getData(page)` returns `navigations[0]` (current navigation). `getData(page, includePreserved=true)` concatenates all preserved navigations in oldest-first order for chronological display.
+- Use `browser.on('targetcreated' / 'targetdestroyed')` to attach/detach listeners, and clean up the `WeakMap` entry on destruction so closed tabs don't pin their event history.
+
+## Example
+
+```ts
+export class PageCollector<T> {
+  protected storage = new WeakMap<Page, Array<Array<WithSymbolId<T>>>>();
+  protected maxNavigationSaved = 3;
+
+  #initializePage(page: Page) {
+    const idGen = createIdGenerator();
+    this.storage.set(page, [[]]);
+    const listeners = this.#listenersInitializer(value => {
+      (value as WithSymbolId<T>)[stableIdSymbol] = idGen();
+      this.storage.get(page)![0].push(value);
+    });
+    listeners.framenavigated = (frame) => {
+      if (frame !== page.mainFrame()) return;
+      const navs = this.storage.get(page)!;
+      navs.unshift([]);
+      navs.splice(this.maxNavigationSaved);
+    };
+    for (const [name, l] of Object.entries(listeners)) page.on(name, l);
+  }
+
+  getData(page: Page, includePreserved = false): T[] {
+    const navs = this.storage.get(page) ?? [];
+    if (!includePreserved) return navs[0] ?? [];
+    const out: T[] = [];
+    for (let i = this.maxNavigationSaved; i >= 0; i--) if (navs[i]) out.push(...navs[i]);
+    return out;
+  }
+}
+```
+
+## Gotchas
+
+- Filter `framenavigated` to `frame === page.mainFrame()`. Otherwise every iframe navigation rotates storage and you lose the current request list.
+- For network requests specifically, don't blindly rotate on navigation — move the tail of requests belonging to the new navigation into the new bucket (the nav request itself plus everything after). Otherwise the first in-flight request of the new page gets orphaned in the old bucket.
+- `Symbol('stableId')` used as a map key: if you serialize to JSON elsewhere, that symbol is invisible — it's an explicit map from event back to id, not a user-visible field.
+- `WeakMap` is correct here because event retention must die with the Page. Don't replace it with a regular Map during debugging; you will cause slow leaks.
+- Listener cleanup on `targetdestroyed` must mirror every listener you added, or the Page object is pinned via listener closures and the WeakMap never drops it.

--- a/skills/reverse-engineering/obfuscated-jvm-string-anchor-navigation/SKILL.md
+++ b/skills/reverse-engineering/obfuscated-jvm-string-anchor-navigation/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: obfuscated-jvm-string-anchor-navigation
+description: Navigate ProGuard/R8-obfuscated JVM bytecode by anchoring on artifacts that the obfuscator cannot rename — string literals, Android framework classes, library public APIs, and manifest entries — then walking outward through call-site greps to recover logical class names one hop at a time.
+category: reverse-engineering
+version: 1.0.0
+tags: [android, reverse-engineering, obfuscation, proguard, r8, deobfuscation]
+source_type: extracted-from-git
+source_url: https://github.com/SimoneAvogadro/android-reverse-engineering-skill.git
+source_ref: master
+source_commit: ddeb9bc33272db1e34107fd286098bb1e9896e51
+source_project: android-reverse-engineering-skill
+source_path: plugins/android-reverse-engineering/skills/android-reverse-engineering/references/call-flow-analysis.md
+imported_at: 2026-04-18T03:36:29Z
+confidence: medium
+version_origin: extracted
+---
+
+# Obfuscated JVM String-Anchor Navigation
+
+ProGuard/R8 renames classes, methods, and fields but cannot touch identifiers required at runtime. Every obfuscated JAR/APK still ships with a rich set of **unobfuscated anchors** that you can grep for and use as entry points into the rename graph.
+
+## What gets renamed
+
+- Class names → `a`, `b`, `c`, `a$b`, …
+- Method names → `a()`, `b()`, `c()`
+- Field names → `f1234a`, `f1235b`
+
+## What survives obfuscation
+
+| Anchor | Why it survives |
+|---|---|
+| **String literals** (URLs, error messages, log tags) | Values, not names — obfuscators don't touch them |
+| **Android framework classes** (`Activity`, `Fragment`, `Intent`) | Resolved by the Android runtime by fully-qualified name |
+| **Library public APIs** (Retrofit `@GET`, OkHttp `Request.Builder`, Dagger `@Provides`) | Part of library ABIs; renaming breaks reflection/DI |
+| **AndroidManifest entries** (Activity, Service, Receiver names) | Must match real class names at runtime |
+| **Resource IDs** (`R.layout.*`, `R.string.*`) | Not part of the renamed bytecode graph |
+| **Native method names** declared `native` | Must match JNI symbol names |
+| **Serialization field names** (`@SerializedName`, Jackson `@JsonProperty`) | Consumed at runtime by the parser |
+
+## The anchor-walk loop
+
+```
+1. Pick an anchor (a string, an annotation, a framework superclass).
+2. grep for it across sources/.
+3. Note the obfuscated class it lives in.
+4. grep for usages of that class → find its callers.
+5. Repeat until you hit something named (Activity, Fragment, Application, Service).
+```
+
+Each iteration recovers one logical boundary (service interface → repository → viewmodel → screen). The chain terminates at the manifest because manifest entries must use real class names.
+
+## Practical starter anchors
+
+- **Any URL** — `grep -rn '"https://' sources/` → lands on every API definition site.
+- **Retrofit `@GET`/`@POST`** — one hit per endpoint; the enclosing interface is the API service even if its class name is `c.a.b.d`.
+- **`extends Activity` / `extends Fragment`** — direct lookup of UI entry points.
+- **`Retrofit.create(X.class)`** — the argument `X` is the service interface, confirming any Retrofit-annotated class.
+- **Error/log strings** — `Log.e(TAG, "Login failed: …")` uniquely identifies a feature area.
+
+## When `--deobf` or mapping files are available
+
+- `jadx --deobf` synthesizes readable replacement names and writes `deobf-mapping.txt`. Helpful, but the names are guessed — still verify via the anchors above.
+- A shipped ProGuard `mapping.txt` (occasionally in `assets/` or obtainable from build pipelines) is authoritative. Pass it to jadx:
+  ```bash
+  jadx --deobf-map mapping.txt -d output app.apk
+  ```
+
+## Why this beats pure static analysis
+
+Running a decompiler alone gives you thousands of classes named `a.b.c.d`. Anchoring first gives you a handful of **true** names (URLs, annotation classes, manifest entries) that each point into the rename graph. Every subsequent grep shrinks the remaining unknown set — typical auth-flow trace resolves in 5–8 hops.
+
+## Cross-reference tip
+
+If `class a` calls `Retrofit.create(b.class)`, then `b` is a Retrofit service interface — a free renaming hint even when neither `a` nor `b` has any other identifying feature. Log these as you go; they compound.

--- a/skills/text-normalization/multilingual-tts-text-normalize-and-split/SKILL.md
+++ b/skills/text-normalization/multilingual-tts-text-normalize-and-split/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: multilingual-tts-text-normalize-and-split
+description: Multilingual TTS text normalization via wetext + inflect with budget-aware paragraph splitting
+category: text-normalization
+version: 1.0.0
+tags: [text-normalization, tts, multilingual, chinese, nlp]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/OpenBMB/VoxCPM.git
+source_ref: main
+source_commit: 13605c5a0e6b99d6d3527a43bd1a4e0e69c8800e
+source_project: VoxCPM
+source_paths:
+  - src/voxcpm/utils/text_normalize.py
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+---
+
+# Multilingual text normalization via wetext + inflect, with budget-aware paragraph splitting
+
+## When to use
+Use this pipeline when feeding raw user text to a TTS model that:
+1. Expects normalized text (numbers as words, no special characters)
+2. Processes text in chunks due to context length limits
+3. Needs to handle Chinese and English (or other CJK + Latin mixes) in the same string
+
+The budget-aware splitter prevents OOM on long inputs and keeps chunk lengths predictable for batching.
+
+## Pattern
+
+### Language detection
+```python
+import re
+
+_CJK_RANGE = re.compile(r'[\u4e00-\u9fff\u3400-\u4dbf\uff00-\uffef\u3000-\u303f]')
+
+def detect_language(text: str) -> str:
+    """Returns 'zh' for predominantly Chinese text, 'en' otherwise."""
+    cjk_count = len(_CJK_RANGE.findall(text))
+    return "zh" if cjk_count / max(len(text), 1) > 0.3 else "en"
+```
+
+### Number normalization
+```python
+import inflect
+
+_inflect = inflect.engine()
+
+def normalize_numbers_en(text: str) -> str:
+    """Replace digits with English words."""
+    def _replace(m):
+        return _inflect.number_to_words(m.group(0))
+    return re.sub(r'\b\d+(\.\d+)?\b', _replace, text)
+
+def normalize_text(text: str) -> str:
+    lang = detect_language(text)
+    if lang == "zh":
+        # wetext handles Chinese number normalization
+        from wetext import Normalizer
+        normalizer = Normalizer(remove_erhua=False)
+        return normalizer.normalize(text)
+    else:
+        return normalize_numbers_en(text)
+```
+
+### Budget-aware paragraph splitting
+```python
+from typing import List
+
+# Punctuation that ends a sentence
+_ZH_PUNCT = re.compile(r'[。！？；…]')
+_EN_PUNCT = re.compile(r'[.!?;]')
+
+def split_paragraph(
+    text: str,
+    token_max_n: int = 100,
+    merge_len: int = 10,
+) -> List[str]:
+    """
+    Split text into chunks, each under token_max_n tokens.
+    Short sentences (< merge_len chars) are merged into the next chunk.
+    """
+    lang = detect_language(text)
+    punct = _ZH_PUNCT if lang == "zh" else _EN_PUNCT
+
+    # Split on sentence-ending punctuation, keeping the delimiter
+    raw_sentences = [s.strip() for s in punct.split(text) if s.strip()]
+
+    chunks = []
+    current = ""
+
+    for sentence in raw_sentences:
+        # For CJK: use char count as proxy for tokens
+        # For EN: use word count as proxy
+        if lang == "zh":
+            sentence_len = len(sentence)
+            current_len = len(current)
+        else:
+            sentence_len = len(sentence.split())
+            current_len = len(current.split())
+
+        if current_len + sentence_len > token_max_n and current:
+            if current_len >= merge_len:
+                chunks.append(current)
+                current = sentence
+            else:
+                # Merge short tail into next sentence
+                current = current + " " + sentence if current else sentence
+        else:
+            current = current + " " + sentence if current else sentence
+
+    if current:
+        chunks.append(current)
+
+    return [c.strip() for c in chunks if c.strip()]
+```
+
+### Full normalization pipeline
+```python
+def normalize_and_split(
+    text: str,
+    token_max_n: int = 100,
+    merge_len: int = 10,
+) -> List[str]:
+    normalized = normalize_text(text)
+    return split_paragraph(normalized, token_max_n=token_max_n, merge_len=merge_len)
+```
+
+## Source reference
+- Upstream: `OpenBMB/VoxCPM` @ `main` / `13605c5a`
+- Key files:
+  - `src/voxcpm/utils/text_normalize.py:1-100` — full normalization + splitting implementation
+
+## Notes
+- `wetext` is a Chinese-specific library; install separately (`pip install wetext`). It handles numbers, dates, and abbreviations.
+- CJK character count is a better token proxy than word count for Chinese — there are no spaces between words.
+- Setting `merge_len` too low causes unnecessary chunk fragmentation; too high and you lose the benefit of merging short sentences.

--- a/skills/workflow/multi-turn-repl-chatbot/SKILL.md
+++ b/skills/workflow/multi-turn-repl-chatbot/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: multi-turn-repl-chatbot
+description: Build an interactive CLI chatbot with a while loop that preserves conversation history across turns.
+category: workflow
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [openai-agents, chatbot, repl, cli, conversation, multi-turn]
+source_type: extracted-from-git
+source_url: https://github.com/openai/openai-agents-python.git
+source_ref: main
+source_commit: e80d2d2319eb300ac17ec496988b70246a5042d6
+source_project: openai-agents-python
+source_path: src/agents/repl.py, examples/agent_patterns/routing.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# multi-turn-repl-chatbot
+
+Build a CLI chatbot where each user input is added to the conversation history and the agent responds in-context. Uses `result.to_input_list()` to thread history between turns.
+
+## When to apply
+
+Quick CLI demos, developer testing tools, or customer-facing chat when you want simple conversation continuity without a full session backend.
+
+## Core snippet
+
+```python
+import asyncio
+import uuid
+from agents import Agent, Runner, TResponseInputItem, trace
+
+agent = Agent(
+    name="Assistant",
+    instructions="You are a helpful assistant.",
+)
+
+async def main():
+    conversation_id = str(uuid.uuid4().hex[:16])
+    inputs: list[TResponseInputItem] = []
+
+    print("Chat with the agent. Type 'quit' to exit.\n")
+    while True:
+        user_input = input("You: ").strip()
+        if not user_input or user_input.lower() == "quit":
+            break
+
+        inputs.append({"role": "user", "content": user_input})
+
+        with trace("Chat turn", group_id=conversation_id):
+            result = await Runner.run(agent, inputs)
+
+        print(f"Agent: {result.final_output}\n")
+        inputs = result.to_input_list()
+
+asyncio.run(main())
+```
+
+## With streaming
+
+```python
+from openai.types.responses import ResponseTextDeltaEvent
+from agents import Runner
+
+async def chat_turn_streaming(agent, inputs):
+    result = Runner.run_streamed(agent, inputs)
+    print("Agent: ", end="", flush=True)
+    async for event in result.stream_events():
+        if event.type == "raw_response_event" and isinstance(event.data, ResponseTextDeltaEvent):
+            print(event.data.delta, end="", flush=True)
+    print()
+    return result.to_input_list()
+```
+
+## Key notes
+
+- `result.to_input_list()` includes all prior messages AND new agent responses
+- Each turn gets its own trace; use `group_id=conversation_id` to link them in the dashboard
+- For persistence across restarts, use `SQLiteSession` or `OpenAIConversationsSession` instead
+- The SDK's built-in REPL: `from agents import run_demo_loop` for a quick testing harness


### PR DESCRIPTION
## Batch
- batch 14/24

## Knowledge (29)
- `llm-model-routing/multi-provider-llm-client-config`
- `integration/multi-source-alert-routing-rationale`
- `llm-agents/multimodal-llm-architectures`
- `training/multimodal-loss-mask-strategy`
- `pitfall/mutation-onsuccess-side-effect-races`
- `observability/narrative-memory-event-storytelling`
- `networking/nat-type-detection-stun-pattern`
- `native-modules/native-module-stub-layered-fallback`
- `pitfall/navigate-about-blank-before-trace-start`
- `pitfall/nested-claude-code-session-deadlock`
- `pitfall/network-collector-preserves-navigation-request`
- `pitfall/next-cross-component-state-update`
- `nix/nix-npm-lock-fsevents-macos-exclusion`
- `nix/nix-stock-electron-wrapper-reuse`
- `nix/nix-store-resource-path-immutability`
- `arch/no-autonomous-lifecycle-mutation`
- `decision/no-backwards-compat-pre-launch`
- `api/no-dereference-option-symlinks`
- `pitfall/no-finer-grained-metadata`
- `development/no-formatting-only-changes-rule`
- _... and 9 more_

## Skills (21)
- `input/multi-platform-input-dispatch-abstraction`
- `preprocessing/multi-signal-mime-detection-stream-info`
- `puppeteer/multi-source-browser-connection`
- `kernel-heuristics/multi-stage-heuristic-selection-with-comparators`
- `patterns/multi-tenant-session-isolation`
- `llm-agents/multi-turn-conversation-history`
- `workflow/multi-turn-repl-chatbot`
- `flutter/multi-window-parameter-passing`
- `text-normalization/multilingual-tts-text-normalize-and-split`
- `native-modules/native-module-stub-with-electron-fallback`
- `architecture/navigation-adapter-cross-platform`
- `puppeteer/navigation-aware-event-collector`
- `agents/new-ml-backend-dependency-audit`
- `devops/nextjs-docker-standalone-build`
- `nix/nix-electron-resource-path-copy`
- `nix/node-pty-native-module-rebuild-nix`
- `moe-optimization/num-experts-per-wave-by-sm-occupancy`
- `electron/oauth-define-at-buildtime`
- `reverse-engineering/obfuscated-jvm-string-anchor-navigation`
- `meta/onboard`
- _... and 1 more_

## Source
- project: F:/workspace/tool (bulk extract)
- batch plan: .omc/batch-plan.json

## Post-merge
After squash-merge, run step 7 to re-anchor skill tags at the merge commit.