### PR TITLE
Publish batch 16/24: 19 knowledge + 31 skills

### DIFF
--- a/index.json
+++ b/index.json
@@ -1772,6 +1772,24 @@
   },
   {
     "kind": "knowledge",
+    "name": "polymorphic-assignees-member-or-agent",
+    "slug": "polymorphic-assignees-member-or-agent",
+    "category": "arch",
+    "description": "An issue's assignee can be a human member OR an AI agent; stored as (assignee_type, assignee_id) tuple and rendered with distinct styling.",
+    "tags": [
+      "domain",
+      "assignees",
+      "polymorphism",
+      "agents",
+      "issue-tracker"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/polymorphic-assignees-member-or-agent.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "polymorphic-metadata-via-enum-switch",
     "slug": "polymorphic-metadata-via-enum-switch",
     "category": "arch",
@@ -2040,6 +2058,44 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/architecture/agent-native-software-philosophy.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "priority-lower-is-higher-stable-sort",
+    "slug": "priority-lower-is-higher-stable-sort",
+    "category": "architecture",
+    "description": "Common registry pitfall — priority numbers where 0 = highest (tried first), 10 = lowest. Pick one convention, document it loudly, and combine with stable sort so insertion order breaks ties.",
+    "tags": [
+      "architecture",
+      "registry",
+      "priority",
+      "stable-sort",
+      "pitfall"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/architecture/priority-lower-is-higher-stable-sort.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "playwright-stealth-cloudflare-bypass",
+    "slug": "playwright-stealth-cloudflare-bypass",
+    "category": "automation",
+    "description": "Playwright can bypass Cloudflare JS challenges by injecting init scripts that hide the `webdriver` property and fake `navigator.platform`/`navigator.vendor`; use `wait_for_timeout` instead of navigation timeout to capture download redirect URLs.",
+    "tags": [
+      "playwright",
+      "cloudflare",
+      "stealth",
+      "automation",
+      "download-url",
+      "headless",
+      "browser"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/automation/playwright-stealth-cloudflare-bypass.md",
     "has_content": true
   },
   {
@@ -3274,6 +3330,41 @@
   },
   {
     "kind": "knowledge",
+    "name": "powersync-backend-minimal-indexes",
+    "slug": "powersync-backend-minimal-indexes",
+    "category": "decision",
+    "description": "",
+    "tags": [
+      "powersync",
+      "postgresql",
+      "indexing",
+      "e2e-encryption",
+      "architecture"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/powersync/powersync-backend-minimal-indexes.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "powersync-deploy-order-two-pr-invariant",
+    "slug": "powersync-deploy-order-two-pr-invariant",
+    "category": "decision",
+    "description": "",
+    "tags": [
+      "powersync",
+      "deployment",
+      "sync-rules",
+      "invariants"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/powersync/powersync-deploy-order-two-pr-invariant.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "prefer-static-import-over-constant-inheritance",
     "slug": "prefer-static-import-over-constant-inheritance",
     "category": "decision",
@@ -3287,6 +3378,23 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/decision/prefer-static-import-over-constant-inheritance.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "process-title-for-debug-visibility",
+    "slug": "process-title-for-debug-visibility",
+    "category": "decision",
+    "description": "Setting `process.title` early in each process (CLI, daemon, MCP server, watchdog) gives `ps`/`top`/Task Manager immediately-recognizable names — critical when a single install spawns four cooperating node processes.",
+    "tags": [
+      "debugging",
+      "process-title",
+      "multi-process",
+      "ops"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/process-title-for-debug-visibility.md",
     "has_content": true
   },
   {
@@ -3680,6 +3788,24 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/decision/vllm-kv-cache-fp8-with-mtp.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "pgvector-pg17-for-ai-native-apps",
+    "slug": "pgvector-pg17-for-ai-native-apps",
+    "category": "devops",
+    "description": "For AI-native apps that need both relational data and semantic search, use the pgvector/pgvector:pg17 image — one database, no extra infra.",
+    "tags": [
+      "postgres",
+      "pgvector",
+      "ai",
+      "vector-search",
+      "docker"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/devops/pgvector-pg17-for-ai-native-apps.md",
     "has_content": true
   },
   {
@@ -5757,6 +5883,42 @@
   },
   {
     "kind": "knowledge",
+    "name": "posix-socket-path-length-limit",
+    "slug": "posix-socket-path-length-limit",
+    "category": "pitfall",
+    "description": "POSIX Unix domain socket paths are capped at around 104 characters on macOS (108 on Linux), so daemons that naively drop a socket under `~/Library/Application Support/...` silently fail to bind. Use `XDG_RUNTIME_DIR` or `/tmp` with uid-suffixed names instead.",
+    "tags": [
+      "unix-socket",
+      "macos",
+      "path-length",
+      "daemon",
+      "ipc"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/posix-socket-path-length-limit.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "powersync-sharedworker-multi-tab-constraint",
+    "slug": "powersync-sharedworker-multi-tab-constraint",
+    "category": "pitfall",
+    "description": "",
+    "tags": [
+      "powersync",
+      "sharedworker",
+      "sqlite",
+      "comlink",
+      "vite"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/powersync/powersync-sharedworker-multi-tab-constraint.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "pub-sub-implementation-pitfall",
     "slug": "pub-sub-implementation-pitfall",
     "category": "pitfall",
@@ -6662,6 +6824,25 @@
   },
   {
     "kind": "knowledge",
+    "name": "portable-app-detection-env-var",
+    "slug": "portable-app-detection-env-var",
+    "category": "platform",
+    "description": "Portable mode detection: check RUSTDESK_APPNAME env var; changes temp dir and config paths.",
+    "tags": [
+      "app",
+      "detection",
+      "env",
+      "platform",
+      "portable",
+      "var"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/platform/portable-app-detection-env-var.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "android-ios-feature-parity-gap",
     "slug": "android-ios-feature-parity-gap",
     "category": "platform/mobile",
@@ -6677,6 +6858,60 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/mobile/android-ios-feature-parity-gap.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "privacy-mode-implementation-choices",
+    "slug": "privacy-mode-implementation-choices",
+    "category": "platform/windows",
+    "description": "Three privacy-mode strategies coexist: MAG (fast but limited), exclude-from-capture (Win10 2004+), virtual-display (fullscreen gaming).",
+    "tags": [
+      "choices",
+      "implementation",
+      "mode",
+      "platform",
+      "privacy",
+      "windows"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/windows/privacy-mode-implementation-choices.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "plugin-framework-feature-conditional",
+    "slug": "plugin-framework-feature-conditional",
+    "category": "plugin",
+    "description": "Plugin framework gated by feature='plugin_framework' and non-mobile; dynamic .dll/.so loading.",
+    "tags": [
+      "conditional",
+      "feature",
+      "framework",
+      "plugin"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/plugin/plugin-framework-feature-conditional.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "plugin-interface-version-convention",
+    "slug": "plugin-interface-version-convention",
+    "category": "plugin-architecture",
+    "description": "Plugin packages expose a module-level __plugin_interface_version__ = 1 constant so the host can detect ABI-incompatible plugins at load time and either refuse them or invoke a compatibility shim.",
+    "tags": [
+      "plugin-architecture",
+      "versioning",
+      "abi",
+      "contract",
+      "python"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/plugin-architecture/plugin-interface-version-convention.md",
     "has_content": true
   },
   {
@@ -6793,6 +7028,24 @@
   },
   {
     "kind": "knowledge",
+    "name": "posthog-cli-telemetry-conventions",
+    "slug": "posthog-cli-telemetry-conventions",
+    "category": "reference",
+    "description": "OpenSRE's CLI telemetry uses PostHog with a public anon key embedded in the binary, anonymous_id stored in ~/.config, no-PII guarantee, opt-out via DO_NOT_TRACK or app-specific env, and StrEnum-based event naming.",
+    "tags": [
+      "posthog",
+      "telemetry",
+      "cli",
+      "conventions",
+      "opt-out"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/reference/posthog-cli-telemetry-conventions.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "vector-clock-ui-dominance-tri-state-color",
     "slug": "vector-clock-ui-dominance-tri-state-color",
     "category": "reference",
@@ -6801,6 +7054,42 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/reference/vector-clock-ui-dominance-tri-state-color.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "policy-check-sandboxing-evolution",
+    "slug": "policy-check-sandboxing-evolution",
+    "category": "safety",
+    "description": "Enforce evolution policies — no self-modification, no external network, no file deletions",
+    "tags": [
+      "evolver",
+      "safety",
+      "policy",
+      "sandbox",
+      "reference"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/safety/policy-check-sandboxing-evolution.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "privacy-client-secure-credential-handling",
+    "slug": "privacy-client-secure-credential-handling",
+    "category": "safety",
+    "description": "Client for secure credential handling, secrets caching with TTL, encryption at rest",
+    "tags": [
+      "evolver",
+      "safety",
+      "credentials",
+      "secrets",
+      "reference"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/safety/privacy-client-secure-credential-handling.md",
     "has_content": true
   },
   {
@@ -6820,6 +7109,26 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/schema-design/identifier-regex-loose-when-legacy-coexists.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "pre-broadcast-log-sanitization",
+    "slug": "pre-broadcast-log-sanitization",
+    "category": "security",
+    "description": "Before any autonomous process ships logs or error context to an upstream target (issue tracker, hub API, telemetry), it must redact secrets, absolute paths, emails, and host fingerprints at the entry point — not on the way out.",
+    "tags": [
+      "security",
+      "sanitization",
+      "redaction",
+      "secrets",
+      "pii",
+      "autonomous-agent",
+      "log-broadcast"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/security/pre-broadcast-log-sanitization.md",
     "has_content": true
   },
   {
@@ -6857,6 +7166,24 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/testing/agent-test-spec-template.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "pinecone-metadata-filtering-rag",
+    "slug": "pinecone-metadata-filtering-rag",
+    "category": "vector-search-rag",
+    "description": "Structured Pinecone RAG query with $and/$or metadata filters across people/topics/entities/dates, plus a graceful retry-without-filters fallback when the filtered set is empty.",
+    "tags": [
+      "pinecone",
+      "rag",
+      "vector-search",
+      "metadata-filtering",
+      "openai-embeddings"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/vector-search-rag/pinecone-metadata-filtering-rag.md",
     "has_content": true
   },
   {
@@ -6900,6 +7227,23 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/workflow/dropin-module-reality-check-before-wire.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "pre-push-discipline-test-lint-typecheck",
+    "slug": "pre-push-discipline-test-lint-typecheck",
+    "category": "workflow",
+    "description": "OpenSRE's CLAUDE.md / AGENTS.md mandate \"before push\" gates — clean working tree, then test-cov, lint, typecheck — and a self-improvement loop that captures lessons in tasks/lessons.md after every correction. Useful guardrail pattern for AI-assisted dev workflows.",
+    "tags": [
+      "pre-push",
+      "discipline",
+      "ai-workflow",
+      "self-improvement"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/workflow/pre-push-discipline-test-lint-typecheck.md",
     "has_content": true
   },
   {
@@ -6964,6 +7308,30 @@
   },
   {
     "kind": "skill",
+    "name": "playtest-report",
+    "slug": "playtest-report",
+    "category": "",
+    "description": "\"Generates a structured playtest report template or analyzes existing playtest notes into a structured format. Use this to standardize playtest feedback collection and analysis.\"",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/qa/playtest-report",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "project-stage-detect",
+    "slug": "project-stage-detect",
+    "category": "",
+    "description": "\"Automatically analyze project state, detect stage, identify gaps, and recommend next steps based on existing artifacts. Use when user asks 'where are we in development', 'what stage are we in', 'full project audit'.\"",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/production/project-stage-detect",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "alert-time-window-with-buffer",
     "slug": "alert-time-window-with-buffer",
     "category": "agent-sdk",
@@ -6994,6 +7362,23 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/agent-sdk/claude-agent-sdk-multi-provider-bridge",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "plan-audit-entry-per-step",
+    "slug": "plan-audit-entry-per-step",
+    "category": "agent-sdk",
+    "description": "Emit a structured audit dict on every planning iteration (loop count, tool budget, planned action count, rerouted flag, rerouted reason) and stash it in state so post-mortem analysis can replay every planner decision.",
+    "tags": [
+      "audit",
+      "planner",
+      "observability",
+      "langgraph"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/agent-sdk/plan-audit-entry-per-step",
     "has_content": false
   },
   {
@@ -7082,6 +7467,24 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/agents/coding-agent-cli-backend-interface",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "pre-release-pr-triage-worktree",
+    "slug": "pre-release-pr-triage-worktree",
+    "category": "agents",
+    "description": "Triage open PRs for a release in a dedicated git worktree, classify each into merge/candidate/supersede/defer, and work the loop end-to-end.",
+    "tags": [
+      "release-management",
+      "git-worktree",
+      "gh-cli",
+      "triage",
+      "open-source"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/agents/pre-release-pr-triage-worktree",
     "has_content": false
   },
   {
@@ -8111,6 +8514,42 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/architecture/accepts-then-convert-two-phase-dispatch",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "platform-bridge-core-provider",
+    "slug": "platform-bridge-core-provider",
+    "category": "architecture",
+    "description": "Single CoreProvider in the shared packages layer initializes API client, auth/workspace stores, WS connection, and QueryClient — each app wraps its root and injects platform adapters.",
+    "tags": [
+      "react",
+      "provider",
+      "cross-platform",
+      "bootstrap",
+      "monorepo"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/architecture/platform-bridge-core-provider",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "polymorphic-assignee-rendering",
+    "slug": "polymorphic-assignee-rendering",
+    "category": "architecture",
+    "description": "Model an assignee that may be a human member OR an AI agent with (assignee_type, assignee_id) columns and render-time dispatch to distinct visual styling.",
+    "tags": [
+      "domain-model",
+      "polymorphism",
+      "agents",
+      "issue-tracker",
+      "ui"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/architecture/polymorphic-assignee-rendering",
     "has_content": false
   },
   {
@@ -11002,6 +11441,42 @@
   },
   {
     "kind": "skill",
+    "name": "posthog-analytics-with-opt-out-and-thread-queue",
+    "slug": "posthog-analytics-with-opt-out-and-thread-queue",
+    "category": "cli",
+    "description": "Background-thread CLI analytics that respects DO_NOT_TRACK + custom opt-out env, persists an anonymous UUID in ~/.config, queues events with bounded size, and flushes on atexit with a timeout.",
+    "tags": [
+      "analytics",
+      "posthog",
+      "opt-out",
+      "background-thread",
+      "cli"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/posthog-analytics-with-opt-out-and-thread-queue",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "profile-scoped-config-dir",
+    "slug": "profile-scoped-config-dir",
+    "category": "cli",
+    "description": "Per-profile CLI config directories (~/.myapp/profiles/<name>/) so users can run multiple environments (prod, staging, worktrees) side-by-side without collisions.",
+    "tags": [
+      "cli",
+      "config",
+      "profiles",
+      "daemon",
+      "isolation"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cli/profile-scoped-config-dir",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "qa",
     "slug": "qa",
     "category": "cli",
@@ -11191,6 +11666,42 @@
   },
   {
     "kind": "skill",
+    "name": "platform-screen-capture-abstraction",
+    "slug": "platform-screen-capture-abstraction",
+    "category": "codecs",
+    "description": "Pluggable screen-capture backends: Windows DXGI, macOS Quartz, Linux X11/Wayland behind one Capturer trait.",
+    "tags": [
+      "abstraction",
+      "capture",
+      "codecs",
+      "platform",
+      "screen"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/codecs/platform-screen-capture-abstraction",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "platform-specific-code-organization",
+    "slug": "platform-specific-code-organization",
+    "category": "cross-platform",
+    "description": "Use cfg-gated modules to split Windows/macOS/Linux/Android/iOS implementations behind one trait facade.",
+    "tags": [
+      "code",
+      "cross",
+      "organization",
+      "platform",
+      "specific"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/cross-platform/platform-specific-code-organization",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "content-type-info-metadata-embedding",
     "slug": "content-type-info-metadata-embedding",
     "category": "data",
@@ -11203,6 +11714,24 @@
     "version": "1.0.0",
     "path": "skills/data/content-type-info-metadata-embedding",
     "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "presampled-sliding-window-index",
+    "slug": "presampled-sliding-window-index",
+    "category": "data-pipeline",
+    "description": "Pre-compute every valid (series, start_idx) pair once at dataset init and random-sample from that list, instead of recomputing windows per __getitem__.",
+    "tags": [
+      "pytorch-dataset",
+      "sliding-window",
+      "time-series",
+      "dataloader",
+      "preindexing"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/data-pipeline/presampled-sliding-window-index",
+    "has_content": false
   },
   {
     "kind": "skill",
@@ -13577,6 +14106,54 @@
   },
   {
     "kind": "skill",
+    "name": "programmatic-dependent-launch-attribute-toggle",
+    "slug": "programmatic-dependent-launch-attribute-toggle",
+    "category": "gpu-kernels",
+    "description": "Enable CUDA Programmatic Dependent Launch (PDL) per-call via `cudaLaunchAttributeProgrammaticStreamSerialization`, allowing a downstream kernel to start before the upstream completes — exposed as a runtime-tunable flag, not a compile flag.",
+    "tags": [
+      "pdl",
+      "programmatic-dependent-launch",
+      "cuda-12",
+      "launch-attributes",
+      "kernel-overlap"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/gpu-kernels/programmatic-dependent-launch-attribute-toggle",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "platform-agnostic-file-input-abstraction",
+    "slug": "platform-agnostic-file-input-abstraction",
+    "category": "inference",
+    "description": "Trait-based input abstraction (SyncInput / AsyncInput) so a single inference codebase accepts file paths, byte slices, BytesIO, and tokio::File without conditional compilation.",
+    "tags": [
+      "magika",
+      "inference"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/inference/platform-agnostic-file-input-abstraction",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "predict-mode-dispatch-with-fallback-heuristics",
+    "slug": "predict-mode-dispatch-with-fallback-heuristics",
+    "category": "inference",
+    "description": "Cascade inference through model output → ruled heuristics (UTF-8 validity for tiny files) → generic fallback (txt / unknown), each emitting a distinct overwrite_reason.",
+    "tags": [
+      "magika",
+      "inference"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/inference/predict-mode-dispatch-with-fallback-heuristics",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
     "name": "a2a-protocol-with-hello-publish-decision",
     "slug": "a2a-protocol-with-hello-publish-decision",
     "category": "integration",
@@ -13641,6 +14218,43 @@
   },
   {
     "kind": "skill",
+    "name": "platform-adapter-interface",
+    "slug": "platform-adapter-interface",
+    "category": "integration",
+    "description": "Unify Slack/Telegram/Discord/GitHub/Web behind one `IPlatformAdapter` interface with sendMessage/ensureThread/getStreamingMode/getPlatformType/start/stop, plus an optional structured-event hook for web-only rich UI.",
+    "tags": [
+      "adapter",
+      "plugin",
+      "multi-platform",
+      "interface",
+      "chat-bot"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/integration/platform-adapter-interface",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "pid-aware-temp-dir-uuid-generator",
+    "slug": "pid-aware-temp-dir-uuid-generator",
+    "category": "jit-compilation",
+    "description": "Generate unique temporary directory names with `pid + steady_clock + mt19937(xor-seeded)` — survives fork, co-exists across multiple processes on the same filesystem, no crypto deps.",
+    "tags": [
+      "uuid",
+      "temp-files",
+      "pid",
+      "random",
+      "fork-safe",
+      "filesystem"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/jit-compilation/pid-aware-temp-dir-uuid-generator",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "agent-handoff-routing",
     "slug": "agent-handoff-routing",
     "category": "llm-agents",
@@ -13672,6 +14286,42 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/llm-agents/agents-as-tools",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "plan-based-multi-step-task-decomposition",
+    "slug": "plan-based-multi-step-task-decomposition",
+    "category": "llm-agents",
+    "description": "Plan mode for multi-step agent tasks — exploration via subagent, gated planning with user confirmation, strict execution loop, and adversarial verification.",
+    "tags": [
+      "llm-agents",
+      "planning",
+      "subagents",
+      "verification",
+      "orchestration"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/llm-agents/plan-based-multi-step-task-decomposition",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "ppo-rlhf-trl-gpt2-sentiment",
+    "slug": "ppo-rlhf-trl-gpt2-sentiment",
+    "category": "llm-agents",
+    "description": "Fine-tune GPT-2 with PPO RLHF using TRL to generate positive IMDB reviews, with DistilBERT as the sentiment reward model.",
+    "tags": [
+      "rlhf",
+      "ppo",
+      "trl",
+      "gpt-2",
+      "sentiment"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/llm-agents/ppo-rlhf-trl-gpt2-sentiment",
     "has_content": false
   },
   {
@@ -13790,6 +14440,42 @@
   },
   {
     "kind": "skill",
+    "name": "pnpm-catalog-version-pinning",
+    "slug": "pnpm-catalog-version-pinning",
+    "category": "monorepo",
+    "description": "Use pnpm's catalog: references in pnpm-workspace.yaml to guarantee a single version of shared deps across all monorepo packages.",
+    "tags": [
+      "pnpm",
+      "monorepo",
+      "versioning",
+      "workspace",
+      "react"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/monorepo/pnpm-catalog-version-pinning",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "port-forwarding-tunnel-multiplexer",
+    "slug": "port-forwarding-tunnel-multiplexer",
+    "category": "networking",
+    "description": "TCP tunnel multiplexing for port forwarding with Framed codec and login handshake.",
+    "tags": [
+      "forwarding",
+      "multiplexer",
+      "networking",
+      "port",
+      "tunnel"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/networking/port-forwarding-tunnel-multiplexer",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "agent-tracing-spans",
     "slug": "agent-tracing-spans",
     "category": "observability",
@@ -13826,6 +14512,23 @@
   },
   {
     "kind": "skill",
+    "name": "personality-state-tracking-with-aggregation",
+    "slug": "personality-state-tracking-with-aggregation",
+    "category": "observability",
+    "description": "Aggregate agent evolution metrics into personality state (success rate, velocity, trait vectors)",
+    "tags": [
+      "evolver",
+      "observability",
+      "personality",
+      "metrics"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/observability/personality-state-tracking-with-aggregation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "claude-cli-unattended-wrapper",
     "slug": "claude-cli-unattended-wrapper",
     "category": "operations",
@@ -13844,6 +14547,114 @@
     "version": "1.0.0",
     "path": "skills/operations/claude-cli-unattended-wrapper",
     "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "privacy-mode-trait-abstraction",
+    "slug": "privacy-mode-trait-abstraction",
+    "category": "platform",
+    "description": "Pluggable privacy-mode implementations: Windows MAG, exclude-from-capture, virtual-display drivers.",
+    "tags": [
+      "abstraction",
+      "mode",
+      "platform",
+      "privacy",
+      "trait"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/platform/privacy-mode-trait-abstraction",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "powersync-add-synced-table-two-pr-flow",
+    "slug": "powersync-add-synced-table-two-pr-flow",
+    "category": "powersync",
+    "description": "Add a new PowerSync-synced table across frontend SQLite, backend Postgres, shared table registry, and sync-rules YAML using a strict two-PR process so the frontend never ships before the PowerSync Cloud dashboard rules exist.",
+    "tags": [
+      "powersync",
+      "postgresql",
+      "drizzle",
+      "deployment",
+      "sync-rules"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/powersync/powersync-add-synced-table-two-pr-flow",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "powersync-composite-primary-key-seed",
+    "slug": "powersync-composite-primary-key-seed",
+    "category": "powersync",
+    "description": "Design default-data tables (settings, models, modes, tasks) so each user can hold the same default IDs by using composite primary keys (id, user_id) or (key, user_id) on the backend and reconciling with a default-hash column on the frontend.",
+    "tags": [
+      "powersync",
+      "postgresql",
+      "drizzle",
+      "default-data",
+      "seeding"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/powersync/powersync-composite-primary-key-seed",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "powersync-custom-sharedworker-override",
+    "slug": "powersync-custom-sharedworker-override",
+    "category": "powersync",
+    "description": "Ship a custom SharedWorker that extends PowerSync's internal SharedSyncImplementation so you can inject a custom BucketStorageAdapter (e.g. a TransformableBucketStorage) without giving up multi-tab sync efficiency.",
+    "tags": [
+      "powersync",
+      "sharedworker",
+      "vite",
+      "sqlite",
+      "e2e-encryption"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/powersync/powersync-custom-sharedworker-override",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "powersync-no-foreign-keys-on-sync-backend",
+    "slug": "powersync-no-foreign-keys-on-sync-backend",
+    "category": "powersync",
+    "description": "Skip composite foreign-key constraints on a PowerSync-style backend schema and use plain text columns for cross-table references, so partial syncs don't fail and encrypted columns don't block writes.",
+    "tags": [
+      "powersync",
+      "postgresql",
+      "drizzle",
+      "foreign-keys",
+      "sync"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/powersync/powersync-no-foreign-keys-on-sync-backend",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "powersync-transformable-bucket-storage",
+    "slug": "powersync-transformable-bucket-storage",
+    "category": "powersync",
+    "description": "Intercept PowerSync sync data before it hits SQLite by subclassing SqliteBucketStorage and running a middleware pipeline on PROCESS_TEXT_LINE payloads, so you can decrypt, decompress, or normalize rows before they are written.",
+    "tags": [
+      "powersync",
+      "sqlite",
+      "middleware",
+      "sync",
+      "e2e-encryption"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/powersync/powersync-transformable-bucket-storage",
+    "has_content": true
   },
   {
     "kind": "skill",
@@ -13910,6 +14721,39 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "skills/refactor/request-refactor-plan",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "pre-release-version-validation-script",
+    "slug": "pre-release-version-validation-script",
+    "category": "release",
+    "description": "Pre-release script validates: tag matches pyproject version, copyright headers exist on all source files, package metadata fields complete, type checker passes.",
+    "tags": [
+      "magika",
+      "release"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/release/pre-release-version-validation-script",
+    "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "process-singleton-guard-with-lockfile",
+    "slug": "process-singleton-guard-with-lockfile",
+    "category": "resilience",
+    "description": "Prevent multiple daemon instances using exclusive lockfile creation and PID validation",
+    "tags": [
+      "evolver",
+      "resilience",
+      "singleton",
+      "daemon",
+      "lockfile"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/resilience/process-singleton-guard-with-lockfile",
     "has_content": false
   },
   {
@@ -14140,6 +14984,24 @@
   },
   {
     "kind": "skill",
+    "name": "pid-watchdog-sidecar-survival",
+    "slug": "pid-watchdog-sidecar-survival",
+    "category": "tauri",
+    "description": "Make a Tauri sidecar self-terminate when the parent app exits (or optionally survive it) using parent-PID monitoring plus a filesystem sentinel.",
+    "tags": [
+      "tauri",
+      "sidecar",
+      "process-management",
+      "watchdog",
+      "windows"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/tauri/pid-watchdog-sidecar-survival",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "clearcut-batch-flush-with-retry",
     "slug": "clearcut-batch-flush-with-retry",
     "category": "telemetry",
@@ -14317,6 +15179,24 @@
     "version": "1.0.0",
     "path": "skills/testing/llm-integration-test-failure-diagnosis",
     "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "playwright-api-fixtures-cleanup",
+    "slug": "playwright-api-fixtures-cleanup",
+    "category": "testing",
+    "description": "Self-contained Playwright E2E tests using a TestApiClient fixture that creates entities over HTTP and tears them down in afterEach — no shared DB seed, no cross-test pollution.",
+    "tags": [
+      "playwright",
+      "e2e",
+      "fixtures",
+      "testing",
+      "cleanup"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/testing/playwright-api-fixtures-cleanup",
+    "has_content": false
   },
   {
     "kind": "skill",

--- a/knowledge/arch/polymorphic-assignees-member-or-agent.md
+++ b/knowledge/arch/polymorphic-assignees-member-or-agent.md
@@ -1,0 +1,34 @@
+---
+name: polymorphic-assignees-member-or-agent
+summary: An issue's assignee can be a human member OR an AI agent; stored as (assignee_type, assignee_id) tuple and rendered with distinct styling.
+category: arch
+tags: [domain, assignees, polymorphism, agents, issue-tracker]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: CLAUDE.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+In an AI-native issue tracker, agents are first-class citizens, not decorations. Model it polymorphically:
+
+- `assignee_type` column: `"member" | "agent"`.
+- `assignee_id` column: UUID into the matching table.
+- Two tables (`members`, `agents`), each with workspace scoping.
+- Foreign key validity enforced by application logic (not a DB constraint) because you can't FK on a polymorphic column.
+
+Render them with distinct visual affordances (agents: purple background, robot icon) so a glance at the board tells you which issues a human owns vs which an agent is running.
+
+## Why
+
+The alternative — treating agents as members with a boolean flag — leaks the "agent-ness" into code that only cares about humans (permissions, billing, invite flows) and vice versa. A clean type split keeps those concerns separated. The tradeoff is the UI layer has to dispatch on `assignee_type`, but that's a single component.
+
+Agents also create issues, post comments, change status, and report blockers — anywhere a human member appears in the data model, an agent may too. This is the core design decision of the product.
+
+## Evidence
+
+- CLAUDE.md, "Agent Assignees" section.
+- README.md, "Agents as Teammates" feature.

--- a/knowledge/architecture/priority-lower-is-higher-stable-sort.md
+++ b/knowledge/architecture/priority-lower-is-higher-stable-sort.md
@@ -1,0 +1,97 @@
+---
+name: priority-lower-is-higher-stable-sort
+summary: Common registry pitfall — priority numbers where 0 = highest (tried first), 10 = lowest. Pick one convention, document it loudly, and combine with stable sort so insertion order breaks ties.
+category: architecture
+confidence: medium
+tags: [architecture, registry, priority, stable-sort, pitfall]
+source_type: extracted-from-git
+source_url: https://github.com/microsoft/markitdown.git
+source_ref: main
+source_commit: 604bba13da2f43b756b49122cb65bdedb85b1dff
+source_project: markitdown
+source_path: packages/markitdown/src/markitdown/_markitdown.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Priority convention: lower value = tried first + stable sort for tie-breaking
+
+Registries with a `priority` field on each entry run into two decisions that trip up plugin authors:
+
+1. **Direction.** Is `priority=0` "highest priority" (tried first) or "lowest priority" (tried last)?
+2. **Tie-breaking.** When two entries share a priority, who wins?
+
+Markitdown's stated answer:
+
+> By default, most converters get priority `PRIORITY_SPECIFIC_FILE_FORMAT` (== 0). The exception is the PlainTextConverter, HtmlConverter, and ZipConverter, which get priority `PRIORITY_GENERIC_FILE_FORMAT` (== 10), with **lower values being tried first** (i.e., higher priority).
+>
+> Just prior to conversion, the converters are sorted by priority, using a **stable sort**. This means that converters with the same priority will remain in the same order, with the most recently registered converters appearing first.
+
+## Why "lower = first" is actually readable
+
+The semantic here is "position" or "rank", not "importance":
+
+- Specific format match → **rank 0** (goes at the front)
+- Generic format match → **rank 10** (goes near the back)
+
+Think of it like CSS `z-index` inverted, or database query-plan cost — low numbers win. Compared to "higher = more important," neither is objectively better; what matters is that you pick one, document it, and never change it.
+
+## The stable-sort tie-breaker
+
+```python
+sorted_registrations = sorted(self._converters, key=lambda x: x.priority)
+```
+
+Python's `sorted` is stable. If entries A and B share a priority, their output order matches input order. Combined with `insert(0, ...)` on every registration — meaning the newest registration goes to the front of the *input* list — the newest entry wins any tie.
+
+This is what lets plugins shadow built-ins without an unregister API:
+
+```python
+# Built-in is registered at priority 0 (specific format).
+host.register_converter(BuiltinPdfConverter())     # input: [Builtin]
+# Plugin registers its own PDF handler, also at priority 0.
+host.register_converter(MyPdfConverter())           # input: [MyPdf, Builtin]
+# Stable sort keeps [MyPdf, Builtin] order; MyPdf runs first.
+```
+
+## Pitfalls to avoid
+
+### Pitfall 1: reversing the convention halfway through
+
+Someone adds a new entry with "I'll give this a priority of 100 so it runs first" — and now it's last. Or they add a third convention ("negative = first") for a special edge case. Pick one and enforce it in code review. Constants like `PRIORITY_SPECIFIC = 0` / `PRIORITY_GENERIC = 10` make the convention visible at every call site.
+
+### Pitfall 2: using `heapq` or an unstable sort
+
+`heapq.heappush` is *not* stable; it breaks ties arbitrarily. `sorted()` is stable on CPython (guaranteed since 2.2). If you must use a heap for performance, include a monotonic sequence number as secondary key:
+
+```python
+@dataclass
+class Registration:
+    priority: float
+    seq: int               # monotonic counter, descending for "newest first"
+    converter: ...
+
+heapq.heappush(reg_heap, (reg.priority, -reg.seq, reg))
+```
+
+### Pitfall 3: caching the sorted list
+
+Markitdown re-sorts on *every* dispatch call. Tempting to cache — it's a tiny list, but priorities can theoretically change at runtime, and the sort is O(n log n) on a very small n (typically <30). Re-sorting is cheaper than the bug that would happen if something slipped past the cache invalidation.
+
+### Pitfall 4: `append()` instead of `insert(0, ...)`
+
+Append means the *oldest* registration wins ties — the opposite of what plugin authors expect. Insert-at-head gives newest-wins, which matches every plugin override pattern in the wild.
+
+## Documentation checklist
+
+If your project uses this pattern, the registry module's docstring should say, explicitly:
+
+1. "Priority is a float; lower values are tried first (higher priority)."
+2. "At equal priority, the most recently registered entry wins."
+3. "Use `PRIORITY_SPECIFIC_*` and `PRIORITY_GENERIC_*` constants instead of raw numbers."
+
+One paragraph, at the top of the file, visible in every IDE tooltip.
+
+## Related
+
+- `document-converter-priority-registry` skill — the full pattern this knowledge entry annotates.
+- Alternatives: priority queues (heapq) with monotonic-counter tiebreaker; ordered dicts; explicit position-insertion API (`register_after(name, ...)`).

--- a/knowledge/automation/playwright-stealth-cloudflare-bypass.md
+++ b/knowledge/automation/playwright-stealth-cloudflare-bypass.md
@@ -1,0 +1,109 @@
+---
+name: playwright-stealth-cloudflare-bypass
+summary: Playwright can bypass Cloudflare JS challenges by injecting init scripts that hide the `webdriver` property and fake `navigator.platform`/`navigator.vendor`; use `wait_for_timeout` instead of navigation timeout to capture download redirect URLs.
+category: automation
+tags: [playwright, cloudflare, stealth, automation, download-url, headless, browser]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: medium
+---
+
+# Playwright Stealth for Cloudflare Bypass
+
+## Context
+
+Cloudflare's Bot Management (JS Challenge) runs JavaScript in the browser to
+detect automation frameworks. Playwright in its default configuration exposes
+several properties that Cloudflare checks: `navigator.webdriver === true`,
+platform/vendor strings that match headless Chrome, and other fingerprint
+signals. Cloudflare serves a challenge page instead of the real content when
+these are detected.
+
+This pattern is useful when automating download URL resolution for CI/CD
+pipelines that need to follow redirect chains behind Cloudflare-protected pages.
+
+## Observation
+
+The `navigator.webdriver` property is the strongest automation signal.
+Additionally, `navigator.platform` may be set to a headless-specific string
+and `navigator.vendor` may be empty in default headless mode.
+
+Separately, download redirect pages (e.g., `download.example.com/latest/redirect`)
+are designed to immediately trigger a file download. Playwright's `page.goto()`
+with `wait_until="networkidle"` or `"load"` will raise a timeout because the
+page never actually loads HTML — it just emits an HTTP redirect or
+`Content-Disposition: attachment` header. The navigation never "finishes" from
+Playwright's perspective.
+
+## Why it happens
+
+`navigator.webdriver` is a W3C WebDriver spec requirement: automation-driven
+browsers must set it to `true`. Cloudflare checks this and other browser
+fingerprint properties to distinguish bots from humans.
+
+Download pages trigger browser-level download handling, which Playwright's
+network stack intercepts. The page navigation is considered "failed" or
+"pending" by the page lifecycle because no document is loaded.
+
+## Practical implication
+
+**Stealth init script:**
+
+```python
+context.add_init_script("""
+    Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+    Object.defineProperty(navigator, 'platform',  { get: () => 'Linux x86_64' });
+    Object.defineProperty(navigator, 'vendor',    { get: () => 'Google Inc.' });
+""")
+```
+
+**Capturing download URL from a redirect page:**
+
+```python
+resolved_url = None
+
+def handle_request(request):
+    global resolved_url
+    url = request.url
+    # Intercept the final resolved URL (e.g., storage.googleapis.com .exe)
+    if 'storage.googleapis.com' in url and url.endswith('.exe'):
+        resolved_url = url
+
+def handle_download(download):
+    global resolved_url
+    resolved_url = download.url
+
+page.on('request', handle_request)
+page.on('download', handle_download)
+
+try:
+    page.goto(redirect_url, timeout=30000, wait_until='commit')
+    # wait_for_timeout is safer than goto timeout for download pages:
+    # the navigation never "completes" — we just need a moment to capture
+    # the URL from the request/download events.
+    page.wait_for_timeout(2000)
+except TimeoutError:
+    pass  # Expected for redirect/download pages
+except Exception as e:
+    # "Download is starting" is an expected Playwright exception
+    if 'Download is starting' not in str(e):
+        raise
+```
+
+Use `wait_until='commit'` (fires when the first bytes are received and the
+response is committed, before full page load) as the navigation condition,
+then use `wait_for_timeout()` as a deliberate pause for event capture.
+
+The browser context should set `accept_downloads=True` to enable the
+`download` event handler.
+
+## Source reference
+
+- `scripts/resolve-download-url.py`: `resolve_download_url()` — complete
+  production implementation with both `handle_request` and `handle_download`
+  callbacks, stealth init script, and timeout-tolerant navigation.

--- a/knowledge/decision/process-title-for-debug-visibility.md
+++ b/knowledge/decision/process-title-for-debug-visibility.md
@@ -1,0 +1,46 @@
+---
+name: process-title-for-debug-visibility
+summary: Setting `process.title` early in each process (CLI, daemon, MCP server, watchdog) gives `ps`/`top`/Task Manager immediately-recognizable names — critical when a single install spawns four cooperating node processes.
+category: decision
+confidence: medium
+tags: [debugging, process-title, multi-process, ops]
+source_type: extracted-from-git
+source_url: https://github.com/ChromeDevTools/chrome-devtools-mcp.git
+source_ref: main
+source_commit: 0a6aaa52ebacb2db834ffa437863e5844aa3730b
+source_project: chrome-devtools-mcp
+source_path: src/bin/chrome-devtools.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Set `process.title` Early in Each Binary
+
+## Context
+
+The chrome-devtools-mcp install can have several node processes running simultaneously: the MCP stdio server, the daemon, the watchdog subprocess, the CLI client, plus the spawned Chrome. In `ps aux`, they all look like `node /usr/local/lib/node_modules/chrome-devtools-mcp/...` unless you do something.
+
+## The fact / decision / pitfall
+
+Set `process.title` as the very first statement after imports in each binary:
+
+```ts
+// src/bin/chrome-devtools.ts
+process.title = 'chrome-devtools';
+// src/bin/chrome-devtools-mcp.ts (implied)
+process.title = 'chrome-devtools-mcp';
+// daemon, watchdog similar
+```
+
+The CHANGELOG entry `set process titles for easier debugging (#1770)` marks this as an intentional ops-quality improvement.
+
+## Evidence
+
+- `src/bin/chrome-devtools.ts` line 9: `process.title = 'chrome-devtools';`
+- `CHANGELOG.md` 0.21.0 entry: `🏗️ Refactor: set process titles for easier debugging`.
+
+## Implications
+
+- When a user reports "my machine is slow", `ps aux | grep chrome-devtools` with distinct titles tells you which component is hot. Without it, you stare at three identical `node` lines.
+- On Linux, `process.title` is truncated to the length of the original argv buffer. For long titles, pad by launching with `node --title=foo`, or accept the truncation.
+- On macOS, `process.title` shows in Activity Monitor as a "Process Name" column.
+- This is one-line tooling hygiene with large payoff. Apply it to every long-running subprocess you ship, not just the top-level binary.

--- a/knowledge/devops/pgvector-pg17-for-ai-native-apps.md
+++ b/knowledge/devops/pgvector-pg17-for-ai-native-apps.md
@@ -1,0 +1,32 @@
+---
+name: pgvector-pg17-for-ai-native-apps
+summary: For AI-native apps that need both relational data and semantic search, use the pgvector/pgvector:pg17 image — one database, no extra infra.
+category: devops
+tags: [postgres, pgvector, ai, vector-search, docker]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: docker-compose.selfhost.yml
+imported_at: 2026-04-18T00:00:00Z
+---
+
+Rather than pair a relational DB with a separate vector store (Pinecone, Weaviate, Qdrant), run Postgres with the `pgvector` extension baked in. The `pgvector/pgvector:pg17` image ships Postgres 17 with pgvector pre-installed, so you get:
+
+- One container, one connection pool, one backup story.
+- Vector columns (`embedding vector(1536)`) alongside normal columns in the same table.
+- Joins between structured filters and similarity search in a single query.
+- Standard Postgres tooling (pg_dump, logical replication, SQL migrations).
+
+## Why
+
+For a Linear-scale issue tracker (low millions of rows, not billion-scale) the performance difference vs a dedicated vector store is negligible, and the ops win is large: no extra service to self-host, no extra auth story, no extra network hop. Self-hosters already need Postgres; not asking them to also install a vector DB lowers the barrier.
+
+When the data gets large enough to need a dedicated vector store, you can add one later behind the same query interface; starting with pgvector keeps options open.
+
+## Evidence
+
+- `docker-compose.selfhost.yml:14-29` — `pgvector/pgvector:pg17` service.
+- README.md "Architecture" table — Postgres 17 with pgvector as the database tier.

--- a/knowledge/pitfall/posix-socket-path-length-limit.md
+++ b/knowledge/pitfall/posix-socket-path-length-limit.md
@@ -1,0 +1,49 @@
+---
+name: posix-socket-path-length-limit
+summary: POSIX Unix domain socket paths are capped at around 104 characters on macOS (108 on Linux), so daemons that naively drop a socket under `~/Library/Application Support/...` silently fail to bind. Use `XDG_RUNTIME_DIR` or `/tmp` with uid-suffixed names instead.
+category: pitfall
+confidence: high
+tags: [unix-socket, macos, path-length, daemon, ipc]
+source_type: extracted-from-git
+source_url: https://github.com/ChromeDevTools/chrome-devtools-mcp.git
+source_ref: main
+source_commit: 0a6aaa52ebacb2db834ffa437863e5844aa3730b
+source_project: chrome-devtools-mcp
+source_path: src/daemon/utils.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# POSIX Socket Path Length Limit
+
+## Context
+
+When you design a daemon that listens on a Unix domain socket, your instinct is to put the socket alongside other per-app state, e.g. `~/Library/Application Support/myapp/daemon.sock` on macOS. This fails mysteriously: the socket doesn't bind, the client can't connect, and the error is often truncated to "ENAMETOOLONG" or "address not available".
+
+## The fact / decision / pitfall
+
+macOS caps `sockaddr_un.sun_path` at **104 characters including the NUL**; Linux at 108. Full absolute paths are what's counted, so a path like:
+
+```
+/Users/someuser/Library/Application Support/chrome-devtools-mcp/server.sock
+```
+
+is already 75 chars before your user has a long username. Homebrew's Python, multi-word usernames, or nested app directories will push you over quickly.
+
+Correct approach:
+
+- If `process.env.XDG_RUNTIME_DIR` is set (Linux standard, sometimes macOS), use `$XDG_RUNTIME_DIR/myapp/server.sock`.
+- Otherwise on macOS/Linux, use `/tmp/myapp-${uid}.sock`. `/tmp` is cleared on boot, short, and uid-suffixed avoids collisions in shared-tenancy environments.
+- On Windows, use Named Pipes instead: `path.join('\\\\.\\pipe', APP_NAME, 'server.sock')`. Windows named pipes have a completely different namespace and a much more generous length.
+
+## Evidence
+
+- `src/daemon/utils.ts::getSocketPath()` explicitly comments: "We use /tmp/ because it is much shorter than ~/Library/Application Support/ and keeps us well under the 104-character limit."
+- The same file uses `path.join('\\\\.\\pipe', APP_NAME, 'server.sock')` on Windows.
+- `chrome://inspect` / Chrome's own DevTools pipes also live under `/tmp` on macOS for this reason.
+
+## Implications
+
+- Never share code paths between "where do I put sockets" and "where do I put logs/state" — they have different length constraints. Logs can live under `~/Library/Application Support`; sockets can't.
+- Test with a long username and a path-heavy CI container. The bug is invisible until it fires.
+- PID files and log files should *not* live next to the socket just because the socket location was forced short — keep runtime (socket) vs. persistent (state) dirs distinct.
+- If you must put the socket elsewhere for isolation reasons, symlinking into `/tmp` is legal and the sender/receiver both see the short name.

--- a/knowledge/platform/portable-app-detection-env-var.md
+++ b/knowledge/platform/portable-app-detection-env-var.md
@@ -1,0 +1,28 @@
+---
+name: portable-app-detection-env-var
+type: knowledge
+category: platform
+summary: Portable mode detection: check RUSTDESK_APPNAME env var; changes temp dir and config paths.
+confidence: medium
+tags: [app, detection, env, platform, portable, var]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: src/common.rs
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Portable App Detection Env Var
+
+## Fact
+Portable mode detection: check RUSTDESK_APPNAME env var; changes temp dir and config paths.
+
+## Why it matters
+Env-var switch is cleaner than a sidecar file marker.
+
+## Evidence
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- `src/common.rs`

--- a/knowledge/plugin-architecture/plugin-interface-version-convention.md
+++ b/knowledge/plugin-architecture/plugin-interface-version-convention.md
@@ -1,0 +1,86 @@
+---
+name: plugin-interface-version-convention
+summary: Plugin packages expose a module-level __plugin_interface_version__ = 1 constant so the host can detect ABI-incompatible plugins at load time and either refuse them or invoke a compatibility shim.
+category: plugin-architecture
+confidence: medium
+tags: [plugin-architecture, versioning, abi, contract, python]
+source_type: extracted-from-git
+source_url: https://github.com/microsoft/markitdown.git
+source_ref: main
+source_commit: 604bba13da2f43b756b49122cb65bdedb85b1dff
+source_project: markitdown
+source_path: packages/markitdown-sample-plugin/README.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# `__plugin_interface_version__` — a stable, plugin-declared contract version
+
+The convention markitdown ships with in its sample plugin:
+
+```python
+# mylib_sample_plugin/__init__.py
+
+# The version of the plugin interface that this plugin uses.
+# The only supported version is 1 for now.
+__plugin_interface_version__ = 1
+
+def register_converters(markitdown, **kwargs):
+    """Called each time a MarkItDown instance is created."""
+    markitdown.register_converter(MyConverter())
+```
+
+## Why a dedicated version constant
+
+Package version (`__version__`) tracks the plugin's own evolution. It says nothing about which host API the plugin was written against. When the host's plugin contract evolves — new required methods, changed signatures, new kwargs — the host needs a cheap way to tell the plugin apart from incompatible ones *without executing them*.
+
+`__plugin_interface_version__` is:
+
+- **Host-contract-scoped.** The host defines the legal values (currently `1`). Plugins pick from that set.
+- **Independent of the plugin's own version.** A plugin at `__version__ = "3.7.2"` still declares `__plugin_interface_version__ = 1`.
+- **Cheap to read.** `getattr(plugin, "__plugin_interface_version__", None)` before calling any registration code.
+
+## Host-side usage (when the contract evolves)
+
+```python
+SUPPORTED_INTERFACE_VERSIONS = {1, 2}
+
+for plugin in _load_plugins():
+    v = getattr(plugin, "__plugin_interface_version__", None)
+    if v not in SUPPORTED_INTERFACE_VERSIONS:
+        warn(
+            f"Plugin {plugin.__name__} declares interface version {v}; "
+            f"this host supports {sorted(SUPPORTED_INTERFACE_VERSIONS)}. Skipping."
+        )
+        continue
+
+    if v == 1:
+        plugin.register_converters(host, **kwargs)        # legacy shape
+    elif v == 2:
+        plugin.register(host, context=host.context, **kwargs)  # new shape
+```
+
+Migration path: plugins can be written for v1 forever; new plugins opt into v2; the host carries both branches until v1 is removed.
+
+## What v1 means in markitdown specifically
+
+The v1 contract, as of markitdown's sample plugin:
+
+1. **Entry-point group**: `markitdown.plugin`.
+2. **Module exports**: `__plugin_interface_version__` (int) and `register_converters(markitdown, **kwargs)` (callable).
+3. **Registration method**: `markitdown.register_converter(converter_instance[, priority=...])`.
+4. **Converter contract**: subclass `DocumentConverter`, implement `accepts()` and `convert()` with the documented `(file_stream, stream_info, **kwargs)` signature.
+
+Any breaking change to items 2–4 → bump to v2.
+
+## When not to use this
+
+For plugin systems whose surface is small and stable (one function, one data shape), the version constant is ceremony. Reserve it for hosts where:
+
+- The plugin API is big enough to actually break.
+- You expect a long tail of third-party plugins you don't control.
+- You want to ship v2 before deleting v1.
+
+## Related
+
+- `python-entrypoint-plugin-loader` skill — the broader loader pattern this constant plugs into.
+- Any semver-for-libraries discussion — but note: `__plugin_interface_version__` is narrower, covering only the host contract, not the plugin's own API surface.

--- a/knowledge/plugin/plugin-framework-feature-conditional.md
+++ b/knowledge/plugin/plugin-framework-feature-conditional.md
@@ -1,0 +1,28 @@
+---
+name: plugin-framework-feature-conditional
+type: knowledge
+category: plugin
+summary: Plugin framework gated by feature='plugin_framework' and non-mobile; dynamic .dll/.so loading.
+confidence: medium
+tags: [conditional, feature, framework, plugin]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: src/plugin/
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Plugin Framework Feature Conditional
+
+## Fact
+Plugin framework gated by feature='plugin_framework' and non-mobile; dynamic .dll/.so loading.
+
+## Why it matters
+Mobile platforms disallow dynamic code loading — don't expose the feature there.
+
+## Evidence
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- `src/plugin/`

--- a/knowledge/powersync/powersync-backend-minimal-indexes.md
+++ b/knowledge/powersync/powersync-backend-minimal-indexes.md
@@ -1,0 +1,55 @@
+---
+name: powersync-backend-minimal-indexes
+type: knowledge
+category: decision
+confidence: high
+source: thunderbolt/docs/composite-primary-keys-and-default-data.md
+source_type: extracted-from-git
+source_url: https://github.com/thunderbird/thunderbolt.git
+source_ref: main
+source_commit: 9d9c18ba511decfd3b45fc0f72c265d83355fe95
+source_project: thunderbolt
+imported_at: 2026-04-18T00:00:00Z
+linked_skills: [powersync-add-synced-table-two-pr-flow, powersync-composite-primary-key-seed]
+tags: [powersync, postgresql, indexing, e2e-encryption, architecture]
+---
+
+# Backend PowerSync schema: only primary keys + user_id index
+
+For PowerSync-backed Postgres, the backend schema is intentionally **minimal**:
+
+- Primary keys (required)
+- A single `user_id` index on every synced table (required — sync rules filter by `user_id`)
+- **No** composite foreign-key constraints
+- **No** active indexes like `WHERE deleted_at IS NULL`
+- **No** indexes on foreign-key columns
+
+## Why
+
+1. The backend is a sync server, not a query engine. Complex queries and JOINs happen on the client's local SQLite database.
+2. With end-to-end encryption, indexes on encrypted columns are useless — you can't filter or search ciphertext.
+3. Extra indexes add write overhead on every INSERT/UPDATE/DELETE during sync, which happens constantly.
+4. Keeps ON CONFLICT handling simple for composite-PK "default data" tables (see linked skill).
+
+## The one exception
+
+`user_id` is indexed on every table. PowerSync sync rules like `SELECT * FROM tasks WHERE tasks.user_id = bucket.user_id` run constantly, and without the index they degrade to full-table scans.
+
+## Implications for new tables
+
+When adding a PowerSync-synced table:
+
+- Do add `index('idx_<table>_user_id').on(table.userId)`.
+- Do use composite primary keys `(id, user_id)` or `(key, user_id)` for tables seeded with default data.
+- Don't add `.references()` to other PowerSync tables. Use plain column-level references (`text('mode_id')`).
+- Don't add "active-row" indexes or foreign-key indexes. Let the frontend SQLite do the heavy querying.
+
+## Counter / caveats
+
+- If you ever introduce non-sync, server-side query endpoints (admin, analytics) against the same Postgres, you may need ad-hoc indexes. Colocating them in a separate schema or migration makes the intent visible and avoids polluting the sync-oriented schema.
+- Before E2E encryption is enabled account-wide, some indexes would be useful for debugging; the team chose to keep them off anyway to avoid regressing later.
+
+## Evidence
+
+- `docs/composite-primary-keys-and-default-data.md:56-99`
+- `docs/powersync-account-devices.md:36-72`

--- a/knowledge/powersync/powersync-deploy-order-two-pr-invariant.md
+++ b/knowledge/powersync/powersync-deploy-order-two-pr-invariant.md
@@ -1,0 +1,39 @@
+---
+name: powersync-deploy-order-two-pr-invariant
+type: knowledge
+category: decision
+confidence: high
+source: thunderbolt/CLAUDE.md
+source_type: extracted-from-git
+source_url: https://github.com/thunderbird/thunderbolt.git
+source_ref: main
+source_commit: 9d9c18ba511decfd3b45fc0f72c265d83355fe95
+source_project: thunderbolt
+imported_at: 2026-04-18T00:00:00Z
+linked_skills: [powersync-add-synced-table-two-pr-flow]
+tags: [powersync, deployment, sync-rules, invariants]
+---
+
+# Deploy order invariant: backend + dashboard rules before frontend
+
+For every new PowerSync-synced table, the frontend **must not** ship before PowerSync Cloud's dashboard sync rules match the backend config. If the frontend deploys first:
+
+- The new table replicates locally but never cross-device.
+- There is no error surface — no 4xx, no exception, no console warning.
+- The first user to hit a multi-device flow discovers the bug, usually after writing data that will silently not sync.
+
+## Required order
+
+1. Ship backend Drizzle migration + `shared/powersync-tables.ts` + `powersync-service/config/config.yaml` update.
+2. Deploy the backend and run the migration.
+3. Update PowerSync Cloud dashboard sync rules to match the new `config.yaml`.
+4. Ship the frontend schema + feature code.
+
+## Related invariant: journal file
+
+Drizzle migrations are discovered through `backend/drizzle/meta/_journal.json`. When cherry-picking migration SQL across branches, always verify the journal entry was cherry-picked too. Missing journal entry = migration never runs = schema drift.
+
+## Evidence
+
+- `CLAUDE.md:82-93`
+- `docs/powersync-account-devices.md:51-72`

--- a/knowledge/powersync/powersync-sharedworker-multi-tab-constraint.md
+++ b/knowledge/powersync/powersync-sharedworker-multi-tab-constraint.md
@@ -1,0 +1,48 @@
+---
+name: powersync-sharedworker-multi-tab-constraint
+type: knowledge
+category: pitfall
+confidence: high
+source: thunderbolt/docs/powersync-sync-middleware.md
+source_type: extracted-from-git
+source_url: https://github.com/thunderbird/thunderbolt.git
+source_ref: main
+source_commit: 9d9c18ba511decfd3b45fc0f72c265d83355fe95
+source_project: thunderbolt
+imported_at: 2026-04-18T00:00:00Z
+linked_skills: [powersync-custom-sharedworker-override, powersync-transformable-bucket-storage]
+tags: [powersync, sharedworker, sqlite, comlink, vite]
+---
+
+# PowerSync SharedWorker ignores main-thread BucketStorageAdapter
+
+When `enableMultiTabs: true` (the default on Chrome/Edge/Firefox), PowerSync spawns a SharedWorker that manages a single sync connection across tabs. The SharedWorker creates its own `SqliteBucketStorage` instance inside `SharedSyncImplementation.generateStreamingImplementation()` and **completely ignores** any custom `BucketStorageAdapter` configured on the main-thread database.
+
+Concrete failure mode: you register an adapter / transformer on `PowerSyncDatabase` expecting it to decrypt or normalize sync data, and on Chromium it silently has no effect — the SharedWorker writes raw bytes to SQLite. The only way you notice is that your DAL reads get raw encrypted / malformed data.
+
+Root causes (all architectural):
+
+1. `SharedSyncImplementation` hardcodes `new SqliteBucketStorage(...)` with no injection hook.
+2. Transformer functions cannot be serialized across the Comlink worker boundary.
+3. The `adapter` field is explicitly omitted from the `SharedSyncInitOptions` type passed to the worker.
+
+## Environments where you can't even use the workaround
+
+- **Safari / iOS**: `OPFSCoopSyncVFS` (required for WKWebView stack limits) does not support SharedWorker.
+- **Tauri**: the `tauri://` protocol blocks SharedWorker and `import.meta.url`-based worker loading.
+- **iOS WKWebView**: SharedWorker exceeds memory limits and causes black-screen crashes.
+
+For these environments, keep `enableMultiTabs: false` and run transformers on the main thread via `generateBucketStorageAdapter()`.
+
+## Workaround (Chromium/Firefox)
+
+Ship a custom SharedWorker that subclasses `SharedSyncImplementation` and overrides `generateStreamingImplementation()`. Middleware must be embedded at bundle time — there is no runtime hand-off path. See the linked `powersync-custom-sharedworker-override` skill.
+
+## Upgrade hazard
+
+`SharedSyncImplementation` is marked `@internal`, imported via a Vite alias to `node_modules/@powersync/web/lib/src/...`. Upgrading `@powersync/web` may silently change the copied method body without any TypeScript error, because the import is path-aliased through string resolution. Diff the upstream `generateStreamingImplementation()` on every bump.
+
+## Evidence
+
+- `docs/powersync-sync-middleware.md:136-207` — explicit statement of the constraint and workaround
+- `vite.config.ts:73-82` — internal alias used to reach the non-public class

--- a/knowledge/reference/posthog-cli-telemetry-conventions.md
+++ b/knowledge/reference/posthog-cli-telemetry-conventions.md
@@ -1,0 +1,71 @@
+---
+name: posthog-cli-telemetry-conventions
+summary: OpenSRE's CLI telemetry uses PostHog with a public anon key embedded in the binary, anonymous_id stored in ~/.config, no-PII guarantee, opt-out via DO_NOT_TRACK or app-specific env, and StrEnum-based event naming.
+category: reference
+tags: [posthog, telemetry, cli, conventions, opt-out]
+source_type: extracted-from-git
+source_url: https://github.com/Tracer-Cloud/opensre.git
+source_ref: main
+source_commit: fb5ba0a1b4ef511d16c56a80f1f126b1f581d724
+source_project: opensre
+source_path: app/analytics/provider.py
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+---
+
+# PostHog CLI Telemetry — Conventions
+
+## What goes in
+Hardcoded constants in source:
+```python
+_POSTHOG_API_KEY = "phc_zutpVhmQw7..."  # PostHog public key (safe to embed)
+_POSTHOG_HOST = "https://us.i.posthog.com"
+_QUEUE_SIZE = 128
+_SEND_TIMEOUT = 2.0
+_SHUTDOWN_WAIT = 1.0
+```
+
+## Anonymous ID lifecycle
+- First run: generate UUID4, save to `~/.config/<app>/anonymous_id`.
+- Subsequent runs: read existing.
+- Failure to read/write: fall back to per-process UUID (still anonymous, just not persistent).
+
+## Opt-out
+Both honored:
+- `DO_NOT_TRACK=1` (industry standard from consoledonottrack.com)
+- `<APP>_ANALYTICS_DISABLED=1` (project-specific)
+
+## Event naming via StrEnum
+```python
+class Event(StrEnum):
+    CLI_INVOKED            = "cli_invoked"
+    INSTALL_DETECTED       = "install_detected"
+    ONBOARD_STARTED        = "onboard_started"
+    ONBOARD_COMPLETED      = "onboard_completed"
+    INVESTIGATION_STARTED  = "investigation_started"
+    INVESTIGATION_COMPLETED= "investigation_completed"
+    INTEGRATION_VERIFIED   = "integration_verified"
+    DEPLOY_STARTED         = "deploy_started"
+    # ...
+```
+
+Single source of truth for event names; impossible to typo because the enum is required at the call site.
+
+## Property hygiene
+Base properties auto-attached: `cli_version`, `python_version`, `os_family`, `os_version`, `$process_person_profile: false` (PostHog tells the server not to create a person profile).
+
+## What is explicitly NOT collected
+Per OpenSRE's README:
+- Alert contents
+- File contents
+- Hostnames
+- Credentials
+- Any PII
+
+Per-event properties only contain command names, success/failure, rough runtime, command-specific safe metadata (e.g. which provider was selected, whether `--interactive` was passed).
+
+## Disabled environments
+Telemetry is automatically disabled in GitHub Actions and pytest runs to keep adoption metrics meaningful — i.e. real human users only.
+
+## The pattern
+PostHog public key + opt-out flags + StrEnum event names + bounded queue + atexit flush is the canonical "open-source CLI telemetry" recipe. Easily lifted to any other CLI.

--- a/knowledge/safety/policy-check-sandboxing-evolution.md
+++ b/knowledge/safety/policy-check-sandboxing-evolution.md
@@ -1,0 +1,35 @@
+---
+name: policy-check-sandboxing-evolution
+summary: Enforce evolution policies — no self-modification, no external network, no file deletions
+category: safety
+confidence: medium
+tags: [evolver, safety, policy, sandbox, reference]
+source_type: extracted-from-git
+source_url: https://github.com/EvoMap/evolver.git
+source_ref: main
+source_commit: 22773782475cecf43dc9c1af264bf5f9cacc28bc
+source_project: evolver
+source_paths:
+  - src/gep/policyCheck.js
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Pre-apply policy checks for self-evolving systems
+
+Before applying a mutation, run it through a policy gate. Baseline policies worth enforcing:
+
+- **No self-modification** — the mutation must not touch the evolution engine's own source.
+- **No outbound network** — no new `fetch` / `http.request` call sites, except to the allow-listed hub.
+- **No destructive ops** — no `fs.rm`, `fs.unlink`, `rimraf`, `rm -rf`. Additions and edits only.
+- **No shell escape hatches** — no `exec`, `spawn('bash')`, `eval`.
+- **Bounded diff** — max lines / max files changed.
+
+Violations block promotion and emit a `policy_violation` event for audit.
+
+## Why this is critical
+
+Self-modifying code is the sharpest footgun in the agent toolbox. Policies convert "implicit trust in the model's judgment" into explicit, reviewable rules.
+
+## Reuse notes
+
+Start with a tiny allow-list and deny everything else. Add policies as need arises; never loosen existing ones silently. Treat the policy file like a security boundary — PRs changing it need dedicated review.

--- a/knowledge/safety/privacy-client-secure-credential-handling.md
+++ b/knowledge/safety/privacy-client-secure-credential-handling.md
@@ -1,0 +1,33 @@
+---
+name: privacy-client-secure-credential-handling
+summary: Client for secure credential handling, secrets caching with TTL, encryption at rest
+category: safety
+confidence: medium
+tags: [evolver, safety, credentials, secrets, reference]
+source_type: extracted-from-git
+source_url: https://github.com/EvoMap/evolver.git
+source_ref: main
+source_commit: 22773782475cecf43dc9c1af264bf5f9cacc28bc
+source_project: evolver
+source_paths:
+  - src/gep/privacyClient.js
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Privacy client — TTL-cached, encrypted credential handling
+
+A small client that owns all secret material for the agent. Its contract:
+
+- **Fetch** from a secure backing store (OS keychain, secret manager, KMS-wrapped env).
+- **Cache** in memory with a short TTL (e.g., 60s). No plaintext on disk.
+- **Evict** on TTL expiry *or* on any auth failure.
+- **Encrypt** any at-rest cache (if one is needed for offline resilience) with a key derived from machine state (hardware ID + salt).
+- **Redact** secrets from every log path by default; opt-in unredacted output behind an env flag for debugging.
+
+## Why centralize
+
+Scatter secrets through modules and you'll inevitably log one. A single client with redaction and TTL is much easier to audit.
+
+## Reuse notes
+
+Use the platform's native secret store where possible (Windows Credential Manager, macOS Keychain, Linux libsecret, KMS). The TTL cache is the layer that minimizes provider API calls without extending blast radius.

--- a/knowledge/security/pre-broadcast-log-sanitization.md
+++ b/knowledge/security/pre-broadcast-log-sanitization.md
@@ -1,0 +1,52 @@
+---
+name: pre-broadcast-log-sanitization
+summary: Before any autonomous process ships logs or error context to an upstream target (issue tracker, hub API, telemetry), it must redact secrets, absolute paths, emails, and host fingerprints at the entry point — not on the way out.
+category: security
+confidence: medium
+tags: [security, sanitization, redaction, secrets, pii, autonomous-agent, log-broadcast]
+source_type: extracted-from-git
+source_url: https://github.com/EvoMap/evolver.git
+source_ref: main
+source_commit: 4c51382092f9cb125d3ec55475861ead8d1463a6
+source_project: evolver
+imported_at: 2026-04-18T02:45:00Z
+---
+
+# Pre-Broadcast Log Sanitization
+
+## Threat model
+
+An autonomous daemon (evolver, monitoring agent, bug reporter) routinely packages:
+
+- Recent log lines (may contain env var expansions, request bodies, stack traces).
+- Environment fingerprint (hostname, username, paths).
+- Error message strings (may echo configuration values back out).
+
+…and sends them somewhere less trusted than the host: a public issue tracker, a third-party observability endpoint, a shared mailbox. One leaked token = one compromise.
+
+## Redact on entry, not on exit
+
+The rule of thumb: the payload that gets written to local disk or held in memory should **already be redacted**. If you redact only inside the `POST` call, an earlier `console.log` or crash-dump already leaked the raw form.
+
+## Patterns to match (minimum)
+
+- **Credential-shaped strings.** Known provider prefixes: AWS (`AKIA…`, `ASIA…`), Google (`AIza…`), GitHub (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`), Slack (`xox[bpoa]-`), generic bearer (`Bearer [A-Za-z0-9._\-]{16,}`), PEM headers (`-----BEGIN [A-Z ]+ PRIVATE KEY-----`).
+- **Absolute paths** under user home or system roots. Replace with `~/` or a fixed marker so structure is preserved but identity is not (e.g. `C:\Users\jane\project\…` → `~/project/…`).
+- **Email addresses.** `[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}` — redact the local part; keep the domain only if domain identity is the point (`***@company.com`).
+- **Hostnames / device fingerprints.** If you must send them, hash them (stable salt) so two reports from the same host correlate without naming it.
+- **Custom patterns from config.** Let operators add regexes via env / file; apply them alongside the built-in set.
+
+## Invariants
+
+- **Fail-closed.** If redaction throws, drop the payload. A broken sanitizer must never fall through to "send the original."
+- **Unit-test each pattern.** Each regex gets at least one positive and one negative case. Over-redaction is preferred to under-redaction, but "everything is `[REDACTED]`" is also a failure mode.
+- **Version the sanitizer.** Include `sanitizer_version: N` in the body so downstream reviewers know what rules were applied.
+- **Never log the raw payload at any level.** Not `debug`, not `trace`, not "just while we're developing."
+
+## When patterns need to grow
+
+Most leaks are discovered post-hoc: someone sees a token in an issue, files a fix, patch adds a new regex. Treat the pattern set as a living document. A single PR in the evolver repo (PR #107) added 11 new credential patterns in one go — expect yours to grow the same way.
+
+## Source
+
+- Evolver's pre-broadcast sanitization, hardened across multiple PRs. Public surface is the `envFingerprint` + sanitize helpers under `src/gep/`. The specific regexes aren't reusable as-is — write your own based on the providers and path shapes you actually emit.

--- a/knowledge/vector-search-rag/pinecone-metadata-filtering-rag.md
+++ b/knowledge/vector-search-rag/pinecone-metadata-filtering-rag.md
@@ -1,0 +1,97 @@
+---
+name: pinecone-metadata-filtering-rag
+summary: Structured Pinecone RAG query with $and/$or metadata filters across people/topics/entities/dates, plus a graceful retry-without-filters fallback when the filtered set is empty.
+category: vector-search-rag
+confidence: high
+tags: [pinecone, rag, vector-search, metadata-filtering, openai-embeddings]
+source_type: extracted-from-git
+source_url: https://github.com/BasedHardware/omi.git
+source_ref: main
+source_commit: 1c310f7fc4c37acf7e1bedb014e3a4adfd56546e
+source_project: omi
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Pinecone Metadata-Filtered RAG with Graceful Fallback
+
+Reference pattern for RAG retrieval that combines semantic similarity with structured metadata constraints (time range, named people, topics, entities) — and degrades gracefully when the filter set returns zero matches.
+
+## Filter shape
+
+```python
+filter_data = {
+  '$and': [
+    {'uid': {'$eq': uid}},
+    {'$or': [
+      {'people':   {'$in': people}},
+      {'topics':   {'$in': topics}},
+      {'entities': {'$in': entities}},
+    ]},
+    {'created_at': {'$gte': start_ts, '$lte': end_ts}},
+  ]
+}
+```
+
+Rules:
+
+- Outer `$and` always carries `uid` — multi-tenancy is mandatory, not optional.
+- Inner `$or` groups the "soft" filters (any-match is good enough).
+- Date range is a separate `$and` clause so it composes with either the presence or absence of soft filters.
+- `top_k = 1000` when filter is strict (metadata narrows the set); `top_k = 20` on the fallback (no structured filter → must rank by similarity only).
+
+## Graceful fallback
+
+```
+1st query with full filter
+   └─ if matches empty AND len(filter_data['$and']) == 3:
+        drop filter_data['$and'][1]  (the soft $or block)
+        retry with top_k=20
+      else:
+        return []  # tenant-only filter already tried
+```
+
+This is crucial when the user's question implies an entity that was never extracted ("meeting with *Lisa*" but no segment ever tagged `Lisa` in `people`). Without the fallback, the retrieval returns empty and the agent hallucinates.
+
+## Metadata design (upsert side)
+
+```python
+metadata = {
+  'uid': uid,
+  'memory_id': conversation_id,
+  'created_at': int(utcnow_ts),  # unix seconds
+  'people': [...],
+  'topics': [...],
+  'entities': [...],
+  'people_mentioned': [...],  # superset of people, for soft matches
+}
+```
+
+- Store timestamps as integer unix seconds; Pinecone filters do numeric comparisons.
+- Keep per-vector ID format as `{uid}-{conversation_id}` so single-tenant deletes (`delete_vector(uid, cid)`) are O(1).
+- Maintain a single namespace (`ns1`) per environment; use separate indexes for prod vs. staging to avoid cross-contamination.
+
+## Post-ranking
+
+After Pinecone returns, rescore by metadata match count:
+
+```python
+match_count = sum(
+  (topic in meta['topics']) +
+  (entity in meta['entities']) +
+  (person in meta['people_mentioned'])
+  for topic/entity/person in filters
+)
+sort conversations by match_count desc
+trim to `limit`
+```
+
+This compensates for Pinecone's pure-vector ranking when a conversation mentions all three of people+topics+entities — it should outrank one that only matches the vector.
+
+## Evidence in source
+
+- `backend/database/vector_db.py` — `query_vectors_by_metadata()`, `upsert_vector()`, `upsert_vector2()`
+- `backend/utils/llm/clients.py` — `OpenAIEmbeddings("text-embedding-3-large")` wiring
+
+## Reusability
+
+Any RAG product with both semantic + structured retrieval (meeting search, document Q&A with tags, CRM-aware chatbots) benefits from the two-tier filter + fallback design. The pattern is index-agnostic — Weaviate, Qdrant, pgvector all support the same `$and`/`$or` shape.

--- a/knowledge/windows/privacy-mode-implementation-choices.md
+++ b/knowledge/windows/privacy-mode-implementation-choices.md
@@ -1,0 +1,28 @@
+---
+name: privacy-mode-implementation-choices
+type: knowledge
+category: platform/windows
+summary: Three privacy-mode strategies coexist: MAG (fast but limited), exclude-from-capture (Win10 2004+), virtual-display (fullscreen gaming).
+confidence: high
+tags: [choices, implementation, mode, platform, privacy, windows]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: src/privacy_mode.rs
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Privacy Mode Implementation Choices
+
+## Fact
+Three privacy-mode strategies coexist: MAG (fast but limited), exclude-from-capture (Win10 2004+), virtual-display (fullscreen gaming).
+
+## Why it matters
+Each has different compatibility + UX trade-offs — choose per use case, not one globally.
+
+## Evidence
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- `src/privacy_mode.rs`

--- a/knowledge/workflow/pre-push-discipline-test-lint-typecheck.md
+++ b/knowledge/workflow/pre-push-discipline-test-lint-typecheck.md
@@ -1,0 +1,46 @@
+---
+name: pre-push-discipline-test-lint-typecheck
+summary: OpenSRE's CLAUDE.md / AGENTS.md mandate "before push" gates — clean working tree, then test-cov, lint, typecheck — and a self-improvement loop that captures lessons in tasks/lessons.md after every correction. Useful guardrail pattern for AI-assisted dev workflows.
+category: workflow
+tags: [pre-push, discipline, ai-workflow, self-improvement]
+source_type: extracted-from-git
+source_url: https://github.com/Tracer-Cloud/opensre.git
+source_ref: main
+source_commit: fb5ba0a1b4ef511d16c56a80f1f126b1f581d724
+source_project: opensre
+source_path: AGENTS.md
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+---
+
+# Pre-Push Discipline + Self-Improvement Loop
+
+## The pattern
+OpenSRE's `AGENTS.md` lays out a six-step workflow orchestration that's worth borrowing for any AI-assisted codebase:
+
+1. **Plan Mode Default** — non-trivial tasks (3+ steps) start with a plan. Re-plan immediately if something diverges.
+2. **Subagent Strategy** — offload research and parallel analysis to subagents to keep main context clean.
+3. **Self-Improvement Loop** — after ANY correction from the user, append the pattern to `tasks/lessons.md`. Review at session start.
+4. **Verification Before Done** — never mark complete without proving it works. Run `make test-cov`, `make lint`, `make typecheck`.
+5. **Demand Elegance (Balanced)** — for non-trivial changes, pause and ask "is there a more elegant way?". Skip for trivial fixes.
+6. **Autonomous Bug Fixing** — given a bug report, just fix it. Don't ask for hand-holding.
+
+Plus a four-line "Before Push" checklist:
+1. Clean working tree.
+2. `make test-cov`.
+3. `make lint`.
+4. `make typecheck`.
+
+## Why this works
+- Explicit pre-push commands are easier for an AI agent to follow than implicit "make sure tests pass".
+- The lessons file becomes a project-specific lint of past mistakes.
+- "Plan first, verify after" bookends the work without micromanaging the middle.
+
+## How OpenSRE enforces it
+- Makefile targets `lint`, `typecheck`, `test-cov`, `check`.
+- `pyproject.toml` declares ruff config (E, F, I, S) and per-file-ignores so lint passes consistently.
+- Coverage data file moved into `.pytest_cache/` to keep `git status` clean (helps with rule 1).
+- `tasks/todo.md` and `tasks/lessons.md` referenced as canonical locations.
+
+## Generalizable
+Any team using Claude Code, Cursor, or similar AI dev tools can adopt this nearly verbatim. The key insight is that the workflow document is itself an asset — the AI re-reads it every session and the rules compound.

--- a/registry.json
+++ b/registry.json
@@ -2409,6 +2409,161 @@
       "category": "build",
       "path": "skills/build/coverage-data-file-under-pytest-cache/SKILL.md",
       "version": "1.0.0"
+    },
+    "personality-state-tracking-with-aggregation": {
+      "category": "observability",
+      "path": "skills/observability/personality-state-tracking-with-aggregation/SKILL.md",
+      "version": "1.0.0"
+    },
+    "pid-aware-temp-dir-uuid-generator": {
+      "category": "jit-compilation",
+      "path": "skills/jit-compilation/pid-aware-temp-dir-uuid-generator/SKILL.md",
+      "version": "1.0.0"
+    },
+    "pid-watchdog-sidecar-survival": {
+      "category": "tauri",
+      "path": "skills/tauri/pid-watchdog-sidecar-survival/SKILL.md",
+      "version": "1.0.0"
+    },
+    "plan-audit-entry-per-step": {
+      "category": "agent-sdk",
+      "path": "skills/agent-sdk/plan-audit-entry-per-step/SKILL.md",
+      "version": "1.0.0"
+    },
+    "plan-based-multi-step-task-decomposition": {
+      "category": "llm-agents",
+      "path": "skills/llm-agents/plan-based-multi-step-task-decomposition/SKILL.md",
+      "version": "1.0.0"
+    },
+    "platform-adapter-interface": {
+      "category": "integration",
+      "path": "skills/integration/platform-adapter-interface/SKILL.md",
+      "version": "1.0.0"
+    },
+    "platform-agnostic-file-input-abstraction": {
+      "category": "inference",
+      "path": "skills/inference/platform-agnostic-file-input-abstraction/SKILL.md",
+      "version": "1.0.0"
+    },
+    "platform-bridge-core-provider": {
+      "category": "architecture",
+      "path": "skills/architecture/platform-bridge-core-provider/SKILL.md",
+      "version": "1.0.0"
+    },
+    "platform-screen-capture-abstraction": {
+      "category": "codecs",
+      "path": "skills/codecs/platform-screen-capture-abstraction/SKILL.md",
+      "version": "1.0.0"
+    },
+    "platform-specific-code-organization": {
+      "category": "cross-platform",
+      "path": "skills/cross-platform/platform-specific-code-organization/SKILL.md",
+      "version": "1.0.0"
+    },
+    "playtest-report": {
+      "category": "qa",
+      "path": "skills/qa/playtest-report/SKILL.md",
+      "version": "1.0.0"
+    },
+    "playwright-api-fixtures-cleanup": {
+      "category": "testing",
+      "path": "skills/testing/playwright-api-fixtures-cleanup/SKILL.md",
+      "version": "1.0.0"
+    },
+    "pnpm-catalog-version-pinning": {
+      "category": "monorepo",
+      "path": "skills/monorepo/pnpm-catalog-version-pinning/SKILL.md",
+      "version": "1.0.0"
+    },
+    "polymorphic-assignee-rendering": {
+      "category": "architecture",
+      "path": "skills/architecture/polymorphic-assignee-rendering/SKILL.md",
+      "version": "1.0.0"
+    },
+    "port-forwarding-tunnel-multiplexer": {
+      "category": "networking",
+      "path": "skills/networking/port-forwarding-tunnel-multiplexer/SKILL.md",
+      "version": "1.0.0"
+    },
+    "posthog-analytics-with-opt-out-and-thread-queue": {
+      "category": "cli",
+      "path": "skills/cli/posthog-analytics-with-opt-out-and-thread-queue/SKILL.md",
+      "version": "1.0.0"
+    },
+    "powersync-add-synced-table-two-pr-flow": {
+      "category": "powersync",
+      "path": "skills/powersync/powersync-add-synced-table-two-pr-flow/SKILL.md",
+      "version": "1.0.0"
+    },
+    "powersync-composite-primary-key-seed": {
+      "category": "powersync",
+      "path": "skills/powersync/powersync-composite-primary-key-seed/SKILL.md",
+      "version": "1.0.0"
+    },
+    "powersync-custom-sharedworker-override": {
+      "category": "powersync",
+      "path": "skills/powersync/powersync-custom-sharedworker-override/SKILL.md",
+      "version": "1.0.0"
+    },
+    "powersync-no-foreign-keys-on-sync-backend": {
+      "category": "powersync",
+      "path": "skills/powersync/powersync-no-foreign-keys-on-sync-backend/SKILL.md",
+      "version": "1.0.0"
+    },
+    "powersync-transformable-bucket-storage": {
+      "category": "powersync",
+      "path": "skills/powersync/powersync-transformable-bucket-storage/SKILL.md",
+      "version": "1.0.0"
+    },
+    "ppo-rlhf-trl-gpt2-sentiment": {
+      "category": "llm-agents",
+      "path": "skills/llm-agents/ppo-rlhf-trl-gpt2-sentiment/SKILL.md",
+      "version": "1.0.0"
+    },
+    "pre-release-pr-triage-worktree": {
+      "category": "agents",
+      "path": "skills/agents/pre-release-pr-triage-worktree/SKILL.md",
+      "version": "1.0.0"
+    },
+    "pre-release-version-validation-script": {
+      "category": "release",
+      "path": "skills/release/pre-release-version-validation-script/SKILL.md",
+      "version": "1.0.0"
+    },
+    "predict-mode-dispatch-with-fallback-heuristics": {
+      "category": "inference",
+      "path": "skills/inference/predict-mode-dispatch-with-fallback-heuristics/SKILL.md",
+      "version": "1.0.0"
+    },
+    "presampled-sliding-window-index": {
+      "category": "data-pipeline",
+      "path": "skills/data-pipeline/presampled-sliding-window-index/SKILL.md",
+      "version": "1.0.0"
+    },
+    "privacy-mode-trait-abstraction": {
+      "category": "platform",
+      "path": "skills/platform/privacy-mode-trait-abstraction/SKILL.md",
+      "version": "1.0.0"
+    },
+    "process-singleton-guard-with-lockfile": {
+      "category": "resilience",
+      "path": "skills/resilience/process-singleton-guard-with-lockfile/SKILL.md",
+      "version": "1.0.0"
+    },
+    "profile-scoped-config-dir": {
+      "category": "cli",
+      "path": "skills/cli/profile-scoped-config-dir/SKILL.md",
+      "version": "1.0.0"
+    },
+    "programmatic-dependent-launch-attribute-toggle": {
+      "category": "gpu-kernels",
+      "path": "skills/gpu-kernels/programmatic-dependent-launch-attribute-toggle/SKILL.md",
+      "version": "1.0.0"
+    },
+    "project-stage-detect": {
+      "category": "production",
+      "path": "skills/production/project-stage-detect/SKILL.md",
+      "version": "1.0.0"
     }
   },
   "knowledge": {
@@ -4427,6 +4582,82 @@
     "craft-cli-command-surface": {
       "category": "reference",
       "path": "knowledge/reference/craft-cli-command-surface.md"
+    },
+    "pgvector-pg17-for-ai-native-apps": {
+      "category": "devops",
+      "path": "knowledge/devops/pgvector-pg17-for-ai-native-apps.md"
+    },
+    "pinecone-metadata-filtering-rag": {
+      "category": "vector-search-rag",
+      "path": "knowledge/vector-search-rag/pinecone-metadata-filtering-rag.md"
+    },
+    "playwright-stealth-cloudflare-bypass": {
+      "category": "automation",
+      "path": "knowledge/automation/playwright-stealth-cloudflare-bypass.md"
+    },
+    "plugin-framework-feature-conditional": {
+      "category": "plugin",
+      "path": "knowledge/plugin/plugin-framework-feature-conditional.md"
+    },
+    "plugin-interface-version-convention": {
+      "category": "plugin-architecture",
+      "path": "knowledge/plugin-architecture/plugin-interface-version-convention.md"
+    },
+    "policy-check-sandboxing-evolution": {
+      "category": "safety",
+      "path": "knowledge/safety/policy-check-sandboxing-evolution.md"
+    },
+    "polymorphic-assignees-member-or-agent": {
+      "category": "arch",
+      "path": "knowledge/arch/polymorphic-assignees-member-or-agent.md"
+    },
+    "portable-app-detection-env-var": {
+      "category": "platform",
+      "path": "knowledge/platform/portable-app-detection-env-var.md"
+    },
+    "posix-socket-path-length-limit": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/posix-socket-path-length-limit.md"
+    },
+    "posthog-cli-telemetry-conventions": {
+      "category": "reference",
+      "path": "knowledge/reference/posthog-cli-telemetry-conventions.md"
+    },
+    "powersync-backend-minimal-indexes": {
+      "category": "powersync",
+      "path": "knowledge/powersync/powersync-backend-minimal-indexes.md"
+    },
+    "powersync-deploy-order-two-pr-invariant": {
+      "category": "powersync",
+      "path": "knowledge/powersync/powersync-deploy-order-two-pr-invariant.md"
+    },
+    "powersync-sharedworker-multi-tab-constraint": {
+      "category": "powersync",
+      "path": "knowledge/powersync/powersync-sharedworker-multi-tab-constraint.md"
+    },
+    "pre-broadcast-log-sanitization": {
+      "category": "security",
+      "path": "knowledge/security/pre-broadcast-log-sanitization.md"
+    },
+    "pre-push-discipline-test-lint-typecheck": {
+      "category": "workflow",
+      "path": "knowledge/workflow/pre-push-discipline-test-lint-typecheck.md"
+    },
+    "priority-lower-is-higher-stable-sort": {
+      "category": "architecture",
+      "path": "knowledge/architecture/priority-lower-is-higher-stable-sort.md"
+    },
+    "privacy-client-secure-credential-handling": {
+      "category": "safety",
+      "path": "knowledge/safety/privacy-client-secure-credential-handling.md"
+    },
+    "privacy-mode-implementation-choices": {
+      "category": "windows",
+      "path": "knowledge/windows/privacy-mode-implementation-choices.md"
+    },
+    "process-title-for-debug-visibility": {
+      "category": "decision",
+      "path": "knowledge/decision/process-title-for-debug-visibility.md"
     }
   }
 }

--- a/skills/agent-sdk/plan-audit-entry-per-step/SKILL.md
+++ b/skills/agent-sdk/plan-audit-entry-per-step/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: plan-audit-entry-per-step
+description: Emit a structured audit dict on every planning iteration (loop count, tool budget, planned action count, rerouted flag, rerouted reason) and stash it in state so post-mortem analysis can replay every planner decision.
+category: agent-sdk
+version: 1.0.0
+version_origin: extracted
+tags: [audit, planner, observability, langgraph]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/Tracer-Cloud/opensre.git
+source_ref: main
+source_commit: fb5ba0a1b4ef511d16c56a80f1f126b1f581d724
+source_project: opensre
+source_path: app/nodes/plan_actions/node.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Plan Audit Entry per Loop Step
+
+## When to use
+Your agent has a planner that runs multiple times (one per loop iteration). When it misbehaves, you want to know exactly what was decided, with what budget, and whether the planner rerouted to a different source family. Logging via `print` makes this lossy; you want a typed dict in state.
+
+## How it works
+- A `PlanAudit` TypedDict declares the audit shape: `loop`, `tool_budget`, `planned_count`, `rerouted`, optional `reroute_reason`.
+- Every planning node populates it before returning.
+- Downstream nodes (e.g. `investigate`) read the audit so summaries can include "loop 2: planner re-routed from grafana to datadog because Grafana returned no logs".
+
+## Example
+```python
+class PlanAudit(TypedDict, total=False):
+    loop: int
+    tool_budget: int
+    planned_count: int
+    rerouted: bool
+    reroute_reason: str
+
+def node_plan_actions(state):
+    loop_count = state.get("investigation_loop_count", 0)
+    plan, available_sources, available_action_names, _, rerouted, reroute_reason = build_plan_actions(...)
+    audit_entry: PlanAudit = {
+        "loop": loop_count,
+        "tool_budget": input_data.tool_budget,
+        "planned_count": len(plan.actions if plan else []),
+        "rerouted": rerouted,
+    }
+    if rerouted:
+        audit_entry["reroute_reason"] = reroute_reason
+    return {
+        "planned_actions": plan.actions if plan else [],
+        "plan_rationale": plan.rationale if plan else "",
+        "available_sources": available_sources,
+        "available_action_names": available_action_names,
+        "plan_audit": audit_entry,
+    }
+```
+
+## Gotchas
+- Use `TypedDict(total=False)` so you can omit optional fields without forcing a sentinel value.
+- Don't accumulate the entire history in state — keep only the most recent `plan_audit`. The full history can be reconstructed from LangSmith traces or LangGraph's checkpoint table.
+- Surface the audit in the final report so users can self-debug ("agent looped 3 times because Grafana returned no logs" is more actionable than "couldn't find root cause").

--- a/skills/agents/pre-release-pr-triage-worktree/SKILL.md
+++ b/skills/agents/pre-release-pr-triage-worktree/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: pre-release-pr-triage-worktree
+description: Triage open PRs for a release in a dedicated git worktree, classify each into merge/candidate/supersede/defer, and work the loop end-to-end.
+category: agents
+version: 1.0.0
+version_origin: extracted
+tags: [release-management, git-worktree, gh-cli, triage, open-source]
+source_type: extracted-from-git
+source_url: https://github.com/jamiepine/voicebox.git
+source_ref: main
+source_commit: 476abe07fc2c1587f4b3e3916134018ebacd143d
+source_project: voicebox
+confidence: high
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Pre-release PR triage (worktree)
+
+## When to use
+A solo maintainer (or small team) has accumulated 10+ open PRs and wants to land the critical subset before cutting a minor/major release — without losing the changelog narrative and without deep-reviewing everything.
+
+## Steps
+1. Create a dedicated PR-review worktree: `git worktree add ../<repo>-pr-review -b pr-review-<version> main`. Keep the main worktree for release prep (changelog, direct follow-ups); use the review worktree for `gh pr checkout` so HEAD moves without contaminating release work.
+2. Bulk-gather metadata once: `gh pr list --state open --limit 50 --json number,title,author,mergeable,mergeStateStatus,additions,deletions,maintainerCanModify,files`. Capture size, mergeable state, file paths (for overlap detection), and whether maintainer can push to the fork.
+3. Sort every PR into one of four tiers:
+   - **Tier 1 (merge)**: small, mergeable, clean CI, low review cost.
+   - **Tier 2 (candidate)**: 50-200 lines, needs a close read but looks sound.
+   - **Supersede**: covered by something already merged — verify by diff, not by title similarity.
+   - **Defer**: big features, dirty conflicts, draft PRs, anything risky.
+4. Write `<VERSION>_PR_TRIAGE.md` with a Progress header, per-tier tables (with checkbox status columns), supersede table, defer list, and order-of-attack. The doc is your session state.
+5. For each PR: `gh pr checkout N`, review via `git show HEAD` / `git show --stat HEAD` (NEVER `main..HEAD` on a stale branch — it lies), `git rebase origin/main` if behind, and `git push <author> HEAD:<branch> --force-with-lease` if `maintainerCanModify=true`. Then `gh pr merge N --squash`.
+6. Batch obviously-correct one-liners in a loop: `for pr in ...; do gh pr merge $pr --squash; done`. Verify each with `gh pr view $pr --json state,mergeCommit`.
+7. For partial-applies: `git checkout <pr-sha> -- <files>`, review staged, commit with a `Co-Authored-By:` trailer crediting the original author, then close the PR with a comment naming the applied commit.
+8. Update `<VERSION>_PR_TRIAGE.md` after every action. If interrupted, the doc is the only source of truth.
+
+## Counter / Caveats
+- `main..HEAD` on a stale PR branch shows every main commit as deletions, turning a 3-line PR into what looks like a 700-line revert. **Always** review via `git show HEAD`.
+- Squash-merging an unrebased branch reverts in-between work — rebase first or GitHub's squash computes a bad merge-base diff.
+- `mergeable=UNKNOWN` is transient after a push; just try the merge and see.
+- Route-ordering bugs (FastAPI-style `DELETE /history/failed` vs `DELETE /history/{id}`) are a class of bug that pairs of PRs frequently re-introduce — verify param-path routes land after the literal ones.
+
+Source references: `.agents/skills/triage-prs/SKILL.md` (the full triage workflow that this skill extracts).

--- a/skills/architecture/platform-bridge-core-provider/SKILL.md
+++ b/skills/architecture/platform-bridge-core-provider/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: platform-bridge-core-provider
+description: Single CoreProvider in the shared packages layer initializes API client, auth/workspace stores, WS connection, and QueryClient — each app wraps its root and injects platform adapters.
+category: architecture
+version: 1.0.0
+tags: [react, provider, cross-platform, bootstrap, monorepo]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- Monorepo with multiple frontend apps (web + desktop + mobile) sharing business logic.
+- Each app needs the same bootstrap order (API → auth → workspace → WS → queries) but has different framework-specific wiring.
+
+## Steps
+
+1. In `packages/core/platform/core-provider.tsx`, own the bootstrap sequence:
+   ```tsx
+   export function CoreProvider({
+     storageAdapter,
+     navigationAdapter,
+     apiBaseUrl,
+     wsBaseUrl,
+     cookieAuth,
+     children,
+   }: CoreProviderProps) {
+     // 1. API client + auth store
+     const api = useMemo(() => createApiClient({ baseUrl: apiBaseUrl, storage: storageAdapter }), []);
+     const authStore = useMemo(() => createAuthStore({ api, storage: storageAdapter }), []);
+     // 2. Workspace store
+     const workspaceStore = useMemo(() => createWorkspaceStore({ api, storage: storageAdapter }), []);
+     // 3. QueryClient
+     const qc = useMemo(() => createQueryClient(), []);
+     // 4. WS client (depends on auth)
+     const wsClient = useMemo(() => new WSClient(wsBaseUrl, { cookieAuth }), []);
+     return (
+       <QueryClientProvider client={qc}>
+         <WSProvider ws={wsClient} auth={authStore} workspace={workspaceStore}>
+           <NavigationProvider value={navigationAdapter}>
+             <StorageProvider value={storageAdapter}>
+               {children}
+             </StorageProvider>
+           </NavigationProvider>
+         </WSProvider>
+       </QueryClientProvider>
+     );
+   }
+   ```
+2. Each app wraps with its platform adapters:
+   ```tsx
+   // apps/web/app/layout.tsx
+   export default function RootLayout({ children }) {
+     return (
+       <html>
+         <body>
+           <CoreProvider
+             storageAdapter={browserStorageAdapter}
+             navigationAdapter={webNavigationAdapter}
+             apiBaseUrl={process.env.NEXT_PUBLIC_API_URL!}
+             wsBaseUrl={process.env.NEXT_PUBLIC_WS_URL!}
+             cookieAuth={true}
+           >
+             {children}
+           </CoreProvider>
+         </body>
+       </html>
+     );
+   }
+   ```
+3. Apps never touch `QueryClient`, `WSClient`, or the auth/workspace stores directly — they consume them through the hooks the core package exposes.
+4. Test harness wraps with `CoreProvider` using in-memory storage and a no-op navigation adapter.
+
+## Example
+
+Add a new platform (mobile React Native):
+- Implement `rnStorageAdapter` (AsyncStorage-backed) and `rnNavigationAdapter` (React Navigation).
+- Wrap app root with `<CoreProvider storageAdapter={rnStorageAdapter} ... />`.
+- Everything else — queries, mutations, WS events, workspace switching — works.
+
+## Caveats
+
+- Adapters must be stable references (pass memoized instances, not inline objects) or every render tears down and rebuilds the core stack.
+- Bootstrapping order matters: API before auth (auth uses API); auth before workspace (workspace depends on auth); QueryClient before WS (WS invalidates queries). Changing order breaks things subtly.
+- This provider is where "the platform ends and the app logic begins" — resist adding app-specific bootstrapping here.

--- a/skills/architecture/polymorphic-assignee-rendering/SKILL.md
+++ b/skills/architecture/polymorphic-assignee-rendering/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: polymorphic-assignee-rendering
+description: Model an assignee that may be a human member OR an AI agent with (assignee_type, assignee_id) columns and render-time dispatch to distinct visual styling.
+category: architecture
+version: 1.0.0
+tags: [domain-model, polymorphism, agents, issue-tracker, ui]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- A product where AI agents are first-class actors: they can be assigned, create work, comment, and change status.
+- You want to avoid leaking agent semantics into code that only cares about humans, and vice versa.
+
+## Steps
+
+1. Schema: two columns on the parent entity, plus separate tables for members and agents:
+   ```sql
+   ALTER TABLE issues
+     ADD COLUMN assignee_type TEXT
+       CHECK (assignee_type IN ('member', 'agent')),
+     ADD COLUMN assignee_id UUID;
+   CREATE INDEX idx_issues_assignee ON issues (assignee_type, assignee_id);
+   ```
+   No foreign key — you can't FK a polymorphic column. Enforce existence at the application layer.
+2. Query helper that hydrates either an Agent or Member based on `assignee_type`:
+   ```go
+   type AssigneeRef struct {
+       Type string  // "member" | "agent"
+       ID   string
+   }
+   func LoadAssignee(ctx context.Context, q *db.Queries, ref *AssigneeRef) (Member, *Agent, error) {
+       if ref == nil { return Member{}, nil, nil }
+       switch ref.Type {
+       case "member": m, err := q.GetMember(ctx, ref.ID); return m, nil, err
+       case "agent":  a, err := q.GetAgent(ctx,  ref.ID); return Member{}, &a, err
+       }
+       return Member{}, nil, fmt.Errorf("unknown assignee_type: %q", ref.Type)
+   }
+   ```
+3. TS type union on the frontend:
+   ```ts
+   export type Assignee =
+     | { type: "member"; id: string; name: string; avatar_url: string }
+     | { type: "agent";  id: string; name: string; icon: string };
+   ```
+4. Render-time dispatch with distinct styling:
+   ```tsx
+   function AssigneeAvatar({ assignee }: { assignee: Assignee }) {
+     if (assignee.type === "agent") {
+       return <div className="bg-purple-500/10 text-purple-600 rounded-full p-1"><RobotIcon /></div>;
+     }
+     return <Avatar src={assignee.avatar_url} />;
+   }
+   ```
+5. Permission checks branch on type too: "can assign" may allow assigning to any workspace member but only to non-archived agents, etc.
+
+## Example
+
+Issue list shows a mix of `assignee_type: "member"` (standard avatar) and `assignee_type: "agent"` (purple robot icon). Users can filter by assignee kind as well as by specific assignee.
+
+## Caveats
+
+- Keep validation server-side: reject writes where `assignee_type = "agent"` and the referenced UUID is not in the agents table for this workspace.
+- Don't try to merge members and agents into one logical table; their lifecycle and permissions diverge enough that you'd regret it. The polymorphism is at the reference site only.
+- Report filters and dashboards that split by type are worth the effort — hiding the distinction in aggregate stats loses signal ("how much work did agents do this week?").

--- a/skills/cli/posthog-analytics-with-opt-out-and-thread-queue/SKILL.md
+++ b/skills/cli/posthog-analytics-with-opt-out-and-thread-queue/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: posthog-analytics-with-opt-out-and-thread-queue
+description: Background-thread CLI analytics that respects DO_NOT_TRACK + custom opt-out env, persists an anonymous UUID in ~/.config, queues events with bounded size, and flushes on atexit with a timeout.
+category: cli
+version: 1.0.0
+version_origin: extracted
+tags: [analytics, posthog, opt-out, background-thread, cli]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/Tracer-Cloud/opensre.git
+source_ref: main
+source_commit: fb5ba0a1b4ef511d16c56a80f1f126b1f581d724
+source_project: opensre
+source_path: app/analytics/provider.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# CLI Analytics with Opt-Out and Thread Queue
+
+## When to use
+You're shipping an open-source CLI and want anonymous telemetry to demonstrate adoption to sponsors, but with strict guarantees: never block CLI execution, respect industry-standard opt-out flags, never collect PII, always be ready for the user to disable it.
+
+## How it works
+- Honor both `DO_NOT_TRACK=1` and a custom `<APP>_ANALYTICS_DISABLED=1`.
+- Anonymous ID = first-run UUID stored in `~/.config/<app>/anonymous_id`. Falls back to a per-process UUID if writing fails.
+- Events queue into a bounded `queue.Queue(maxsize=128)`; full queue silently drops.
+- A daemon thread drains the queue with httpx, posting to PostHog with a 2-second timeout.
+- `atexit.register(self.shutdown)` ensures pending events flush within 1 second on CLI exit.
+- A drained Event is signalled via `threading.Event` so shutdown can wait for in-flight sends.
+- Base properties (cli_version, python_version, os_family) attached to every event automatically.
+
+## Example
+```python
+class Analytics:
+    def __init__(self):
+        self._disabled = _is_opted_out()
+        self._anonymous_id = _get_or_create_anonymous_id()
+        self._queue: queue.Queue = queue.Queue(maxsize=128)
+        self._pending = 0; self._drained = threading.Event(); self._drained.set()
+        self._worker = None; self._shutdown = False
+        if not self._disabled:
+            atexit.register(self.shutdown)
+
+    def capture(self, event, properties=None):
+        if self._disabled or self._shutdown: return
+        envelope = _Envelope(event=event.value,
+                             properties=_BASE_PROPERTIES | (properties or {}))
+        self._ensure_worker()
+        try:
+            with self._pending_lock:
+                self._pending += 1; self._drained.clear()
+            self._queue.put_nowait(envelope)
+        except queue.Full:
+            self._mark_done()
+
+    def _worker_loop(self):
+        with httpx.Client(timeout=2.0) as client:
+            while True:
+                item = self._queue.get()
+                if item is None: self._queue.task_done(); break
+                try: self._send(client, item)
+                finally:
+                    self._queue.task_done()
+                    self._mark_done()
+            # drain remainder on shutdown ...
+
+def _is_opted_out():
+    return os.getenv("MYAPP_ANALYTICS_DISABLED","0") == "1" or os.getenv("DO_NOT_TRACK","0") == "1"
+```
+
+## Gotchas
+- Always honor `DO_NOT_TRACK` (consoledoc.org standard) — it's the universal opt-out.
+- Bounded queue + dropped overflow keeps the CLI responsive even when the network is slow.
+- `atexit` flush MUST have a timeout (1s here) so CLI exit isn't held hostage by a stuck network.
+- Disable analytics inside CI runners and pytest by detecting `CI=1`/`PYTEST_CURRENT_TEST` env so adoption metrics aren't polluted.
+- Never include hostnames, file contents, or alert payloads in event properties — only OS-level metadata.

--- a/skills/cli/profile-scoped-config-dir/SKILL.md
+++ b/skills/cli/profile-scoped-config-dir/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: profile-scoped-config-dir
+description: Per-profile CLI config directories (~/.myapp/profiles/<name>/) so users can run multiple environments (prod, staging, worktrees) side-by-side without collisions.
+category: cli
+version: 1.0.0
+tags: [cli, config, profiles, daemon, isolation]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- CLI that manages long-lived background state (daemon PID, local token, workspace roots).
+- Users want to point at cloud and a self-host at the same time, or run multiple dev environments.
+
+## Steps
+
+1. Define a profile root per-profile, everything in it is scoped:
+   ```
+   ~/.myapp/
+     config.json               # default profile (legacy / implicit)
+     daemon.pid                # default daemon PID
+     profiles/
+       staging/
+         config.json
+         daemon.pid
+         daemon.log
+       dev-feat-auth-347/
+         config.json
+         daemon.pid
+         workspaces/           # per-profile work dir
+   ```
+2. Accept `--profile <name>` on every command that reads/writes profile state. Without it, use the default root:
+   ```go
+   profile, _ := cmd.Flags().GetString("profile")
+   cfgDir := defaultConfigDir()
+   if profile != "" { cfgDir = filepath.Join(defaultConfigDir(), "profiles", profile) }
+   ```
+3. Derive per-profile ports deterministically from the profile name:
+   ```go
+   func profileHealthPort(profile string) int {
+       if profile == "" { return defaultHealthPort }
+       h := fnv.New32a(); h.Write([]byte(profile))
+       return defaultHealthPort + 1 + int(h.Sum32()%1000)
+   }
+   ```
+4. Include the profile name in log lines and in any daemon-registered runtime display name, so "which daemon is this?" is obvious from UI.
+5. Document the isolation table in CONTRIBUTING:
+   | Resource        | Default                    | Profile mode                              |
+   |-----------------|----------------------------|-------------------------------------------|
+   | Config          | `~/.myapp/config.json`     | `~/.myapp/profiles/<name>/config.json`    |
+   | Daemon PID      | `~/.myapp/daemon.pid`      | `~/.myapp/profiles/<name>/daemon.pid`     |
+   | Health port     | e.g. 19514                 | 19514 + 1 + hash(name)%1000               |
+   | Workspaces dir  | `~/myapp_workspaces/`      | `~/myapp_workspaces_<name>/`              |
+
+## Example
+
+Concurrent environments:
+
+```bash
+myapp setup                                  # default profile → cloud
+myapp setup self-host                        # default profile → now localhost (overwrites!)
+myapp setup self-host --profile staging      # staging profile → staging server
+myapp daemon start --profile staging         # staging daemon
+myapp daemon status --profile staging        # only reports this daemon
+myapp daemon logs -f                         # default daemon's logs, unaffected
+```
+
+## Caveats
+
+- Commands MUST error loud if a profile name doesn't exist, rather than silently falling back to default — users trust the flag to be strict.
+- Before `setup` overwrites an existing profile config, prompt "continue? y/N" unless `--force`.
+- When building `PATH` for the daemon's child processes, prepend the daemon's own binary dir so agent-spawned `myapp` calls hit the same binary.

--- a/skills/codecs/platform-screen-capture-abstraction/SKILL.md
+++ b/skills/codecs/platform-screen-capture-abstraction/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: platform-screen-capture-abstraction
+description: Pluggable screen-capture backends: Windows DXGI, macOS Quartz, Linux X11/Wayland behind one Capturer trait.
+category: codecs
+version: 1.0.0
+version_origin: extracted
+tags: [abstraction, capture, codecs, platform, screen]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: [libs/scrap/src/dxgi/, libs/scrap/src/quartz/, libs/scrap/src/x11/, libs/scrap/src/wayland/]
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Platform Screen Capture Abstraction
+
+## When to use
+Pluggable screen-capture backends: Windows DXGI, macOS Quartz, Linux X11/Wayland behind one Capturer trait.
+
+## Source context
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- Demonstrated in: `libs/scrap/src/dxgi/`, `libs/scrap/src/quartz/`, `libs/scrap/src/x11/`, `libs/scrap/src/wayland/`
+
+## Why this generalizes
+General template for any tool that needs desktop capture across OSes.
+
+## Next steps before publishing
+- Read the source files above and rewrite this as a product-agnostic `how-to` — keep the pattern, drop rustdesk-specific names.
+- Add a minimal code example in the target language (Rust + Dart / Rust only / etc.).
+- List 2-3 gotchas you hit while reproducing it.

--- a/skills/cross-platform/platform-specific-code-organization/SKILL.md
+++ b/skills/cross-platform/platform-specific-code-organization/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: platform-specific-code-organization
+description: Use cfg-gated modules to split Windows/macOS/Linux/Android/iOS implementations behind one trait facade.
+category: cross-platform
+version: 1.0.0
+version_origin: extracted
+tags: [code, cross, organization, platform, specific]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: [src/platform/windows.rs, src/platform/macos.rs, src/platform/linux.rs]
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Platform Specific Code Organization
+
+## When to use
+Use cfg-gated modules to split Windows/macOS/Linux/Android/iOS implementations behind one trait facade.
+
+## Source context
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- Demonstrated in: `src/platform/windows.rs`, `src/platform/macos.rs`, `src/platform/linux.rs`
+
+## Why this generalizes
+Applies to any Rust crate needing per-OS backend with a shared API.
+
+## Next steps before publishing
+- Read the source files above and rewrite this as a product-agnostic `how-to` — keep the pattern, drop rustdesk-specific names.
+- Add a minimal code example in the target language (Rust + Dart / Rust only / etc.).
+- List 2-3 gotchas you hit while reproducing it.

--- a/skills/data-pipeline/presampled-sliding-window-index/SKILL.md
+++ b/skills/data-pipeline/presampled-sliding-window-index/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: presampled-sliding-window-index
+description: Pre-compute every valid (series, start_idx) pair once at dataset init and random-sample from that list, instead of recomputing windows per __getitem__.
+category: data-pipeline
+tags: [pytorch-dataset, sliding-window, time-series, dataloader, preindexing]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/shiyu-coder/Kronos.git
+source_ref: master
+source_commit: 67b630e67f6a18c9e9be918d9b4337c960db1e9a
+source_project: Kronos
+source_paths: [finetune/dataset.py, finetune/qlib_test.py]
+version: 1.0.0
+version_origin: extracted
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Pre-build a flat index of (series, start) for uniform sampling across heterogeneous series
+
+## When to use
+- You have many time series of different lengths and want uniform sampling across every possible window, not weighted by series length.
+- You want cheap `__getitem__` — O(1) lookup into a pre-built list and a single DataFrame slice, rather than recomputing valid starts each call.
+- You want an epoch that doesn't iterate every window once (too many), but instead draws `n_samples` at random — with reproducible per-epoch seeds.
+
+## Pattern
+At init time, walk every series, compute `num_samples = len(series) - window + 1`, and for each valid offset append `(symbol, start_idx)` to a flat `self.indices` list. Also pre-compute derived per-step columns (calendar features) once and store in the DataFrame so they aren't recomputed per sample. Hold a dedicated `random.Random(seed)` to avoid polluting global state, and expose `set_epoch_seed(epoch)` for reproducible DDP shuffling.
+
+```python
+# finetune/dataset.py QlibDataset
+self.indices = []
+for symbol in self.symbols:
+    df = self.data[symbol].reset_index()
+    num_samples = len(df) - self.window + 1
+    if num_samples > 0:
+        df['minute']  = df['datetime'].dt.minute
+        df['hour']    = df['datetime'].dt.hour
+        df['weekday'] = df['datetime'].dt.weekday
+        df['day']     = df['datetime'].dt.day
+        df['month']   = df['datetime'].dt.month
+        self.data[symbol] = df[self.feature_list + self.time_feature_list]
+        for i in range(num_samples):
+            self.indices.append((symbol, i))
+
+self.n_samples = min(self.n_samples, len(self.indices))
+
+def set_epoch_seed(self, epoch: int):
+    self.py_rng.seed(self.config.seed + epoch)
+
+def __getitem__(self, idx):
+    random_idx         = self.py_rng.randint(0, len(self.indices) - 1)
+    symbol, start_idx  = self.indices[random_idx]
+    win_df             = self.data[symbol].iloc[start_idx:start_idx + self.window]
+    ...
+```
+
+## Why it works / tradeoffs
+Pre-building the index takes ~constant memory per valid window (`O(total_windows)` tuples) and makes sampling uniform over windows instead of series — this matters when some series are 10x longer than others. Caching calendar features on the DataFrame avoids repeated `.dt.hour` calls which are surprisingly slow in a hot dataloader loop. Tradeoff: the index can be huge if total_windows is in the tens of millions; in that case store per-symbol `num_samples` and index lazily. The pattern assumes stationary data — if you regenerate data, you must rebuild the index.
+
+## References
+- `finetune/dataset.py` in Kronos — `QlibDataset`
+- `finetune/qlib_test.py` — `QlibTestDataset` applies the same pattern for sequential eval

--- a/skills/gpu-kernels/programmatic-dependent-launch-attribute-toggle/SKILL.md
+++ b/skills/gpu-kernels/programmatic-dependent-launch-attribute-toggle/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: programmatic-dependent-launch-attribute-toggle
+description: Enable CUDA Programmatic Dependent Launch (PDL) per-call via `cudaLaunchAttributeProgrammaticStreamSerialization`, allowing a downstream kernel to start before the upstream completes — exposed as a runtime-tunable flag, not a compile flag.
+category: gpu-kernels
+version: 1.0.0
+version_origin: extracted
+tags: [pdl, programmatic-dependent-launch, cuda-12, launch-attributes, kernel-overlap]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - csrc/jit/handle.hpp
+  - csrc/jit/device_runtime.hpp
+  - csrc/jit/kernel_runtime.hpp
+imported_at: 2026-04-18T13:30:00Z
+---
+
+# Toggle Programmatic Dependent Launch Per Kernel Call
+
+## When to use
+CUDA 12 added Programmatic Dependent Launch (PDL): if the downstream kernel declares it's willing to start early, the driver can launch it *before* the upstream fully drains — the downstream blocks on `cudaGridDependencySynchronize()` only when it needs the upstream's data. This lets you overlap the tail of kernel A with the preamble of kernel B.
+
+You want to:
+- Enable PDL for specific launches without recompiling.
+- Default it on (the kernel code already includes the dep-sync barrier), but let the user flip it off for A/B comparison or to isolate kernel timings under Nsight.
+
+## Steps
+1. **Declare the runtime flag** in your device-runtime singleton, default `false`:
+   ```cpp
+   class DeviceRuntime {
+       bool enable_pdl = false;
+   public:
+       void set_pdl(const bool& new_enable_pdl) { enable_pdl = new_enable_pdl; }
+       bool get_pdl() const { return enable_pdl; }
+   };
+   ```
+2. **Expose via pybind11:**
+   ```cpp
+   m.def("set_pdl", [&](const bool& v) { device_runtime->set_pdl(v); });
+   m.def("get_pdl", [&]() { return device_runtime->get_pdl(); });
+   ```
+3. **Pass through the launch-args struct** so every call-site has a single "pdl?" bool:
+   ```cpp
+   struct LaunchArgs {
+       std::pair<int,int> grid_dim; int num_threads; int smem_size;
+       int cluster_dim; bool enable_pdl;
+   };
+   ```
+4. **Override the struct-level default with the runtime global** at launch time — this way individual kernels can set a sensible default, but the user's runtime flip wins:
+   ```cpp
+   LaunchArgs launch_args = args.launch_args;
+   launch_args.enable_pdl = device_runtime->get_pdl();  // global override
+   ```
+5. **Add the PDL attribute to the launch config** alongside cluster dims. Both APIs (driver + runtime) use the same attribute struct:
+   ```cpp
+   if (enable_pdl) {
+       auto& attr = attrs[config.numAttrs++];
+       attr.id = CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION;
+       attr.val.programmaticStreamSerializationAllowed = 1;
+   }
+   ```
+   `numAttrs` is the explicit count — don't over-allocate.
+6. **The kernel still needs `cudaGridDependencySynchronize`** (or the equivalent `griddepcontrol` PTX) before it reads any upstream data. PDL without the sync is a bug: you may read garbage.
+
+## Evidence (from DeepGEMM)
+- `csrc/jit/device_runtime.hpp:15,127-133`: `enable_pdl` field, default `false`; `set_pdl`/`get_pdl` accessors.
+- `csrc/jit/kernel_runtime.hpp:19,21-22,145-147`: `LaunchArgs::enable_pdl`, then the `launch_args.enable_pdl = device_runtime->get_pdl();` override on launch.
+- `csrc/jit/handle.hpp:100-106,205-210`: the attribute setup — identical shape across runtime-API and driver-API builds.
+
+## Counter / Caveats
+- **PDL requires compute capability 9.0+.** Enabling on Volta/Ampere is silently a no-op (or errors depending on runtime); check `get_arch_major() >= 9`.
+- **Order of attributes matters on some driver versions.** Keep PDL and cluster setup in fixed positions within the `attrs[]` array to avoid driver bugs.
+- **The global flag masks per-call intent.** Some kernels might legitimately want PDL off (sharing a stream with latency-sensitive ops). Consider a per-call override that passes through: `enable_pdl_explicit ? enable_pdl_explicit : device_runtime->get_pdl()`.
+- **Nsight Compute profiling flips all PDL-enabled kernels to serial** by default; don't trust PDL savings in profiled runs — measure with `bench_kineto` + no Nsight.

--- a/skills/inference/platform-agnostic-file-input-abstraction/SKILL.md
+++ b/skills/inference/platform-agnostic-file-input-abstraction/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: platform-agnostic-file-input-abstraction
+description: Trait-based input abstraction (SyncInput / AsyncInput) so a single inference codebase accepts file paths, byte slices, BytesIO, and tokio::File without conditional compilation.
+category: inference
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [magika, inference]
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Platform Agnostic File Input Abstraction
+
+**Trigger:** An inference engine must serve multiple input sources (file, bytes, stream) without duplicating logic per source type.
+
+## Steps
+
+- Define a trait with two methods: length() -> u64 and read_at(buf, offset) -> Result.
+- Implement for File (seek+read), &[u8] (slice copy), and BytesIO/BinaryIO (seek+read).
+- For async, wrap sync impls via ready() futures; provide native impls for tokio::File when needed.
+- Inference functions accept generic <T: Input>; no runtime branching on input type.
+- Expose ergonomic public API: identify_file(path), identify_bytes(bytes), identify_stream(stream).
+- In Python, fall back to duck typing (hasattr 'seek' / 'read') with explicit error messages for unsupported objects.
+
+## Counter / Caveats
+
+- Seekable requirement excludes pipes / stdin; buffer first if you need to support them.
+- Reading whole-file into &[u8] or BytesIO loses the streaming benefit; design APIs to discourage it.
+- Async trait objects (Box<dyn AsyncInput>) lose monomorphization; trade ergonomics vs perf.
+- metadata().len() can be wrong on sparse / special files (/dev/random returns u64::MAX).
+
+## Source
+
+Extracted from `magika` (https://github.com/google/magika.git @ main).
+
+Files of interest:
+- `rust/lib/src/input.rs:15-102`
+- `python/src/magika/magika.py:139-210`
+- `go/magika/scanner.go:48-54`

--- a/skills/inference/platform-agnostic-file-input-abstraction/content.md
+++ b/skills/inference/platform-agnostic-file-input-abstraction/content.md
@@ -1,0 +1,22 @@
+# platform-agnostic-file-input-abstraction — extended notes
+
+This is an extracted draft from the **magika** project at commit `0a8cb9626b`.
+See `SKILL.md` for the procedure. Use the source references below to study the
+original implementation before adapting the pattern to a new codebase.
+
+## Source references
+
+- `rust/lib/src/input.rs:15-102`
+- `python/src/magika/magika.py:139-210`
+- `go/magika/scanner.go:48-54`
+
+## When this pattern is a fit
+
+An inference engine must serve multiple input sources (file, bytes, stream) without duplicating logic per source type.
+
+## When to walk away
+
+- Seekable requirement excludes pipes / stdin; buffer first if you need to support them.
+- Reading whole-file into &[u8] or BytesIO loses the streaming benefit; design APIs to discourage it.
+- Async trait objects (Box<dyn AsyncInput>) lose monomorphization; trade ergonomics vs perf.
+- metadata().len() can be wrong on sparse / special files (/dev/random returns u64::MAX).

--- a/skills/inference/predict-mode-dispatch-with-fallback-heuristics/SKILL.md
+++ b/skills/inference/predict-mode-dispatch-with-fallback-heuristics/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: predict-mode-dispatch-with-fallback-heuristics
+description: Cascade inference through model output → ruled heuristics (UTF-8 validity for tiny files) → generic fallback (txt / unknown), each emitting a distinct overwrite_reason.
+category: inference
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [magika, inference]
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Predict Mode Dispatch With Fallback Heuristics
+
+**Trigger:** Robust file-type or content classification that must handle edge cases (empty files, <8-byte files, corrupted files, symlinks).
+
+## Steps
+
+- If size == 0 → return Empty without invoking the model.
+- If 0 < size < min_file_size_for_dl → skip model; check UTF-8 validity → Text else Unknown.
+- If size >= threshold → extract features (beg/mid/end) and run model.
+- Compare model score against per-label threshold; if below, apply overwrite_map to redirect to fallback type.
+- Treat symlinks/directories as their own special types without invoking the model.
+- Return a structured result {path, status, prediction:{dl, output, score, overwrite_reason}} so callers can audit.
+
+## Counter / Caveats
+
+- min_file_size_for_dl is model-specific; too low = wasted inference, too high = silent miss.
+- UTF-8 validity check is naive — Latin-1, UTF-16, etc. look invalid; consider extending if you support non-UTF-8 text.
+- Symlink semantics differ on Windows vs *nix; check is_symlink() before reading.
+- Score thresholds are per-model-version; bumping the model requires recalibrating thresholds.
+
+## Source
+
+Extracted from `magika` (https://github.com/google/magika.git @ main).
+
+Files of interest:
+- `go/magika/scanner.go:59-93`
+- `python/src/magika/magika.py:170-210`
+- `rust/lib/src/file.rs:1-70`

--- a/skills/inference/predict-mode-dispatch-with-fallback-heuristics/content.md
+++ b/skills/inference/predict-mode-dispatch-with-fallback-heuristics/content.md
@@ -1,0 +1,22 @@
+# predict-mode-dispatch-with-fallback-heuristics — extended notes
+
+This is an extracted draft from the **magika** project at commit `0a8cb9626b`.
+See `SKILL.md` for the procedure. Use the source references below to study the
+original implementation before adapting the pattern to a new codebase.
+
+## Source references
+
+- `go/magika/scanner.go:59-93`
+- `python/src/magika/magika.py:170-210`
+- `rust/lib/src/file.rs:1-70`
+
+## When this pattern is a fit
+
+Robust file-type or content classification that must handle edge cases (empty files, <8-byte files, corrupted files, symlinks).
+
+## When to walk away
+
+- min_file_size_for_dl is model-specific; too low = wasted inference, too high = silent miss.
+- UTF-8 validity check is naive — Latin-1, UTF-16, etc. look invalid; consider extending if you support non-UTF-8 text.
+- Symlink semantics differ on Windows vs *nix; check is_symlink() before reading.
+- Score thresholds are per-model-version; bumping the model requires recalibrating thresholds.

--- a/skills/integration/platform-adapter-interface/SKILL.md
+++ b/skills/integration/platform-adapter-interface/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: platform-adapter-interface
+description: Unify Slack/Telegram/Discord/GitHub/Web behind one `IPlatformAdapter` interface with sendMessage/ensureThread/getStreamingMode/getPlatformType/start/stop, plus an optional structured-event hook for web-only rich UI.
+category: integration
+version: 1.0.0
+version_origin: extracted
+tags: [adapter, plugin, multi-platform, interface, chat-bot]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/coleam00/Archon.git
+source_ref: dev
+source_commit: d89bc767d291f52687beea91c9fcf155459be0d9
+source_project: Archon
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Unified Platform Adapter Interface Across Chat + Forge + Web
+
+## When to use
+
+- You deliver AI-assistant responses through multiple surfaces: Slack threads, Telegram chats, Discord channels, GitHub issue/PR comments, a web UI with SSE streaming.
+- You want one `IPlatformAdapter` interface so the core orchestrator doesn't know (or care) which platform it's talking to.
+- You want to share common logic (message splitting, auth, retry) at the edge and keep the business core free of platform branching.
+
+## Steps
+
+1. **Name the shared concepts in the interface**, not platform details:
+
+   ```ts
+   interface IPlatformAdapter {
+     sendMessage(conversationId: string, message: string, metadata?: MessageMetadata): Promise<void>;
+     ensureThread(originalConversationId: string, messageContext?: unknown): Promise<string>;
+     getStreamingMode(): 'stream' | 'batch';
+     getPlatformType(): string; // 'telegram' | 'github' | 'slack' | 'discord' | 'web'
+     start(): Promise<void>;
+     stop(): void;
+     sendStructuredEvent?(conversationId: string, event: MessageChunk): Promise<void>;  // optional
+     emitRetract?(conversationId: string): Promise<void>;                               // optional
+   }
+   ```
+
+   The core uses `getStreamingMode()` to decide between per-chunk and per-turn delivery (Slack/GitHub want "batch"; Telegram and Web want "stream"). `ensureThread` abstracts the platform-specific "respond in a thread" semantics — on GitHub and Slack it's a no-op that returns the same conversation ID; on Telegram it's a thread-creation call if needed.
+
+2. **Encode platform-specific conversation IDs as strings** and document the format per platform:
+   - Slack: `thread_ts` (string)
+   - Telegram: `chat_id` (stringified number)
+   - GitHub: `owner/repo#number`
+   - Web: arbitrary UUID
+   - Discord: channel ID
+
+3. **Use a discriminated-union `MessageChunk` type** for the structured event hook:
+
+   ```ts
+   type MessageChunk =
+     | { type: 'assistant'; content: string }
+     | { type: 'system'; content: string }
+     | { type: 'thinking'; content: string }
+     | { type: 'result'; sessionId?: string; tokens?: TokenUsage; … }
+     | { type: 'rate_limit'; rateLimitInfo: … }
+     | …;
+   ```
+
+   Adapters that don't support rich display simply don't implement `sendStructuredEvent` (it's optional). Adapters that do (`web`) implement both `sendMessage` (for prose) and `sendStructuredEvent` (for rich cards).
+
+4. **Extend, don't widen, for platform-specific surfaces.** Web needs setup-event-bridge, set-conversation-db-id, emit-lock-event — none of those make sense on Slack. Put them in a subinterface:
+
+   ```ts
+   interface IWebPlatformAdapter extends IPlatformAdapter {
+     sendStructuredEvent(conversationId: string, event: MessageChunk): Promise<void>;
+     setConversationDbId(platformConversationId: string, dbId: string): void;
+     setupEventBridge(...): () => void;
+     emitLockEvent(...): Promise<void>;
+     registerOutputCallback(...): void;
+     removeOutputCallback(...): void;
+   }
+   ```
+
+   Provide a narrow type guard:
+
+   ```ts
+   export function isWebAdapter(a: IPlatformAdapter): a is IWebPlatformAdapter {
+     return a.getPlatformType() === 'web';
+   }
+   ```
+
+5. **Encapsulate auth inside each adapter**, not at the router. Each adapter parses its allowed-users env var in the constructor (`TELEGRAM_ALLOWED_USER_IDS`, GitHub username whitelist) and **silently rejects** unauthorized senders (no error response, just a masked-username log). This keeps the core free of per-platform auth branches.
+
+6. **Each adapter exposes an `onMessage(handler)` callback**. The outer code registers a single handler that receives `{ conversationId, message, attachedFiles, … }` and returns a Promise. Errors propagate — adapters don't swallow them.
+
+7. **Share message-splitting utilities** via a side module (`packages/adapters/src/utils/message-splitting.ts`). Every chat platform has a max-length limit (Slack 40k, Telegram 4096, Discord 2000) so the util lives in one place.
+
+## Counter / Caveats
+
+- Resist making the interface "smart." It is a **transport** abstraction. Business logic (streaming cadence decision, retry, deduplication) belongs in the core, not in adapters.
+- `ensureThread` is messy: on platforms where threading is automatic (GitHub) it's a no-op; on Slack it's implicit from `thread_ts` on the triggering message; on Telegram it may need an explicit chat creation. Document each platform's semantics.
+- `getStreamingMode()` is a string union literal, not an enum — keeps the interface zero-cost. If you add a third mode ("chunked-with-retract"), add it here before implementing.
+- `stop()` is synchronous in the interface; some adapters need to await shutdown. Archon accepts "stop initiates teardown, full cleanup is best-effort"; if your adapters need guaranteed-awaited shutdown, make it `Promise<void>`.
+
+## Evidence
+
+- `packages/core/src/types/index.ts:118-163`: full `IPlatformAdapter` declaration.
+- `packages/core/src/types/index.ts:165-184`: `IWebPlatformAdapter` + `isWebAdapter` type guard.
+- Implementations at `packages/adapters/src/chat/slack/adapter.ts`, `…/chat/telegram/adapter.ts`, `…/forge/github/adapter.ts`, `…/community/chat/discord/adapter.ts`, `packages/server/src/adapters/web.ts`.
+- Shared message-splitting util at `packages/adapters/src/utils/message-splitting.ts`.
+- Root `CLAUDE.md` lines 422-438 document the pattern and per-platform conversation-ID semantics.
+- Commit SHA: d89bc767d291f52687beea91c9fcf155459be0d9.

--- a/skills/jit-compilation/pid-aware-temp-dir-uuid-generator/SKILL.md
+++ b/skills/jit-compilation/pid-aware-temp-dir-uuid-generator/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: pid-aware-temp-dir-uuid-generator
+description: Generate unique temporary directory names with `pid + steady_clock + mt19937(xor-seeded)` — survives fork, co-exists across multiple processes on the same filesystem, no crypto deps.
+category: jit-compilation
+version: 1.0.0
+version_origin: extracted
+tags: [uuid, temp-files, pid, random, fork-safe, filesystem]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - csrc/utils/system.hpp
+  - csrc/jit/compiler.hpp
+imported_at: 2026-04-18T13:30:00Z
+---
+
+# PID-Aware Temp Directory UUID Generator
+
+## When to use
+Your JIT compiler creates a temp directory per compile (into which it writes `kernel.cu`, then `.cubin`, then renames to the final cache path). On a shared filesystem with dozens of training ranks, you need names that:
+- Never collide between processes (same machine, same user, same millisecond).
+- Are readable enough to debug (the PID tells you which process).
+- Survive `fork()` — the post-fork child must not generate the same sequence as the parent.
+
+## Steps
+1. **Seed an `mt19937` once with `random_device XOR steady_clock`.** Keep it `static`:
+   ```cpp
+   static std::random_device rd;
+   static std::mt19937 gen([]() {
+       return rd() ^ std::chrono::steady_clock::now().time_since_epoch().count();
+   }());
+   static std::uniform_int_distribution<uint32_t> dist;
+   ```
+   - `random_device` provides OS-level entropy.
+   - The XOR with `steady_clock` protects against platforms where `random_device` is deterministic (e.g. older MinGW).
+   - Lambda initializer runs once per process.
+2. **Format as `PID-XXXXXXXX-XXXXXXXX-XXXXXXXX`:**
+   ```cpp
+   std::stringstream ss;
+   ss << getpid() << "-" << std::hex << std::setfill('0')
+      << std::setw(8) << dist(gen) << "-"
+      << std::setw(8) << dist(gen) << "-"
+      << std::setw(8) << dist(gen);
+   return ss.str();
+   ```
+   - Leading PID segments all temp files from the same process — easy to `grep` or batch-remove.
+   - 3 × 32 = 96 random bits is plenty to avoid within-process collision even at 10⁶ temps.
+3. **Use for the temp directory name, not the final cache directory.** Temp names can be ugly; cache names should be content-addressable (hex digest of the source).
+4. **Pair with directory-rename atomic commit.** Once the tmp dir is fully populated and fsynced, atomically rename to the content-keyed final name. Temp names never survive.
+
+## Evidence (from DeepGEMM)
+- `csrc/utils/system.hpp:84-98`: `get_uuid()` — exactly this pattern with a single `static` seed.
+- `csrc/jit/compiler.hpp:111`: use site — `make_tmp_dir() / get_uuid()`, so the final path is `~/.deep_gemm/tmp/{pid}-{rand}-{rand}-{rand}/`.
+
+## Counter / Caveats
+- **Fork inherits the `mt19937` state.** Parent and child generate the same next number on their first call. Mitigation: call `gen.seed(pid_xor_now)` in a `pthread_atfork` child handler, or always include `getpid()` in the filename so collision is impossible even if the random bits coincide.
+- **`random_device` on some platforms blocks** (Linux `/dev/random`). If init is on the hot path, consider pre-seeding at module load.
+- **Not cryptographic.** Attacker-controlled UUIDs can be predicted. Don't use in security-sensitive paths.

--- a/skills/llm-agents/plan-based-multi-step-task-decomposition/SKILL.md
+++ b/skills/llm-agents/plan-based-multi-step-task-decomposition/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: plan-based-multi-step-task-decomposition
+description: Plan mode for multi-step agent tasks — exploration via subagent, gated planning with user confirmation, strict execution loop, and adversarial verification.
+category: llm-agents
+version: 1.0.0
+tags: [llm-agents, planning, subagents, verification, orchestration]
+source_type: extracted-from-git
+source_url: https://github.com/lsdefine/GenericAgent.git
+source_ref: main
+source_commit: ec34b7e1c0f11fbb9709680ccfe313187a1b942b
+source_project: GenericAgent
+source_path: memory/plan_sop.md, memory/subagent.md
+imported_at: 2026-04-18T00:00:00Z
+confidence: high
+version_origin: extracted
+---
+
+# Plan-based multi-step task decomposition
+
+A five-phase orchestration pattern for agents handling non-trivial tasks: exploration (delegated), planning (gated by a user-confirm step), execution (strict tick-off loop), verification (adversarial subagent), and fix loop (bounded). Designed to keep the main agent's context window clean and force evidence-based completion.
+
+## When to use
+
+Trigger when the task is 3+ dependent steps, crosses multiple files, has conditional branches, or can benefit from parallelism. **Skip** for 1–2 step trivial work — the overhead dominates.
+
+## Artifact layout
+
+```
+plan_<TASK>/
+├── plan.md                        ← the living plan (source of truth)
+├── exploration_findings.md        ← produced by exploration subagent
+├── verify_context.json            ← input to verification subagent
+├── result.md                      ← verification subagent's verdict + evidence
+└── ... (any task-specific scratch files)
+```
+
+## Phase 1 — Exploration (mandatory, delegated)
+
+**Hard rule: the main agent MUST NOT do environment probing itself.** The main agent creates the directory, indexes available SOPs, and launches an exploration subagent. The main agent's context window is the scarcest resource; long probe outputs would crowd out planning and execution.
+
+The exploration subagent is invoked read-only with a `--verbose` surveillance flag so the main agent can inspect raw tool output (not just summaries). It writes to `exploration_findings.md` with sections: `## Current environment` / `## Key findings` / `## Risks & unknowns`. It is bounded to ≤10 tool calls.
+
+While it runs, the main agent actively **watches output**, does NOT blindly sleep-poll. Intervention files let the main agent steer without restarting:
+
+| File | Effect |
+|---|---|
+| `_intervene` | Append extra instructions to correct direction |
+| `_keyinfo` | Inject working-memory context the subagent lacks |
+| `_stop` | Terminate at next round boundary (save turns) |
+
+## Phase 2 — Planning (gated by user confirmation)
+
+Main agent reads the domain SOPs matched in Phase 1 and writes `plan.md`. The plan header includes:
+
+- `# Task title` (one-line purpose)
+- `## Exploration findings` (copied/summarized from the subagent)
+- `## Execution plan` with numbered steps, each carrying a status marker:
+
+| Marker | Meaning |
+|---|---|
+| `[ ]` | Pending |
+| `[✓]` | Done (append a short outcome) |
+| `[✗]` | Failed, skipped |
+| `[D]` | Must be delegated to a subagent (>3 files / >100 lines read / web scrape / 3+ repeats / build-analysis) |
+| `[P]` | Parallel (multiple subagents, map-mode) |
+| `[?]` | Conditional branch — must list branches + conditions |
+| `[VERIFY]` | Verification checkpoint (cannot be skipped) |
+
+`[VERIFY]` is a **required** step at the bottom of every plan: `run verification subagent → read VERDICT → act accordingly`.
+
+The plan.md MUST embed its own execution protocol as a comment at the top — the main agent re-reads this every turn so it cannot drift into memory-based execution:
+
+```markdown
+<!-- EXECUTION PROTOCOL (re-read EVERY turn)
+1. read plan.md, find first [ ]
+2. if it has an SOP tag → read the SOP's quick-lookup section
+3. execute the step + a mini validation of the output
+4. patch [ ] → [✓ short result], go back to step 1
+5. after last step → terminal check: re-read plan.md, confirm 0 remaining [ ]
+FORBIDDEN: executing from memory | skipping verification | declaring done without terminal check | pausing to output prose summaries
+-->
+```
+
+Before leaving the planning phase the main agent walks a self-check list (every exploration finding reflected? every step has a reasonable SOP? dependencies explicit? `[D]` markers applied where the step is heavy? `[VERIFY]` present?). Then it asks the user to confirm — **no execution without confirmation.**
+
+## Phase 3 — Execution (strict tick loop)
+
+Each turn: read `plan.md`, find first `[ ]`, read its SOP, execute (respecting `[D]`/`[P]` delegation), mini-validate, patch to `[✓ …]`, loop immediately. No prose progress reports between ticks. No tick-from-memory.
+
+**Dynamic delegation:** even for steps not marked `[D]`, if execution discovers the step requires reading lots of files, long debug loops, or web scraping, spin up a subagent on the fly and ask it for a brief summary. Keeping the main agent's context clean is first-priority.
+
+## Phase 4 — Verification (adversarial subagent, mandatory)
+
+After the last substantive step is `[✓]`, the main agent populates `verify_context.json`:
+
+```json
+{
+  "task_description": "user's original request, verbatim",
+  "plan_file": "/abs/path/plan_XXX/plan.md",
+  "task_type": "code|data|browser|file|system",
+  "deliverables": [{"type": "...", "path": "...", "expected": "..."}],
+  "required_checks": [{"check": "...", "tool": "..."}]
+}
+```
+
+It then launches a **separate** verification subagent with an adversarial brief: "Your job is to *disprove* that the deliverables work." The subagent must actually run tools — narration without tool output is treated as SKIP, not PASS. The last line of `result.md` MUST be `VERDICT: PASS` / `FAIL` / `PARTIAL`.
+
+Critically: the verification context does NOT include the execution history or debug notes. The verifier gets only the original task statement, the plan, the deliverables list, and the required-check list. This prevents context contamination and confirmation bias from the implementation phase.
+
+## Phase 5 — Fix loop (bounded)
+
+| Verdict | Action |
+|---|---|
+| `PASS` | Mark `[VERIFY]` as `[✓]`, update the long-term checkpoint, announce completion |
+| `FAIL` | Append failed items to plan as `[FIX]` steps; re-execute only those; re-run verification — max 2 rounds before escalating to user |
+| `PARTIAL` | Main agent judges if the partials are acceptable; otherwise treat as FAIL |
+| (missing) | Extract verdict signal from raw output; if ambiguous, main agent decides |
+
+## Why this works
+
+- **Exploration delegation** protects the main agent's context window; the main agent spends its tokens on decisions, not data.
+- **User-confirmation gate** forces a plan review before any work — the plan is cheap to throw away, the execution is not.
+- **Plan-as-source-of-truth** + re-read-every-turn prevents LLM drift and "I think I already did that."
+- **Adversarial verification** in a fresh subagent eliminates the confirmation bias the executing agent has.
+- **Bounded fix loop** prevents infinite retry cycles.
+
+## Anti-patterns
+
+- Main agent skips exploration and "just looks at the code briefly." This is where the context starts to fill with noise.
+- Verification done by the same agent that executed the work. Confirmation bias wins.
+- Plan without a `[VERIFY]` step. The agent will self-certify completion.
+- Batch-ticking multiple `[ ]` → `[✓]` between turns. Breaks the tick loop's invariants.
+- User-confirmation skipped "because it's obvious." Obvious plans can still be wrong.
+
+---
+
+Adapted from GenericAgent's `plan_sop.md` and `subagent.md`. Original files are Chinese-language; concepts translated and generalized for reuse.

--- a/skills/llm-agents/ppo-rlhf-trl-gpt2-sentiment/SKILL.md
+++ b/skills/llm-agents/ppo-rlhf-trl-gpt2-sentiment/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: ppo-rlhf-trl-gpt2-sentiment
+description: Fine-tune GPT-2 with PPO RLHF using TRL to generate positive IMDB reviews, with DistilBERT as the sentiment reward model.
+category: llm-agents
+version: 1.0.0
+version_origin: extracted
+tags: [rlhf, ppo, trl, gpt-2, sentiment]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/Lordog/dive-into-llms.git
+source_ref: main
+source_commit: f84c04268794ef94f8949808bbc14ab8636763a0
+source_project: dive-into-llms
+source_path: documents/chapter11/README.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# PPO RLHF with TRL: GPT-2 Sentiment Fine-Tuning
+
+## When to use
+- Fine-tune an LLM using reinforcement learning from a scalar reward signal.
+- TRL PPOTrainer with a sentiment classifier as the reward.
+- Reference: single A800-80GB, ~35 min training, ~10GB VRAM.
+
+## Steps
+
+1. Download model and dataset:
+
+```bash
+export HF_ENDPOINT=https://hf-mirror.com
+huggingface-cli download --resume-download stanfordnlp/imdb --local-dir dataset/imdb --repo-type dataset
+huggingface-cli download --resume-download lvwerra/gpt2-imdb --local-dir model/gpt2-imdb
+huggingface-cli download --resume-download lvwerra/distilbert-imdb --local-dir model/distilbert-imdb
+```
+
+2. Configure PPO training:
+
+```python
+from trl import PPOConfig, PPOTrainer, AutoModelForCausalLMWithValueHead
+from transformers import AutoTokenizer, pipeline
+
+config = PPOConfig(model_name='model/gpt2-imdb', learning_rate=1.41e-5)
+model     = AutoModelForCausalLMWithValueHead.from_pretrained(config.model_name)
+ref_model = AutoModelForCausalLMWithValueHead.from_pretrained(config.model_name)
+tokenizer = AutoTokenizer.from_pretrained(config.model_name)
+tokenizer.pad_token = tokenizer.eos_token
+```
+
+3. Load sentiment reward model:
+
+```python
+sentiment_pipe = pipeline('sentiment-analysis', model='model/distilbert-imdb', device=0)
+```
+
+4. PPO training loop (Rollout, Evaluate, Optimize):
+
+```python
+for epoch, batch in enumerate(ppo_trainer.dataloader):
+    response_tensors = [ppo_trainer.generate(q, **gen_kwargs) for q in batch['input_ids']]
+    texts = [q + r for q, r in zip(batch['query'], batch['response'])]
+    rewards = [torch.tensor(o['score']) for out in sentiment_pipe(texts)
+               for o in out if o['label'] == 'POSITIVE']
+    stats = ppo_trainer.step(batch['input_ids'], response_tensors, rewards)
+```
+
+5. Save the fine-tuned model:
+
+```python
+model.save_pretrained('model/gpt2-imdb-pos-v2')
+tokenizer.save_pretrained('model/gpt2-imdb-pos-v2')
+```
+
+## Example
+
+Before PPO: mean reward ~0.59. After PPO: mean reward ~2.24.
+
+## Pitfalls
+- KL divergence between policy and reference model is added as auxiliary reward to prevent reward hacking.
+- ref_model is loaded separately (not shared) to correctly compute KL divergence.
+
+## Source
+- Chapter 11 of dive-into-llms - documents/chapter11/README.md

--- a/skills/monorepo/pnpm-catalog-version-pinning/SKILL.md
+++ b/skills/monorepo/pnpm-catalog-version-pinning/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: pnpm-catalog-version-pinning
+description: Use pnpm's catalog: references in pnpm-workspace.yaml to guarantee a single version of shared deps across all monorepo packages.
+category: monorepo
+version: 1.0.0
+tags: [pnpm, monorepo, versioning, workspace, react]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- Pnpm workspace with 3+ packages that share React, TypeScript, Vitest, or any UI library.
+- You've hit "two Reacts" bugs (duplicate hook-state errors, `Invalid hook call`, hook-order mismatch).
+- You want upgrading React to be a one-file change, not N package.json edits.
+
+## Steps
+
+1. In `pnpm-workspace.yaml`, declare shared versions under a `catalog:` block:
+   ```yaml
+   packages:
+     - "apps/*"
+     - "packages/*"
+   catalog:
+     react: "19.2.3"
+     react-dom: "19.2.3"
+     typescript: "^5.9.3"
+     "@tanstack/react-query": "^5.96.2"
+     zustand: "^5.0.0"
+     vitest: "^4.1.0"
+   ```
+2. In every package.json that consumes these deps, reference the catalog instead of pinning versions:
+   ```json
+   {
+     "dependencies": {
+       "react": "catalog:",
+       "react-dom": "catalog:",
+       "@tanstack/react-query": "catalog:"
+     }
+   }
+   ```
+3. For types that must match React majors (common source of "two Reacts"), add a pnpm override in the root `package.json`:
+   ```json
+   "pnpm": {
+     "overrides": {
+       "@types/react": "catalog:",
+       "@types/react-dom": "catalog:"
+     }
+   }
+   ```
+4. Run `pnpm install` to regenerate the lockfile. All packages now resolve to the single catalog version.
+5. To upgrade React across the monorepo, change one line in `pnpm-workspace.yaml` and reinstall.
+
+## Example
+
+Upgrade TanStack Query from 5.96 to 5.100:
+
+```diff
+ catalog:
+-  "@tanstack/react-query": "^5.96.2"
++  "@tanstack/react-query": "^5.100.0"
+```
+
+No package.json touches. No drift. `pnpm why @tanstack/react-query` shows one version across all packages.

--- a/skills/networking/port-forwarding-tunnel-multiplexer/SKILL.md
+++ b/skills/networking/port-forwarding-tunnel-multiplexer/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: port-forwarding-tunnel-multiplexer
+description: TCP tunnel multiplexing for port forwarding with Framed codec and login handshake.
+category: networking
+version: 1.0.0
+version_origin: extracted
+tags: [forwarding, multiplexer, networking, port, tunnel]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: src/port_forward.rs
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Port Forwarding Tunnel Multiplexer
+
+## When to use
+TCP tunnel multiplexing for port forwarding with Framed codec and login handshake.
+
+## Source context
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- Demonstrated in: `src/port_forward.rs`
+
+## Why this generalizes
+Reusable for SSH-style tunnel builders.
+
+## Next steps before publishing
+- Read the source files above and rewrite this as a product-agnostic `how-to` — keep the pattern, drop rustdesk-specific names.
+- Add a minimal code example in the target language (Rust + Dart / Rust only / etc.).
+- List 2-3 gotchas you hit while reproducing it.

--- a/skills/observability/personality-state-tracking-with-aggregation/SKILL.md
+++ b/skills/observability/personality-state-tracking-with-aggregation/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: personality-state-tracking-with-aggregation
+description: Aggregate agent evolution metrics into personality state (success rate, velocity, trait vectors)
+category: observability
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [evolver, observability, personality, metrics]
+source_type: extracted-from-git
+source_url: https://github.com/EvoMap/evolver.git
+source_ref: main
+source_commit: 22773782475cecf43dc9c1af264bf5f9cacc28bc
+source_project: evolver
+source_paths:
+  - src/gep/personality.js
+  - scripts/gep_personality_report.js
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Personality state from rolling evolution metrics
+
+Maintain a personality object aggregated from recent evolution events:
+- success/failure counts, average score
+- velocity (events per day)
+- trait scores (risk aversion, innovation bias, repair tendency), normalized to [0,1]
+
+Computed on demand from the event log — no separate write path. Gives agents introspection into their own behavior and helps humans spot drift.
+
+## Mechanism
+
+1. Tail the last N events (e.g., 5000) from the event JSONL.
+2. Bucket by outcome; sum scores; compute rate and velocity.
+3. Derive traits via weighted combinations of event tags (e.g., `rollback` events → risk aversion).
+4. Clamp to [0,1], round to 2 decimals, surface through a status endpoint and human-readable report.
+
+## When to reuse
+
+Agent dashboards, long-running worker health pages, any system where emergent behavior benefits from a summary vector rather than raw event traversal.

--- a/skills/platform/privacy-mode-trait-abstraction/SKILL.md
+++ b/skills/platform/privacy-mode-trait-abstraction/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: privacy-mode-trait-abstraction
+description: Pluggable privacy-mode implementations: Windows MAG, exclude-from-capture, virtual-display drivers.
+category: platform
+version: 1.0.0
+version_origin: extracted
+tags: [abstraction, mode, platform, privacy, trait]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: src/privacy_mode.rs
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Privacy Mode Trait Abstraction
+
+## When to use
+Pluggable privacy-mode implementations: Windows MAG, exclude-from-capture, virtual-display drivers.
+
+## Source context
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- Demonstrated in: `src/privacy_mode.rs`
+
+## Why this generalizes
+Reusable pattern where multiple mutually-exclusive OS strategies back one feature.
+
+## Next steps before publishing
+- Read the source files above and rewrite this as a product-agnostic `how-to` — keep the pattern, drop rustdesk-specific names.
+- Add a minimal code example in the target language (Rust + Dart / Rust only / etc.).
+- List 2-3 gotchas you hit while reproducing it.

--- a/skills/powersync/powersync-add-synced-table-two-pr-flow/SKILL.md
+++ b/skills/powersync/powersync-add-synced-table-two-pr-flow/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: powersync-add-synced-table-two-pr-flow
+description: Add a new PowerSync-synced table across frontend SQLite, backend Postgres, shared table registry, and sync-rules YAML using a strict two-PR process so the frontend never ships before the PowerSync Cloud dashboard rules exist.
+category: powersync
+confidence: high
+version: 1.0.0
+version_origin: extracted
+source_type: extracted-from-git
+source_url: https://github.com/thunderbird/thunderbolt.git
+source_ref: main
+source_commit: 9d9c18ba511decfd3b45fc0f72c265d83355fe95
+source_project: thunderbolt
+imported_at: 2026-04-18T00:00:00Z
+tags: [powersync, postgresql, drizzle, deployment, sync-rules]
+linked_knowledge: [powersync-backend-minimal-indexes, powersync-deploy-order-two-pr-invariant]
+---
+
+## When to use
+
+You are adding a brand-new PowerSync-synced table to an app where the backend schema, shared table registry, sync-rules YAML, and frontend schema all have to stay in lock-step with PowerSync Cloud's dashboard rules.
+
+## Steps
+
+**PR 1 — backend only**
+
+1. Add the table to the backend Drizzle schema file (e.g. `backend/src/db/powersync-schema.ts`). Include a `user_id` column and exactly one index: `index('idx_<table>_user_id').on(table.userId)`.
+2. Generate and register the Drizzle migration with `bun db generate`. Verify the new entry appears in `backend/drizzle/meta/_journal.json` — Drizzle discovers pending migrations through the journal, not the file system, so a missing entry means the migration will never run.
+3. Update `shared/powersync-tables.ts`: add the table name to `POWERSYNC_TABLE_NAMES` and wire its React Query keys in `powersyncTableToQueryKeys`.
+4. Add a sync rule line under `bucket_definitions.user_data.data` in `powersync-service/config/config.yaml`: `- SELECT * FROM <table> WHERE <table>.user_id = bucket.user_id`.
+5. For default-data tables, use a composite PK `(id, user_id)` or `(key, user_id)` and update `powersyncConflictTarget` in the backend schema.
+6. Merge PR 1. Run the migration in production. **Then** update sync rules in the PowerSync Cloud dashboard so they match `config.yaml`.
+
+**PR 2 — frontend + feature code**
+
+7. Add the table to `src/db/tables.ts` (frontend SQLite schema). Single-column `id` or `key` is fine — the frontend is per-user, so composite PKs are not needed locally.
+8. Register the table in `src/db/powersync/schema.ts` (`drizzleSchema`).
+9. Add any UI, DAL, and feature logic.
+10. Merge PR 2 only after PR 1 is fully deployed *and* PowerSync Cloud dashboard rules are live.
+
+## Counter / Caveats
+
+- Shipping PR 2 before the dashboard rules are updated causes silent sync failure: the table works locally but nothing replicates across devices, and there is no error surface.
+- Do not add composite foreign keys or secondary indexes to the backend schema — see the linked `powersync-backend-minimal-indexes` knowledge for rationale.
+- Cherry-picking migration SQL across branches without the matching `_journal.json` entry is a common failure mode; re-run `bun db generate` after cherry-picks.
+
+## Evidence
+
+- `CLAUDE.md:82-93` — deploying new synced tables (two-PR process) and journal warning
+- `docs/powersync-account-devices.md:51-72` — full adding-a-new-table steps
+- `powersync-service/config/config.yaml` — sync rule format

--- a/skills/powersync/powersync-add-synced-table-two-pr-flow/content.md
+++ b/skills/powersync/powersync-add-synced-table-two-pr-flow/content.md
@@ -1,0 +1,35 @@
+# Adding a PowerSync-synced table (two-PR flow)
+
+PowerSync sync rules live in three places that all must agree: backend Postgres schema, the `config.yaml` under `powersync-service/config/`, and the PowerSync Cloud dashboard. If any of them drifts, sync silently stops working for that table.
+
+The process that Thunderbolt settled on is a hard two-PR split:
+
+## PR 1 — backend + sync rules, no frontend
+
+- Backend Drizzle schema gets the table, with only a `user_id` index.
+- `bun db generate` creates the migration. Verify `backend/drizzle/meta/_journal.json` has the new entry — Drizzle reads the journal, not the filesystem, so a missing entry silently skips the migration.
+- `shared/powersync-tables.ts` adds the name + query keys so both frontend and backend agree on the set of tables that are synced.
+- `powersync-service/config/config.yaml` gets the sync rule: `- SELECT * FROM my_table WHERE my_table.user_id = bucket.user_id`.
+- Merge, deploy, run the migration, **then** update the dashboard rules.
+
+## PR 2 — frontend + feature
+
+- Frontend SQLite schema in `src/db/tables.ts`.
+- `src/db/powersync/schema.ts` `drizzleSchema` registration.
+- DAL + UI + any feature code.
+- Merge only after PR 1 is deployed *and* dashboard rules are live.
+
+## Why the split
+
+If the frontend ships first, clients try to sync a table that PowerSync Cloud doesn't yet know about. Sync fails silently — no 4xx, no error event — and rows appear only locally. You don't notice until a user opens the app on a second device.
+
+## Common mistakes
+
+- Forgetting the `_journal.json` entry after cherry-picking a migration file. Re-run `bun db generate` on the destination branch.
+- Adding composite foreign-key constraints to the backend schema (don't — see linked knowledge).
+- Skipping the dashboard update between PR 1 and PR 2.
+
+## Evidence
+
+- `CLAUDE.md:82-93`
+- `docs/powersync-account-devices.md:51-72`

--- a/skills/powersync/powersync-composite-primary-key-seed/SKILL.md
+++ b/skills/powersync/powersync-composite-primary-key-seed/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: powersync-composite-primary-key-seed
+description: Design default-data tables (settings, models, modes, tasks) so each user can hold the same default IDs by using composite primary keys (id, user_id) or (key, user_id) on the backend and reconciling with a default-hash column on the frontend.
+category: powersync
+confidence: high
+version: 1.0.0
+version_origin: extracted
+source_type: extracted-from-git
+source_url: https://github.com/thunderbird/thunderbolt.git
+source_ref: main
+source_commit: 9d9c18ba511decfd3b45fc0f72c265d83355fe95
+source_project: thunderbolt
+imported_at: 2026-04-18T00:00:00Z
+tags: [powersync, postgresql, drizzle, default-data, seeding]
+linked_knowledge: [powersync-backend-minimal-indexes]
+---
+
+## When to use
+
+You have tables seeded at app initialization with shared default IDs (e.g. `openai-gpt-4o`, `theme`, `inbox`). In a PowerSync world, two users can both legitimately own a row with the same default ID, so a single-column primary key on the backend collides.
+
+## Steps
+
+1. On the **backend** (Postgres), declare the table with a composite primary key. For id-based tables use `(id, user_id)`, for settings-style tables use `(key, user_id)`.
+2. Update `powersyncConflictTarget` in `backend/src/db/powersync-schema.ts` to include both columns so `INSERT ... ON CONFLICT (id, user_id)` / `ON CONFLICT (key, user_id)` upserts per user.
+3. Update `powersyncPkColumn` for the table so PATCH/DELETE use the "business" id column (not `user_id`) in their `WHERE` clauses. Always AND the clause with `user_id` from the JWT so users can only mutate their own rows.
+4. Do **not** add `.references()` to this table from other tables. Use a plain column like `modeId: text('mode_id')`. PowerSync treats the server as a sync target, not a query engine, so FKs add overhead and block valid partial-sync states.
+5. On the **frontend** (SQLite), keep a single-column PK (`id` or `key`). Local data is already scoped to one user.
+6. Add a `default_hash` column to detect user modifications. At startup, `reconcileDefaultsForTable()` inserts new defaults, back-fills `default_hash` on rows that lack it, and updates only when the *previous* default hash matches the stored hash (i.e. the user has not edited).
+7. Guard against wiping user-set values with null defaults: if `existing.value !== null` and `defaultItem.value === null`, skip the update. This protects fields like locale/units that users set via other code paths.
+
+## Counter / Caveats
+
+- Hash equality is the only modification signal. Any column not fed into the hash function effectively becomes unmanageable by `reconcileDefaults`; include every field you want to keep in sync.
+- The approach assumes an idempotent `uuidv7()` seed per device for an anonymous-id setting. If you add other per-user unique seeds, create them in the same transaction as reconcile so they survive the reset-and-reseed flow atomically.
+- Do not rely on composite PKs on the frontend — it confuses Drizzle tooling and PowerSync upload builds the `WHERE` clause from a single business key plus user_id on the server.
+
+## Evidence
+
+- `docs/composite-primary-keys-and-default-data.md:7-53`
+- `src/lib/reconcile-defaults.ts:22-101` — the reconcile implementation with hash guard
+- `src/db/tables.ts` / `backend/src/db/powersync-schema.ts` — composite PK declarations

--- a/skills/powersync/powersync-composite-primary-key-seed/content.md
+++ b/skills/powersync/powersync-composite-primary-key-seed/content.md
@@ -1,0 +1,70 @@
+# Composite PK seeding for default-data tables in PowerSync
+
+PowerSync's backend holds data from every user in the same Postgres schema. When you seed default rows (e.g. a built-in model with id `openai-gpt-4o`) for each user, two users legitimately have rows with the same business id. A single-column primary key collides. Solution: composite PK that includes `user_id`.
+
+## Backend shape
+
+```ts
+export const modelsTable = pgTable('models', {
+  id: text('id').notNull(),
+  userId: text('user_id').notNull(),
+  // ...other columns
+}, (t) => ({
+  pk: primaryKey({ columns: [t.id, t.userId] }),
+  idxUser: index('idx_models_user_id').on(t.userId),
+}))
+
+// Registered in the conflict target map
+export const powersyncConflictTarget = {
+  models: ['id', 'user_id'],
+  settings: ['key', 'user_id'],
+  // ...
+}
+
+// Tells the upload handler which column to use in the WHERE clause for PATCH/DELETE
+export const powersyncPkColumn = {
+  models: 'id',
+  settings: 'key',
+}
+```
+
+## Frontend shape
+
+Single-column PK is fine — the local DB is per-user:
+
+```ts
+export const modelsTable = sqliteTable('models', {
+  id: text('id').primaryKey(),
+  // ...
+})
+```
+
+## Reconcile defaults
+
+`reconcileDefaultsForTable()` is the safety net that keeps defaults up-to-date without clobbering user edits:
+
+```ts
+const currentHash = hashFn(existing)
+const defaultHashValue = hashFn(defaultItem)
+
+if (!existing.defaultHash) {
+  // Backfill: first time we see the row, record what shape it had.
+  await update().set({ defaultHash: defaultHashValue })
+} else if (currentHash === existing.defaultHash) {
+  // User hasn't modified it since we last looked.
+  if (existing.defaultHash === defaultHashValue) continue // no-op
+  const wouldOverwriteUserValue =
+    existing.value !== null && defaultItem.value === null
+  if (wouldOverwriteUserValue) continue
+  // Safe to update to new default.
+  await update().set({ ...defaultItem, defaultHash: defaultHashValue })
+}
+// If hashes diverge, the user edited; leave their row alone.
+```
+
+The null-guard is specifically for localization settings (distance_unit, etc.) where the user sets a value through other code paths and the code default is `null`. Without the guard, rolling out a new default revision would silently wipe their choice.
+
+## Evidence
+
+- `docs/composite-primary-keys-and-default-data.md:7-53`
+- `src/lib/reconcile-defaults.ts:22-101`

--- a/skills/powersync/powersync-custom-sharedworker-override/SKILL.md
+++ b/skills/powersync/powersync-custom-sharedworker-override/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: powersync-custom-sharedworker-override
+description: Ship a custom SharedWorker that extends PowerSync's internal SharedSyncImplementation so you can inject a custom BucketStorageAdapter (e.g. a TransformableBucketStorage) without giving up multi-tab sync efficiency.
+category: powersync
+confidence: high
+version: 1.0.0
+version_origin: extracted
+source_type: extracted-from-git
+source_url: https://github.com/thunderbird/thunderbolt.git
+source_ref: main
+source_commit: 9d9c18ba511decfd3b45fc0f72c265d83355fe95
+source_project: thunderbolt
+imported_at: 2026-04-18T00:00:00Z
+tags: [powersync, sharedworker, vite, sqlite, e2e-encryption]
+linked_knowledge: [powersync-sharedworker-multi-tab-constraint]
+---
+
+## When to use
+
+You run PowerSync on Chrome/Edge/Firefox with `enableMultiTabs: true`, and you need the SharedWorker to use a custom `BucketStorageAdapter` (e.g. to decrypt sync data). The default SharedWorker hardcodes `new SqliteBucketStorage(...)` and ignores any adapter you configure on the main thread.
+
+## Steps
+
+1. Add a Vite alias and matching `tsconfig.json` `paths` entry named `powersync-web-internal` pointing at `node_modules/@powersync/web/lib/src`. `SharedSyncImplementation` is `@internal` and not in the public exports map, so you need the compiled lib path.
+2. Subclass `SharedSyncImplementation` and override only `generateStreamingImplementation()` — the one `protected` method that controls which storage adapter is used. Copy the parent body, replace `new SqliteBucketStorage(...)` with `new TransformableBucketStorage(...)` and attach your middleware before returning.
+3. Write a SharedWorker entry file that mirrors PowerSync's original `SharedSyncImplementation.worker.ts` but instantiates your subclass.
+4. Wire it up in the PowerSync database config: `sync: { worker: () => new SharedWorker(new URL('./worker/YourSharedSyncImplementation.worker.ts', import.meta.url), { type: 'module', name: 'shared-sync-<dbFilename>' }) }`. Vite detects this pattern and bundles the worker as a separate ES module chunk.
+5. Access side-channel data (like content keys) directly from IndexedDB inside the worker — transformer functions cannot be passed in at runtime because Comlink cannot serialize closures.
+6. Every time you upgrade `@powersync/web`, diff `SharedSyncImplementation.generateStreamingImplementation()` against your override; silent API drift is the main failure mode.
+
+## Counter / Caveats
+
+- Safari / iOS / Tauri cannot run this path: `OPFSCoopSyncVFS` does not support SharedWorker, Tauri's `tauri://` protocol blocks `import.meta.url`-based worker loading, and iOS WKWebView crashes with SharedWorker. Keep `enableMultiTabs: false` + the main-thread transformer path for those environments.
+- Using an internal import path trades public-API stability for feature access. Upgrades of `@powersync/web` may silently move or rename files without TypeScript errors because the path is string-aliased.
+- Any middleware you need at runtime must be importable from worker code — no closures, no factory parameters, no runtime registration from the main thread.
+
+## Evidence
+
+- `docs/powersync-sync-middleware.md:136-207` — why the multi-tab constraint exists and how the override works
+- `src/db/powersync/worker/ThunderboltSharedSyncImplementation.ts` — the subclass
+- `src/db/powersync/worker/ThunderboltSharedSyncImplementation.worker.ts` — the worker entry
+- `vite.config.ts:73-82` — `powersync-web-internal` alias

--- a/skills/powersync/powersync-custom-sharedworker-override/content.md
+++ b/skills/powersync/powersync-custom-sharedworker-override/content.md
@@ -1,0 +1,69 @@
+# Custom SharedWorker for PowerSync middleware
+
+PowerSync defaults to `enableMultiTabs: true` on Chromium and Firefox, which spawns a SharedWorker that deduplicates the sync connection across tabs. That worker hardcodes `new SqliteBucketStorage(...)` and never reads the `adapter` you configured on the main thread — Comlink cannot serialize transformer functions across the worker boundary, and the `adapter` field is explicitly omitted from `SharedSyncInitOptions`.
+
+The fix is to embed the transformer **inside** a custom SharedWorker bundle at build time.
+
+## Alias the internal path
+
+```ts
+// vite.config.ts
+resolve: {
+  alias: {
+    'powersync-web-internal': path.resolve(__dirname, 'node_modules/@powersync/web/lib/src'),
+  },
+}
+```
+
+```json
+// tsconfig.json
+"paths": {
+  "powersync-web-internal/*": ["./node_modules/@powersync/web/lib/src/*"]
+}
+```
+
+`SharedSyncImplementation` is marked `@internal`, so this is the only way to import it.
+
+## Subclass and override
+
+```ts
+import { SharedSyncImplementation } from 'powersync-web-internal/worker/sync/SharedSyncImplementation.js'
+
+export class ThunderboltSharedSyncImplementation extends SharedSyncImplementation {
+  protected generateStreamingImplementation() {
+    // Copy parent body but swap SqliteBucketStorage -> TransformableBucketStorage
+    const storage = new TransformableBucketStorage(this.dbAdapter)
+    storage.addTransformer(encryptionMiddleware)
+    // ... rest of parent's implementation
+    return { ...existingImpl, storage }
+  }
+}
+```
+
+## Worker entry
+
+Mirror PowerSync's `SharedSyncImplementation.worker.ts` and instantiate the subclass.
+
+## Register it in the PowerSync config
+
+```ts
+sync: {
+  worker: () =>
+    new SharedWorker(
+      new URL('./worker/ThunderboltSharedSyncImplementation.worker.ts', import.meta.url),
+      { type: 'module', name: `shared-sync-${dbFilename}` },
+    ),
+}
+```
+
+Vite recognizes `new SharedWorker(new URL(...))` and emits a separate ES module chunk.
+
+## Side-channel data inside the worker
+
+The content key lives in IndexedDB. The codec reads it lazily inside the worker; a `BroadcastChannel` propagates cache invalidation (e.g. on sign-out) across main thread, SharedWorker, and other tabs.
+
+## Evidence
+
+- `docs/powersync-sync-middleware.md:136-207`
+- `src/db/powersync/database.ts` — worker wiring
+- `vite.config.ts:73-82` — alias

--- a/skills/powersync/powersync-no-foreign-keys-on-sync-backend/SKILL.md
+++ b/skills/powersync/powersync-no-foreign-keys-on-sync-backend/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: powersync-no-foreign-keys-on-sync-backend
+description: Skip composite foreign-key constraints on a PowerSync-style backend schema and use plain text columns for cross-table references, so partial syncs don't fail and encrypted columns don't block writes.
+category: powersync
+confidence: medium
+version: 1.0.0
+version_origin: extracted
+source_type: extracted-from-git
+source_url: https://github.com/thunderbird/thunderbolt.git
+source_ref: main
+source_commit: 9d9c18ba511decfd3b45fc0f72c265d83355fe95
+source_project: thunderbolt
+imported_at: 2026-04-18T00:00:00Z
+tags: [powersync, postgresql, drizzle, foreign-keys, sync]
+linked_knowledge: [powersync-backend-minimal-indexes]
+---
+
+## When to use
+
+You are modelling PowerSync-synced Postgres tables where some parent tables have composite primary keys like `(id, user_id)`. The natural instinct is to add a matching composite foreign key from children. Don't.
+
+## Steps
+
+1. Declare the child column as a plain text column: `modeId: text('mode_id')`. No `.references()`, no `foreignKey()`.
+2. Enforce relationships on the **frontend** — SQLite queries already JOIN there, and that's where business logic lives in a PowerSync app.
+3. Skip indexes on the foreign-key column. Only `user_id` gets an index on the backend.
+4. For default-data tables that ship with predefined IDs, expect children to temporarily point at a default parent ID that isn't yet synced on a brand-new device; the reconcile-defaults step will populate it.
+5. Validate referential integrity at the application layer (DAL or service), not the database.
+
+## Counter / Caveats
+
+- Confidence is `medium` because this inverts the default relational-DB advice; teams coming from a traditional stack often push back. Document the decision prominently in `AGENTS.md` or a schema comment.
+- You lose cascade-delete at the database level. If you rely on ON DELETE CASCADE, you must replicate it in the DAL or accept orphaned rows (which PowerSync tolerates by design during partial syncs).
+- If the backend gains non-sync query endpoints (admin, analytics) in the future, add FKs per-endpoint in a separate schema rather than the shared PowerSync schema.
+
+## Evidence
+
+- `docs/composite-primary-keys-and-default-data.md:56-99`
+- Example callouts: `chatThreadsTable.modeId references modesTable without foreignKey()`

--- a/skills/powersync/powersync-no-foreign-keys-on-sync-backend/content.md
+++ b/skills/powersync/powersync-no-foreign-keys-on-sync-backend/content.md
@@ -1,0 +1,20 @@
+# Why the PowerSync backend deliberately skips foreign keys
+
+In a traditional relational schema, if `chatThreads.modeId` references `modes.id` and `modes` has a composite PK `(id, user_id)`, you would add a composite FK to keep the data clean. In a PowerSync-backed schema, Thunderbolt deliberately does not — `modeId` is just `text('mode_id')` with no `.references()` and no `foreignKey()`.
+
+Four reasons:
+
+1. **Sync server, not query engine.** Joins happen on the frontend SQLite. The backend exists to route writes into Postgres and stream diffs to other devices.
+2. **E2E encryption.** Once rows contain ciphertext, the backend cannot meaningfully join or filter on them anyway.
+3. **Write performance.** FK checks add a SELECT + lock on every INSERT/UPDATE. Sync traffic is constant.
+4. **Partial-sync tolerance.** A new device may have the child row before the parent has arrived. Enforcing FKs would reject the write and force PowerSync into a retry loop.
+
+## Hazards to watch
+
+- You lose cascade-delete. Soft deletes (set `deletedAt`) sidestep this — if you must hard delete, mirror the cascade in the DAL.
+- If non-sync query endpoints appear later, do not add FKs to the PowerSync tables. Put the queryable copy in a separate schema or materialized view.
+- Don't add foreign-key indexes either. The backend gets exactly one index per table: `user_id`.
+
+## Evidence
+
+- `docs/composite-primary-keys-and-default-data.md:56-99`

--- a/skills/powersync/powersync-transformable-bucket-storage/SKILL.md
+++ b/skills/powersync/powersync-transformable-bucket-storage/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: powersync-transformable-bucket-storage
+description: Intercept PowerSync sync data before it hits SQLite by subclassing SqliteBucketStorage and running a middleware pipeline on PROCESS_TEXT_LINE payloads, so you can decrypt, decompress, or normalize rows before they are written.
+category: powersync
+confidence: high
+version: 1.0.0
+version_origin: extracted
+source_type: extracted-from-git
+source_url: https://github.com/thunderbird/thunderbolt.git
+source_ref: main
+source_commit: 9d9c18ba511decfd3b45fc0f72c265d83355fe95
+source_project: thunderbolt
+imported_at: 2026-04-18T00:00:00Z
+tags: [powersync, sqlite, middleware, sync, e2e-encryption]
+linked_knowledge: [powersync-sharedworker-multi-tab-constraint]
+---
+
+## When to use
+
+You have a PowerSync client and need to transform sync data (decrypt, normalize, decompress) before it lands in SQLite. PowerSync's Rust client bypasses `saveSyncData` and calls `adapter.control(PROCESS_TEXT_LINE, payload)` directly, so you can't simply wrap the DAL.
+
+## Steps
+
+1. Subclass `SqliteBucketStorage` with a `TransformableBucketStorage` that overrides `control()`.
+2. Keep a `transformers: DataTransformMiddleware[]` array and expose `addTransformer/removeTransformer/clearTransformers`.
+3. In `control(cmd, payload)`: if `cmd === PowerSyncControlCommand.PROCESS_TEXT_LINE`, `JSON.parse` the payload into a `SyncDataBatch`, run it through each transformer in order, re-serialize, then call `super.control(cmd, serialized)`. For every other command, call `super.control` unchanged.
+4. Define the middleware contract: `type DataTransformMiddleware = { transform(batch: SyncDataBatch): Promise<SyncDataBatch> | SyncDataBatch }`.
+5. Subclass `PowerSyncDatabase` into a `ThunderboltPowerSyncDatabase` that overrides `generateBucketStorageAdapter()` to return a `TransformableBucketStorage` with the desired transformers registered.
+6. Register your middleware on both the main-thread storage (`getPowerSyncOptions().transformers`) and inside any custom SharedWorker's `generateStreamingImplementation()` — PowerSync instantiates a separate storage inside the SharedWorker that ignores main-thread config.
+
+## Counter / Caveats
+
+- Transformers cannot be serialized across the Comlink worker boundary. The SharedWorker path must embed transformers at bundle time, not pass them at runtime — see the linked knowledge about the multi-tab constraint.
+- Transformers run on every sync frame, so keep them allocation-light; parse once and mutate `OplogEntry.data` in place where possible.
+- `PROCESS_BSON_LINE`, `START`, `STOP` and other control commands must pass through unchanged. Filtering only on `PROCESS_TEXT_LINE` is the safe default.
+
+## Evidence
+
+- `src/db/powersync/TransformableBucketStorage.ts:1-60` — class shape, transformer list, control override
+- `docs/powersync-sync-middleware.md:93-135` — design rationale and middleware interface
+- `src/db/powersync/ThunderboltPowerSyncDatabase.ts` — registration point

--- a/skills/powersync/powersync-transformable-bucket-storage/content.md
+++ b/skills/powersync/powersync-transformable-bucket-storage/content.md
@@ -1,0 +1,37 @@
+# Transformable bucket storage for PowerSync
+
+PowerSync's sync client writes downloaded data to SQLite by calling `adapter.control(PROCESS_TEXT_LINE, jsonPayload)` directly on the configured `BucketStorageAdapter`. That means any transformation you want to apply to sync data (decryption, decompression, normalization) must happen inside `control()`, not in your DAL — by the time DAL reads fire the data is already persisted.
+
+The Thunderbolt implementation subclasses `SqliteBucketStorage` and treats the override as a small middleware pipeline:
+
+```typescript
+export type DataTransformMiddleware = {
+  transform(batch: SyncDataBatch): Promise<SyncDataBatch> | SyncDataBatch
+}
+
+export class TransformableBucketStorage extends SqliteBucketStorage {
+  private transformers: DataTransformMiddleware[] = []
+
+  addTransformer(t: DataTransformMiddleware) { this.transformers.push(t) }
+
+  async control(cmd: PowerSyncControlCommand, payload: string) {
+    if (cmd !== PowerSyncControlCommand.PROCESS_TEXT_LINE) {
+      return super.control(cmd, payload)
+    }
+    const batch = SyncDataBatchClass.fromJSON(JSON.parse(payload))
+    let transformed = batch
+    for (const t of this.transformers) transformed = await t.transform(transformed)
+    return super.control(cmd, JSON.stringify(transformed))
+  }
+}
+```
+
+To make PowerSync actually use it, subclass `PowerSyncDatabase` and return a populated `TransformableBucketStorage` from `generateBucketStorageAdapter()`. That covers the Safari / Tauri main-thread path.
+
+For Chrome / Edge / Firefox, `enableMultiTabs: true` spawns a SharedWorker that builds its own `SqliteBucketStorage` internally — main-thread transformers are silently ignored. See the linked knowledge for how to subclass `SharedSyncImplementation` and inject the transformer inside the worker bundle.
+
+## Evidence
+
+- `src/db/powersync/TransformableBucketStorage.ts:1-60` — the override pattern
+- `docs/powersync-sync-middleware.md:93-135` — middleware interface and integration points
+- `src/db/powersync/middleware/EncryptionMiddleware.ts` — a real consumer (AES-GCM decrypt)

--- a/skills/production/project-stage-detect/SKILL.md
+++ b/skills/production/project-stage-detect/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: project-stage-detect
+description: "Automatically analyze project state, detect stage, identify gaps, and recommend next steps based on existing artifacts. Use when user asks 'where are we in development', 'what stage are we in', 'full project audit'."
+argument-hint: "[optional: role filter like 'programmer' or 'designer']"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Bash, Write
+model: haiku
+# Read-only diagnostic skill — no specialist agent delegation needed
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version: 1.0.0
+version_origin: extracted
+---
+
+# Project Stage Detection
+
+This skill scans your project to determine its current development stage, completeness
+of artifacts, and gaps that need attention. It's especially useful when:
+- Starting with an existing project
+- Onboarding to a codebase
+- Checking what's missing before a milestone
+- Understanding "where are we?"
+
+---
+
+## Workflow
+
+### 1. Scan Key Directories
+
+Analyze project structure and content:
+
+**Design Documentation** (`design/`):
+- Count GDD files in `design/gdd/*.md`
+- Check for game-concept.md, game-pillars.md, systems-index.md
+- If systems-index.md exists, count total systems vs. designed systems
+- Analyze completeness (Overview, Detailed Design, Edge Cases, etc.)
+- Count narrative docs in `design/narrative/`
+- Count level designs in `design/levels/`
+
+**Source Code** (`src/`):
+- Count source files (language-agnostic)
+- Identify major systems (directories with 5+ files)
+- Check for core/, gameplay/, ai/, networking/, ui/ directories
+- Estimate lines of code (rough scale)
+
+**Production Artifacts** (`production/`):
+- Check for active sprint plans
+- Look for milestone definitions
+- Find roadmap documents
+
+**Prototypes** (`prototypes/`):
+- Count prototype directories
+- Check for READMEs (documented vs undocumented)
+- Assess if prototypes are archived or active
+
+**Architecture Docs** (`docs/architecture/`):
+- Count ADRs (Architecture Decision Records)
+- Check for overview/index documents
+
+**Tests** (`tests/`):
+- Count test files
+- Estimate test coverage (rough heuristic)
+
+### 2. Classify Project Stage
+
+Based on scanned artifacts, determine stage. Check `production/stage.txt` first —
+if it exists, use its value (explicit override from `/gate-check`). Otherwise,
+auto-detect using these heuristics (check from most-advanced backward):
+
+| Stage | Indicators |
+|-------|-----------|
+| **Concept** | No game concept doc, brainstorming phase |
+| **Systems Design** | Game concept exists, systems index missing or incomplete |
+| **Technical Setup** | Systems index exists, engine not configured |
+| **Pre-Production** | Engine configured, `src/` has <10 source files |
+| **Production** | `src/` has 10+ source files, active development |
+| **Polish** | Explicit only (set by `/gate-check` Production → Polish gate) |
+| **Release** | Explicit only (set by `/gate-check` Polish → Release gate) |
+
+### 3. Collaborative Gap Identification
+
+**DO NOT** just list missing files. Instead, **ask clarifying questions**:
+
+- "I see combat code (`src/gameplay/combat/`) but no `design/gdd/combat-system.md`. Was this prototyped first, or should we reverse-document?"
+- "You have 15 ADRs but no architecture overview. Should I create one to help new contributors?"
+- "No sprint plans in `production/`. Are you tracking work elsewhere (Jira, Trello, etc.)?"
+- "I found a game concept but no systems index. Have you decomposed the concept into individual systems yet, or should we run `/map-systems`?"
+- "Prototypes directory has 3 projects with no READMEs. Were these experiments, or do they need documentation?"
+
+### 4. Generate Stage Report
+
+Use template: `.claude/docs/templates/project-stage-report.md`
+
+**Report structure**:
+```markdown
+# Project Stage Analysis
+
+**Date**: [date]
+**Stage**: [Concept/Systems Design/Technical Setup/Pre-Production/Production/Polish/Release]
+**Stage Confidence**: [PASS — clearly detected / CONCERNS — ambiguous signals / FAIL — critical gaps block progress]
+
+## Completeness Overview
+- Design: [X%] ([N] docs, [gaps])
+- Code: [X%] ([N] files, [systems])
+- Architecture: [X%] ([N] ADRs, [gaps])
+- Production: [X%] ([status])
+- Tests: [X%] ([coverage estimate])
+
+## Gaps Identified
+1. [Gap description + clarifying question]
+2. [Gap description + clarifying question]
+
+## Recommended Next Steps
+[Priority-ordered list based on stage and role]
+```
+
+### 5. Role-Filtered Recommendations (Optional)
+
+If user provided a role argument (e.g., `/project-stage-detect programmer`):
+
+**Programmer**:
+- Focus on architecture docs, test coverage, missing ADRs
+- Code-to-docs gaps
+
+**Designer**:
+- Focus on GDD completeness, missing design sections
+- Prototype documentation
+
+**Producer**:
+- Focus on sprint plans, milestone tracking, roadmap
+- Cross-team coordination docs
+
+**General** (no role):
+- Holistic view of all gaps
+- Highest-priority items across domains
+
+### 6. Request Approval Before Writing
+
+**Collaborative protocol**:
+```
+I've analyzed your project. Here's what I found:
+
+[Show summary]
+
+Gaps identified:
+1. [Gap 1 + question]
+2. [Gap 2 + question]
+
+Recommended next steps:
+- [Priority 1]
+- [Priority 2]
+- [Priority 3]
+
+May I write the full stage analysis to production/project-stage-report.md?
+```
+
+Wait for user approval before creating the file.
+
+---
+
+## Example Usage
+
+```bash
+# General project analysis
+/project-stage-detect
+
+# Programmer-focused analysis
+/project-stage-detect programmer
+
+# Designer-focused analysis
+/project-stage-detect designer
+```
+
+---
+
+## Follow-Up Actions
+
+After generating the report, suggest relevant next steps:
+
+- **Concept exists but no systems index?** → `/map-systems` to decompose into systems
+- **Missing design docs?** → `/reverse-document design src/[system]`
+- **Missing architecture docs?** → `/architecture-decision` or `/reverse-document architecture`
+- **Prototypes need documentation?** → `/reverse-document concept prototypes/[name]`
+- **No sprint plan?** → `/sprint-plan`
+- **Approaching milestone?** → `/milestone-review`
+
+---
+
+## Collaborative Protocol
+
+This skill follows the collaborative design principle:
+
+1. **Question First**: Ask about gaps, don't assume
+2. **Present Options**: "Should I create X, or is it tracked elsewhere?"
+3. **User Decides**: Wait for direction
+4. **Show Draft**: Display report summary
+5. **Get Approval**: "May I write to production/project-stage-report.md?"
+
+**Never** silently write files. **Always** show findings and ask before creating artifacts.

--- a/skills/qa/playtest-report/SKILL.md
+++ b/skills/qa/playtest-report/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: playtest-report
+description: "Generates a structured playtest report template or analyzes existing playtest notes into a structured format. Use this to standardize playtest feedback collection and analysis."
+argument-hint: "[new|analyze path-to-notes] [--review full|lean|solo]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write, Task, AskUserQuestion
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version: 1.0.0
+version_origin: extracted
+---
+
+## Phase 1: Parse Arguments
+
+Resolve the review mode (once, store for all gate spawns this run):
+1. If `--review [full|lean|solo]` was passed → use that
+2. Else read `production/review-mode.txt` → use that value
+3. Else → default to `lean`
+
+See `.claude/docs/director-gates.md` for the full check pattern.
+
+Determine the mode:
+
+- `new` → generate a blank playtest report template
+- `analyze [path]` → read raw notes and fill in the template with structured findings
+
+---
+
+## Phase 2A: New Template Mode
+
+Generate this template and output it to the user:
+
+```markdown
+# Playtest Report
+
+## Session Info
+- **Date**: [Date]
+- **Build**: [Version/Commit]
+- **Duration**: [Time played]
+- **Tester**: [Name/ID]
+- **Platform**: [PC/Console/Mobile]
+- **Input Method**: [KB+M / Gamepad / Touch]
+- **Session Type**: [First time / Returning / Targeted test]
+
+## Test Focus
+[What specific features or flows were being tested]
+
+## First Impressions (First 5 minutes)
+- **Understood the goal?** [Yes/No/Partially]
+- **Understood the controls?** [Yes/No/Partially]
+- **Emotional response**: [Engaged/Confused/Bored/Frustrated/Excited]
+- **Notes**: [Observations]
+
+## Gameplay Flow
+### What worked well
+- [Observation 1]
+
+### Pain points
+- [Issue 1 -- Severity: High/Medium/Low]
+
+### Confusion points
+- [Where the player was confused and why]
+
+### Moments of delight
+- [What surprised or pleased the player]
+
+## Bugs Encountered
+| # | Description | Severity | Reproducible |
+|---|-------------|----------|-------------|
+
+## Feature-Specific Feedback
+### [Feature 1]
+- **Understood purpose?** [Yes/No]
+- **Found engaging?** [Yes/No]
+- **Suggestions**: [Tester suggestions]
+
+## Quantitative Data (if available)
+- **Deaths**: [Count and locations]
+- **Time per area**: [Breakdown]
+- **Items used**: [What and when]
+- **Features discovered vs missed**: [List]
+
+## Overall Assessment
+- **Would play again?** [Yes/No/Maybe]
+- **Difficulty**: [Too Easy / Just Right / Too Hard]
+- **Pacing**: [Too Slow / Good / Too Fast]
+- **Session length preference**: [Shorter / Good / Longer]
+
+## Top 3 Priorities from this session
+1. [Most important finding]
+2. [Second priority]
+3. [Third priority]
+```
+
+---
+
+## Phase 2B: Analyze Mode
+
+Read the raw notes at the provided path. Cross-reference with existing design documents. Fill in the template above with structured findings. Flag any playtest observations that conflict with design intent.
+
+---
+
+## Phase 3: Action Routing
+
+Categorize all findings into four buckets:
+
+- **Design changes needed** — fun issues, player confusion, broken mechanics, observations that conflict with the GDD's intended experience
+- **Balance adjustments** — numbers feel wrong, difficulty too spiked or too flat
+- **Bug reports** — clear implementation defects that are reproducible
+- **Polish items** — not blocking progress, but friction or feel issues for later
+
+Present the categorized list, then route:
+
+- **Design changes:** "Run `/propagate-design-change [path]` on the affected design document to find downstream impacts before making changes."
+- **Balance adjustments:** "Run `/balance-check [system]` to verify the full balance picture before tuning values."
+- **Bugs:** "Use `/bug-report` to formally track these."
+- **Polish items:** "Add to the polish backlog in `production/` when the team reaches that phase."
+
+---
+
+## Phase 3b: Creative Director Player Experience Review
+
+**Review mode check** — apply before spawning CD-PLAYTEST:
+- `solo` → skip. Note: "CD-PLAYTEST skipped — Solo mode." Proceed to Phase 4 (save the report).
+- `lean` → skip (not a PHASE-GATE). Note: "CD-PLAYTEST skipped — Lean mode." Proceed to Phase 4 (save the report).
+- `full` → spawn as normal.
+
+After categorising findings, spawn `creative-director` via Task using gate **CD-PLAYTEST** (`.claude/docs/director-gates.md`).
+
+Pass: the structured report content, game pillars and core fantasy (from `design/gdd/game-concept.md`), the specific hypothesis being tested.
+
+Present the creative director's assessment before saving the report. If CONCERNS or REJECT, add a `## Creative Director Assessment` section to the report capturing the verdict and feedback. If APPROVE, note the approval in the report.
+
+---
+
+## Phase 4: Save Report
+
+Ask: "May I write this playtest report to `production/qa/playtests/playtest-[date]-[tester].md`?"
+
+If yes, write the file, creating the directory if needed.
+
+---
+
+## Phase 5: Next Steps
+
+Verdict: **COMPLETE** — playtest report generated.
+
+- Act on the highest-priority finding category first.
+- After addressing design changes: re-run `/design-review` on the updated GDD.
+- After fixing bugs: re-run `/bug-triage` to update priorities.

--- a/skills/release/pre-release-version-validation-script/SKILL.md
+++ b/skills/release/pre-release-version-validation-script/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: pre-release-version-validation-script
+description: Pre-release script validates: tag matches pyproject version, copyright headers exist on all source files, package metadata fields complete, type checker passes.
+category: release
+version: 1.0.0
+version_origin: extracted
+confidence: medium
+tags: [magika, release]
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Pre Release Version Validation Script
+
+**Trigger:** Automating a release pipeline and adding guard rails so you never publish a broken or mis-tagged package.
+
+## Steps
+
+- Read the git tag from $GITHUB_REF_NAME or env var; extract the version (strip prefix like 'python-v').
+- Compare against pyproject.toml [project].version; exit 1 on mismatch.
+- Walk source files and check for the copyright header (regex); list all offenders if any are missing.
+- Validate that name, version, author, license, urls are all populated in pyproject.toml.
+- Run mypy / type checker; fail on any error.
+- Optionally check that the package name is taken on PyPI (via API) — guards against typos.
+
+## Counter / Caveats
+
+- Copyright regex is fragile; comment styles vary across languages and decades.
+- Tag-to-version extraction must be consistent — off-by-one or prefix-mismatch is a common bug.
+- Type checking can be slow on large codebases; parallelize or cache.
+- The script is language-specific; you'll want similar guards in every binding (Cargo.toml version, package.json version).
+
+## Source
+
+Extracted from `magika` (https://github.com/google/magika.git @ main).
+
+Files of interest:
+- `python/scripts/pre_release_check.py:1-60`
+- `.github/workflows/python-build-and-release-package.yml:50-70`

--- a/skills/release/pre-release-version-validation-script/content.md
+++ b/skills/release/pre-release-version-validation-script/content.md
@@ -1,0 +1,21 @@
+# pre-release-version-validation-script — extended notes
+
+This is an extracted draft from the **magika** project at commit `0a8cb9626b`.
+See `SKILL.md` for the procedure. Use the source references below to study the
+original implementation before adapting the pattern to a new codebase.
+
+## Source references
+
+- `python/scripts/pre_release_check.py:1-60`
+- `.github/workflows/python-build-and-release-package.yml:50-70`
+
+## When this pattern is a fit
+
+Automating a release pipeline and adding guard rails so you never publish a broken or mis-tagged package.
+
+## When to walk away
+
+- Copyright regex is fragile; comment styles vary across languages and decades.
+- Tag-to-version extraction must be consistent — off-by-one or prefix-mismatch is a common bug.
+- Type checking can be slow on large codebases; parallelize or cache.
+- The script is language-specific; you'll want similar guards in every binding (Cargo.toml version, package.json version).

--- a/skills/resilience/process-singleton-guard-with-lockfile/SKILL.md
+++ b/skills/resilience/process-singleton-guard-with-lockfile/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: process-singleton-guard-with-lockfile
+description: Prevent multiple daemon instances using exclusive lockfile creation and PID validation
+category: resilience
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [evolver, resilience, singleton, daemon, lockfile]
+source_type: extracted-from-git
+source_url: https://github.com/EvoMap/evolver.git
+source_ref: main
+source_commit: 22773782475cecf43dc9c1af264bf5f9cacc28bc
+source_project: evolver
+source_paths:
+  - index.js
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Singleton daemon guard via exclusive lockfile
+
+Acquire a singleton lock by writing the current PID to a file with exclusive-create (`{ flag: 'wx' }`). If the file exists, read the PID and probe liveness with `process.kill(pid, 0)`. Dead PID → stale lock, overwrite. Live PID → abort.
+
+## Mechanism
+
+```js
+function acquireLock(path) {
+  try {
+    fs.writeFileSync(path, String(process.pid), { flag: 'wx' });
+    return true;
+  } catch (e) {
+    if (e.code !== 'EEXIST') throw e;
+    const pid = parseInt(fs.readFileSync(path, 'utf8'), 10);
+    try { process.kill(pid, 0); return false; } // alive → abort
+    catch { fs.writeFileSync(path, String(process.pid)); return true; } // stale → take
+  }
+}
+process.on('exit', () => fs.unlinkSync(path));
+```
+
+## When to reuse
+
+Background workers, evolution loops, schedulers, anything where parallel invocation would corrupt shared state.

--- a/skills/tauri/pid-watchdog-sidecar-survival/SKILL.md
+++ b/skills/tauri/pid-watchdog-sidecar-survival/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: pid-watchdog-sidecar-survival
+description: Make a Tauri sidecar self-terminate when the parent app exits (or optionally survive it) using parent-PID monitoring plus a filesystem sentinel.
+category: tauri
+version: 1.0.0
+version_origin: extracted
+tags: [tauri, sidecar, process-management, watchdog, windows]
+source_type: extracted-from-git
+source_url: https://github.com/jamiepine/voicebox.git
+source_ref: main
+source_commit: 476abe07fc2c1587f4b3e3916134018ebacd143d
+source_project: voicebox
+confidence: high
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# PID watchdog sidecar survival
+
+## When to use
+A Tauri desktop app launches a heavier backend (Python/Rust/Node) as a sidecar. The sidecar must (a) clean up when the user closes the app, but (b) optionally keep running when the user enables "remain running after close" so other local clients can still use it.
+
+## Steps
+1. Tauri passes `--parent-pid <pid>` when spawning the sidecar. The sidecar stores this and starts a background thread that polls "is parent alive?" every 2 s.
+2. Use a cross-platform liveness probe. On Unix: `os.kill(pid, 0)`. On Windows: `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION) + GetExitCodeProcess` — and treat `ACCESS_DENIED` as "alive" (the process exists, you just can't introspect it).
+3. When the parent disappears, do NOT exit immediately. Sleep a grace period (~1 s) first so the Tauri `RunEvent::Exit` handler has a chance to deliver its "disable watchdog" signal. Race conditions on Windows are real.
+4. Provide two disable paths, both checked during the grace period:
+   - HTTP: expose `POST /watchdog/disable` that flips an in-process flag.
+   - Filesystem sentinel: the Tauri app writes `<data_dir>/.keep-running` before exiting. The watchdog checks for this file after the grace period and consumes it (unlinks) if present.
+5. The sentinel is the reliable path on Windows where process teardown frequently wins the race against the HTTP request. Emit both from the Tauri side (`RunEvent::Exit` handler) so whichever one lands keeps the sidecar alive.
+6. On shutdown, use `os._exit(0)` on Windows (so uvicorn-style shutdown hooks can run on ReadyRequest) and `os.kill(os.getpid(), SIGTERM)` on Unix.
+7. Clear any stale sentinel on startup. If the previous session's HTTP-disable won the race but then the sidecar crashed, the sentinel is left on disk and would spuriously extend the next session.
+
+## Counter / Caveats
+- On Unix also `signal(SIGHUP, SIG_IGN)` when disabling the watchdog. Otherwise the sidecar dies of SIGHUP when the parent's session leader exits, even though your watchdog never tripped.
+- Windows `TerminateProcess` (which is what `os.kill(SIGTERM)` becomes) hard-kills without shutdown handlers. On Windows prefer `os._exit(0)` inside a SIGINT-like path, or graceful `/shutdown` via HTTP first.
+- Do not rely on the HTTP request alone; the sentinel file is the fallback that makes the feature production-reliable.
+- Always consume (unlink) the sentinel once its signal has been used — otherwise the next session starts with a stale "keep running" request.
+
+Source references: `backend/server.py` (`_start_parent_watchdog`, `disable_watchdog`), `tauri/src-tauri/src/main.rs` (`RunEvent::Exit` handler, `set_keep_server_running`, `.keep-running` sentinel).

--- a/skills/testing/playwright-api-fixtures-cleanup/SKILL.md
+++ b/skills/testing/playwright-api-fixtures-cleanup/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: playwright-api-fixtures-cleanup
+description: Self-contained Playwright E2E tests using a TestApiClient fixture that creates entities over HTTP and tears them down in afterEach — no shared DB seed, no cross-test pollution.
+category: testing
+version: 1.0.0
+tags: [playwright, e2e, fixtures, testing, cleanup]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- Multi-user / multi-tenant app with an HTTP API.
+- You want E2E tests to run against a real backend, in parallel, without step-on-toes failures.
+- You're tired of `beforeAll` migration/seed scripts that get out of sync with app behavior.
+
+## Steps
+
+1. Build a `TestApiClient` class that:
+   - Logs in as a fixed test user (dev verification code in non-prod).
+   - Tracks every entity it creates (issues, workspaces, comments).
+   - Exposes `cleanup()` to delete them all.
+   ```ts
+   export class TestApiClient {
+     private token: string | null = null;
+     private createdIssues: string[] = [];
+     async login(email: string, name: string) {
+       await fetch(`${API}/auth/send-code`, { method: "POST", body: JSON.stringify({ email }) });
+       const r = await fetch(`${API}/auth/verify-code`, { method: "POST", body: JSON.stringify({ email, code: "888888" }) });
+       this.token = (await r.json()).token;
+     }
+     async createIssue(title: string): Promise<Issue> {
+       const r = await fetch(`${API}/api/issues`, { method: "POST", headers: { Authorization: `Bearer ${this.token}` }, body: JSON.stringify({ title }) });
+       const issue = await r.json();
+       this.createdIssues.push(issue.id);
+       return issue;
+     }
+     async cleanup() {
+       for (const id of this.createdIssues) {
+         await fetch(`${API}/api/issues/${id}`, { method: "DELETE", headers: { Authorization: `Bearer ${this.token}` } });
+       }
+     }
+     getToken() { return this.token!; }
+   }
+   ```
+2. Expose helpers that combine login + workspace scaffolding:
+   ```ts
+   export async function loginAsDefault(page: Page): Promise<string> {
+     const api = new TestApiClient();
+     await api.login(E2E_EMAIL, E2E_NAME);
+     const ws = await api.ensureWorkspace("E2E Workspace", "e2e-workspace");
+     await page.goto("/login");
+     await page.evaluate(t => localStorage.setItem("app_token", t), api.getToken());
+     await page.goto(`/${ws.slug}/issues`);
+     return ws.slug;
+   }
+   ```
+3. Use in each spec:
+   ```ts
+   let api: TestApiClient;
+   test.beforeEach(async ({ page }) => {
+     api = await createTestApi();
+     await loginAsDefault(page);
+   });
+   test.afterEach(() => api.cleanup());
+
+   test("create and view issue", async ({ page }) => {
+     const issue = await api.createIssue("Test Issue");
+     await page.goto(`/issues/${issue.id}`);
+     await expect(page.getByText("Test Issue")).toBeVisible();
+   });
+   ```
+
+## Example
+
+See the source repo's `e2e/helpers.ts` and `e2e/fixtures.ts`.
+
+## Caveats
+
+- `cleanup()` should tolerate already-deleted entities (404s from earlier cleanup paths or cascading deletes are fine).
+- Don't share the `TestApiClient` across parallel tests — each gets its own via `beforeEach`.
+- The dev-master verification code (e.g. `888888`) must only work in non-production builds; see the "verification-code-dev-master" knowledge entry.


### PR DESCRIPTION
## Batch
- batch 16/24

## Knowledge (19)
- `devops/pgvector-pg17-for-ai-native-apps`
- `vector-search-rag/pinecone-metadata-filtering-rag`
- `automation/playwright-stealth-cloudflare-bypass`
- `plugin/plugin-framework-feature-conditional`
- `plugin-architecture/plugin-interface-version-convention`
- `safety/policy-check-sandboxing-evolution`
- `arch/polymorphic-assignees-member-or-agent`
- `platform/portable-app-detection-env-var`
- `pitfall/posix-socket-path-length-limit`
- `reference/posthog-cli-telemetry-conventions`
- `powersync/powersync-backend-minimal-indexes`
- `powersync/powersync-deploy-order-two-pr-invariant`
- `powersync/powersync-sharedworker-multi-tab-constraint`
- `security/pre-broadcast-log-sanitization`
- `workflow/pre-push-discipline-test-lint-typecheck`
- `architecture/priority-lower-is-higher-stable-sort`
- `safety/privacy-client-secure-credential-handling`
- `windows/privacy-mode-implementation-choices`
- `decision/process-title-for-debug-visibility`

## Skills (31)
- `observability/personality-state-tracking-with-aggregation`
- `jit-compilation/pid-aware-temp-dir-uuid-generator`
- `tauri/pid-watchdog-sidecar-survival`
- `agent-sdk/plan-audit-entry-per-step`
- `llm-agents/plan-based-multi-step-task-decomposition`
- `integration/platform-adapter-interface`
- `inference/platform-agnostic-file-input-abstraction`
- `architecture/platform-bridge-core-provider`
- `codecs/platform-screen-capture-abstraction`
- `cross-platform/platform-specific-code-organization`
- `qa/playtest-report`
- `testing/playwright-api-fixtures-cleanup`
- `monorepo/pnpm-catalog-version-pinning`
- `architecture/polymorphic-assignee-rendering`
- `networking/port-forwarding-tunnel-multiplexer`
- `cli/posthog-analytics-with-opt-out-and-thread-queue`
- `powersync/powersync-add-synced-table-two-pr-flow`
- `powersync/powersync-composite-primary-key-seed`
- `powersync/powersync-custom-sharedworker-override`
- `powersync/powersync-no-foreign-keys-on-sync-backend`
- _... and 11 more_

## Source
- project: F:/workspace/tool (bulk extract)
- batch plan: .omc/batch-plan.json

## Post-merge
After squash-merge, run step 7 to re-anchor skill tags at the merge commit.