### PR TITLE
Publish batch 18/24: 21 knowledge + 29 skills

### DIFF
--- a/index.json
+++ b/index.json
@@ -243,6 +243,22 @@
   },
   {
     "kind": "knowledge",
+    "name": "runtime-mode-approval-policy-and-sandbox-mode",
+    "slug": "runtime-mode-approval-policy-and-sandbox-mode",
+    "category": "api",
+    "description": "T3 Code has a global runtime mode that controls whether commands need approval and what filesystem access is allowed",
+    "tags": [
+      "api",
+      "safety",
+      "design"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/api/runtime-mode-approval-policy-and-sandbox-mode.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "stomp-heartbeat-10s-bidirectional",
     "slug": "stomp-heartbeat-10s-bidirectional",
     "category": "api",
@@ -1882,6 +1898,21 @@
   },
   {
     "kind": "knowledge",
+    "name": "seekable-abstraction-for-io",
+    "slug": "seekable-abstraction-for-io",
+    "category": "arch",
+    "description": "Python uses a Seekable wrapper to unify bytes / paths / streams under one feature-extraction codepath.",
+    "tags": [
+      "magika",
+      "arch"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/seekable-abstraction-for-io.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "shallow-clone-mktemp-cleanup-pattern",
     "slug": "shallow-clone-mktemp-cleanup-pattern",
     "category": "arch",
@@ -2044,6 +2075,24 @@
   },
   {
     "kind": "knowledge",
+    "name": "scheduler-and-cron-task-execution-model",
+    "slug": "scheduler-and-cron-task-execution-model",
+    "category": "automation",
+    "description": "File-based lightweight cron alternative — JSON task definitions, report-timestamp cooldown tracking, health-check introspection, max-delay guardrails.",
+    "tags": [
+      "automation",
+      "scheduling",
+      "cron-alternative",
+      "file-based",
+      "agents"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/automation/scheduler-and-cron-task-execution-model.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "ci-gpg-signing-batch-mode-non-interactive",
     "slug": "ci-gpg-signing-batch-mode-non-interactive",
     "category": "ci-cd",
@@ -2114,6 +2163,25 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/clipboard/clipboard-ownership-protocol.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "screen-capture-api-evolution-macos",
+    "slug": "screen-capture-api-evolution-macos",
+    "category": "codecs",
+    "description": "macOS capture has shifted: legacy Quartz CGDisplayCreateImage → ScreenCaptureKit (Monterey+) behind a feature flag.",
+    "tags": [
+      "api",
+      "capture",
+      "codecs",
+      "evolution",
+      "macos",
+      "screen"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/codecs/screen-capture-api-evolution-macos.md",
     "has_content": true
   },
   {
@@ -3684,6 +3752,23 @@
   },
   {
     "kind": "knowledge",
+    "name": "release-auto-update-publish-url",
+    "slug": "release-auto-update-publish-url",
+    "category": "devops",
+    "description": "electron-updater pulls update manifests from https://agents.craft.do/electron/latest — a generic static URL provider, not GitHub Releases or S3 — so Craft Docs Ltd. controls rollout without electron-builder's built-in providers.",
+    "tags": [
+      "electron-updater",
+      "auto-update",
+      "release",
+      "distribution"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/devops/release-auto-update-publish-url.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "a11y-uid-tool-targeting-over-selectors",
     "slug": "a11y-uid-tool-targeting-over-selectors",
     "category": "domain",
@@ -3864,6 +3949,37 @@
   },
   {
     "kind": "knowledge",
+    "name": "repository-identity-vs-project-vs-thread",
+    "slug": "repository-identity-vs-project-vs-thread",
+    "category": "domain",
+    "description": "A RepositoryIdentity is a logical grouping (e.g., for UI); a Project is environment-local with a workspace root; a Thread is a conversation within a project",
+    "tags": [
+      "domain",
+      "terminology",
+      "modeling"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/domain/repository-identity-vs-project-vs-thread.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "research-paper-published-icse-2025",
+    "slug": "research-paper-published-icse-2025",
+    "category": "domain",
+    "description": "Magika's design and evaluation are published at ICSE 2025 (IEEE/ACM International Conference on Software Engineering).",
+    "tags": [
+      "magika",
+      "domain"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/domain/research-paper-published-icse-2025.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "root-span-error-propagation",
     "slug": "root-span-error-propagation",
     "category": "domain",
@@ -3911,6 +4027,92 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/engineering/condition-based-waiting.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "reproduce-bug-with-failing-test-first",
+    "slug": "reproduce-bug-with-failing-test-first",
+    "category": "engineering",
+    "description": "Before fixing a reported bug, write a test that reproduces it. The test failing proves you understand the bug; the test passing proves the fix works. Especially important for non-deterministic bugs.",
+    "tags": [
+      "tdd",
+      "bug-reproduction",
+      "verification",
+      "non-determinism"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/engineering/reproduce-bug-with-failing-test-first.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "root-cause-tracing",
+    "slug": "root-cause-tracing",
+    "category": "engineering",
+    "description": "Trace bugs upward from symptom through the call stack to the true root cause before fixing, avoiding symptom-level patches",
+    "tags": [
+      "superpowers",
+      "engineering"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/engineering/root-cause-tracing.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "sciter-ui-deprecation-path",
+    "slug": "sciter-ui-deprecation-path",
+    "category": "flutter",
+    "description": "Legacy Sciter UI is deprecated; migration path is Flutter desktop for all platforms.",
+    "tags": [
+      "deprecation",
+      "flutter",
+      "path",
+      "sciter"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/flutter/sciter-ui-deprecation-path.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "retry-badcase-token-ratio-heuristic",
+    "slug": "retry-badcase-token-ratio-heuristic",
+    "category": "inference",
+    "description": "VoxCPM retries generation when audio_tokens/text_tokens falls below a threshold (default 6.0), up to a configurable max retry count",
+    "tags": [
+      "inference",
+      "retry",
+      "quality",
+      "heuristic",
+      "tts"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/inference/retry-badcase-token-ratio-heuristic.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "relative-mouse-mode-flutter-only",
+    "slug": "relative-mouse-mode-flutter-only",
+    "category": "input",
+    "description": "Relative mouse (delta-based) mode is Flutter-UI-only; legacy Sciter can't deliver pointer-lock events.",
+    "tags": [
+      "flutter",
+      "input",
+      "mode",
+      "mouse",
+      "only",
+      "relative"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/input/relative-mouse-mode-flutter-only.md",
     "has_content": true
   },
   {
@@ -3988,6 +4190,60 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/llm-agents/agent-runner-loop-semantics.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "run-context-and-shared-state",
+    "slug": "run-context-and-shared-state",
+    "category": "llm-agents",
+    "description": "How RunContextWrapper provides typed shared state to tools and hooks without sending it to the LLM.",
+    "tags": [
+      "openai-agents",
+      "context",
+      "shared-state",
+      "dependency-injection",
+      "run-context"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/llm-agents/run-context-and-shared-state.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "rlhf-ppo-trl",
+    "slug": "rlhf-ppo-trl",
+    "category": "llm-fundamentals",
+    "description": "Reinforcement Learning from Human Feedback (RLHF) aligns LLMs to human preferences using a reward model as the environment.",
+    "tags": [
+      "rlhf",
+      "ppo",
+      "trl",
+      "reward-model",
+      "kl-divergence"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/llm-fundamentals/rlhf-ppo-trl.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "safetensors-pth-fallback",
+    "slug": "safetensors-pth-fallback",
+    "category": "model-loading",
+    "description": "VoxCPM loaders try audiovae.safetensors first, fall back to audiovae.pth; new exports should prefer safetensors for safety and speed",
+    "tags": [
+      "safetensors",
+      "checkpoint",
+      "model-loading",
+      "fallback",
+      "compatibility"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/model-loading/safetensors-pth-fallback.md",
     "has_content": true
   },
   {
@@ -6793,6 +7049,22 @@
   },
   {
     "kind": "knowledge",
+    "name": "rpc-channel-namespaces",
+    "slug": "rpc-channel-namespaces",
+    "category": "reference",
+    "description": "The RPC channel namespace convention (system:*, workspaces:*, sessions:*, sources:*, skills:*, credentials:*, LLM_Connection:*, transfer:*) defined in @craft-agent/shared/protocol and used by every client (Electron renderer, CLI, web UI).",
+    "tags": [
+      "rpc",
+      "protocol",
+      "channels"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/reference/rpc-channel-namespaces.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "vector-clock-ui-dominance-tri-state-color",
     "slug": "vector-clock-ui-dominance-tri-state-color",
     "category": "reference",
@@ -6801,6 +7073,61 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/reference/vector-clock-ui-dominance-tri-state-color.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "rpm-version-field-hyphen-constraint",
+    "slug": "rpm-version-field-hyphen-constraint",
+    "category": "rpm",
+    "description": "The RPM `Version` field forbids hyphens; when an upstream version string contains a hyphen (e.g., `1.1.799-1.3.3`), it must be split on the hyphen into `Version` (part before) and `Release` (part after) to satisfy `rpmbuild`.",
+    "tags": [
+      "rpm",
+      "rpmbuild",
+      "version",
+      "packaging",
+      "fedora",
+      "rhel",
+      "version-string"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/rpm/rpm-version-field-hyphen-constraint.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "rollback-strategy-git-based-three-modes",
+    "slug": "rollback-strategy-git-based-three-modes",
+    "category": "safety",
+    "description": "Three rollback modes for failed evolution — hard reset, stash, or none",
+    "tags": [
+      "evolver",
+      "safety",
+      "rollback",
+      "git",
+      "reference"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/safety/rollback-strategy-git-based-three-modes.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "sandbox-soft-vs-hard-trade-off",
+    "slug": "sandbox-soft-vs-hard-trade-off",
+    "category": "safety",
+    "description": "OpenSRE's Python sandbox is a \"soft\" sandbox — monkeypatching socket/subprocess/open at the start of an injected preamble. Sufficient for the SRE agent threat model (LLM-generated diagnostic snippets), insufficient for adversarial code; understand the boundary.",
+    "tags": [
+      "sandbox",
+      "threat-model",
+      "security",
+      "llm-generated-code"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/safety/sandbox-soft-vs-hard-trade-off.md",
     "has_content": true
   },
   {
@@ -6820,6 +7147,25 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/schema-design/identifier-regex-loose-when-legacy-coexists.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "sanitized-environment-fingerprint-for-auto-report",
+    "slug": "sanitized-environment-fingerprint-for-auto-report",
+    "category": "security",
+    "description": "Before an autonomous process files a public bug report (GitHub issue, telemetry event, hub submission), pass every string field through a centralized `redactString()` and include only a fixed allowlist of env-fingerprint fields — version, node version, platform/arch, container flag, truncated node id. Never include hostname, cwd, env dump, or raw logs.",
+    "tags": [
+      "pii",
+      "sanitization",
+      "redaction",
+      "auto-reporting",
+      "env-fingerprint",
+      "allowlist"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/security/sanitized-environment-fingerprint-for-auto-report.md",
     "has_content": true
   },
   {
@@ -6915,6 +7261,24 @@
     "has_content": true
   },
   {
+    "kind": "knowledge",
+    "name": "reverse-document-workflow-example",
+    "slug": "reverse-document-workflow-example",
+    "category": "workflow",
+    "description": "Step-by-step example of using the reverse-document skill to generate docs from existing code",
+    "tags": [
+      "game-studios",
+      "ccgs",
+      "reverse-document",
+      "example",
+      "brownfield"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/workflow/reverse-document-workflow-example.md",
+    "has_content": true
+  },
+  {
     "kind": "skill",
     "name": "adopt",
     "slug": "adopt",
@@ -6960,6 +7324,90 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/qa/content-audit",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "regression-suite",
+    "slug": "regression-suite",
+    "category": "",
+    "description": "\"Map test coverage to GDD critical paths, identify fixed bugs without regression tests, flag coverage drift from new features, and maintain tests/regression-suite.md. Run after implementing a bug fix or before a release gate.\"",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/qa/regression-suite",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "release-checklist",
+    "slug": "release-checklist",
+    "category": "",
+    "description": "\"Generates a comprehensive pre-release validation checklist covering build verification, certification requirements, store metadata, and launch readiness.\"",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/production/release-checklist",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "retrospective",
+    "slug": "retrospective",
+    "category": "",
+    "description": "\"Generates a sprint or milestone retrospective by analyzing completed work, velocity, blockers, and patterns. Produces actionable insights for the next iteration.\"",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/production/retrospective",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "reverse-document",
+    "slug": "reverse-document",
+    "category": "",
+    "description": "\"Generate design or architecture documents from existing implementation. Works backwards from code/prototypes to create missing planning docs.\"",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/design/reverse-document",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "review-all-gdds",
+    "slug": "review-all-gdds",
+    "category": "",
+    "description": "\"Holistic cross-GDD consistency and game design review. Reads all system GDDs simultaneously and checks for contradictions between them, stale references, ownership conflicts, formula incompatibilities, and game design theory violations (dominant strategies, economic imbalance, cognitive overload, pillar drift). Run after all MVP GDDs are written, before architecture begins.\"",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/design/review-all-gdds",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "scope-check",
+    "slug": "scope-check",
+    "category": "",
+    "description": "\"Analyze a feature or sprint for scope creep by comparing current scope against the original plan. Flags additions, quantifies bloat, and recommends cuts. Use when user says 'any scope creep', 'scope review', 'are we staying in scope'.\"",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/production/scope-check",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "security-audit",
+    "slug": "security-audit",
+    "category": "",
+    "description": "\"Audit the game for security vulnerabilities: save tampering, cheat vectors, network exploits, data exposure, and input validation gaps. Produces a prioritised security report with remediation guidance. Run before any public release or multiplayer launch.\"",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/engineering/security-audit",
     "has_content": false
   },
   {
@@ -7082,6 +7530,59 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/agents/coding-agent-cli-backend-interface",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "run-config-global-settings",
+    "slug": "run-config-global-settings",
+    "category": "agents",
+    "description": "Use RunConfig to set run-wide defaults for model, max turns, tracing, and guardrails.",
+    "tags": [
+      "openai-agents",
+      "run-config",
+      "model-settings",
+      "max-turns",
+      "tracing"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/agents/run-config-global-settings",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "run-context-shared-state",
+    "slug": "run-context-shared-state",
+    "category": "agents",
+    "description": "Pass typed shared state to all tools and hooks within an agent run via RunContextWrapper.",
+    "tags": [
+      "openai-agents",
+      "context",
+      "shared-state",
+      "dependency-injection"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/agents/run-context-shared-state",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "sandbox-agent-workspace",
+    "slug": "sandbox-agent-workspace",
+    "category": "agents",
+    "description": "Run an agent inside an isolated sandbox workspace with a manifest-defined filesystem using SandboxAgent.",
+    "tags": [
+      "openai-agents",
+      "sandbox",
+      "workspace",
+      "files",
+      "git-repo"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/agents/sandbox-agent-workspace",
     "has_content": false
   },
   {
@@ -8111,6 +8612,44 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/architecture/accepts-then-convert-two-phase-dispatch",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "reserved-slugs-coordinated-list",
+    "slug": "reserved-slugs-coordinated-list",
+    "category": "architecture",
+    "description": "Maintain a single reserved-slug list in both frontend and backend with per-entry category rationale so url-based multi-tenancy never collides with top-level routes.",
+    "tags": [
+      "multi-tenancy",
+      "routing",
+      "reserved-slugs",
+      "url-design",
+      "validation"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/architecture/reserved-slugs-coordinated-list",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "resolve-cloudflare-protected-download-url",
+    "slug": "resolve-cloudflare-protected-download-url",
+    "category": "automation",
+    "description": "Use Playwright in headless stealth mode to bypass Cloudflare and capture the final download URL from network requests. Derive secondary-architecture URLs by pattern substitution from the resolved primary URL, then verify with HEAD requests.",
+    "tags": [
+      "playwright",
+      "cloudflare",
+      "download",
+      "url-resolution",
+      "stealth",
+      "automation",
+      "python"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/automation/resolve-cloudflare-protected-download-url",
     "has_content": false
   },
   {
@@ -12972,6 +13511,74 @@
   },
   {
     "kind": "skill",
+    "name": "repackage-electron-asar-with-patterns",
+    "slug": "repackage-electron-asar-with-patterns",
+    "category": "electron-packaging",
+    "description": "Extract an Electron .asar archive, apply regex-based patches to minified JS that survive minifier renames by anchoring on stable string literals, then repack. Includes dynamic variable extraction so patches remain version-agnostic.",
+    "tags": [
+      "electron",
+      "asar",
+      "patching",
+      "regex",
+      "minified-js",
+      "build"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/electron-packaging/repackage-electron-asar-with-patterns",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "requesting-code-review",
+    "slug": "requesting-code-review",
+    "category": "engineering",
+    "description": "Use when completing tasks, implementing major features, or before merging to verify work meets requirements",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/engineering/requesting-code-review",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "safe-content-disposition-rfc5987",
+    "slug": "safe-content-disposition-rfc5987",
+    "category": "fastapi",
+    "description": "Build a Content-Disposition header that survives non-ASCII filenames on every browser using the RFC 5987 filename* encoding.",
+    "tags": [
+      "http",
+      "headers",
+      "fastapi",
+      "i18n",
+      "downloads"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/fastapi/safe-content-disposition-rfc5987",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "rust-flutter-ffi-bridge-async-pattern",
+    "slug": "rust-flutter-ffi-bridge-async-pattern",
+    "category": "ffi",
+    "description": "Async Rust-Flutter FFI with tokio channels and StreamSink for bi-directional event streaming.",
+    "tags": [
+      "async",
+      "bridge",
+      "ffi",
+      "flutter",
+      "pattern",
+      "rust"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/ffi/rust-flutter-ffi-bridge-async-pattern",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "ag-grid-cell-renderer-pattern",
     "slug": "ag-grid-cell-renderer-pattern",
     "category": "frontend",
@@ -13577,6 +14184,44 @@
   },
   {
     "kind": "skill",
+    "name": "sample-count-parallel-path-averaging",
+    "slug": "sample-count-parallel-path-averaging",
+    "category": "inference",
+    "description": "Replicate each input N times inside the batch, run stochastic decoding in parallel, then average the N sampled paths to reduce variance.",
+    "tags": [
+      "monte-carlo",
+      "ensemble",
+      "sampling",
+      "variance-reduction",
+      "autoregressive",
+      "forecasting"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/inference/sample-count-parallel-path-averaging",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "relative-mouse-mode-state-machine",
+    "slug": "relative-mouse-mode-state-machine",
+    "category": "input",
+    "description": "Atomic state tracking for relative mouse mode with exit-shortcut detection across platforms.",
+    "tags": [
+      "input",
+      "machine",
+      "mode",
+      "mouse",
+      "relative",
+      "state"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/input/relative-mouse-mode-state-machine",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "a2a-protocol-with-hello-publish-decision",
     "slug": "a2a-protocol-with-hello-publish-decision",
     "category": "integration",
@@ -13641,6 +14286,46 @@
   },
   {
     "kind": "skill",
+    "name": "safe-remove-all-for-distributed-filesystems",
+    "slug": "safe-remove-all-for-distributed-filesystems",
+    "category": "jit-compilation",
+    "description": "Replace `std::filesystem::remove_all` with a recursive walk that tolerates concurrent mutation on NFS/Lustre — use pre-incremented iterators, skip-permission-denied options, and error-code overloads that never throw.",
+    "tags": [
+      "filesystem",
+      "nfs",
+      "distributed",
+      "concurrency",
+      "error-handling",
+      "cleanup"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/jit-compilation/safe-remove-all-for-distributed-filesystems",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "sandbox-backend-pluggable-architecture",
+    "slug": "sandbox-backend-pluggable-architecture",
+    "category": "linux-sandbox",
+    "description": "Three-backend dispatcher (Host/Bwrap/KVM) with auto-detection priority and env override. Abstract base class defines the interface; concrete implementations handle isolation. Used to run untrusted subprocess workloads on Linux with progressive isolation.",
+    "tags": [
+      "sandbox",
+      "bubblewrap",
+      "bwrap",
+      "kvm",
+      "linux",
+      "isolation",
+      "pluggable",
+      "daemon"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/linux-sandbox/sandbox-backend-pluggable-architecture",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "agent-handoff-routing",
     "slug": "agent-handoff-routing",
     "category": "llm-agents",
@@ -13672,6 +14357,24 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/llm-agents/agents-as-tools",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "response-pagination-with-metadata",
+    "slug": "response-pagination-with-metadata",
+    "category": "mcp",
+    "description": "Expose pageSize/pageIdx in MCP tool schemas and return pagination metadata (currentPage, totalPages, hasNextPage, startIndex, endIndex) in both the text and structured response so agents can iterate large result sets deterministically.",
+    "tags": [
+      "mcp",
+      "pagination",
+      "token-budget",
+      "response-design",
+      "agent-ux"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/mcp/response-pagination-with-metadata",
     "has_content": false
   },
   {
@@ -13769,6 +14472,24 @@
     "version": "0.1.0-draft",
     "path": "skills/mobile/react-native-android-emulator-localhost",
     "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "rope-dynamic-ntk-scaling",
+    "slug": "rope-dynamic-ntk-scaling",
+    "category": "model-architecture",
+    "description": "RoPE with Dynamic NTK scaling to extend context beyond training max position length",
+    "tags": [
+      "rope",
+      "positional-encoding",
+      "context-extension",
+      "transformer",
+      "attention"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/model-architecture/rope-dynamic-ntk-scaling",
+    "has_content": false
   },
   {
     "kind": "skill",
@@ -13954,6 +14675,46 @@
   },
   {
     "kind": "skill",
+    "name": "retrofit-okhttp-api-endpoint-extraction",
+    "slug": "retrofit-okhttp-api-endpoint-extraction",
+    "category": "reverse-engineering",
+    "description": "Enumerate and document all HTTP endpoints from decompiled Android code by grepping annotation/builder signatures (Retrofit @GET/@POST, OkHttp Request.Builder, Volley request classes) then capturing method, path, headers, body, response type, and call site for each hit.",
+    "tags": [
+      "android",
+      "reverse-engineering",
+      "retrofit",
+      "okhttp",
+      "volley",
+      "api-extraction",
+      "http"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/reverse-engineering/retrofit-okhttp-api-endpoint-extraction",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "rpm-package-from-electron-no-hyphens",
+    "slug": "rpm-package-from-electron-no-hyphens",
+    "category": "rpm",
+    "description": "Generate an RPM spec file for an Electron app that correctly splits hyphenated version strings into Version/Release fields, maps Debian architecture names (amd64→x86_64, arm64→aarch64), and disables binary stripping and debug package generation.",
+    "tags": [
+      "rpm",
+      "fedora",
+      "packaging",
+      "electron",
+      "spec",
+      "arch-mapping",
+      "version-string"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/rpm/rpm-package-from-electron-no-hyphens",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "contextual-identifier-detectors-overlap-resolution",
     "slug": "contextual-identifier-detectors-overlap-resolution",
     "category": "safety",
@@ -13968,6 +14729,24 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/safety/contextual-identifier-detectors-overlap-resolution",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "reversible-pii-masking-context",
+    "slug": "reversible-pii-masking-context",
+    "category": "safety",
+    "description": "Replace sensitive identifiers with stable placeholders before LLM calls and reverse-map them on the way out, using a per-investigation context that survives node-to-node state transitions in a graph pipeline.",
+    "tags": [
+      "masking",
+      "pii",
+      "llm",
+      "reversible",
+      "langgraph"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/safety/reversible-pii-masking-context",
     "has_content": false
   },
   {
@@ -14140,6 +14919,23 @@
   },
   {
     "kind": "skill",
+    "name": "reject-insecure-bind-without-tls",
+    "slug": "reject-insecure-bind-without-tls",
+    "category": "security",
+    "description": "Refuse to bind a token-authenticated WebSocket/HTTP server to a non-loopback address unless TLS is configured, with an explicit --allow-insecure-bind escape hatch.",
+    "tags": [
+      "websocket",
+      "tls",
+      "tokens",
+      "bind-safety"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/security/reject-insecure-bind-without-tls",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "clearcut-batch-flush-with-retry",
     "slug": "clearcut-batch-flush-with-retry",
     "category": "telemetry",
@@ -14154,6 +14950,24 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/telemetry/clearcut-batch-flush-with-retry",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "sanitize-tool-params-for-metrics",
+    "slug": "sanitize-tool-params-for-metrics",
+    "category": "telemetry",
+    "description": "When logging tool-invocation metrics, record only privacy-safe derivatives of arguments — string lengths, array counts, enum values — never raw values; drive the transformation from the tool's zod schema.",
+    "tags": [
+      "telemetry",
+      "privacy",
+      "zod",
+      "schema",
+      "metrics"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/telemetry/sanitize-tool-params-for-metrics",
     "has_content": false
   },
   {
@@ -15791,6 +16605,24 @@
   },
   {
     "kind": "skill",
+    "name": "run-messages-incremental-polling",
+    "slug": "run-messages-incremental-polling",
+    "category": "workflow",
+    "description": "Monotonic sequence numbers on streamed task messages enable cheap incremental polling (--since seq) so live UI fetches only the tail, not the whole log.",
+    "tags": [
+      "polling",
+      "streaming",
+      "task-messages",
+      "cli",
+      "pagination"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/run-messages-incremental-polling",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "saga-pattern-data-simulation",
     "slug": "saga-pattern-data-simulation",
     "category": "workflow",
@@ -16142,6 +16974,24 @@
     "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/x-filterable-fields-extraction",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "registeropenapiroute-wrapper",
+    "slug": "registeropenapiroute-wrapper",
+    "category": "zod",
+    "description": "Thin wrapper around `@hono/zod-openapi`'s `app.openapi(route, handler)` that casts the handler to `never`, bypassing the TypedResponse constraint while keeping runtime Zod validation of inputs.",
+    "tags": [
+      "zod",
+      "hono",
+      "openapi",
+      "typed-response",
+      "route-registration"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/zod/registeropenapiroute-wrapper",
     "has_content": false
   }
 ]

--- a/knowledge/api/runtime-mode-approval-policy-and-sandbox-mode.md
+++ b/knowledge/api/runtime-mode-approval-policy-and-sandbox-mode.md
@@ -1,0 +1,43 @@
+---
+name: runtime-mode-approval-policy-and-sandbox-mode
+summary: T3 Code has a global runtime mode that controls whether commands need approval and what filesystem access is allowed
+type: knowledge
+category: api
+confidence: high
+tags: [api, safety, design]
+source_type: extracted-from-git
+source_url: https://github.com/pingdotgg/t3code.git
+source_ref: main
+source_commit: 9df3c640210fecccb58f7fbc735f81ca0ee011bd
+source_project: t3code
+imported_at: 2026-04-18
+evidence:
+  - .docs/runtime-modes.md
+  - packages/contracts/src/orchestration.ts
+---
+
+## Fact
+T3 Code's runtime mode is a UI switch in the chat toolbar. It controls two settings for new sessions:
+1. **approvalPolicy: "never" vs "on-request"** — whether provider commands (shell, file write) need in-app approval
+2. **sandboxMode: "danger-full-access" vs "workspace-write"** — what filesystem paths the agent can touch
+
+Full access (default): `approvalPolicy: never`, `sandboxMode: danger-full-access`. Supervised: `approvalPolicy: on-request`, `sandboxMode: workspace-write`.
+
+## Why it matters
+1. **User safety** — in Supervised mode, agents can't delete system files or run arbitrary shell; human must approve each command
+2. **Iteration speed** — Full access lets agents work uninterrupted; useful for trusted environments or disposable sandboxes
+3. **Audit trail** — approvals are recorded as activities, showing who approved what
+4. **Per-session control** — mode is set when session is created; can't change mid-turn (forces new session)
+
+## Evidence
+- Runtime modes doc lists approvalPolicy values and sandboxMode values
+- Contracts define these as session properties
+- ProviderCommandReactor checks approval policy before executing commands
+- Runtime modes doc states these are the main values; extensibility path exists
+
+## How to apply
+- When creating a session (thread), pass the global runtime mode setting to provider
+- In approval handling, read `session.approvalPolicy`; if "on-request", add command to pending approval queue before executing
+- UI shows pending approvals as a list; user clicks to approve/deny
+- If user denies, emit an activity record and skip execution
+- Document that mode is global (not per-thread) and persisted in user settings

--- a/knowledge/arch/seekable-abstraction-for-io.md
+++ b/knowledge/arch/seekable-abstraction-for-io.md
@@ -1,0 +1,26 @@
+---
+name: seekable-abstraction-for-io
+type: knowledge
+category: arch
+summary: Python uses a Seekable wrapper to unify bytes / paths / streams under one feature-extraction codepath.
+confidence: medium
+tags: [magika, arch]
+linked_skills: [platform-agnostic-file-input-abstraction]
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Seekable Abstraction For Io
+
+## Fact
+
+The Python API wraps file-like objects and byte buffers in a Seekable abstraction with a consistent seek/read interface. Lets identify_bytes / identify_path / identify_stream share core logic without duplication.
+
+## Evidence
+
+- `python/src/magika/magika.py:43`
+- `commit 595c093`

--- a/knowledge/automation/scheduler-and-cron-task-execution-model.md
+++ b/knowledge/automation/scheduler-and-cron-task-execution-model.md
@@ -1,0 +1,139 @@
+---
+name: scheduler-and-cron-task-execution-model
+summary: File-based lightweight cron alternative — JSON task definitions, report-timestamp cooldown tracking, health-check introspection, max-delay guardrails.
+category: automation
+tags: [automation, scheduling, cron-alternative, file-based, agents]
+source_type: extracted-from-git
+source_url: https://github.com/lsdefine/GenericAgent.git
+source_ref: main
+source_commit: ec34b7e1c0f11fbb9709680ccfe313187a1b942b
+source_project: GenericAgent
+source_path: memory/scheduled_task_sop.md
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+---
+
+# Scheduler and cron task execution model
+
+Design pattern for a lightweight file-based scheduler suitable for driving scheduled work in an agent framework or similar environment where installing systemd/cron would be overkill or impossible (Windows user account, Docker container without cron, etc.).
+
+## Directory layout
+
+```
+sche_tasks/
+├── *.json              ← task definitions (one file per scheduled task)
+├── done/
+│   └── YYYY-MM-DD_task-name.md   ← per-run reports; existence doubles as "ran today"
+└── scheduler.log       ← scheduler lifecycle + trigger/skip/error events
+```
+
+`done/` serves double duty: it's the report archive AND the cooldown source of truth. The scheduler asks "did this task already run in its current window?" by looking at the newest report file's timestamp for that task. No database, no in-memory state — all durable.
+
+## Task definition schema
+
+```json
+{
+  "schedule": "08:00",
+  "repeat": "daily",
+  "enabled": true,
+  "prompt": "...",
+  "max_delay_hours": 6
+}
+```
+
+| Field | Purpose |
+|---|---|
+| `schedule` | When to fire. Time-of-day for daily-ish types; ISO for `once` |
+| `repeat` | `daily` / `weekday` / `weekly` / `monthly` / `once` / `every_Nh` / `every_Nd` |
+| `enabled` | Hard kill-switch; `false` means never fire, but the task file stays for history |
+| `prompt` | The payload handed to whatever worker executes the task (often an LLM-agent prompt) |
+| `max_delay_hours` | How late the task may fire past its nominal time before being silently skipped (default 6) |
+
+`max_delay_hours` is the small detail that matters: if the user turned the machine off overnight and boots it at 10am, a daily-08:00 task doesn't pile up and fire immediately. With `max_delay_hours: 6`, it fires as normal (10am is within window). With `max_delay_hours: 1`, it's silently skipped and waits for tomorrow — no more stale "good morning" tasks popping at dinner.
+
+## Trigger loop
+
+```
+every 60 seconds:
+  for each *.json in sche_tasks/:
+    load task
+    if not task.enabled: skip
+    if now < task.schedule_next_fire_time: skip
+    if now > task.schedule + max_delay_hours: skip + log "stale, waiting for next window"
+    if newest report for this task within cooldown window: skip + log "already ran"
+    → FIRE (build prompt with injected report path, dispatch to worker)
+```
+
+60 seconds is a reasonable poll interval: short enough that an 08:00 task fires by 08:01 on most systems, long enough that the scheduler is nearly free.
+
+## Report-path injection
+
+The scheduler generates the report path and injects it into the prompt:
+
+```
+... original prompt text ...
+
+Please write your report to:
+  sche_tasks/done/2026-04-18_daily-digest.md
+```
+
+The worker agent now has a contract: finish the task AND write the report to this exact path. The scheduler uses the file's *existence and mtime* to determine cooldown status. No IPC, no status message — presence of the file IS the completion signal.
+
+### First-thing checkpoint rule
+
+The worker's **first** action on receiving the task should be to update its durable working-checkpoint with the report path. This prevents long tasks from losing track of where they were supposed to write — if the worker crashes halfway through, the next session's recovery can see "oh, I was supposed to write to X; that file doesn't exist; I haven't finished yet."
+
+## Health-check introspection
+
+```python
+scheduler.health_check()
+# → [
+#     {"name": "daily-digest", "status": "HEALTHY", "last_run": "2026-04-17T08:03:12"},
+#     {"name": "weekly-tidy",  "status": "OVERDUE", "last_run": "2026-04-01T09:00:00"},
+#     {"name": "experimental", "status": "DISABLED"},
+#     {"name": "once-upgrade", "status": "NEVER_RUN"},
+#     {"name": "broken-task",  "status": "ERROR", "reason": "bad schedule format"},
+#   ]
+```
+
+Five states — HEALTHY, OVERDUE, DISABLED, NEVER_RUN, ERROR — surface in one call. Useful for:
+
+- Dashboard rendering ("what's red").
+- Startup sanity check ("after a long absence, what needs attention?").
+- Alerting ("any ERROR state pages oncall").
+
+## Logged events
+
+The `scheduler.log` records:
+
+- **trigger**: task about to run, with injected prompt path
+- **skip**: reason (disabled / in cooldown / past max_delay / stale window)
+- **error**: JSON parse failure, bad schedule format, unknown repeat type, worker invocation failure
+- **startup/shutdown**: for debugging lifecycle
+
+A tight log format means grepping `scheduler.log | grep ERROR` is enough for most triage.
+
+## `once` type: effectively-permanent cooldown
+
+`repeat: "once"` is implemented by setting the cooldown to 100 years after first run. The task file remains (for history) but never fires again. To re-arm, either delete the last report file or set `enabled: false` then replace the JSON.
+
+## Why file-based beats in-memory for this class of problem
+
+1. **Restart-resilient.** The scheduler process can crash, be upgraded, be rebooted — next startup reads the same task files, knows the same history, keeps running.
+2. **Human-editable.** A user can disable a task by editing one JSON; a user can rerun by deleting one report file. No admin CLI needed.
+3. **Audit-friendly.** The done/ directory *is* the audit trail. No separate log correlation.
+4. **Cheap.** 60-second polling across a dozen JSON files is sub-millisecond CPU.
+
+## When this pattern breaks down
+
+- **High cardinality** (hundreds of tasks) — the directory scan per poll is still cheap, but human management becomes untenable. Switch to a database.
+- **Sub-minute precision** — 60-second polling can't do that; drop interval or use OS-level scheduling.
+- **Distributed scheduling** (multiple hosts) — file-based races on shared storage; add locking or switch to a proper job queue.
+
+## Related
+
+- Pairs well with `autonomous-operation-principles-for-unattended-agents` (knowledge) — the scheduler is the driver for autonomous sessions.
+
+---
+
+Reference extracted from GenericAgent's `scheduled_task_sop.md`. Chinese-language original; translated.

--- a/knowledge/codecs/screen-capture-api-evolution-macos.md
+++ b/knowledge/codecs/screen-capture-api-evolution-macos.md
@@ -1,0 +1,28 @@
+---
+name: screen-capture-api-evolution-macos
+type: knowledge
+category: codecs
+summary: macOS capture has shifted: legacy Quartz CGDisplayCreateImage → ScreenCaptureKit (Monterey+) behind a feature flag.
+confidence: high
+tags: [api, capture, codecs, evolution, macos, screen]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: libs/scrap/src/quartz/
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Screen Capture Api Evolution Macos
+
+## Fact
+macOS capture has shifted: legacy Quartz CGDisplayCreateImage → ScreenCaptureKit (Monterey+) behind a feature flag.
+
+## Why it matters
+Plan for dual-code-path during the OS-version transition window; Apple deprecates old APIs aggressively.
+
+## Evidence
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- `libs/scrap/src/quartz/`

--- a/knowledge/devops/release-auto-update-publish-url.md
+++ b/knowledge/devops/release-auto-update-publish-url.md
@@ -1,0 +1,57 @@
+---
+name: release-auto-update-publish-url
+summary: electron-updater pulls update manifests from https://agents.craft.do/electron/latest — a generic static URL provider, not GitHub Releases or S3 — so Craft Docs Ltd. controls rollout without electron-builder's built-in providers.
+category: devops
+tags: [electron-updater, auto-update, release, distribution]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: apps/electron/electron-builder.yml
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Auto-update via generic static URL
+
+### Setup
+```yaml
+# apps/electron/electron-builder.yml
+publish:
+  provider: generic
+  url: https://agents.craft.do/electron/latest
+```
+
+electron-builder's `generic` provider means: drop the release manifests (`latest-mac.yml`, `latest.yml`, `latest-linux.yml`) + binary files at a static URL. electron-updater polls that URL for version bumps.
+
+### Why not GitHub Releases provider
+- `https://agents.craft.do/electron/latest` is a controlled CDN Craft Docs Ltd. owns; GitHub Releases rate-limits unauthenticated users.
+- Custom URL = custom gating logic (canary cohorts, A/B, region-specific rollouts) via the backend serving it.
+- GitHub Releases ties updates to GitHub accounts visible to users; generic is anonymous.
+
+### One URL, multi-platform
+electron-builder generates:
+- `latest-mac.yml` (ZIP + DMG, x64 + arm64)
+- `latest.yml` (Windows NSIS)
+- `latest-linux.yml` (AppImage)
+
+Each manifest lists files + sha512 checksums. electron-updater downloads the binary from the same base URL.
+
+### Rollback considerations
+- Users auto-update as soon as the URL returns a higher version.
+- To roll back, remove the offending `latest-*.yml` AND the new binary; electron-updater sees no update available and stays on current.
+- There's no ability to force downgrade (electron-updater only advances).
+
+### Per-channel (beta / stable)
+Could have separate URLs (`/electron/beta/latest`, `/electron/stable/latest`), the app picks one based on a config toggle. The repo ships only "stable" URL.
+
+### Signing
+Auto-update on macOS/Windows requires signed binaries:
+- macOS: `CSC_LINK`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID` (set in CI; disabled for local builds).
+- Windows: signed NSIS installer.
+- electron-updater verifies signature before applying the update.
+
+### Reference
+- `apps/electron/electron-builder.yml#publish`.
+- `README.md` debug-mode sections reference log paths under `@craft-agent/electron/`.

--- a/knowledge/domain/repository-identity-vs-project-vs-thread.md
+++ b/knowledge/domain/repository-identity-vs-project-vs-thread.md
@@ -1,0 +1,55 @@
+---
+name: repository-identity-vs-project-vs-thread
+summary: A RepositoryIdentity is a logical grouping (e.g., for UI); a Project is environment-local with a workspace root; a Thread is a conversation within a project
+type: knowledge
+category: domain
+confidence: high
+tags: [domain, terminology, modeling]
+source_type: extracted-from-git
+source_url: https://github.com/pingdotgg/t3code.git
+source_ref: main
+source_commit: 9df3c640210fecccb58f7fbc735f81ca0ee011bd
+source_project: t3code
+imported_at: 2026-04-18
+evidence:
+  - .docs/encyclopedia.md
+  - .docs/remote-architecture.md
+---
+
+## Fact
+T3 Code has three nested concepts that newcomers often conflate:
+
+1. **RepositoryIdentity** — a logical grouping for the same repository cloned in multiple places (e.g., local and remote)
+   - Used for UI sidebar grouping and correlation, not for routing
+   - Best-effort; derived from git remote URL
+   - Not authoritative
+
+2. **Project** — an environment-local workspace record
+   - Belongs to one execution environment (one T3 server)
+   - Has a workspaceRoot (filesystem path on that server)
+   - May have worktrees for thread isolation
+   - A local clone and a remote clone are different projects (different servers/paths)
+
+3. **Thread** — a conversation within a project
+   - A durable timeline of messages, activities, and turns
+   - Bound to one project (so bound to one environment)
+   - Has optional worktreePath (if isolated from project root)
+   - Multiple threads can share a worktree or have separate worktrees
+
+## Why it matters
+1. **Remote support depends on this** — remote architecture doc says projects stay environment-local; only RepositoryIdentity is shared
+2. **UI grouping clarity** — UI groups by RepositoryIdentity but routes to Projects by environment, then Threads within project
+3. **Persistence model** — Events are stored per project; Projects and Threads are durable, RepositoryIdentity is derived
+4. **Avoids false unification** — tempting to merge local and remote clones as "the same project"; wrong, they're different projects with same logical identity
+
+## Evidence
+- Encyclopedia defines all three separately
+- Remote architecture explicitly states: "a local clone and a remote clone are different projects"
+- Project has workspaceRoot, Thread has optional worktreePath
+- RepositoryIdentityResolver derives identity from git remote, not vice versa
+
+## How to apply
+- When designing project/thread picker UI, group by RepositoryIdentity for UX but route by Project/Thread for logic
+- When persisting, store project-local state only; RepositoryIdentity is UI sugar
+- In remote support, same RepositoryIdentity can map to different Projects on different environments
+- Document this hierarchy in onboarding; confusion here is common

--- a/knowledge/domain/research-paper-published-icse-2025.md
+++ b/knowledge/domain/research-paper-published-icse-2025.md
@@ -1,0 +1,26 @@
+---
+name: research-paper-published-icse-2025
+type: knowledge
+category: domain
+summary: Magika's design and evaluation are published at ICSE 2025 (IEEE/ACM International Conference on Software Engineering).
+confidence: high
+tags: [magika, domain]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Research Paper Published Icse 2025
+
+## Fact
+
+The paper documents the deep learning approach, model architecture, training methodology, and evaluation on 100M+ samples. Useful as the authoritative reference for the ~99% accuracy claim and the design rationale.
+
+## Evidence
+
+- `python/README.md:213-227`
+- `README.md:25`

--- a/knowledge/engineering/reproduce-bug-with-failing-test-first.md
+++ b/knowledge/engineering/reproduce-bug-with-failing-test-first.md
@@ -1,0 +1,48 @@
+---
+name: reproduce-bug-with-failing-test-first
+summary: Before fixing a reported bug, write a test that reproduces it. The test failing proves you understand the bug; the test passing proves the fix works. Especially important for non-deterministic bugs.
+category: engineering
+tags: [tdd, bug-reproduction, verification, non-determinism]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/forrestchang/andrej-karpathy-skills.git
+source_ref: main
+source_commit: c9a44ae835fa2f5765a697216692705761a53f40
+source_project: andrej-karpathy-skills
+source_path: EXAMPLES.md#goal-driven-example-3
+imported_at: 2026-04-18T08:26:22Z
+---
+
+# Pattern — Reproduce the bug with a failing test first
+
+## When to apply
+Any reported bug, especially:
+- Non-deterministic behavior (e.g., sort is unstable on duplicate keys).
+- Rare edge cases the current suite doesn't cover.
+- Anything you'd otherwise "fix" without confirming.
+
+## Procedure
+1. **Write a test** that asserts the *correct* behavior.
+2. **Run it** — it must fail. If it passes, either the bug isn't what you think, or your assertion is wrong. Investigate.
+3. **Implement the fix.**
+4. **Re-run** — the test now passes.
+5. **Run the full suite** — no regressions.
+
+## Example from source
+Sort breaks when two scores tie. The test:
+```python
+def test_sort_with_duplicate_scores():
+    scores = [
+        {'name': 'Alice', 'score': 100},
+        {'name': 'Bob',   'score': 100},
+        {'name': 'Charlie', 'score': 90},
+    ]
+    result = sort_scores(scores)
+    assert result[0]['score'] == 100
+    assert result[1]['score'] == 100
+    assert result[2]['score'] == 90
+```
+Run 10 times to confirm non-determinism, then fix with a stable tie-break key: `key=lambda x: (-x['score'], x['name'])`.
+
+## Why it works
+A failing test converts "fix the bug" into a verifiable goal, letting the LLM (or human) loop to green without further clarification.

--- a/knowledge/engineering/root-cause-tracing.md
+++ b/knowledge/engineering/root-cause-tracing.md
@@ -1,0 +1,184 @@
+---
+name: root-cause-tracing
+summary: Trace bugs upward from symptom through the call stack to the true root cause before fixing, avoiding symptom-level patches
+category: engineering
+confidence: medium
+tags: [superpowers, engineering]
+source_type: extracted-from-git
+source_url: https://github.com/obra/superpowers.git
+source_ref: main
+source_commit: b55764852ac78870e65c6565fb585b6cd8b3c5c9
+source_project: superpowers
+source_path: skills/systematic-debugging/root-cause-tracing.md
+imported_at: 2026-04-18T06:36:49Z
+---
+
+# Root Cause Tracing
+
+## Overview
+
+Bugs often manifest deep in the call stack (git init in wrong directory, file created in wrong location, database opened with wrong path). Your instinct is to fix where the error appears, but that's treating a symptom.
+
+**Core principle:** Trace backward through the call chain until you find the original trigger, then fix at the source.
+
+## When to Use
+
+```dot
+digraph when_to_use {
+    "Bug appears deep in stack?" [shape=diamond];
+    "Can trace backwards?" [shape=diamond];
+    "Fix at symptom point" [shape=box];
+    "Trace to original trigger" [shape=box];
+    "BETTER: Also add defense-in-depth" [shape=box];
+
+    "Bug appears deep in stack?" -> "Can trace backwards?" [label="yes"];
+    "Can trace backwards?" -> "Trace to original trigger" [label="yes"];
+    "Can trace backwards?" -> "Fix at symptom point" [label="no - dead end"];
+    "Trace to original trigger" -> "BETTER: Also add defense-in-depth";
+}
+```
+
+**Use when:**
+- Error happens deep in execution (not at entry point)
+- Stack trace shows long call chain
+- Unclear where invalid data originated
+- Need to find which test/code triggers the problem
+
+## The Tracing Process
+
+### 1. Observe the Symptom
+```
+Error: git init failed in /Users/jesse/project/packages/core
+```
+
+### 2. Find Immediate Cause
+**What code directly causes this?**
+```typescript
+await execFileAsync('git', ['init'], { cwd: projectDir });
+```
+
+### 3. Ask: What Called This?
+```typescript
+WorktreeManager.createSessionWorktree(projectDir, sessionId)
+  → called by Session.initializeWorkspace()
+  → called by Session.create()
+  → called by test at Project.create()
+```
+
+### 4. Keep Tracing Up
+**What value was passed?**
+- `projectDir = ''` (empty string!)
+- Empty string as `cwd` resolves to `process.cwd()`
+- That's the source code directory!
+
+### 5. Find Original Trigger
+**Where did empty string come from?**
+```typescript
+const context = setupCoreTest(); // Returns { tempDir: '' }
+Project.create('name', context.tempDir); // Accessed before beforeEach!
+```
+
+## Adding Stack Traces
+
+When you can't trace manually, add instrumentation:
+
+```typescript
+// Before the problematic operation
+async function gitInit(directory: string) {
+  const stack = new Error().stack;
+  console.error('DEBUG git init:', {
+    directory,
+    cwd: process.cwd(),
+    nodeEnv: process.env.NODE_ENV,
+    stack,
+  });
+
+  await execFileAsync('git', ['init'], { cwd: directory });
+}
+```
+
+**Critical:** Use `console.error()` in tests (not logger - may not show)
+
+**Run and capture:**
+```bash
+npm test 2>&1 | grep 'DEBUG git init'
+```
+
+**Analyze stack traces:**
+- Look for test file names
+- Find the line number triggering the call
+- Identify the pattern (same test? same parameter?)
+
+## Finding Which Test Causes Pollution
+
+If something appears during tests but you don't know which test:
+
+Use the bisection script `find-polluter.sh` in this directory:
+
+```bash
+./find-polluter.sh '.git' 'src/**/*.test.ts'
+```
+
+Runs tests one-by-one, stops at first polluter. See script for usage.
+
+## Real Example: Empty projectDir
+
+**Symptom:** `.git` created in `packages/core/` (source code)
+
+**Trace chain:**
+1. `git init` runs in `process.cwd()` ← empty cwd parameter
+2. WorktreeManager called with empty projectDir
+3. Session.create() passed empty string
+4. Test accessed `context.tempDir` before beforeEach
+5. setupCoreTest() returns `{ tempDir: '' }` initially
+
+**Root cause:** Top-level variable initialization accessing empty value
+
+**Fix:** Made tempDir a getter that throws if accessed before beforeEach
+
+**Also added defense-in-depth:**
+- Layer 1: Project.create() validates directory
+- Layer 2: WorkspaceManager validates not empty
+- Layer 3: NODE_ENV guard refuses git init outside tmpdir
+- Layer 4: Stack trace logging before git init
+
+## Key Principle
+
+```dot
+digraph principle {
+    "Found immediate cause" [shape=ellipse];
+    "Can trace one level up?" [shape=diamond];
+    "Trace backwards" [shape=box];
+    "Is this the source?" [shape=diamond];
+    "Fix at source" [shape=box];
+    "Add validation at each layer" [shape=box];
+    "Bug impossible" [shape=doublecircle];
+    "NEVER fix just the symptom" [shape=octagon, style=filled, fillcolor=red, fontcolor=white];
+
+    "Found immediate cause" -> "Can trace one level up?";
+    "Can trace one level up?" -> "Trace backwards" [label="yes"];
+    "Can trace one level up?" -> "NEVER fix just the symptom" [label="no"];
+    "Trace backwards" -> "Is this the source?";
+    "Is this the source?" -> "Trace backwards" [label="no - keeps going"];
+    "Is this the source?" -> "Fix at source" [label="yes"];
+    "Fix at source" -> "Add validation at each layer";
+    "Add validation at each layer" -> "Bug impossible";
+}
+```
+
+**NEVER fix just where the error appears.** Trace back to find the original trigger.
+
+## Stack Trace Tips
+
+**In tests:** Use `console.error()` not logger - logger may be suppressed
+**Before operation:** Log before the dangerous operation, not after it fails
+**Include context:** Directory, cwd, environment variables, timestamps
+**Capture stack:** `new Error().stack` shows complete call chain
+
+## Real-World Impact
+
+From debugging session (2025-10-03):
+- Found root cause through 5-level trace
+- Fixed at source (getter validation)
+- Added 4 layers of defense
+- 1847 tests passed, zero pollution

--- a/knowledge/flutter/sciter-ui-deprecation-path.md
+++ b/knowledge/flutter/sciter-ui-deprecation-path.md
@@ -1,0 +1,29 @@
+---
+name: sciter-ui-deprecation-path
+type: knowledge
+category: flutter
+summary: Legacy Sciter UI is deprecated; migration path is Flutter desktop for all platforms.
+confidence: medium
+tags: [deprecation, flutter, path, sciter]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: [CLAUDE.md, src/ui/]
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Sciter Ui Deprecation Path
+
+## Fact
+Legacy Sciter UI is deprecated; migration path is Flutter desktop for all platforms.
+
+## Why it matters
+Plan to retire Sciter-specific features rather than invest further.
+
+## Evidence
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- `CLAUDE.md`
+- `src/ui/`

--- a/knowledge/inference/retry-badcase-token-ratio-heuristic.md
+++ b/knowledge/inference/retry-badcase-token-ratio-heuristic.md
@@ -1,0 +1,31 @@
+---
+name: retry-badcase-token-ratio-heuristic
+summary: VoxCPM retries generation when audio_tokens/text_tokens falls below a threshold (default 6.0), up to a configurable max retry count
+category: inference
+tags: [inference, retry, quality, heuristic, tts]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/OpenBMB/VoxCPM.git
+source_ref: main
+source_commit: 13605c5a0e6b99d6d3527a43bd1a4e0e69c8800e
+source_project: VoxCPM
+source_paths:
+  - src/voxcpm/model/voxcpm2.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Retry-on-short-output heuristic via token-ratio threshold
+
+VoxCPM2's generation loop includes a retry heuristic for detecting truncated or degenerate outputs. After generating, the model checks whether the ratio of generated audio tokens to input text tokens meets a minimum threshold (`retry_badcase_ratio_threshold`, default 6.0). If `audio_tokens / text_tokens < threshold`, the generation is considered bad and is retried with a different random seed, up to `retry_badcase_max_times` attempts.
+
+The intuition is that a well-formed TTS output should produce significantly more audio tokens than input text tokens — each phoneme expands into multiple audio patches. A very short audio sequence relative to the input text indicates premature termination: the model generated a silence token or end-of-sequence too early, likely due to numerical instability or an unlucky sampling path.
+
+Setting `retry_badcase_ratio_threshold=0.0` effectively disables the heuristic (all outputs accepted), which is necessary for deterministic inference (fixed seed, no retries). Very short inputs (single words) can legitimately produce low ratios, so consider reducing the threshold for short-text use cases.
+
+## Why it matters
+Without the retry heuristic, VoxCPM occasionally produces silent or clipped audio on short or unusual inputs, which is a poor user experience. The heuristic catches the majority of degenerate cases automatically. When debugging determinism issues in production, the retry mechanism is the first thing to disable — it introduces non-determinism even when the random seed is fixed, because retry count affects the overall random state.
+
+## Source reference
+- Upstream: `OpenBMB/VoxCPM` @ `main` / `13605c5a`
+- Key files:
+  - `src/voxcpm/model/voxcpm2.py:700-850` — generation loop with `retry_badcase_ratio_threshold` check and retry counter

--- a/knowledge/input/relative-mouse-mode-flutter-only.md
+++ b/knowledge/input/relative-mouse-mode-flutter-only.md
@@ -1,0 +1,28 @@
+---
+name: relative-mouse-mode-flutter-only
+type: knowledge
+category: input
+summary: Relative mouse (delta-based) mode is Flutter-UI-only; legacy Sciter can't deliver pointer-lock events.
+confidence: high
+tags: [flutter, input, mode, mouse, only, relative]
+linked_skills: []
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: src/keyboard.rs
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Relative Mouse Mode Flutter Only
+
+## Fact
+Relative mouse (delta-based) mode is Flutter-UI-only; legacy Sciter can't deliver pointer-lock events.
+
+## Why it matters
+Don't promise the feature to Sciter users; gate by UI framework.
+
+## Evidence
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- `src/keyboard.rs`

--- a/knowledge/llm-agents/run-context-and-shared-state.md
+++ b/knowledge/llm-agents/run-context-and-shared-state.md
@@ -1,0 +1,87 @@
+---
+name: run-context-and-shared-state
+summary: How RunContextWrapper provides typed shared state to tools and hooks without sending it to the LLM.
+category: llm-agents
+confidence: high
+tags: [openai-agents, context, shared-state, dependency-injection, run-context]
+source_type: extracted-from-git
+source_url: https://github.com/openai/openai-agents-python.git
+source_ref: main
+source_commit: e80d2d2319eb300ac17ec496988b70246a5042d6
+source_project: openai-agents-python
+source_path: docs/context.md, src/agents/run_context.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Run Context and Shared State
+
+## Two Kinds of Context
+
+The SDK uses "context" to mean two different things:
+
+1. **Local context** (`RunContextWrapper`) — your app-defined state, NOT sent to the LLM
+2. **LLM context** — the conversation messages the model sees
+
+This document covers #1.
+
+## RunContextWrapper
+
+`RunContextWrapper[T]` is a wrapper around your typed context object. It is passed to:
+- All `@function_tool` functions (as first param if declared)
+- `RunHooks` / `AgentHooks` callbacks
+- `on_handoff` callbacks
+- Dynamic instructions functions
+- Dynamic prompt functions
+
+### Key attributes
+
+| Attribute | Description |
+|---|---|
+| `wrapper.context` | Your app-defined object (mutable) |
+| `wrapper.usage` | Cumulative `Usage` (requests, input_tokens, output_tokens) |
+| `wrapper.tool_input` | Structured input when running as `Agent.as_tool()` |
+| `wrapper.approve_tool(...)` | Programmatically approve a tool call |
+| `wrapper.reject_tool(...)` | Programmatically reject a tool call |
+
+### ToolContext subclass
+
+For function-tool hooks, the SDK passes `ToolContext` (a subclass):
+- `tool_context.tool_name` — name of the tool being called
+- `tool_context.tool_call_id` — unique ID for the call
+- `tool_context.tool_arguments` — raw JSON string of arguments
+
+## Usage Pattern
+
+```python
+from dataclasses import dataclass
+from agents import Agent, RunContextWrapper, Runner, function_tool
+
+@dataclass
+class AppContext:
+    db: Database
+    user_id: str
+    logger: Logger
+
+@function_tool
+def fetch_user_profile(ctx: RunContextWrapper[AppContext]) -> str:
+    """Fetch the current user's profile."""
+    profile = ctx.context.db.get_user(ctx.context.user_id)
+    ctx.context.logger.info(f"Fetched profile for {ctx.context.user_id}")
+    return str(profile)
+
+app_ctx = AppContext(db=db, user_id="123", logger=logger)
+agent = Agent[AppContext](name="Assistant", tools=[fetch_user_profile])
+result = await Runner.run(agent, "Show me my profile", context=app_ctx)
+```
+
+## Critical Rule
+
+Every agent, tool, and hook in a single run must use the **same context type**. Mixing types causes type errors. Use `Agent[MyContext]` for type-checked access.
+
+## Serialization Warning
+
+Context is NOT serialized with `RunState`. If you persist `RunState` for HITL flows, avoid putting sensitive secrets in the context that would be exposed via serialized state.
+
+## Source paths
+- `src/agents/run_context.py` — RunContextWrapper, ToolContext
+- `docs/context.md` — conceptual guide

--- a/knowledge/llm-fundamentals/rlhf-ppo-trl.md
+++ b/knowledge/llm-fundamentals/rlhf-ppo-trl.md
@@ -1,0 +1,47 @@
+---
+name: rlhf-ppo-trl
+summary: Reinforcement Learning from Human Feedback (RLHF) aligns LLMs to human preferences using a reward model as the environment.
+category: llm-fundamentals
+tags: [rlhf, ppo, trl, reward-model, kl-divergence]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/Lordog/dive-into-llms.git
+source_ref: main
+source_commit: f84c04268794ef94f8949808bbc14ab8636763a0
+source_project: dive-into-llms
+source_path: documents/chapter11/README.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# RLHF with PPO and TRL Library
+
+## Overview
+
+Reinforcement Learning from Human Feedback (RLHF) aligns LLMs to human preferences using a reward model as the environment. TRL provides PPOTrainer which implements the Rollout-Evaluate-Optimize loop.
+
+## Key Facts
+
+- Three-phase PPO loop: Rollout (generate responses), Evaluate (score with reward model), Optimize (PPO gradient update).
+- TRL PPOTrainer requires: policy model (with value head), reference model (frozen copy), reward pipeline, tokenizer.
+- KL divergence between policy and frozen reference model is added as negative reward to prevent reward hacking.
+- AutoModelForCausalLMWithValueHead: policy model variant that adds a scalar value head for PPO critic.
+- Reference model is loaded separately (not shared) to correctly compute KL divergence.
+- Typical result: mean sentiment reward increases from ~0.59 (before) to ~2.24 (after PPO) on IMDB task.
+- Reference hardware: single A800-80GB; ~35 min training; ~10GB VRAM for GPT-2.
+
+## Taxonomy
+
+RLHF pipeline components:
+- SFT model: initial policy
+- Reward model: scalar scorer trained on human preference pairs
+- PPO policy: SFT model trained via RL
+- Reference model: frozen SFT model for KL penalty
+
+TRL key classes:
+- PPOConfig: hyperparameters (lr, batch size, etc.)
+- PPOTrainer: orchestrates rollout, reward, PPO step
+- AutoModelForCausalLMWithValueHead: policy model with value head
+
+## References
+- https://github.com/huggingface/trl
+- https://github.com/Lordog/dive-into-llms/tree/main/documents/chapter11

--- a/knowledge/model-loading/safetensors-pth-fallback.md
+++ b/knowledge/model-loading/safetensors-pth-fallback.md
@@ -1,0 +1,33 @@
+---
+name: safetensors-pth-fallback
+summary: VoxCPM loaders try audiovae.safetensors first, fall back to audiovae.pth; new exports should prefer safetensors for safety and speed
+category: model-loading
+tags: [safetensors, checkpoint, model-loading, fallback, compatibility]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/OpenBMB/VoxCPM.git
+source_ref: main
+source_commit: 13605c5a0e6b99d6d3527a43bd1a4e0e69c8800e
+source_project: VoxCPM
+source_paths:
+  - src/voxcpm/model/voxcpm2.py
+  - scripts/train_voxcpm_finetune.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Prefer safetensors, fall back to .pth
+
+VoxCPM's model loader implements a try-first-then-fallback pattern for AudioVAE checkpoint loading: it first attempts to load `audiovae.safetensors` from the model directory. If that file does not exist, it falls back to `audiovae.pth`. This maintains backward compatibility with older checkpoint releases (which shipped only `.pth` files) while preferring the safer and faster safetensors format for new checkpoints.
+
+The safetensors format is preferred because it cannot execute arbitrary Python code during deserialization (unlike pickle-based `.pth` files), making it safe to load from untrusted sources. It also supports memory-mapped loading, which is faster and has lower peak memory usage for large models.
+
+New checkpoints produced by fine-tuning or training scripts should export AudioVAE weights in safetensors format. The training script (`train_voxcpm_finetune.py`) uses `safetensors.torch.save_file()` for new exports.
+
+## Why it matters
+If you distribute a fine-tuned VoxCPM checkpoint and want users to be able to load it with older VoxCPM code that only checks for `.pth`, include both formats. If your checkpoint directory has neither file (e.g., a corrupted download), the fallback chain will raise `FileNotFoundError` with a clear message naming both expected paths. Check both paths exist before distributing.
+
+## Source reference
+- Upstream: `OpenBMB/VoxCPM` @ `main` / `13605c5a`
+- Key files:
+  - `src/voxcpm/model/voxcpm2.py:1100-1120` — try/except pattern for safetensors-first loading with `.pth` fallback
+  - `scripts/train_voxcpm_finetune.py:22-28` — `safetensors.torch.save_file()` usage for new checkpoint export

--- a/knowledge/reference/rpc-channel-namespaces.md
+++ b/knowledge/reference/rpc-channel-namespaces.md
@@ -1,0 +1,52 @@
+---
+name: rpc-channel-namespaces
+summary: The RPC channel namespace convention (system:*, workspaces:*, sessions:*, sources:*, skills:*, credentials:*, LLM_Connection:*, transfer:*) defined in @craft-agent/shared/protocol and used by every client (Electron renderer, CLI, web UI).
+category: reference
+tags: [rpc, protocol, channels]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: packages/shared/src/protocol/channels.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# RPC channel namespaces
+
+All client-server RPC in Craft Agents goes through named channels defined in `packages/shared/src/protocol/channels.ts` as `RPC_CHANNELS`. Convention: `namespace:verb` with colon separator.
+
+### Namespaces
+
+| Namespace | Purpose | Sample channels |
+|---|---|---|
+| `system:*` | Runtime info | `system:versions`, `system:homeDir` |
+| `credentials:*` | Credential lifecycle | `credentials:healthCheck` |
+| `workspaces:*` | Workspace CRUD | `workspaces:get`, `workspaces:create`, `workspaces:delete` |
+| `sessions:*` | Session ops | `sessions:get`, `sessions:create`, `sessions:getMessages`, `sessions:send`, `sessions:delete`, `sessions:import` |
+| `sources:*` | Source ops | `sources:get`, `sources:create`, `sources:update`, `sources:delete`, `sources:CHANGED` (push) |
+| `skills:*` | Skill ops | `skills:get`, `skills:create`, `skills:delete` |
+| `statuses:*` | Custom status workflow | `statuses:get`, `statuses:update` |
+| `LLM_Connection:*` | LLM connection management | `LLM_Connection:list`, `LLM_Connection:create`, `LLM_Connection:validate` |
+| `transfer:*` | Chunked RPC for big payloads | `transfer:start`, `transfer:chunk`, `transfer:commit`, `transfer:abort` |
+| `session:event` | Push channel for streamed session events | (push-only) |
+| `oauth:*` | OAuth flow coordination | `oauth:start`, `oauth:callback` |
+
+### Push events
+Channels ending in `CHANGED` or matching `session:event` are server-push (no response expected). Clients subscribe via `listen(channel)`; server publishes via `pushTyped(wsServer, channel, target, workspaceId, payload)`. Targeting lets you push to a single client, a workspace, or broadcast.
+
+### Why uppercase `LLM_Connection`
+Inconsistent casing is intentional historical — that namespace predated the convention. Changing it is a breaking change for any external scripts; maintained for stability. Newer namespaces are lowercase.
+
+### Pattern for adding a new namespace
+1. Add to `packages/shared/src/protocol/channels.ts#RPC_CHANNELS` (const-object style so TypeScript literal types flow through).
+2. Declare typed handler signatures in `protocol/dto.ts`.
+3. Implement in `packages/server-core/src/handlers/rpc/<namespace>.ts`.
+4. Register in `registerCoreRpcHandlers`.
+5. CLI can use `invoke <channel> [json-args]` to call raw; for fluent use, add a typed wrapper in `apps/cli/src/client.ts`.
+
+### Reference
+- `packages/shared/src/protocol/channels.ts`
+- `packages/server-core/src/handlers/rpc/*`
+- `apps/electron/src/transport/channel-map.ts` — client-side type map.

--- a/knowledge/rpm/rpm-version-field-hyphen-constraint.md
+++ b/knowledge/rpm/rpm-version-field-hyphen-constraint.md
@@ -1,0 +1,98 @@
+---
+name: rpm-version-field-hyphen-constraint
+summary: The RPM `Version` field forbids hyphens; when an upstream version string contains a hyphen (e.g., `1.1.799-1.3.3`), it must be split on the hyphen into `Version` (part before) and `Release` (part after) to satisfy `rpmbuild`.
+category: rpm
+tags: [rpm, rpmbuild, version, packaging, fedora, rhel, version-string]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+# RPM Version Field Hyphen Constraint
+
+## Context
+
+When building RPM packages that wrap an upstream application, the wrapper
+project often includes its own version suffix appended to the upstream version
+(e.g., upstream is `1.1.799`, wrapper adds `-1.3.3` to produce
+`1.1.799-1.3.3`). This composite version string is convenient for deb packages
+(`Version: 1.1.799-1.3.3` is valid) but causes `rpmbuild` to fail.
+
+## Observation
+
+`rpmbuild` rejects any `Version:` field containing a hyphen with an error
+similar to:
+
+```
+error: illegal char '-' in Version: 1.1.799-1.3.3
+```
+
+The RPM spec format reserves the hyphen as a separator between the `Version`
+and `Release` fields in the EVR (Epoch:Version-Release) tuple. Placing it
+inside the `Version` field is therefore a syntax error.
+
+The same version string that Debian accepts (`dpkg-deb` allows hyphens in
+`Version:`) breaks RPM unconditionally.
+
+## Why it happens
+
+RPM's NEVRA format (Name-Epoch:Version-Release.Architecture) uses the hyphen
+as a structural delimiter. The `Version` field must match `[^-\s]+` — no
+hyphens, no whitespace. This is defined in the RPM File Format specification
+and enforced at spec-parse time.
+
+Debian's version format has the opposite convention: a hyphen in the version
+string separates the "upstream version" from the "Debian revision", both of
+which are valid parts of a `.deb` version.
+
+## Practical implication
+
+When your version string may contain a hyphen, split it before generating the
+RPM spec:
+
+```bash
+VERSION="1.1.799-1.3.3"
+
+if [[ $VERSION == *-* ]]; then
+  RPM_VERSION="${VERSION%%-*}"   # everything before the first hyphen: 1.1.799
+  RPM_RELEASE="${VERSION#*-}"   # everything after the first hyphen:  1.3.3
+else
+  RPM_VERSION="$VERSION"
+  RPM_RELEASE="1"
+fi
+
+# Use in spec file:
+# Version: $RPM_VERSION
+# Release: $RPM_RELEASE%{?dist}
+```
+
+The resulting filename from `rpmbuild` will be
+`package-1.1.799-1.3.3.x86_64.rpm`, which is exactly the same information
+in the standard RPM naming convention.
+
+To maintain filename compatibility with the `.deb` and `.AppImage` artifacts
+(which use the full composite version), rename the final RPM output after
+the build:
+
+```bash
+# rpmbuild output: package-1.1.799-1.3.3.x86_64.rpm
+# Desired:         package-1.1.799-1.3.3-1.x86_64.rpm  (original $VERSION-1.arch)
+final_rpm="$work_dir/${PACKAGE_NAME}-${VERSION}-1.${RPM_ARCH}.rpm"
+mv "$(find $work_dir -name "${PACKAGE_NAME}-${RPM_VERSION}*.rpm")" "$final_rpm"
+```
+
+Research format-specific version constraints before building; do not assume
+that a version string valid for one packaging format is valid for all.
+
+## Source reference
+
+- `scripts/build-rpm-package.sh`: lines 17-26 — the version split with
+  comments explaining the constraint, and the final rename step.
+- `CLAUDE.md`: "Adding New Package Formats" section lists "Version string
+  formats (e.g., RPM cannot have hyphens in Version field)" as the first item
+  to research before implementing a new format.

--- a/knowledge/safety/rollback-strategy-git-based-three-modes.md
+++ b/knowledge/safety/rollback-strategy-git-based-three-modes.md
@@ -1,0 +1,38 @@
+---
+name: rollback-strategy-git-based-three-modes
+summary: Three rollback modes for failed evolution — hard reset, stash, or none
+category: safety
+confidence: high
+tags: [evolver, safety, rollback, git, reference]
+source_type: extracted-from-git
+source_url: https://github.com/EvoMap/evolver.git
+source_ref: main
+source_commit: 22773782475cecf43dc9c1af264bf5f9cacc28bc
+source_project: evolver
+source_paths:
+  - src/gep/solidify.js
+  - index.js
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Three rollback modes, controlled by env var
+
+Self-modifying systems need a clear, operator-visible rollback policy. Evolver exposes three modes via `EVOLVER_ROLLBACK_MODE`:
+
+| Mode | Command | When to pick |
+| --- | --- | --- |
+| `hard` | `git reset --hard HEAD` | Default. Strongest guarantee; loses debug state. |
+| `stash` | `git stash push -u` | Debugging; keeps the failed mutation for inspection. |
+| `none` | (no op) | Agent/operator will clean up manually (CI, nested workflows). |
+
+Compute **blast radius** before rollback (files touched, lines changed, dependencies affected) so the log captures what was reverted.
+
+## Why this matters
+
+- One env var changes risk posture without redeploying the agent.
+- `stash` preserves evidence for post-mortems without pushing junk upstream.
+- `none` allows the pattern to compose with outer rollback systems (e.g., container re-creation, DB transactions).
+
+## Reuse notes
+
+Applies to any code-mutating agent. The same three-mode shape generalizes to DB migrations (`ROLLBACK_MODE=abort|savepoint|none`) and config pushes.

--- a/knowledge/safety/sandbox-soft-vs-hard-trade-off.md
+++ b/knowledge/safety/sandbox-soft-vs-hard-trade-off.md
@@ -1,0 +1,52 @@
+---
+name: sandbox-soft-vs-hard-trade-off
+summary: OpenSRE's Python sandbox is a "soft" sandbox — monkeypatching socket/subprocess/open at the start of an injected preamble. Sufficient for the SRE agent threat model (LLM-generated diagnostic snippets), insufficient for adversarial code; understand the boundary.
+category: safety
+tags: [sandbox, threat-model, security, llm-generated-code]
+source_type: extracted-from-git
+source_url: https://github.com/Tracer-Cloud/opensre.git
+source_ref: main
+source_commit: fb5ba0a1b4ef511d16c56a80f1f126b1f581d724
+source_project: opensre
+source_path: app/sandbox/runner.py
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+---
+
+# Sandbox Trade-offs — Soft vs Hard
+
+## The threat model
+OpenSRE's sandbox runs LLM-generated Python snippets that an SRE agent uses to compute things from evidence (e.g. parse a CloudWatch log JSON, compute percentiles). The threat is **buggy or hallucinated code accidentally exfiltrating data or modifying the system**, not a determined adversary.
+
+For this threat model, a "soft" sandbox is appropriate:
+- Monkeypatch `socket.socket`, `socket.create_connection`, `socket.getaddrinfo` to raise `PermissionError` — blocks ALL network including DNS, HTTP, gRPC.
+- Monkeypatch `subprocess.{Popen,call,check_call,check_output,run}`, `os.system`, `os.popen` — blocks shell escape.
+- Monkeypatch `builtins.open` to allow reads anywhere but reject writes outside `/tmp` and the platform tempdir.
+- `subprocess.run(timeout=N)` provides wall-clock cap; the `MAX_TIMEOUT` constant clamps caller-supplied timeouts.
+
+## What this DOES NOT protect against
+- `ctypes.CDLL("libc.so.6")` — direct syscalls bypass Python-level patches.
+- C extensions that hold their own `socket` reference cached at import time.
+- `os.fork()` + escape via parent's untouched module references.
+- Reading sensitive files (process is allowed read-anywhere).
+- Memory exhaustion (no rlimit).
+
+## When you NEED hard sandboxing
+- User-uploaded code (web IDE, notebook hosting).
+- Multi-tenant code execution.
+- Code from untrusted training data (some agent benchmarks).
+
+For those, use OS-level isolation:
+- **gVisor** — userland kernel; works with Docker.
+- **Firecracker** — microVMs; AWS Lambda's runtime.
+- **Wasm** (Pyodide, RustPython→Wasm) — language-level isolation.
+- **seccomp-bpf** — syscall filtering; available on Linux.
+
+## OpenSRE's choice
+The trade-off makes sense because:
+- Code source is OpenSRE's own LLM (controlled) plus user-defined SRE runbooks (semi-trusted).
+- A determined attacker bypassing the sandbox already has access to send arbitrary alerts to the agent.
+- The cost of running gVisor for every diagnostic snippet would dominate the agent's latency budget.
+
+## Lesson
+Always document your sandbox's threat model explicitly. "We use a sandbox" without "for X threat model" creates a false sense of security that will eventually bite.

--- a/knowledge/security/sanitized-environment-fingerprint-for-auto-report.md
+++ b/knowledge/security/sanitized-environment-fingerprint-for-auto-report.md
@@ -1,0 +1,63 @@
+---
+name: sanitized-environment-fingerprint-for-auto-report
+summary: Before an autonomous process files a public bug report (GitHub issue, telemetry event, hub submission), pass every string field through a centralized `redactString()` and include only a fixed allowlist of env-fingerprint fields — version, node version, platform/arch, container flag, truncated node id. Never include hostname, cwd, env dump, or raw logs.
+category: security
+tags: [pii, sanitization, redaction, auto-reporting, env-fingerprint, allowlist]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/EvoMap/evolver.git
+source_ref: main
+source_commit: 4c51382092f9cb125d3ec55475861ead8d1463a6
+source_project: evolver
+source_paths:
+  - src/gep/issueReporter.js
+  - src/gep/envFingerprint.js
+  - src/gep/sanitize.js
+imported_at: 2026-04-18T03:00:00Z
+---
+
+# Env Fingerprint + Allowlist Redaction for Public Reports
+
+Auto-reporting is useful, but every string you emit is a chance to leak something private. Evolver's pre-broadcast pipeline enforces two rules that are easy to copy elsewhere.
+
+## Rule 1 — Everything goes through `redactString()`
+
+There is a single redactor with an ever-growing list of patterns (tokens, absolute paths, emails, JWTs, API keys). Every field — titles, bodies, event-row reasons, log excerpts — is passed through it before concatenation. One chokepoint, not N.
+
+Known categories (from PR #107, 11 new patterns added):
+
+- `ghp_…`, `github_pat_…`, generic bearer tokens
+- Absolute filesystem paths (`/Users/…`, `/home/…`, `C:\Users\…`)
+- Email addresses
+- Anything matching common secret prefixes
+
+If you're adding a new string-producing feature, the acceptance criterion is: does every string exit through `redactString()`? Not "did I add redaction in this path?"
+
+## Rule 2 — Env fingerprint is an allowlist, not a dump
+
+`captureEnvFingerprint()` returns a *fixed* small object:
+
+```js
+{
+  evolver_version: '1.67.1',
+  node_version: 'v20.11.0',
+  platform: 'linux',
+  arch: 'x64',
+  container: true,        // boolean, not the container id
+}
+```
+
+That's it. No `process.env`, no hostname, no cwd, no user. If you need a node identity, use the **truncated** node id (first 10 chars + `...`). Truncation makes correlation possible while preventing full-ID enumeration.
+
+## Additional guards worth copying
+
+- **Log truncation to the tail.** `sessionLog.slice(-2000)` — the crash is at the end, and you bound the blast radius of a sanitizer miss.
+- **Reason-column cap.** In event tables, truncate each `outcome.reason` to 80 chars before redacting. Shorter strings are easier to audit.
+- **Report ID.** `sha256(nodeId + now + errorSig).slice(0, 12)` gives each issue body a unique correlation handle without leaking raw node id.
+
+## Anti-patterns to watch for
+
+- Embedding `JSON.stringify(process.env)` "just for debugging."
+- Attaching raw log files instead of a truncated excerpt.
+- Printing the full `os.hostname()` (most orgs consider hostnames sensitive).
+- Logging the request body of the GitHub POST for local debugging — that *already-sanitized* body still contains your generated Report ID and nodeId prefix.

--- a/knowledge/workflow/reverse-document-workflow-example.md
+++ b/knowledge/workflow/reverse-document-workflow-example.md
@@ -1,0 +1,136 @@
+---
+name: reverse-document-workflow-example
+summary: Step-by-step example of using the reverse-document skill to generate docs from existing code
+category: workflow
+confidence: medium
+tags: [game-studios, ccgs, reverse-document, example, brownfield]
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+source_path: docs/examples/reverse-document-workflow-example.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Reverse Documentation Workflow Example
+
+## Scenario
+Developer built a working skill tree system but never wrote a design doc.
+Code exists in `src/gameplay/skills/`, but `design/gdd/` has no skill-system.md.
+
+---
+
+## Session Transcript
+
+**User:**
+```
+I have a working skill tree system in src/gameplay/skills/ with about 1200 lines
+of code. I never wrote a design doc. Can we create one from the implementation?
+```
+
+**Game-Designer (reads code, analyzes):**
+```
+I've analyzed your skill tree implementation. Here's what I found:
+
+STRUCTURE:
+- 3 skill trees: Combat, Survival, Tech
+- 5 tiers per tree (unlock via level + prerequisites)
+- Total 45 skills (15 per tree)
+- Cost: skill points (1 per level, can respec for gold)
+
+MECHANICS:
+- Passive skills (stat bonuses)
+- Active skills (abilities with cooldowns)
+- Synergy bonuses (cross-tree unlocks at tier 4+)
+
+IMPLEMENTATION DETAILS:
+- Data-driven (JSON files in assets/data/skills/)
+- Save-compatible (skill state serialized)
+- UI shows locked/unlocked/available states
+
+QUESTIONS before I draft the design doc:
+
+1. **Design Intent:** Was the 3-tree structure meant to represent player archetypes
+   (fighter/survivor/engineer) or playstyle flexibility?
+
+2. **Respec Cost:** Respec costs gold - is this meant to:
+   - Discourage frequent respecs (commitment to builds)?
+   - Create a gold sink (economy balance)?
+   - Or should it be free (experimentation encouraged)?
+
+3. **Synergy System:** Cross-tree synergies appear at tier 4. Was this:
+   - Intentional (reward hybrid builds late-game)?
+   - Or emergent (accidentally creates hybrid meta)?
+
+4. **Balance Philosophy:** I see some skills are clearly better (tier-5 passive
+   is +50% damage). Is this:
+   - Power fantasy (late-game should feel OP)?
+   - Or unbalanced (needs tuning)?
+```
+
+**User:**
+```
+Good questions! Here's the intent:
+
+1. Yes, the 3 trees are archetypes but I want flexibility
+2. Respec should be cheap - I want experimentation
+3. Synergies were intentional - hybrid builds are a feature
+4. Yeah, tier 5 is meant to be powerful, but +50% might be too much
+```
+
+**Game-Designer:**
+```
+Perfect, that clarifies the vision. Let me draft the design doc:
+
+[Shows draft of design/gdd/skill-system.md]
+
+SECTIONS:
+1. Overview (3-tree system, hybrid-friendly, respec-encouraged)
+2. Design Pillars:
+   - Archetype clarity (each tree has identity)
+   - Build flexibility (no lock-in, cheap respec)
+   - Synergy rewards (cross-tree combinations viable)
+3. Detailed Design (tree structure, unlock rules, respec)
+4. Balance Framework (tier power curve, synergy limits)
+5. Edge Cases (respec during combat? max skills? cap?)
+6. Dependencies (UI, save system, tutorial)
+7. Acceptance Criteria (all trees viable, 10+ hybrid builds, clear tooltips)
+8. Open Questions:
+   - Should respec cost scale with level or stay flat?
+   - Tier 5 damage bonus: tune to +30% or keep +50%?
+
+**May I write this to design/gdd/skill-system.md?**
+```
+
+**User:**
+```
+Yes, write it. But let's tune tier 5 to +30% and make respec cost scale.
+```
+
+**Game-Designer:**
+```
+✅ Written to design/gdd/skill-system.md
+✅ Marked as [REVERSE-DOCUMENTED FROM IMPLEMENTATION]
+✅ Added TODO: Update tier-5 passive to +30% in assets/data/skills/combat-tree.json
+✅ Added TODO: Implement scaling respec cost formula
+
+Next steps:
+- Run /balance-check to validate skill tree progression curve?
+- Create ADR documenting why 3 trees instead of 5?
+- Update tutorial to explain hybrid synergies?
+```
+
+---
+
+## Key Observations
+
+1. **Agent asked clarifying questions** - didn't just describe code
+2. **Separated intent from implementation** - user corrected "accidental" imbalance
+3. **Design doc captures "why"** - not just "what the code does"
+4. **Identified missing pieces** - edge cases not in code
+5. **Flagged follow-up work** - balance tuning, ADRs, tutorial
+
+## Outcome
+
+The design doc now exists and **matches reality** while also capturing the **intended vision**. Future changes will reference this doc, and new team members understand the *why* behind decisions.

--- a/registry.json
+++ b/registry.json
@@ -2409,6 +2409,151 @@
       "category": "build",
       "path": "skills/build/coverage-data-file-under-pytest-cache/SKILL.md",
       "version": "1.0.0"
+    },
+    "registeropenapiroute-wrapper": {
+      "category": "zod",
+      "path": "skills/zod/registeropenapiroute-wrapper/SKILL.md",
+      "version": "1.0.0"
+    },
+    "regression-suite": {
+      "category": "qa",
+      "path": "skills/qa/regression-suite/SKILL.md",
+      "version": "1.0.0"
+    },
+    "reject-insecure-bind-without-tls": {
+      "category": "security",
+      "path": "skills/security/reject-insecure-bind-without-tls/SKILL.md",
+      "version": "1.0.0"
+    },
+    "relative-mouse-mode-state-machine": {
+      "category": "input",
+      "path": "skills/input/relative-mouse-mode-state-machine/SKILL.md",
+      "version": "1.0.0"
+    },
+    "release-checklist": {
+      "category": "production",
+      "path": "skills/production/release-checklist/SKILL.md",
+      "version": "1.0.0"
+    },
+    "repackage-electron-asar-with-patterns": {
+      "category": "electron-packaging",
+      "path": "skills/electron-packaging/repackage-electron-asar-with-patterns/SKILL.md",
+      "version": "1.0.0"
+    },
+    "requesting-code-review": {
+      "category": "engineering",
+      "path": "skills/engineering/requesting-code-review/SKILL.md",
+      "version": "1.0.0"
+    },
+    "reserved-slugs-coordinated-list": {
+      "category": "architecture",
+      "path": "skills/architecture/reserved-slugs-coordinated-list/SKILL.md",
+      "version": "1.0.0"
+    },
+    "resolve-cloudflare-protected-download-url": {
+      "category": "automation",
+      "path": "skills/automation/resolve-cloudflare-protected-download-url/SKILL.md",
+      "version": "1.0.0"
+    },
+    "response-pagination-with-metadata": {
+      "category": "mcp",
+      "path": "skills/mcp/response-pagination-with-metadata/SKILL.md",
+      "version": "1.0.0"
+    },
+    "retrofit-okhttp-api-endpoint-extraction": {
+      "category": "reverse-engineering",
+      "path": "skills/reverse-engineering/retrofit-okhttp-api-endpoint-extraction/SKILL.md",
+      "version": "1.0.0"
+    },
+    "retrospective": {
+      "category": "production",
+      "path": "skills/production/retrospective/SKILL.md",
+      "version": "1.0.0"
+    },
+    "reverse-document": {
+      "category": "design",
+      "path": "skills/design/reverse-document/SKILL.md",
+      "version": "1.0.0"
+    },
+    "reversible-pii-masking-context": {
+      "category": "safety",
+      "path": "skills/safety/reversible-pii-masking-context/SKILL.md",
+      "version": "1.0.0"
+    },
+    "review-all-gdds": {
+      "category": "design",
+      "path": "skills/design/review-all-gdds/SKILL.md",
+      "version": "1.0.0"
+    },
+    "rope-dynamic-ntk-scaling": {
+      "category": "model-architecture",
+      "path": "skills/model-architecture/rope-dynamic-ntk-scaling/SKILL.md",
+      "version": "1.0.0"
+    },
+    "rpm-package-from-electron-no-hyphens": {
+      "category": "rpm",
+      "path": "skills/rpm/rpm-package-from-electron-no-hyphens/SKILL.md",
+      "version": "1.0.0"
+    },
+    "run-config-global-settings": {
+      "category": "agents",
+      "path": "skills/agents/run-config-global-settings/SKILL.md",
+      "version": "1.0.0"
+    },
+    "run-context-shared-state": {
+      "category": "agents",
+      "path": "skills/agents/run-context-shared-state/SKILL.md",
+      "version": "1.0.0"
+    },
+    "run-messages-incremental-polling": {
+      "category": "workflow",
+      "path": "skills/workflow/run-messages-incremental-polling/SKILL.md",
+      "version": "1.0.0"
+    },
+    "rust-flutter-ffi-bridge-async-pattern": {
+      "category": "ffi",
+      "path": "skills/ffi/rust-flutter-ffi-bridge-async-pattern/SKILL.md",
+      "version": "1.0.0"
+    },
+    "safe-content-disposition-rfc5987": {
+      "category": "fastapi",
+      "path": "skills/fastapi/safe-content-disposition-rfc5987/SKILL.md",
+      "version": "1.0.0"
+    },
+    "safe-remove-all-for-distributed-filesystems": {
+      "category": "jit-compilation",
+      "path": "skills/jit-compilation/safe-remove-all-for-distributed-filesystems/SKILL.md",
+      "version": "1.0.0"
+    },
+    "sample-count-parallel-path-averaging": {
+      "category": "inference",
+      "path": "skills/inference/sample-count-parallel-path-averaging/SKILL.md",
+      "version": "1.0.0"
+    },
+    "sandbox-agent-workspace": {
+      "category": "agents",
+      "path": "skills/agents/sandbox-agent-workspace/SKILL.md",
+      "version": "1.0.0"
+    },
+    "sandbox-backend-pluggable-architecture": {
+      "category": "linux-sandbox",
+      "path": "skills/linux-sandbox/sandbox-backend-pluggable-architecture/SKILL.md",
+      "version": "1.0.0"
+    },
+    "sanitize-tool-params-for-metrics": {
+      "category": "telemetry",
+      "path": "skills/telemetry/sanitize-tool-params-for-metrics/SKILL.md",
+      "version": "1.0.0"
+    },
+    "scope-check": {
+      "category": "production",
+      "path": "skills/production/scope-check/SKILL.md",
+      "version": "1.0.0"
+    },
+    "security-audit": {
+      "category": "engineering",
+      "path": "skills/engineering/security-audit/SKILL.md",
+      "version": "1.0.0"
     }
   },
   "knowledge": {
@@ -4427,6 +4572,90 @@
     "craft-cli-command-surface": {
       "category": "reference",
       "path": "knowledge/reference/craft-cli-command-surface.md"
+    },
+    "relative-mouse-mode-flutter-only": {
+      "category": "input",
+      "path": "knowledge/input/relative-mouse-mode-flutter-only.md"
+    },
+    "release-auto-update-publish-url": {
+      "category": "devops",
+      "path": "knowledge/devops/release-auto-update-publish-url.md"
+    },
+    "repository-identity-vs-project-vs-thread": {
+      "category": "domain",
+      "path": "knowledge/domain/repository-identity-vs-project-vs-thread.md"
+    },
+    "reproduce-bug-with-failing-test-first": {
+      "category": "engineering",
+      "path": "knowledge/engineering/reproduce-bug-with-failing-test-first.md"
+    },
+    "research-paper-published-icse-2025": {
+      "category": "domain",
+      "path": "knowledge/domain/research-paper-published-icse-2025.md"
+    },
+    "retry-badcase-token-ratio-heuristic": {
+      "category": "inference",
+      "path": "knowledge/inference/retry-badcase-token-ratio-heuristic.md"
+    },
+    "reverse-document-workflow-example": {
+      "category": "workflow",
+      "path": "knowledge/workflow/reverse-document-workflow-example.md"
+    },
+    "rlhf-ppo-trl": {
+      "category": "llm-fundamentals",
+      "path": "knowledge/llm-fundamentals/rlhf-ppo-trl.md"
+    },
+    "rollback-strategy-git-based-three-modes": {
+      "category": "safety",
+      "path": "knowledge/safety/rollback-strategy-git-based-three-modes.md"
+    },
+    "root-cause-tracing": {
+      "category": "engineering",
+      "path": "knowledge/engineering/root-cause-tracing.md"
+    },
+    "rpc-channel-namespaces": {
+      "category": "reference",
+      "path": "knowledge/reference/rpc-channel-namespaces.md"
+    },
+    "rpm-version-field-hyphen-constraint": {
+      "category": "rpm",
+      "path": "knowledge/rpm/rpm-version-field-hyphen-constraint.md"
+    },
+    "run-context-and-shared-state": {
+      "category": "llm-agents",
+      "path": "knowledge/llm-agents/run-context-and-shared-state.md"
+    },
+    "runtime-mode-approval-policy-and-sandbox-mode": {
+      "category": "api",
+      "path": "knowledge/api/runtime-mode-approval-policy-and-sandbox-mode.md"
+    },
+    "safetensors-pth-fallback": {
+      "category": "model-loading",
+      "path": "knowledge/model-loading/safetensors-pth-fallback.md"
+    },
+    "sandbox-soft-vs-hard-trade-off": {
+      "category": "safety",
+      "path": "knowledge/safety/sandbox-soft-vs-hard-trade-off.md"
+    },
+    "sanitized-environment-fingerprint-for-auto-report": {
+      "category": "security",
+      "path": "knowledge/security/sanitized-environment-fingerprint-for-auto-report.md"
+    },
+    "scheduler-and-cron-task-execution-model": {
+      "category": "automation",
+      "path": "knowledge/automation/scheduler-and-cron-task-execution-model.md"
+    },
+    "sciter-ui-deprecation-path": {
+      "category": "flutter",
+      "path": "knowledge/flutter/sciter-ui-deprecation-path.md"
+    },
+    "screen-capture-api-evolution-macos": {
+      "category": "codecs",
+      "path": "knowledge/codecs/screen-capture-api-evolution-macos.md"
+    },
+    "seekable-abstraction-for-io": {
+      "category": "arch",
+      "path": "knowledge/arch/seekable-abstraction-for-io.md"
     }
   }
 }

--- a/skills/agents/run-config-global-settings/SKILL.md
+++ b/skills/agents/run-config-global-settings/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: run-config-global-settings
+description: Use RunConfig to set run-wide defaults for model, max turns, tracing, and guardrails.
+category: agents
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [openai-agents, run-config, model-settings, max-turns, tracing]
+source_type: extracted-from-git
+source_url: https://github.com/openai/openai-agents-python.git
+source_ref: main
+source_commit: e80d2d2319eb300ac17ec496988b70246a5042d6
+source_project: openai-agents-python
+source_path: src/agents/run_config.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# run-config-global-settings
+
+Pass `RunConfig` to `Runner.run(run_config=...)` to set run-wide defaults that apply unless overridden by per-agent settings.
+
+## When to apply
+
+When you want consistent model defaults, turn limits, tracing, or input filters across all agents in a run without configuring each agent individually.
+
+## Core snippet
+
+```python
+import asyncio
+from agents import Agent, Runner, ModelSettings
+from agents.run import RunConfig
+
+run_config = RunConfig(
+    model="gpt-4o-mini",                # Default model for all agents
+    model_settings=ModelSettings(        # Default model settings
+        temperature=0.5,
+        max_tokens=2048,
+    ),
+    max_turns=20,                        # Default is 10
+    tracing_disabled=False,
+    workflow_name="My Workflow",         # Name shown in Traces dashboard
+    trace_include_sensitive_data=True,   # Include tool args/outputs in traces
+)
+
+agent = Agent(
+    name="Assistant",
+    instructions="You are a helpful assistant.",
+    # Agent-level model overrides RunConfig.model for this agent
+    model="gpt-4o",
+)
+
+async def main():
+    result = await Runner.run(agent, "Hello!", run_config=run_config)
+    print(result.final_output)
+
+asyncio.run(main())
+```
+
+## Key properties
+
+| Property | Default | Description |
+|---|---|---|
+| `model` | `None` (agent's model) | Run-wide model override |
+| `max_turns` | `10` | Max agent loop iterations |
+| `tracing_disabled` | `False` | Disable traces for this run |
+| `workflow_name` | `"Agent workflow"` | Name in Traces dashboard |
+| `trace_include_sensitive_data` | `True` | Include args/outputs in traces |
+
+## Key notes
+
+- Per-agent `model` and `model_settings` override `RunConfig` values for that agent
+- `RunConfig` is passed to `Runner.run()`, not stored on the Agent
+- `call_model_input_filter` can intercept and modify the input before each model call

--- a/skills/agents/run-context-shared-state/SKILL.md
+++ b/skills/agents/run-context-shared-state/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: run-context-shared-state
+description: Pass typed shared state to all tools and hooks within an agent run via RunContextWrapper.
+category: agents
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [openai-agents, context, shared-state, dependency-injection]
+source_type: extracted-from-git
+source_url: https://github.com/openai/openai-agents-python.git
+source_ref: main
+source_commit: e80d2d2319eb300ac17ec496988b70246a5042d6
+source_project: openai-agents-python
+source_path: docs/context.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# run-context-shared-state
+
+Create a typed context object (dataclass or Pydantic model) and pass it to `Runner.run(context=...)`. All tools, hooks, and lifecycle callbacks receive it via `RunContextWrapper[T].context`. The context is NOT sent to the LLM.
+
+## When to apply
+
+When tool functions need access to user data, database connections, loggers, or other runtime dependencies that should not appear in the model conversation.
+
+## Core snippet
+
+```python
+import asyncio
+from dataclasses import dataclass
+from agents import Agent, RunContextWrapper, Runner, function_tool
+
+@dataclass
+class UserInfo:
+    name: str
+    uid: int
+
+@function_tool
+async def fetch_user_age(wrapper: RunContextWrapper[UserInfo]) -> str:
+    """Fetch the age of the user."""
+    return f"The user {wrapper.context.name} is 47 years old"
+
+async def main():
+    user_info = UserInfo(name="John", uid=123)
+    agent = Agent[UserInfo](
+        name="Assistant",
+        tools=[fetch_user_age],
+    )
+    result = await Runner.run(
+        starting_agent=agent,
+        input="What is the age of the user?",
+        context=user_info,
+    )
+    print(result.final_output)
+
+asyncio.run(main())
+```
+
+## Key notes
+
+- Context object is mutable; tools can write to it to share state across calls
+- Every agent, tool, and hook in a run must use the same context type
+- `RunContextWrapper` also exposes `.usage` (cumulative token counts) and `.approve_tool()`
+- Context is not serialized into the conversation history; use it for ephemeral runtime state

--- a/skills/agents/sandbox-agent-workspace/SKILL.md
+++ b/skills/agents/sandbox-agent-workspace/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: sandbox-agent-workspace
+description: Run an agent inside an isolated sandbox workspace with a manifest-defined filesystem using SandboxAgent.
+category: agents
+version: 1.0.0
+version_origin: extracted
+confidence: high
+tags: [openai-agents, sandbox, workspace, files, git-repo]
+source_type: extracted-from-git
+source_url: https://github.com/openai/openai-agents-python.git
+source_ref: main
+source_commit: e80d2d2319eb300ac17ec496988b70246a5042d6
+source_project: openai-agents-python
+source_path: README.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# sandbox-agent-workspace
+
+Use `SandboxAgent` with a `Manifest` to define a workspace (git repos, local files, URLs) that the agent can inspect and modify. Run with `SandboxRunConfig` specifying the sandbox client.
+
+## When to apply
+
+Long-horizon tasks that need a real filesystem: inspecting repos, editing code, running shell commands, applying patches. Available from SDK version 0.14.0+.
+
+## Core snippet
+
+```python
+import asyncio
+from agents import Runner
+from agents.run import RunConfig
+from agents.sandbox import Manifest, SandboxAgent, SandboxRunConfig
+from agents.sandbox.entries import GitRepo
+from agents.sandbox.sandboxes import UnixLocalSandboxClient
+
+agent = SandboxAgent(
+    name="Workspace Assistant",
+    instructions="Inspect the sandbox workspace before answering.",
+    default_manifest=Manifest(
+        entries={
+            "repo": GitRepo(repo="openai/openai-agents-python", ref="main"),
+        }
+    ),
+)
+
+async def main():
+    result = await Runner.run(
+        agent,
+        "Inspect the repo README and summarize what this project does.",
+        run_config=RunConfig(
+            sandbox=SandboxRunConfig(client=UnixLocalSandboxClient())
+        ),
+    )
+    print(result.final_output)
+
+asyncio.run(main())
+```
+
+## Key notes
+
+- `SandboxAgent` extends `Agent` with `default_manifest`, `base_instructions`, `capabilities`, `run_as`
+- `Manifest.entries` maps names to `GitRepo`, `LocalDir`, `LocalFile`, `RemoteFile` etc.
+- `UnixLocalSandboxClient` uses the local filesystem; other clients can use Docker or remote environments
+- `SandboxRunConfig` is nested inside `RunConfig(sandbox=...)`
+- The agent has access to `ApplyPatchTool`, `ShellTool`, and other workspace-native tools

--- a/skills/architecture/reserved-slugs-coordinated-list/SKILL.md
+++ b/skills/architecture/reserved-slugs-coordinated-list/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: reserved-slugs-coordinated-list
+description: Maintain a single reserved-slug list in both frontend and backend with per-entry category rationale so url-based multi-tenancy never collides with top-level routes.
+category: architecture
+version: 1.0.0
+tags: [multi-tenancy, routing, reserved-slugs, url-design, validation]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- Multi-tenant URL shape `/:workspace-slug/...` (Linear, Notion, GitHub Orgs).
+- You want users to pick their own slug but need to prevent collisions with auth, platform, and dashboard routes.
+
+## Steps
+
+1. Categorize reserved slugs by reason, not alphabetically. A future editor adding `/teams` should be able to see "this is a dashboard segment, add under that heading":
+   ```ts
+   export const RESERVED_SLUGS = new Set([
+     // Auth flow
+     "login", "logout", "signin", "signout", "signup",
+     "auth", "oauth", "callback", "invite", "verify", "reset", "password",
+
+     // Platform / marketing (current + future)
+     "api", "admin", "help", "about", "pricing", "changelog", "docs",
+     "support", "status", "legal", "privacy", "terms", "security",
+     "contact", "blog", "careers", "press", "download",
+
+     // Dashboard / workspace-scoped segments
+     "issues", "projects", "agents", "inbox", "my-issues",
+     "runtimes", "skills", "settings",
+     "workspaces",   // for `/workspaces/new`
+     "teams",        // future team routes
+
+     // RFC 2142 privileged email mailboxes (spoofing risk)
+     "postmaster", "abuse", "noreply", "webmaster", "hostmaster",
+
+     // Hostname / subdomain confusables (phishing risk)
+     "mail", "ftp", "static", "cdn", "assets", "public", "files", "uploads",
+
+     // Framework-mandated
+     "_next", "favicon.ico", "robots.txt", "sitemap.xml", "manifest.json", ".well-known",
+   ]);
+   export const isReservedSlug = (s: string) => RESERVED_SLUGS.has(s);
+   ```
+2. Mirror the list in the backend language and keep them in sync via a comment reference:
+   ```go
+   // Keep in sync with packages/core/paths/reserved-slugs.ts.
+   var reservedSlugs = map[string]struct{}{ "login": {}, /* ... */ }
+   ```
+3. Enforce server-side on workspace create/rename. Client-side is UX only — don't trust it.
+4. Follow the "single word OR /noun/verb" rule for any new global route. Never use `/new-workspace`-style hyphenated groups — they collide with common user workspace names and force you to reserve the full string. Reserving the noun (`workspaces`) auto-protects the whole `/workspaces/*` subtree.
+5. Add an audit migration after adding new reserved words, renaming any existing workspace that collides (use a suffix like `-1`):
+   ```sql
+   -- 047_audit_extended_reserved_slugs.up.sql
+   UPDATE workspaces SET slug = slug || '-1' WHERE slug IN ('teams', 'runtimes');
+   ```
+
+## Example
+
+File layout:
+```
+packages/core/paths/reserved-slugs.ts       — frontend source of truth
+server/internal/handler/workspace_reserved_slugs.go — backend mirror
+server/migrations/043_audit_reserved_slugs.up.sql   — audit-and-rename existing collisions
+```
+
+## Caveats
+
+- Reserved-slug audits need to be followed by a matching migration. Deploying the frontend alone and letting the server reject creation is brittle; rename existing collisions first.
+- Keep the category comments in the code — future editors skim for category, not for alphabet.
+- Expect to revisit this list every 6-12 months as new routes ship; treat the categorized structure as documentation, not as one-time work.

--- a/skills/automation/resolve-cloudflare-protected-download-url/SKILL.md
+++ b/skills/automation/resolve-cloudflare-protected-download-url/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: resolve-cloudflare-protected-download-url
+description: Use Playwright in headless stealth mode to bypass Cloudflare and capture the final download URL from network requests. Derive secondary-architecture URLs by pattern substitution from the resolved primary URL, then verify with HEAD requests.
+category: automation
+version: 1.0.0
+tags: [playwright, cloudflare, download, url-resolution, stealth, automation, python]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: medium
+---
+
+# Resolve Cloudflare-Protected Download URL
+
+## When to use
+
+Use this pattern when:
+- A download URL is hidden behind a Cloudflare-protected redirect that returns 403 to direct HTTP clients.
+- You need to resolve the final CDN/storage URL for use in a CI pipeline, version checker, or build script.
+- The download service only exposes a per-architecture "latest" redirect rather than version-pinned URLs.
+- A secondary architecture (arm64) URL can be derived from the primary (amd64) URL by string substitution, saving a second browser request.
+
+## Pattern
+
+### Approach
+
+1. Launch Playwright Chromium in headless mode with stealth settings (hide `navigator.webdriver`, spoof `navigator.platform`).
+2. Register a `request` event listener to capture URLs matching the expected CDN pattern.
+3. Register a `download` event listener as a backup.
+4. Navigate to the redirect URL with `wait_until="commit"` (triggers the redirect without waiting for full page load).
+5. Wait 2 seconds for the download to start, then close the browser.
+6. Extract version from the resolved URL with a regex.
+7. For arm64: derive from amd64 by substituting architecture strings; verify with a HEAD request.
+
+### URL derivation pattern
+
+```
+amd64: https://cdn.example.com/releases/win32/x64/1.0.1234/App-abc123.exe
+arm64: https://cdn.example.com/releases/win32/arm64/1.0.1234/App-abc123.exe
+                                              ^^^^
+                                         x64 → arm64
+```
+
+## Minimal example
+
+```python
+#!/usr/bin/env python3
+"""
+Resolve download URLs behind Cloudflare by using a stealth Playwright browser.
+"""
+import re
+import sys
+import argparse
+import requests
+from playwright.sync_api import sync_playwright, TimeoutError as PlaywrightTimeout
+
+# Redirect URL template per architecture
+REDIRECT_URLS = {
+    "amd64": "https://example.com/download/redirect/win32/x64/latest",
+    "arm64": "https://example.com/download/redirect/win32/arm64/latest",
+}
+
+USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+)
+
+
+def resolve_download_url(arch: str, timeout_ms: int = 30000) -> str | None:
+    redirect_url = REDIRECT_URLS.get(arch)
+    if not redirect_url:
+        return None
+
+    resolved_url = None
+
+    def handle_request(request):
+        nonlocal resolved_url
+        url = request.url
+        # Match the CDN pattern for the final download
+        if "storage.googleapis.com" in url and url.endswith(".exe"):
+            resolved_url = url
+
+    def handle_download(download):
+        nonlocal resolved_url
+        resolved_url = download.url
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(
+            user_agent=USER_AGENT,
+            viewport={"width": 1920, "height": 1080},
+            accept_downloads=True,
+        )
+        # Stealth: hide automation indicators
+        context.add_init_script("""
+            Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+            Object.defineProperty(navigator, 'platform',  { get: () => 'Linux x86_64' });
+            Object.defineProperty(navigator, 'vendor',    { get: () => 'Google Inc.' });
+        """)
+        page = context.new_page()
+        page.on("request", handle_request)
+        page.on("download", handle_download)
+        try:
+            page.goto(redirect_url, timeout=timeout_ms, wait_until="commit")
+            page.wait_for_timeout(2000)  # let download trigger
+        except PlaywrightTimeout:
+            pass
+        except Exception as e:
+            if "Download is starting" not in str(e):
+                print(f"Navigation error: {e}", file=sys.stderr)
+        finally:
+            browser.close()
+
+    return resolved_url
+
+
+def extract_version(url: str) -> str | None:
+    m = re.search(r"/(\d+\.\d+\.\d+)/", url)
+    return m.group(1) if m else None
+
+
+def derive_arm64_url(amd64_url: str) -> str | None:
+    if not amd64_url:
+        return None
+    arm64_url = amd64_url.replace("/win32/x64/", "/win32/arm64/")
+    arm64_url = arm64_url.replace("-x64.exe", "-arm64.exe")
+    return arm64_url if arm64_url != amd64_url else None
+
+
+def verify_url(url: str, timeout_s: int = 10) -> bool:
+    try:
+        r = requests.head(url, timeout=timeout_s, allow_redirects=True)
+        return r.status_code == 200
+    except requests.RequestException:
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Resolve protected download URLs")
+    parser.add_argument("arch", choices=["amd64", "arm64", "all"])
+    parser.add_argument("--timeout", type=int, default=30000)
+    parser.add_argument("--format", choices=["url", "version", "both"], default="url")
+    args = parser.parse_args()
+
+    archs = ["amd64", "arm64"] if args.arch == "all" else [args.arch]
+    results = {}
+
+    for arch in archs:
+        print(f"Resolving {arch}...", file=sys.stderr)
+        url = resolve_download_url(arch, args.timeout)
+        if url:
+            results[arch] = {"url": url, "version": extract_version(url)}
+            print(f"  {arch}: {url}", file=sys.stderr)
+        else:
+            results[arch] = None
+
+    # Derive arm64 from amd64 if arm64 resolution failed
+    if args.arch == "all" and not results.get("arm64") and results.get("amd64"):
+        derived = derive_arm64_url(results["amd64"]["url"])
+        if derived and verify_url(derived):
+            results["arm64"] = {"url": derived, "version": extract_version(derived)}
+            print(f"  arm64 (derived): {derived}", file=sys.stderr)
+
+    # Output results
+    for arch, result in results.items():
+        if not result:
+            continue
+        prefix = f"{arch.upper()}_" if len(archs) > 1 else ""
+        if args.format in ("url", "both"):
+            print(f"{prefix}URL={result['url']}")
+        if args.format in ("version", "both") and result.get("version"):
+            print(f"{prefix}VERSION={result['version']}")
+
+    if any(r is None for r in results.values()):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+## Why this works
+
+### `wait_until="commit"` vs `"load"`
+
+Cloudflare-protected download redirects trigger a file download before the page "loads". Using `wait_until="load"` would hang waiting for a page that never loads. `wait_until="commit"` returns as soon as the navigation is committed (HTTP response headers received), which is right when the download starts.
+
+### `page.wait_for_timeout(2000)` after navigation
+
+The `request` event fires when the browser makes the request. After the navigation is committed, the download redirect happens asynchronously. A brief `wait_for_timeout(2000)` ensures the browser has time to follow the redirect chain and emit the `request` event for the final CDN URL before the browser is closed.
+
+### Stealth `add_init_script`
+
+Cloudflare's bot detection checks `navigator.webdriver`. Setting it to `undefined` (not `false` — `undefined` is the value in a real browser) passes the check. Spoofing `navigator.platform` and `navigator.vendor` rounds out the browser fingerprint. `add_init_script` runs on every new page before any page scripts, so it applies to the redirect target as well.
+
+### URL derivation avoids a second browser session
+
+Starting a second browser session for arm64 takes 5-10 seconds. Architecture-specific download URLs typically differ only in the architecture string in the path. Substituting `x64` → `arm64` in the path and verifying with a `HEAD` request (which is fast and does not need Playwright) is far cheaper.
+
+### Catching `"Download is starting"` exception
+
+Playwright raises an exception with the message "Download is starting" when a download begins. This is not an error — it's expected. Catching it and checking for this string prevents false failure reporting while still logging genuine navigation errors.
+
+## Pitfalls
+
+- **Cloudflare bot detection changes** — stealth techniques may stop working as Cloudflare updates its detection. If this happens, consider using a real browser profile, cookies, or a service like Browserless.
+- **`requests.head` may not be sufficient for all CDNs** — some CDNs return 403 to HEAD requests but 200 to GET. Use `requests.get(stream=True)` and immediately close the response if HEAD fails.
+- **`playwright.sync_api` is not thread-safe** — do not share a browser context across threads. Each call to `resolve_download_url` should create its own Playwright context.
+- **The `handle_request` callback matches on a CDN domain** — if the CDN changes (e.g., moves from Google Cloud Storage to S3), the pattern will not match. Make the CDN domain configurable.
+- **`wait_for_timeout(2000)` is a fixed sleep** — on slow connections, 2 seconds may not be enough. Consider using `page.wait_for_event("download")` with a timeout instead of a fixed sleep.
+- **This requires Playwright and its browser binaries** — not suitable for minimal CI environments. Install with `pip install playwright && python -m playwright install chromium`.
+
+## Source reference
+
+`scripts/resolve-download-url.py` — full implementation

--- a/skills/design/reverse-document/SKILL.md
+++ b/skills/design/reverse-document/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: reverse-document
+description: "Generate design or architecture documents from existing implementation. Works backwards from code/prototypes to create missing planning docs."
+argument-hint: "<type> <path> (e.g., 'design src/gameplay/combat' or 'architecture src/core')"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write, Edit, Bash
+# Read-only diagnostic skill — no specialist agent delegation needed
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version: 1.0.0
+version_origin: extracted
+---
+
+# Reverse Documentation
+
+This skill analyzes existing implementation (code, prototypes, systems) and generates
+appropriate design or architecture documentation. Use this when:
+- You built a feature without writing a design doc first
+- You inherited a codebase without documentation
+- You prototyped a mechanic and need to formalize it
+- You need to document "why" behind existing code
+
+---
+
+## Workflow
+
+## Phase 1: Parse Arguments
+
+**Format**: `/reverse-document <type> <path>`
+
+**Type options**:
+- `design` → Generate a game design document (GDD section)
+- `architecture` → Generate an Architecture Decision Record (ADR)
+- `concept` → Generate a concept document from prototype
+
+**Path**: Directory or file to analyze
+- `src/gameplay/combat/` → All combat-related code
+- `src/core/event-system.cpp` → Specific file
+- `prototypes/stealth-mech/` → Prototype directory
+
+**Examples**:
+```bash
+/reverse-document design src/gameplay/magic-system
+/reverse-document architecture src/core/entity-component
+/reverse-document concept prototypes/vehicle-combat
+```
+
+## Phase 2: Analyze Implementation
+
+**Read and understand the code/prototype**:
+
+**For design docs (GDD):**
+- Identify mechanics, rules, formulas
+- Extract gameplay values (damage, cooldowns, ranges)
+- Find state machines, ability systems, progression
+- Detect edge cases handled in code
+- Map dependencies (what systems interact?)
+
+**For architecture docs (ADR):**
+- Identify patterns (ECS, singleton, observer, etc.)
+- Understand technical decisions (threading, serialization, etc.)
+- Map dependencies and coupling
+- Assess performance characteristics
+- Find constraints and trade-offs
+
+**For concept docs (prototype analysis):**
+- Identify core mechanic
+- Extract emergent gameplay patterns
+- Note what worked vs what didn't
+- Find technical feasibility insights
+- Document player fantasy / feel
+
+## Phase 3: Ask Clarifying Questions
+
+**DO NOT** just describe the code. **ASK** about intent:
+
+**Design questions**:
+- "I see a [resource] system that depletes during [activity]. Was this for:
+  - Pacing (prevent spam)?
+  - Resource management (strategic depth)?
+  - Or something else?"
+- "The [mechanic] seems central. Is this a core pillar, or supporting feature?"
+- "[Value] scales exponentially with [factor]. Intentional design, or needs rebalancing?"
+
+**Architecture questions**:
+- "You're using a service locator pattern. Was this chosen for:
+  - Testability (mock dependencies)?
+  - Decoupling (reduce hard references)?
+  - Or inherited from existing code?"
+- "I see manual memory management instead of smart pointers. Performance requirement, or legacy?"
+
+**Concept questions**:
+- "The prototype emphasizes stealth over combat. Is that the intended pillar?"
+- "Players seem to exploit the grappling hook for speed. Feature or bug?"
+
+## Phase 4: Present Findings
+
+Before drafting, show what you discovered:
+
+```
+I've analyzed [path]/. Here's what I found:
+
+MECHANICS IMPLEMENTED:
+- [mechanic-a] with [property] (e.g. timing windows, cooldowns)
+- [mechanic-b] (e.g. interaction between two states)
+- [resource] system (depletes on [action], regens on [condition])
+- [state] system (builds up, triggers [effect])
+
+FORMULAS DISCOVERED:
+- [Output] = [formula using discovered variables]
+- [Secondary output] = [formula]
+
+UNCLEAR INTENT AREAS:
+1. [Resource] system — pacing or resource management?
+2. [Mechanic] — core pillar or supporting feature?
+3. [Value] scaling — intentional design or needs tuning?
+
+Before I draft the design doc, could you clarify these points?
+```
+
+Wait for user to clarify intent before drafting.
+
+## Phase 5: Draft Document Using Template
+
+Based on type, use appropriate template:
+
+| Type | Template | Output Path |
+|------|----------|-------------|
+| `design` | `templates/design-doc-from-implementation.md` | `design/gdd/[system-name].md` |
+| `architecture` | `templates/architecture-doc-from-code.md` | `docs/architecture/[decision-name].md` |
+| `concept` | `templates/concept-doc-from-prototype.md` | `prototypes/[name]/CONCEPT.md` or `design/concepts/[name].md` |
+
+**Draft structure**:
+- Capture **what exists** (mechanics, patterns, implementation)
+- Document **why it exists** (intent clarified with user)
+- Identify **what's missing** (edge cases not handled, gaps in design)
+- Flag **follow-up work** (balance tuning, missing features)
+
+## Phase 6: Show Draft and Request Approval
+
+**Collaborative protocol**:
+```
+I've drafted the [system-name] design doc based on your code and clarifications.
+
+[Show key sections: Overview, Mechanics, Formulas, Design Intent]
+
+ADDITIONS I MADE:
+- Documented [mechanic] as "[intent]" per your clarification
+- Added edge cases not in code (e.g., what if [resource] hits 0 mid-[action]?)
+- Flagged balance concern: [scaling type] scaling at [boundary condition]
+
+SECTIONS MARKED AS INCOMPLETE:
+- "[System] interaction with [other-system]" (not fully implemented yet)
+- "[Variant or feature]" (only [subset] implemented so far)
+
+May I write this to design/gdd/[system-name].md?
+```
+
+Wait for approval. User may request changes before writing.
+
+## Phase 7: Write Document with Metadata
+
+When approved, write the file with special markers:
+
+```markdown
+---
+status: reverse-documented
+source: [path/]
+date: [today]
+verified-by: [User name]
+---
+
+# [System Name] Design
+
+> **Note**: This document was reverse-engineered from the existing implementation.
+> It captures current behavior and clarified design intent. Some sections may be
+> incomplete where implementation is partial or intent was unclear.
+
+[Rest of document...]
+```
+
+## Phase 8: Flag Follow-Up Work
+
+After writing, suggest next steps:
+
+```
+✅ Written to design/gdd/combat-system.md
+
+FOLLOW-UP RECOMMENDED:
+1. Run /balance-check on combat formulas (exponential scaling concern)
+2. Create ADR for stamina system architecture decision
+3. Implement missing edge cases:
+   - Stamina depletion mid-combo behavior
+   - Stagger state during dodge
+4. Extend design doc when weapon variety is implemented
+
+Would you like me to tackle any of these now?
+```
+
+---
+
+## Template Selection Logic
+
+| If analyzing... | Use template... | Because... |
+|----------------|-----------------|------------|
+| `src/gameplay/*` | design-doc-from-implementation.md | Gameplay mechanics → GDD |
+| `src/core/*`, `src/ai/*` | architecture-doc-from-code.md | Core systems → ADR |
+| `prototypes/*` | concept-doc-from-prototype.md | Experiments → concept doc |
+| `src/networking/*` | architecture-doc-from-code.md | Technical systems → ADR |
+| `src/ui/*` | design-doc-from-implementation.md | UI/UX → design spec |
+
+---
+
+## Example Session: Reverse-Document a System
+
+```
+User: /reverse-document design src/gameplay/[system]
+
+Agent: I'll analyze your [system] implementation to create a design doc.
+       [Reads code, discovers mechanics, formulas]
+
+Agent: I've analyzed src/gameplay/[system]/. Here's what I found:
+       [Shows mechanics, formulas, unclear areas]
+
+       Before drafting, could you clarify:
+       1. [Resource] system intent?
+       2. Is [mechanic] a core pillar?
+       3. [Value] scaling — intentional or needs tuning?
+
+User: 1. [Resource] is for pacing, prevent [unwanted behavior]
+      2. [Mechanic] is core — I want [design intent]
+      3. Yeah, exponential is too much, should be linear
+
+Agent: Perfect, that clarifies the vision. Let me draft the design doc.
+       [Shows draft with clarified intent]
+
+       May I write this to design/gdd/[system-name].md?
+
+User: Yes, write it.
+
+Agent: ✅ Written to design/gdd/[system-name].md
+       ✅ Marked as [REVERSE-DOCUMENTED]
+       ✅ Flagged [value] scaling for rebalancing
+
+       Next steps:
+       - Update [formula] to [corrected scaling]
+       - Run /balance-check to validate [curve]
+       - Document [mechanic] as core pillar in game-pillars.md
+```
+
+---
+
+## Collaborative Protocol
+
+This skill follows the collaborative design principle:
+
+1. **Analyze First**: Read code, understand implementation
+2. **Question Intent**: Ask about "why", not just "what"
+3. **Present Findings**: Show discoveries, highlight unclear areas
+4. **User Clarifies**: Separate intent from accidents
+5. **Draft Document**: Create doc based on reality + intent
+6. **Show Draft**: Display key sections, explain additions
+7. **Get Approval**: "May I write to [filepath]?" On approval: Verdict: **COMPLETE** — document generated. On decline: Verdict: **BLOCKED** — user declined write.
+8. **Flag Follow-Up**: Suggest related work, don't auto-execute
+
+**Never assume intent. Always ask before documenting "why".**

--- a/skills/design/review-all-gdds/SKILL.md
+++ b/skills/design/review-all-gdds/SKILL.md
@@ -1,0 +1,637 @@
+---
+name: review-all-gdds
+description: "Holistic cross-GDD consistency and game design review. Reads all system GDDs simultaneously and checks for contradictions between them, stale references, ownership conflicts, formula incompatibilities, and game design theory violations (dominant strategies, economic imbalance, cognitive overload, pillar drift). Run after all MVP GDDs are written, before architecture begins."
+argument-hint: "[focus: full | consistency | design-theory | since-last-review]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write, Bash, AskUserQuestion, Task
+model: opus
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version: 1.0.0
+version_origin: extracted
+---
+
+# Review All GDDs
+
+This skill reads every system GDD simultaneously and performs two complementary
+reviews that cannot be done per-GDD in isolation:
+
+1. **Cross-GDD Consistency** — contradictions, stale references, and ownership
+   conflicts between documents
+2. **Game Design Holism** — issues that only emerge when you see all systems
+   together: dominant strategies, broken economies, cognitive overload, pillar
+   drift, competing progression loops
+
+**This is distinct from `/design-review`**, which reviews one GDD for internal
+completeness. This skill reviews the *relationships* between all GDDs.
+
+**When to run:**
+- After all MVP-tier GDDs are individually approved
+- After any GDD is significantly revised mid-production
+- Before `/create-architecture` begins (architecture built on inconsistent GDDs
+  inherits those inconsistencies)
+
+**Argument modes:**
+
+**Focus:** `$ARGUMENTS[0]` (blank = `full`)
+
+- **No argument / `full`**: Both consistency and design theory passes
+- **`consistency`**: Cross-GDD consistency checks only (faster)
+- **`design-theory`**: Game design holism checks only
+- **`since-last-review`**: Only GDDs modified since the last review report (git-based)
+
+---
+
+## Phase 1: Load Everything
+
+### Phase 1a — L0: Summary Scan (fast, low tokens)
+
+Before reading any full document, use Grep to extract `## Summary` sections
+from all GDD files:
+
+```
+Grep pattern="## Summary" glob="design/gdd/*.md" output_mode="content" -A 5
+```
+
+Display a manifest to the user:
+```
+Found [N] GDDs. Summaries:
+  • combat.md — [summary text]
+  • inventory.md — [summary text]
+  ...
+```
+
+For `since-last-review` mode: run `git log --name-only` to identify GDDs
+modified since the last review report file was written. Show the user which
+GDDs are in scope based on summaries before doing any full reads. Only
+proceed to L1 for those GDDs plus any GDDs listed in their "Key deps".
+
+### Phase 1b — Registry Pre-Load (fast baseline)
+
+Before full-reading any GDD, check for the entity registry:
+
+```
+Read path="design/registry/entities.yaml"
+```
+
+If the registry exists and has entries, use it as a **pre-built conflict
+baseline**: known entities, items, formulas, and constants with their
+authoritative values and source GDDs. In Phase 2, grep GDDs for registered
+names first — this is faster than reading all GDDs in full before knowing
+what to look for.
+
+If the registry is empty or absent: proceed without it. Note in the report:
+"Entity registry is empty — consistency checks rely on full GDD reads only.
+Run `/consistency-check` after this review to populate the registry."
+
+### Phase 1c — L1/L2: Full Document Load
+
+Full-read the in-scope documents:
+
+1. `design/gdd/game-concept.md` — game vision, core loop, MVP definition
+2. `design/gdd/game-pillars.md` if it exists — design pillars and anti-pillars
+3. `design/gdd/systems-index.md` — authoritative system list, layers, dependencies, status
+4. **Every in-scope system GDD in `design/gdd/`** — read completely (skip
+   game-concept.md and systems-index.md — those are read above)
+
+Report: "Loaded [N] system GDDs covering [M] systems. Pillars: [list]. Anti-pillars: [list]."
+
+If fewer than 2 system GDDs exist, stop:
+> "Cross-GDD review requires at least 2 system GDDs. Write more GDDs first,
+> then re-run `/review-all-gdds`."
+
+---
+
+### Parallel Execution
+
+Phase 2 (Consistency) and Phase 3 (Design Theory) are independent — they read
+the same GDD inputs but produce separate reports. Spawn both as parallel Task
+agents simultaneously rather than waiting for Phase 2 to complete before
+starting Phase 3. Collect both results before writing the combined report.
+
+---
+
+## Phase 2: Cross-GDD Consistency
+
+Work through every pair and group of GDDs to find contradictions and gaps.
+
+### 2a: Dependency Bidirectionality
+
+For every GDD's Dependencies section, check that every listed dependency is
+reciprocal:
+- If GDD-A lists "depends on GDD-B", check that GDD-B lists GDD-A as a dependent
+- If GDD-A lists "depended on by GDD-C", check that GDD-C lists GDD-A as a dependency
+- Flag any one-directional dependency as a consistency issue
+
+```
+⚠️  Dependency Asymmetry
+[system-a].md lists: Depends On → [system-b].md
+[system-b].md does NOT list [system-a].md as a dependent
+→ One of these documents has a stale dependency section
+```
+
+### 2b: Rule Contradictions
+
+For each game rule, mechanic, or constraint defined in any GDD, check whether
+any other GDD defines a contradicting rule for the same situation:
+
+Categories to scan:
+- **Floor/ceiling rules**: Does any GDD define a minimum value for an output? Does any other say a different system can bypass that floor? These contradict.
+- **Resource ownership**: If two GDDs both define how a shared resource accumulates or depletes, do they agree?
+- **State transitions**: If GDD-A describes what happens when a character dies,
+  does GDD-B's description of the same event agree?
+- **Timing**: If GDD-A says "X happens on the same frame", does GDD-B assume
+  it happens asynchronously?
+- **Stacking rules**: If GDD-A says status effects stack, does GDD-B assume
+  they don't?
+
+```
+🔴 Rule Contradiction
+[system-a].md: "Minimum [output] after reduction is [floor_value]"
+[system-b].md: "[mechanic] bypasses [system-a]'s rules and can reduce [output] to 0"
+→ These rules directly contradict. Which GDD is authoritative?
+```
+
+### 2c: Stale References
+
+For every cross-document reference (GDD-A mentions a mechanic, value, or
+system name from GDD-B), verify the referenced element still exists in GDD-B
+with the same name and behaviour:
+
+- If GDD-A says "combo multiplier from the combat system feeds into score", check
+  that the combat GDD actually defines a combo multiplier that outputs to score
+- If GDD-A references "the progression curve defined in [system].md", check that
+  [system].md actually has that curve, not a different progression model
+- If GDD-A was written before GDD-B and assumed a mechanic that GDD-B later
+  designed differently, flag GDD-A as containing a stale reference
+
+```
+⚠️  Stale Reference
+inventory.md (written first): "Item weight uses the encumbrance formula
+  from movement.md"
+movement.md (written later): Defines no encumbrance formula — uses a flat
+  carry limit instead
+→ inventory.md references a formula that doesn't exist
+```
+
+### 2d: Data and Tuning Knob Ownership Conflicts
+
+Two GDDs should not both claim to own the same data or tuning knob. Scan all
+Tuning Knobs sections across all GDDs and flag duplicates:
+
+```
+⚠️  Ownership Conflict
+[system-a].md Tuning Knobs: "[multiplier_name] — controls [output] scaling"
+[system-b].md Tuning Knobs: "[multiplier_name] — scales [output] with [factor]"
+→ Two GDDs define multipliers on the same output. Which owns the final value?
+  This will produce either a double-application bug or a design conflict.
+```
+
+### 2e: Formula Compatibility
+
+For GDDs whose formulas are connected (output of one feeds input of another),
+check that the output range of the upstream formula is within the expected
+input range of the downstream formula:
+
+- If [system-a].md outputs values between [min]–[max], and [system-b].md is
+  designed to receive values between [min2]–[max2], is the mismatch intentional?
+- If an economy GDD expects resource acquisition in range X, and the
+  progression GDD generates it at range Y, the economy will be trivial or
+  inaccessible — is that intended?
+
+Flag incompatibilities as CONCERNS (design judgment needed, not necessarily wrong):
+
+```
+⚠️  Formula Range Mismatch
+[system-a].md: Max [output] = [value_a] (at max [condition])
+[system-b].md: Base [input] = [value_b], max [input] = [value_c]
+→ Late-[stage] [scenario] can resolve in a single [event].
+  Is this intentional? If not, either [system-a]'s ceiling or [system-b]'s ceiling needs adjustment.
+```
+
+### 2f: Acceptance Criteria Cross-Check
+
+Scan Acceptance Criteria sections across all GDDs for contradictions:
+
+- GDD-A criteria: "Player cannot die from a single hit"
+- GDD-B criteria: "Boss attack deals 150% of player max health"
+These acceptance criteria cannot both pass simultaneously.
+
+---
+
+## Phase 3: Game Design Holism
+
+Review all GDDs together through the lens of game design theory and player
+psychology. These are issues that individual GDD reviews cannot catch because
+they require seeing all systems at once.
+
+### 3a: Progression Loop Competition
+
+A game should have one dominant progression loop that players feel is "the
+point" of the game, with supporting loops that feed into it. When multiple
+systems compete equally as the primary progression driver, players don't know
+what the game is about.
+
+Scan all GDDs for systems that:
+- Award the player's primary resource (XP, levels, prestige, unlocks)
+- Define themselves as the "core" or "main" loop
+- Have comparable depth and time investment to other systems doing the same
+
+```
+⚠️  Competing Progression Loops
+combat.md: Awards XP, unlocks abilities, is described as "the core loop"
+crafting.md: Awards XP, unlocks recipes, is described as "the primary activity"
+exploration.md: Awards XP, unlocks map areas, described as "the main driver"
+→ Three systems all claim to be the primary progression loop and all award
+  the same primary currency. Players will optimise one and ignore the others.
+  Consider: one primary loop with the others as support systems.
+```
+
+### 3b: Player Attention Budget
+
+Count how many systems require active player attention simultaneously during
+a typical session. Each actively-managed system costs attention:
+
+- Active = player must make decisions about this system regularly during play
+- Passive = system runs automatically, player sees results but doesn't manage it
+
+More than 3-4 simultaneously active systems creates cognitive overload for most
+players. Present the count and flag if it exceeds 4 concurrent active systems:
+
+```
+⚠️  Cognitive Load Risk
+Simultaneously active systems during [core loop moment]:
+  1. [system-a].md — [decision type] (active)
+  2. [system-b].md — [resource management] (active)
+  3. [system-c].md — [tracking] (active)
+  4. [system-d].md — [item/action use] (active)
+  5. [system-e].md — [cooldown/timer management] (active)
+  6. [system-f].md — [coordination decisions] (active)
+→ 6 simultaneously active systems during the core loop.
+  Research suggests 3-4 is the comfortable limit for most players.
+  Consider: which of these can be made passive or simplified?
+```
+
+### 3c: Dominant Strategy Detection
+
+A dominant strategy makes other strategies irrelevant — players discover it,
+use it exclusively, and find the rest of the game boring. Look for:
+
+- **Resource monopolies**: One strategy generates a resource significantly
+  faster than all others
+- **Risk-free power**: A strategy that is both high-reward and low-risk
+  (if high-risk strategies exist, they need proportionally higher reward)
+- **No trade-offs**: An option that is superior in all dimensions to all others
+- **Obvious optimal path**: If any progression choice is "clearly correct",
+  the others aren't real choices
+
+```
+⚠️  Potential Dominant Strategy
+combat.md: Ranged attacks deal 80% of melee damage with no risk
+combat.md: Melee attacks deal 100% damage but require close range
+→ Unless melee has a significant compensating advantage (AOE, stagger,
+  resource regeneration), ranged is dominant — higher safety, only 20% less
+  damage. Consider what melee offers that ranged cannot.
+```
+
+### 3d: Economic Loop Analysis
+
+Identify all resources across all GDDs (gold, XP, crafting materials, stamina,
+health, mana, etc.). For each resource, map its **sources** (how players gain
+it) and **sinks** (how players spend it).
+
+Flag dangerous economic conditions:
+
+| Condition | Sign | Risk |
+|-----------|------|------|
+| **Infinite source, no sink** | Resource accumulates indefinitely | Late game becomes trivially easy |
+| **Sink, no source** | Resource drains to zero | System becomes unavailable |
+| **Source >> Sink** | Surplus accumulates | Resource becomes meaningless |
+| **Sink >> Source** | Constant scarcity | Frustration and gatekeeping |
+| **Positive feedback loop** | More resource → easier to earn more | Runaway leader, snowball |
+| **No catch-up** | Falling behind accelerates deficit | Unrecoverable states |
+
+```
+🔴 Economic Imbalance: Unbounded Positive Feedback
+gold economy:
+  Sources: monster drops (scales with player power), merchant selling (unlimited)
+  Sinks: equipment purchase (one-time), ability upgrades (finite count)
+→ After equipment and abilities are purchased, gold has no sink.
+  Infinite surplus. Gold becomes meaningless mid-game.
+  Add ongoing gold sinks (upkeep, consumables, cosmetics, gambling).
+```
+
+### 3e: Difficulty Curve Consistency
+
+When multiple systems scale with player progression, they must scale in
+compatible directions and at compatible rates. Mismatched scaling curves
+create unintended difficulty spikes or trivialisations.
+
+For each system that scales over time, extract:
+- What scales (enemy health, player damage, resource cost, area size)
+- How it scales (linear, exponential, stepped)
+- When it scales (level, time, area)
+
+Compare all scaling curves. Flag mismatches:
+
+```
+⚠️  Difficulty Curve Mismatch
+combat.md: Enemy health scales exponentially with area (×2 per area)
+progression.md: Player damage scales linearly with level (+10% per level)
+→ By area 5, enemies have 32× base health; player deals ~1.5× base damage.
+  The gap widens indefinitely. Late areas will become inaccessibly difficult
+  unless the curves are reconciled.
+```
+
+### 3f: Pillar Alignment
+
+Every system should clearly serve at least one design pillar. A system that
+serves no pillar is "scope creep by design" — it's in the game but not in
+service of what the game is trying to be.
+
+For each GDD system, check its Player Fantasy section against the design pillars.
+Flag any system whose stated fantasy doesn't map to any pillar:
+
+```
+⚠️  Pillar Drift
+fishing-system.md: Player Fantasy — "peaceful, meditative activity"
+Pillars: "Brutal Combat", "Tense Survival", "Emergent Stories"
+→ The fishing system serves none of the three pillars. Either add a pillar
+  that covers it, redesign it to serve an existing pillar, or cut it.
+```
+
+Also check anti-pillars — flag any system that does what an anti-pillar
+explicitly says the game will NOT do:
+
+```
+🔴 Anti-Pillar Violation
+Anti-Pillar: "We will NOT have linear story progression — player defines their path"
+main-quest.md: Defines a 12-chapter linear story with mandatory sequence
+→ This system directly violates the defined anti-pillar.
+```
+
+### 3g: Player Fantasy Coherence
+
+The player fantasies across all systems should be compatible — they should
+reinforce a consistent identity for what the player IS in this game. Conflicting
+player fantasies create identity confusion.
+
+```
+⚠️  Player Fantasy Conflict
+combat.md: "You are a ruthless, precise warrior — every kill is earned"
+dialogue.md: "You are a charismatic diplomat — violence is always avoidable"
+exploration.md: "You are a reckless adventurer — diving in without a plan"
+→ Three systems present incompatible identities. Players will feel the game
+  doesn't know what it wants them to be. Consider: do these fantasies serve
+  the same core identity from different angles, or do they genuinely conflict?
+```
+
+---
+
+## Phase 4: Cross-System Scenario Walkthrough
+
+Walk through the game from the player's perspective to find problems that only
+appear at the interaction boundary between multiple systems — things static
+analysis of individual GDDs cannot surface.
+
+### 4a: Identify Key Multi-System Moments
+
+Scan all GDDs and identify the 3–5 most important player-facing moments where
+multiple systems activate simultaneously. Look specifically for:
+
+- **Combat + Economy overlap**: killing enemies that drop resources, spending
+  resources during combat, death/respawn interacting with economy state
+- **Progression + Difficulty overlap**: level-up triggering mid-fight, ability
+  unlocks changing combat viability, difficulty scaling at progression milestones
+- **Narrative + Gameplay overlap**: dialogue choices locking/unlocking mechanics,
+  story beats interrupting resource loops, quest completion triggering system
+  state changes
+- **3+ system chains**: any player action that triggers System A, which feeds
+  into System B, which triggers System C (these are highest-risk interaction paths)
+
+List each identified scenario with a one-line description before proceeding.
+
+### 4b: Walk Through Each Scenario
+
+For each scenario, step through the sequence explicitly:
+
+1. **Trigger** — what player action or game event starts this?
+2. **Activation order** — which systems activate, in what sequence?
+3. **Data flow** — what does each system output, and is that output a valid
+   input for the next system in the chain?
+4. **Player experience** — what does the player see, hear, or feel at each step?
+5. **Failure modes** — are there any of the following?
+   - **Race conditions**: two systems trying to modify the same state simultaneously
+   - **Feedback loops**: System A amplifies System B which re-amplifies System A
+     with no cap or dampener
+   - **Broken state transitions**: a system assumes a state that a previous
+     system may have changed (e.g., "player is alive" assumption after a combat
+     step that could have caused death)
+   - **Contradictory messaging**: player receives conflicting feedback from two
+     systems reacting to the same event (e.g., "success" sound + "failure" UI)
+   - **Compounding difficulty spikes**: two systems both scaling up at the same
+     progression point, multiplying the intended difficulty increase
+   - **Reward conflicts**: two systems both reacting to the same trigger with
+     rewards that together exceed the intended value (double-dipping)
+   - **Undefined behavior**: the GDDs don't specify what happens in this combined
+     state (neither system's rules cover it)
+
+```
+Example walkthrough:
+Scenario: Player kills elite enemy at level-up threshold during active quest
+
+Trigger: Player lands killing blow on elite enemy
+→ combat.md: awards kill XP (100 pts)
+→ progression.md: XP total crosses level threshold → triggers level-up
+  Output: new level, stat increases, ability unlock popup
+→ quest.md: kill-count criterion met → triggers quest completion event
+  Output: quest reward XP (500 pts), completion fanfare
+→ progression.md (again): quest XP added → triggers SECOND level-up in same frame
+  ⚠️  Data flow issue: quest.md awards XP without checking if a level-up
+  is already in progress. progression.md has no guard against concurrent
+  level-up events. Undefined behavior: does the player level up once or twice?
+  Does the ability popup fire twice? Does the second level use the updated or
+  pre-update stat baseline?
+```
+
+### 4c: Flag Scenario Issues
+
+For each problem found during the walkthrough, categorize severity:
+
+- **BLOCKER**: undefined behavior, broken state transition, or contradictory
+  player messaging — the experience is broken or incoherent in this scenario
+- **WARNING**: compounding spikes, feedback loops without caps, reward conflicts —
+  the experience works but produces unintended outcomes
+- **INFO**: minor ordering ambiguity or messaging overlap — worth noting but
+  unlikely to cause player-visible problems
+
+Add all findings to the output report under **"Cross-System Scenario Issues"**.
+Each finding must cite: the scenario name, the specific systems involved, the
+step where the issue occurs, and the nature of the failure mode.
+
+---
+
+## Phase 5: Output the Review Report
+
+```
+## Cross-GDD Review Report
+Date: [date]
+GDDs Reviewed: [N]
+Systems Covered: [list]
+
+---
+
+### Consistency Issues
+
+#### Blocking (must resolve before architecture begins)
+🔴 [Issue title]
+[What GDDs are involved, what the contradiction is, what needs to change]
+
+#### Warnings (should resolve, but won't block)
+⚠️  [Issue title]
+[What GDDs are involved, what the concern is]
+
+---
+
+### Game Design Issues
+
+#### Blocking
+🔴 [Issue title]
+[What the problem is, which GDDs are involved, design recommendation]
+
+#### Warnings
+⚠️  [Issue title]
+[What the concern is, which GDDs are affected, recommendation]
+
+---
+
+### Cross-System Scenario Issues
+
+Scenarios walked: [N]
+[List scenario names]
+
+#### Blockers
+🔴 [Scenario name] — [Systems involved]
+[Step where failure occurs, nature of the failure mode, what must be resolved]
+
+#### Warnings
+⚠️  [Scenario name] — [Systems involved]
+[What the unintended outcome is, recommendation]
+
+#### Info
+ℹ️  [Scenario name] — [Systems involved]
+[Minor ordering ambiguity or note]
+
+---
+
+### GDDs Flagged for Revision
+
+| GDD | Reason | Type | Priority |
+|-----|--------|------|----------|
+| [system-a].md | Rule contradiction with [system-b].md | Consistency | Blocking |
+| [system-c].md | Stale reference to nonexistent mechanic | Consistency | Blocking |
+| [system-d].md | No pillar alignment | Design Theory | Warning |
+
+---
+
+### Verdict: [PASS / CONCERNS / FAIL]
+
+PASS: No blocking issues. Warnings present but don't prevent architecture.
+CONCERNS: Warnings present that should be resolved but are not blocking.
+FAIL: One or more blocking issues must be resolved before architecture begins.
+
+### If FAIL — required actions before re-running:
+[Specific list of what must change in which GDD]
+```
+
+---
+
+## Phase 6: Write Report and Flag GDDs
+
+Use `AskUserQuestion` for write permission:
+- Prompt: "May I write this review to `design/gdd/gdd-cross-review-[date].md`?"
+- Options: `[A] Yes — write the report` / `[B] No — skip`
+
+If any GDDs are flagged for revision, use a second `AskUserQuestion`:
+- Prompt: "Should I update the systems index to mark these GDDs as needing revision? ([list of flagged GDDs])"
+- Options: `[A] Yes — update systems index` / `[B] No — leave as-is`
+- If yes: update each flagged GDD's Status field in systems-index.md to "Needs Revision".
+  (Do NOT append parentheticals to the status value — other skills match "Needs Revision"
+  as an exact string and parentheticals break that match.)
+
+### Session State Update
+
+After writing the report (and updating systems index if approved), silently
+append to `production/session-state/active.md`:
+
+    ## Session Extract — /review-all-gdds [date]
+    - Verdict: [PASS / CONCERNS / FAIL]
+    - GDDs reviewed: [N]
+    - Flagged for revision: [comma-separated list, or "None"]
+    - Blocking issues: [N — brief one-line descriptions, or "None"]
+    - Recommended next: [the Phase 7 handoff action, condensed to one line]
+    - Report: design/gdd/gdd-cross-review-[date].md
+
+If `active.md` does not exist, create it with this block as the initial content.
+Confirm in conversation: "Session state updated."
+
+---
+
+## Phase 7: Handoff
+
+After all file writes are complete, use `AskUserQuestion` for a closing widget.
+
+Before building options, check project state:
+- Are there any Warning-level items that are simple edits (flagged with "30-second edit", "brief addition", or similar)? → offer inline quick-fix option
+- Are any GDDs in the "Flagged for Revision" table? → offer /design-review option for each
+- Read systems-index.md for the next system with Status: Not Started → offer /design-system option
+- Is the verdict PASS or CONCERNS? → offer /gate-check or /create-architecture
+
+Build the option list dynamically — only include options that apply:
+
+**Option pool:**
+- `[_] Apply quick fix: [W-XX description] in [gdd-name].md — [effort estimate]` (one option per simple-edit warning; only for Warning-level, not Blocking)
+- `[_] Run /design-review [flagged-gdd-path] — address flagged warnings` (one per flagged GDD, if any)
+- `[_] Run /design-system [next-system] — next in design order` (always include, name the actual system)
+- `[_] Run /create-architecture — begin architecture (verdict is PASS/CONCERNS)` (include if verdict is not FAIL)
+- `[_] Run /gate-check — validate Systems Design phase gate` (include if verdict is PASS)
+- `[_] Stop here`
+
+Assign letters A, B, C… only to included options. Mark the most pipeline-advancing option as `(recommended)`.
+
+Never end the skill with plain text. Always close with this widget.
+
+---
+
+## Error Recovery Protocol
+
+If any spawned agent returns BLOCKED, errors, or fails to complete:
+
+1. **Surface immediately**: Report "[AgentName]: BLOCKED — [reason]" before continuing
+2. **Assess dependencies**: If the blocked agent's output is required by a later phase, do not proceed past that phase without user input
+3. **Offer options** via AskUserQuestion with three choices:
+   - Skip this agent and note the gap in the final report
+   - Retry with narrower scope (fewer GDDs, single-system focus)
+   - Stop here and resolve the blocker first
+4. **Always produce a partial report** — output whatever was completed so work is not lost
+
+---
+
+## Collaborative Protocol
+
+1. **Read silently** — load all GDDs before presenting anything
+2. **Show everything** — present the full consistency and design theory analysis
+   before asking for any action
+3. **Distinguish blocking from advisory** — not every issue needs to block
+   architecture; be clear about which do
+4. **Don't make design decisions** — flag contradictions and options, but never
+   unilaterally decide which GDD is "right"
+5. **Ask before writing** — confirm before writing the report or updating the
+   systems index
+6. **Be specific** — every issue must cite the exact GDD, section, and text
+   involved; no vague warnings

--- a/skills/electron-packaging/repackage-electron-asar-with-patterns/SKILL.md
+++ b/skills/electron-packaging/repackage-electron-asar-with-patterns/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: repackage-electron-asar-with-patterns
+description: Extract an Electron .asar archive, apply regex-based patches to minified JS that survive minifier renames by anchoring on stable string literals, then repack. Includes dynamic variable extraction so patches remain version-agnostic.
+category: electron-packaging
+version: 1.0.0
+tags: [electron, asar, patching, regex, minified-js, build]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+# Repackage Electron .asar with Regex Patch Patterns
+
+## When to use
+
+Use this pattern when:
+- You are repackaging a third-party Electron app (no source access) for a new platform or environment.
+- The bundled JS is minified and variable names change between upstream releases.
+- You need to surgically modify specific behaviors (tray icon logic, window frame, feature flags) without full source access.
+- You want patches that survive upstream version bumps without manual variable-name updates.
+
+## Pattern
+
+The workflow has five stages:
+
+1. **Extract** — unpack the `.asar` to a directory.
+2. **Dynamic extraction** — grep the extracted JS with a capture-group regex anchored on a stable string literal to find the current minified variable or function name.
+3. **Patch** — apply `sed -E` replacements using the dynamically extracted name.
+4. **Handle optional whitespace** — use `\s*` around operators so the same regex works on both minified (`a,b=>`) and beautified (`a, b =>`) code.
+5. **Repack** — reassemble the `.asar` from the patched directory, skipping the `.asar.unpacked` sibling.
+
+### Key rules
+
+- **Never hardcode minified names** — always extract them from a known stable anchor (a string literal, a unique method call, or a structural pattern that the minifier cannot rename).
+- Use `grep -oP` (Perl-regex) with `\K` and lookahead/lookbehind to extract names without capturing surrounding syntax.
+- Use `sed -i -E` for the actual replacement so you can use grouping and alternation.
+- Validate extraction: if `grep` returns empty, fail loudly rather than silently applying a no-op patch.
+
+## Minimal example
+
+```bash
+#!/usr/bin/env bash
+# Stage directories
+STAGING="build/electron-app"
+ASAR="$STAGING/app.asar"
+CONTENTS="$STAGING/app.asar.contents"
+INDEX_JS="$CONTENTS/.vite/build/index.js"
+
+# 1. Extract
+asar extract "$ASAR" "$CONTENTS"
+
+# 2. Dynamic extraction — find the electron module variable by looking at
+#    the require("electron") assignment.
+ELECTRON_VAR=$(grep -oP '\$?\w+(?=\s*=\s*require\("electron"\))' \
+    "$INDEX_JS" | head -1)
+[[ -z $ELECTRON_VAR ]] && { echo "ERROR: could not find electron var" >&2; exit 1; }
+ELECTRON_VAR_RE="${ELECTRON_VAR//\$/\\$}"   # escape $ for sed
+
+# 3. Dynamic extraction — find tray function by anchoring on a stable
+#    string literal it calls.
+TRAY_FUNC=$(grep -oP 'on\("menuBarEnabled",\(\)=>\{\K\w+(?=\(\)\})' \
+    "$INDEX_JS")
+[[ -z $TRAY_FUNC ]] && { echo "ERROR: could not find tray func" >&2; exit 1; }
+
+# 4. Patch: make the tray handler async (stable structural change)
+sed -i "s/function ${TRAY_FUNC}(){/async function ${TRAY_FUNC}(){/g" "$INDEX_JS"
+
+# 5. Patch: fix nativeTheme references on wrong variable (handle whitespace)
+#    Replace wrongVar.nativeTheme with electronVar.nativeTheme
+WRONG_REFS=$(grep -oP '\$?\w+(?=\.nativeTheme)' "$INDEX_JS" | sort -u \
+    | grep -Fxv "$ELECTRON_VAR" || true)
+for REF in $WRONG_REFS; do
+    REF_RE="${REF//\$/\\$}"
+    sed -i -E "s/${REF_RE}\.nativeTheme/${ELECTRON_VAR_RE}.nativeTheme/g" "$INDEX_JS"
+done
+
+# 6. Patch: handle optional whitespace in nativeTheme.on("updated") call
+sed -i -E \
+    's/('"${ELECTRON_VAR_RE}"'\.nativeTheme\.on\(\s*"updated"\s*,\s*\(\)\s*=>\s*\{)/let _startTime=Date.now();\1/g' \
+    "$INDEX_JS"
+
+# 7. Repack (asar skips .asar.unpacked automatically)
+asar pack "$CONTENTS" "$ASAR"
+```
+
+## Why this works
+
+### Minifier stability of string literals
+
+Minifiers rename variables and functions aggressively, but they cannot rename string literals embedded in the source (event names, JSON keys, require paths). Patterns like `require("electron")`, `on("menuBarEnabled", ...)`, and `setAlwaysOnTop(!0, "pop-up-menu")` are stable across releases because they appear verbatim in the application's logic.
+
+### Capture-group extraction vs brittle hardcoding
+
+Using `grep -oP '\$?\w+(?=\.nativeTheme)'` extracts the actual current variable name at patch time. The `\K` anchor and lookahead/lookbehind mean you never capture the delimiter — you get only the identifier you need. Storing it in a shell variable and escaping `$` for sed (`${VAR//\$/\\$}`) lets you build version-agnostic sed commands.
+
+### Optional-whitespace guards
+
+Minified code writes `a.b.on("c",()=>{` while beautified reference copies write `a.b.on("c", () => {`. Using `\s*` between tokens in the sed pattern means the same pattern handles both forms, which is critical because some build tools or intermediate processing steps may partially format the output.
+
+### Validation before apply
+
+Extracting the variable name and then checking for empty string before applying the patch converts a silent "wrong patch applied" failure into an immediate loud failure. This is far cheaper to debug in CI than a silently wrong binary.
+
+## Pitfalls
+
+- **Do not run `asar pack` on the `.asar.unpacked` directory** — `@electron/asar` automatically excludes files listed in the `.asar` header as "unpacked". Packing the unpacked directory separately overwrites the header.
+- **`sed -i` on macOS requires an argument** — use `sed -i ''` on macOS or prefer GNU sed via `gsed`.
+- **Extended regex (`-E`) is needed for grouping** — POSIX BRE does not support `(a|b)` without escaping. Always use `-E`.
+- **grep with `-P` (Perl regex) is GNU-specific** — not available on BSD/macOS `grep`. Use `ggrep` or install gnu-grep if building cross-platform.
+- **Race condition if asar binary is not installed** — pin the `@electron/asar` package version to avoid npm-installing a breaking version. Use `--no-save` and pin to a known-good version in CI.
+- **Empty extraction result on upstream refactor** — if the upstream app restructures the code, your anchor pattern may stop matching. Add a second candidate pattern (fallback) or fail with a clear error message pointing to the specific pattern.
+
+## Source reference
+
+`build.sh` — functions `extract_electron_variable`, `fix_native_theme_references`, `patch_tray_menu_handler`, `patch_asar_workflow`

--- a/skills/engineering/requesting-code-review/SKILL.md
+++ b/skills/engineering/requesting-code-review/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: requesting-code-review
+description: Use when completing tasks, implementing major features, or before merging to verify work meets requirements
+category: engineering
+version: 1.0.0
+version_origin: extracted
+source_type: extracted-from-git
+source_url: https://github.com/obra/superpowers.git
+source_ref: main
+source_commit: b55764852ac78870e65c6565fb585b6cd8b3c5c9
+source_project: superpowers
+imported_at: 2026-04-18T06:36:49Z
+---
+
+# Requesting Code Review
+
+Dispatch superpowers:code-reviewer subagent to catch issues before they cascade. The reviewer gets precisely crafted context for evaluation — never your session's history. This keeps the reviewer focused on the work product, not your thought process, and preserves your own context for continued work.
+
+**Core principle:** Review early, review often.
+
+## When to Request Review
+
+**Mandatory:**
+- After each task in subagent-driven development
+- After completing major feature
+- Before merge to main
+
+**Optional but valuable:**
+- When stuck (fresh perspective)
+- Before refactoring (baseline check)
+- After fixing complex bug
+
+## How to Request
+
+**1. Get git SHAs:**
+```bash
+BASE_SHA=$(git rev-parse HEAD~1)  # or origin/main
+HEAD_SHA=$(git rev-parse HEAD)
+```
+
+**2. Dispatch code-reviewer subagent:**
+
+Use Task tool with superpowers:code-reviewer type, fill template at `code-reviewer.md`
+
+**Placeholders:**
+- `{WHAT_WAS_IMPLEMENTED}` - What you just built
+- `{PLAN_OR_REQUIREMENTS}` - What it should do
+- `{BASE_SHA}` - Starting commit
+- `{HEAD_SHA}` - Ending commit
+- `{DESCRIPTION}` - Brief summary
+
+**3. Act on feedback:**
+- Fix Critical issues immediately
+- Fix Important issues before proceeding
+- Note Minor issues for later
+- Push back if reviewer is wrong (with reasoning)
+
+## Example
+
+```
+[Just completed Task 2: Add verification function]
+
+You: Let me request code review before proceeding.
+
+BASE_SHA=$(git log --oneline | grep "Task 1" | head -1 | awk '{print $1}')
+HEAD_SHA=$(git rev-parse HEAD)
+
+[Dispatch superpowers:code-reviewer subagent]
+  WHAT_WAS_IMPLEMENTED: Verification and repair functions for conversation index
+  PLAN_OR_REQUIREMENTS: Task 2 from docs/superpowers/plans/deployment-plan.md
+  BASE_SHA: a7981ec
+  HEAD_SHA: 3df7661
+  DESCRIPTION: Added verifyIndex() and repairIndex() with 4 issue types
+
+[Subagent returns]:
+  Strengths: Clean architecture, real tests
+  Issues:
+    Important: Missing progress indicators
+    Minor: Magic number (100) for reporting interval
+  Assessment: Ready to proceed
+
+You: [Fix progress indicators]
+[Continue to Task 3]
+```
+
+## Integration with Workflows
+
+**Subagent-Driven Development:**
+- Review after EACH task
+- Catch issues before they compound
+- Fix before moving to next task
+
+**Executing Plans:**
+- Review after each batch (3 tasks)
+- Get feedback, apply, continue
+
+**Ad-Hoc Development:**
+- Review before merge
+- Review when stuck
+
+## Red Flags
+
+**Never:**
+- Skip review because "it's simple"
+- Ignore Critical issues
+- Proceed with unfixed Important issues
+- Argue with valid technical feedback
+
+**If reviewer wrong:**
+- Push back with technical reasoning
+- Show code/tests that prove it works
+- Request clarification
+
+See template at: requesting-code-review/code-reviewer.md

--- a/skills/engineering/requesting-code-review/code-reviewer.md
+++ b/skills/engineering/requesting-code-review/code-reviewer.md
@@ -1,0 +1,146 @@
+# Code Review Agent
+
+You are reviewing code changes for production readiness.
+
+**Your task:**
+1. Review {WHAT_WAS_IMPLEMENTED}
+2. Compare against {PLAN_OR_REQUIREMENTS}
+3. Check code quality, architecture, testing
+4. Categorize issues by severity
+5. Assess production readiness
+
+## What Was Implemented
+
+{DESCRIPTION}
+
+## Requirements/Plan
+
+{PLAN_REFERENCE}
+
+## Git Range to Review
+
+**Base:** {BASE_SHA}
+**Head:** {HEAD_SHA}
+
+```bash
+git diff --stat {BASE_SHA}..{HEAD_SHA}
+git diff {BASE_SHA}..{HEAD_SHA}
+```
+
+## Review Checklist
+
+**Code Quality:**
+- Clean separation of concerns?
+- Proper error handling?
+- Type safety (if applicable)?
+- DRY principle followed?
+- Edge cases handled?
+
+**Architecture:**
+- Sound design decisions?
+- Scalability considerations?
+- Performance implications?
+- Security concerns?
+
+**Testing:**
+- Tests actually test logic (not mocks)?
+- Edge cases covered?
+- Integration tests where needed?
+- All tests passing?
+
+**Requirements:**
+- All plan requirements met?
+- Implementation matches spec?
+- No scope creep?
+- Breaking changes documented?
+
+**Production Readiness:**
+- Migration strategy (if schema changes)?
+- Backward compatibility considered?
+- Documentation complete?
+- No obvious bugs?
+
+## Output Format
+
+### Strengths
+[What's well done? Be specific.]
+
+### Issues
+
+#### Critical (Must Fix)
+[Bugs, security issues, data loss risks, broken functionality]
+
+#### Important (Should Fix)
+[Architecture problems, missing features, poor error handling, test gaps]
+
+#### Minor (Nice to Have)
+[Code style, optimization opportunities, documentation improvements]
+
+**For each issue:**
+- File:line reference
+- What's wrong
+- Why it matters
+- How to fix (if not obvious)
+
+### Recommendations
+[Improvements for code quality, architecture, or process]
+
+### Assessment
+
+**Ready to merge?** [Yes/No/With fixes]
+
+**Reasoning:** [Technical assessment in 1-2 sentences]
+
+## Critical Rules
+
+**DO:**
+- Categorize by actual severity (not everything is Critical)
+- Be specific (file:line, not vague)
+- Explain WHY issues matter
+- Acknowledge strengths
+- Give clear verdict
+
+**DON'T:**
+- Say "looks good" without checking
+- Mark nitpicks as Critical
+- Give feedback on code you didn't review
+- Be vague ("improve error handling")
+- Avoid giving a clear verdict
+
+## Example Output
+
+```
+### Strengths
+- Clean database schema with proper migrations (db.ts:15-42)
+- Comprehensive test coverage (18 tests, all edge cases)
+- Good error handling with fallbacks (summarizer.ts:85-92)
+
+### Issues
+
+#### Important
+1. **Missing help text in CLI wrapper**
+   - File: index-conversations:1-31
+   - Issue: No --help flag, users won't discover --concurrency
+   - Fix: Add --help case with usage examples
+
+2. **Date validation missing**
+   - File: search.ts:25-27
+   - Issue: Invalid dates silently return no results
+   - Fix: Validate ISO format, throw error with example
+
+#### Minor
+1. **Progress indicators**
+   - File: indexer.ts:130
+   - Issue: No "X of Y" counter for long operations
+   - Impact: Users don't know how long to wait
+
+### Recommendations
+- Add progress reporting for user experience
+- Consider config file for excluded projects (portability)
+
+### Assessment
+
+**Ready to merge: With fixes**
+
+**Reasoning:** Core implementation is solid with good architecture and tests. Important issues (help text, date validation) are easily fixed and don't affect core functionality.
+```

--- a/skills/engineering/security-audit/SKILL.md
+++ b/skills/engineering/security-audit/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: security-audit
+description: "Audit the game for security vulnerabilities: save tampering, cheat vectors, network exploits, data exposure, and input validation gaps. Produces a prioritised security report with remediation guidance. Run before any public release or multiplayer launch."
+argument-hint: "[full | network | save | input | quick]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Bash, Write, Task
+agent: security-engineer
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version: 1.0.0
+version_origin: extracted
+---
+
+# Security Audit
+
+Security is not optional for any shipped game. Even single-player games have
+save tampering vectors. Multiplayer games have cheat surfaces, data exposure
+risks, and denial-of-service potential. This skill systematically audits the
+codebase for the most common game security failures and produces a prioritised
+remediation plan.
+
+**Run this skill:**
+- Before any public release (required for the Polish → Release gate)
+- Before enabling any online/multiplayer feature
+- After implementing any system that reads from disk or network
+- When a security-related bug is reported
+
+**Output:** `production/security/security-audit-[date].md`
+
+---
+
+## Phase 1: Parse Arguments and Scope
+
+**Modes:**
+- `full` — all categories (recommended before release)
+- `network` — network/multiplayer only
+- `save` — save file and serialization only
+- `input` — input validation and injection only
+- `quick` — high-severity checks only (fastest, for iterative use)
+- No argument — run `full`
+
+Read `.claude/docs/technical-preferences.md` to determine:
+- Engine and language (affects which patterns to search for)
+- Target platforms (affects which attack surfaces apply)
+- Whether multiplayer/networking is in scope
+
+---
+
+## Phase 2: Spawn Security Engineer
+
+Spawn `security-engineer` via Task. Pass:
+- The audit scope/mode
+- Engine and language from technical preferences
+- A manifest of all source directories: `src/`, `assets/data/`, any config files
+
+The security-engineer runs the audit across 6 categories (see Phase 3). Collect their full findings before proceeding.
+
+---
+
+## Phase 3: Audit Categories
+
+The security-engineer evaluates each of the following. Skip categories not applicable to the project scope.
+
+### Category 1: Save File and Serialization Security
+- Are save files validated before loading? (no blind deserialization)
+- Are save file paths constructed from user input? (path traversal risk)
+- Are save files checksummed or signed? (tamper detection)
+- Does the game trust numeric values from save files without bounds checking?
+- Are there any eval() or dynamic code execution calls near save loading?
+
+Grep patterns: `File.open`, `load`, `deserialize`, `JSON.parse`, `from_json`, `read_file` — check each for validation.
+
+### Category 2: Network and Multiplayer Security (skip if single-player only)
+- Is game state authoritative on the server, or does the client dictate outcomes?
+- Are incoming network packets validated for size, type, and value range?
+- Are player positions and state changes validated server-side?
+- Is there rate limiting on any network calls?
+- Are authentication tokens handled correctly (never sent in plaintext)?
+- Does the game expose any debug endpoints in release builds?
+
+Grep for: `recv`, `receive`, `PacketPeer`, `socket`, `NetworkedMultiplayerPeer`, `rpc`, `rpc_id` — check each call site for validation.
+
+### Category 3: Input Validation
+- Are any player-supplied strings used in file paths? (path traversal)
+- Are any player-supplied strings logged without sanitization? (log injection)
+- Are numeric inputs (e.g., item quantities, character stats) bounds-checked before use?
+- Are achievement/stat values checked before being written to any backend?
+
+Grep for: `get_input`, `Input.get_`, `input_map`, user-facing text fields — check validation.
+
+### Category 4: Data Exposure
+- Are any API keys, credentials, or secrets hardcoded in `src/` or `assets/`?
+- Are debug symbols or verbose error messages included in release builds?
+- Does the game log sensitive player data to disk or console?
+- Are any internal file paths or system information exposed to players?
+
+Grep for: `api_key`, `secret`, `password`, `token`, `private_key`, `DEBUG`, `print(` in release-facing code.
+
+### Category 5: Cheat and Anti-Tamper Vectors
+- Are gameplay-critical values stored only in memory, not in easily-editable files?
+- Are any critical game progression flags (e.g., "has paid for DLC") validated server-side?
+- Is there any protection against memory editing tools (Cheat Engine, etc.) for multiplayer?
+- Are leaderboard/score submissions validated before acceptance?
+
+Note: Client-side anti-cheat is largely unenforceable. Focus on server-side validation for anything competitive or monetised.
+
+### Category 6: Dependency and Supply Chain
+- Are any third-party plugins or libraries used? List them.
+- Do any plugins have known CVEs in the version being used?
+- Are plugin sources verified (official marketplace, reviewed repository)?
+
+Glob for: `addons/`, `plugins/`, `third_party/`, `vendor/` — list all external dependencies.
+
+---
+
+## Phase 4: Classify Findings
+
+For each finding, assign:
+
+**Severity:**
+| Level | Definition |
+|-------|-----------|
+| **CRITICAL** | Remote code execution, data breach, or trivially-exploitable cheat that breaks multiplayer integrity |
+| **HIGH** | Save tampering that bypasses progression, credential exposure, or server-side authority bypass |
+| **MEDIUM** | Client-side cheat enablement, information disclosure, or input validation gap with limited impact |
+| **LOW** | Defence-in-depth improvement — hardening that reduces attack surface but no direct exploit exists |
+
+**Status:** Open / Accepted Risk / Out of Scope
+
+---
+
+## Phase 5: Generate Report
+
+```markdown
+# Security Audit Report
+
+**Date**: [date]
+**Scope**: [full | network | save | input | quick]
+**Engine**: [engine + version]
+**Audited by**: security-engineer via /security-audit
+**Files scanned**: [N source files, N config files]
+
+---
+
+## Executive Summary
+
+| Severity | Count | Must Fix Before Release |
+|----------|-------|------------------------|
+| CRITICAL | [N] | Yes — all |
+| HIGH | [N] | Yes — all |
+| MEDIUM | [N] | Recommended |
+| LOW | [N] | Optional |
+
+**Release recommendation**: [CLEAR TO SHIP / FIX CRITICALS FIRST / DO NOT SHIP]
+
+---
+
+## CRITICAL Findings
+
+### SEC-001: [Title]
+**Category**: [Save / Network / Input / Data / Cheat / Dependency]
+**File**: `[path]` line [N]
+**Description**: [What the vulnerability is]
+**Attack scenario**: [How a malicious user would exploit it]
+**Remediation**: [Specific code change or pattern to apply]
+**Effort**: [Low / Medium / High]
+
+[repeat per finding]
+
+---
+
+## HIGH Findings
+
+[same format]
+
+---
+
+## MEDIUM Findings
+
+[same format]
+
+---
+
+## LOW Findings
+
+[same format]
+
+---
+
+## Accepted Risk
+
+[Any findings explicitly accepted by the team with rationale]
+
+---
+
+## Dependency Inventory
+
+| Plugin / Library | Version | Source | Known CVEs |
+|-----------------|---------|--------|------------|
+| [name] | [version] | [source] | [none / CVE-XXXX-NNNN] |
+
+---
+
+## Remediation Priority Order
+
+1. [SEC-NNN] — [1-line description] — Est. effort: [Low/Medium/High]
+2. ...
+
+---
+
+## Re-Audit Trigger
+
+Run `/security-audit` again after remediating any CRITICAL or HIGH findings.
+The Polish → Release gate requires this report with no open CRITICAL or HIGH items.
+```
+
+---
+
+## Phase 6: Write Report
+
+Present the report summary (executive summary + CRITICAL/HIGH findings only) in conversation.
+
+Ask: "May I write the full security audit report to `production/security/security-audit-[date].md`?"
+
+Write only after approval.
+
+---
+
+## Phase 7: Gate Integration
+
+This report is a required artifact for the **Polish → Release gate**.
+
+After remediating findings, re-run: `/security-audit quick` to confirm CRITICAL/HIGH items are resolved before running `/gate-check release`.
+
+If CRITICAL findings exist:
+> "⛔ CRITICAL security findings must be resolved before any public release. Do not proceed to `/launch-checklist` until these are addressed."
+
+If no CRITICAL/HIGH findings:
+> "✅ No blocking security findings. Report written to `production/security/`. Include this path when running `/gate-check release`."
+
+---
+
+## Collaborative Protocol
+
+- **Never assume a pattern is safe** — flag it and let the user decide
+- **Accepted risk is a valid outcome** — some LOW findings are acceptable trade-offs for a solo team; document the decision
+- **Multiplayer games have a higher bar** — any HIGH finding in a multiplayer context should be treated as CRITICAL
+- **This is not a penetration test** — this audit covers common patterns; a real pentest by a human security professional is recommended before any competitive or monetised multiplayer launch

--- a/skills/fastapi/safe-content-disposition-rfc5987/SKILL.md
+++ b/skills/fastapi/safe-content-disposition-rfc5987/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: safe-content-disposition-rfc5987
+description: Build a Content-Disposition header that survives non-ASCII filenames on every browser using the RFC 5987 filename* encoding.
+category: fastapi
+version: 1.0.0
+version_origin: extracted
+tags: [http, headers, fastapi, i18n, downloads]
+source_type: extracted-from-git
+source_url: https://github.com/jamiepine/voicebox.git
+source_ref: main
+source_commit: 476abe07fc2c1587f4b3e3916134018ebacd143d
+source_project: voicebox
+confidence: high
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Safe Content-Disposition RFC 5987
+
+## When to use
+Your API serves user-authored filenames (uploaded clips, generated audio, exported bundles) which may contain non-ASCII characters, emojis, spaces, or punctuation. You want every browser to download with the correct filename and stop logging header-validation warnings.
+
+## Steps
+1. Strip the "ascii-safe" fallback by keeping only alphanumerics plus a small allowlist (` `, `-`, `_`, `.`). Trim whitespace; if nothing survives, fall back to a sensible default like `"download"`. This becomes the `filename="..."` parameter.
+2. Build the Unicode fallback with `urllib.parse.quote(filename, safe="")`. This percent-encodes UTF-8 bytes so the `filename*` parameter is RFC 5987 compliant (`filename*=UTF-8''<percent-encoded>`).
+3. Concatenate as `"<disposition_type>; filename=\"<ascii>\"; filename*=UTF-8''<utf8>"`. Browsers that understand RFC 5987 use `filename*`; older ones fall back to `filename` and still get something reasonable.
+4. Expose a single helper (e.g. `safe_content_disposition(kind, filename)`) and route every download handler through it. Do not build the header ad-hoc per endpoint.
+5. When serving with FastAPI `FileResponse`, pass `filename=<bare unicode>` only when you own the filename — for user input, use your helper and set the header directly via `Response(..., headers={"content-disposition": ...})`.
+
+## Counter / Caveats
+- Quotes inside the ASCII filename will break the header. The strict `isalnum() or c in " -_."` filter eliminates them by construction — loosen that filter only if you also escape quotes.
+- Don't include control characters (< 0x20) in the ASCII fallback even if your filter allowed them; they corrupt the header.
+- Some older (pre-2013) browsers choke on `filename*` if `filename` is missing entirely; always emit both.
+- If your framework auto-sets `Content-Disposition` from `filename=` on `FileResponse`, explicitly override the header afterwards or the framework's unsafe version may win.
+
+Source references: `backend/app.py` (`safe_content_disposition`).

--- a/skills/ffi/rust-flutter-ffi-bridge-async-pattern/SKILL.md
+++ b/skills/ffi/rust-flutter-ffi-bridge-async-pattern/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: rust-flutter-ffi-bridge-async-pattern
+description: Async Rust-Flutter FFI with tokio channels and StreamSink for bi-directional event streaming.
+category: ffi
+version: 1.0.0
+version_origin: extracted
+tags: [async, bridge, ffi, flutter, pattern, rust]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: [src/flutter_ffi.rs, src/flutter.rs]
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Rust Flutter Ffi Bridge Async Pattern
+
+## When to use
+Async Rust-Flutter FFI with tokio channels and StreamSink for bi-directional event streaming.
+
+## Source context
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- Demonstrated in: `src/flutter_ffi.rs`, `src/flutter.rs`
+
+## Why this generalizes
+Any Rust↔Dart integration on flutter_rust_bridge needs the same async event plumbing.
+
+## Next steps before publishing
+- Read the source files above and rewrite this as a product-agnostic `how-to` — keep the pattern, drop rustdesk-specific names.
+- Add a minimal code example in the target language (Rust + Dart / Rust only / etc.).
+- List 2-3 gotchas you hit while reproducing it.

--- a/skills/inference/sample-count-parallel-path-averaging/SKILL.md
+++ b/skills/inference/sample-count-parallel-path-averaging/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: sample-count-parallel-path-averaging
+description: Replicate each input N times inside the batch, run stochastic decoding in parallel, then average the N sampled paths to reduce variance.
+category: inference
+tags: [monte-carlo, ensemble, sampling, variance-reduction, autoregressive, forecasting]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/shiyu-coder/Kronos.git
+source_ref: master
+source_commit: 67b630e67f6a18c9e9be918d9b4337c960db1e9a
+source_project: Kronos
+source_paths: [model/kronos.py]
+version: 1.0.0
+version_origin: extracted
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Replicate-in-batch Monte Carlo averaging for stochastic decoding
+
+## When to use
+- You sample from a probabilistic model (temperature > 0, top-p < 1) and want a smoother point estimate than a single draw.
+- You have GPU headroom: `batch * sample_count` still fits in memory.
+- Latency matters more than full distribution reporting — you just want the expectation.
+
+## Pattern
+Expand the time-series batch along a new axis of size `sample_count`, reshape to `(B * sample_count, T, F)`, run the stochastic autoregressive decoder once, then reshape back to `(B, sample_count, T, F)` and take the mean along the sample axis. Because the same input is replicated `sample_count` times but randomness diverges per replica (different multinomial draws), the mean is a Monte-Carlo estimate of `E[y | x]`.
+
+```python
+# model/kronos.py auto_regressive_inference
+x       = x.unsqueeze(1).repeat(1, sample_count, 1, 1)          # (B, S, T, F)
+x       = x.reshape(-1, x.size(2), x.size(3)).to(device)        # (B*S, T, F)
+x_stamp = x_stamp.unsqueeze(1).repeat(1, sample_count, 1, 1).reshape(-1, x_stamp.size(1), x_stamp.size(2)).to(device)
+y_stamp = y_stamp.unsqueeze(1).repeat(1, sample_count, 1, 1).reshape(-1, y_stamp.size(1), y_stamp.size(2)).to(device)
+
+# ... full AR generation loop over (B*S, ...) ...
+
+z = tokenizer.decode(input_tokens, half=True)                   # (B*S, T, F)
+z = z.reshape(-1, sample_count, z.size(1), z.size(2))           # (B, S, T, F)
+preds = np.mean(z.cpu().numpy(), axis=1)                        # (B, T, F) — averaged
+```
+
+## Why it works / tradeoffs
+Replicating along a batch dim exploits GPU parallelism: `sample_count=5` is only ~5x compute but the wall clock grows far less than 5x because attention throughput saturates on small batches first. The mean over independent samples has standard error `sigma / sqrt(S)` so diminishing returns kick in around `S ~ 5–10` for most well-calibrated stochastic decoders. If you instead need quantiles / prediction intervals, keep the `sample_count` axis and report percentiles rather than averaging away. Don't confuse `sample_count` with beam search — beam narrows the distribution, this averages over it.
+
+## References
+- `model/kronos.py` in Kronos — `auto_regressive_inference`, the `sample_count` parameter and the `reshape + mean` at the tail
+- `KronosPredictor.predict` / `predict_batch` — public surface that exposes `sample_count` to users

--- a/skills/input/relative-mouse-mode-state-machine/SKILL.md
+++ b/skills/input/relative-mouse-mode-state-machine/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: relative-mouse-mode-state-machine
+description: Atomic state tracking for relative mouse mode with exit-shortcut detection across platforms.
+category: input
+version: 1.0.0
+version_origin: extracted
+tags: [input, machine, mode, mouse, relative, state]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: src/keyboard.rs
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# Relative Mouse Mode State Machine
+
+## When to use
+Atomic state tracking for relative mouse mode with exit-shortcut detection across platforms.
+
+## Source context
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- Demonstrated in: `src/keyboard.rs`
+
+## Why this generalizes
+Reusable for games/remote-control UIs needing pointer capture.
+
+## Next steps before publishing
+- Read the source files above and rewrite this as a product-agnostic `how-to` — keep the pattern, drop rustdesk-specific names.
+- Add a minimal code example in the target language (Rust + Dart / Rust only / etc.).
+- List 2-3 gotchas you hit while reproducing it.

--- a/skills/jit-compilation/safe-remove-all-for-distributed-filesystems/SKILL.md
+++ b/skills/jit-compilation/safe-remove-all-for-distributed-filesystems/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: safe-remove-all-for-distributed-filesystems
+description: Replace `std::filesystem::remove_all` with a recursive walk that tolerates concurrent mutation on NFS/Lustre — use pre-incremented iterators, skip-permission-denied options, and error-code overloads that never throw.
+category: jit-compilation
+version: 1.0.0
+version_origin: extracted
+tags: [filesystem, nfs, distributed, concurrency, error-handling, cleanup]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/deepseek-ai/DeepGEMM.git
+source_ref: main
+source_commit: 7f2a703ed51ac1f7af07f5e1453b2d3267d37d50
+source_project: DeepGEMM
+source_paths:
+  - csrc/utils/system.hpp
+  - csrc/jit/compiler.hpp
+imported_at: 2026-04-18T13:30:00Z
+---
+
+# Safe `remove_all` For Distributed Filesystems
+
+## When to use
+You have a JIT cache on a shared NFS/Lustre filesystem, multiple ranks writing into it concurrently, and the loser of a race needs to clean up its temp directory. `std::filesystem::remove_all` doesn't cut it:
+- On NFS, it can segfault when another process is simultaneously writing into a descendant directory (stale directory entries trip libstdc++).
+- It throws on partial failures (`ENOENT` because a peer already cleaned; `EACCES` because another rank renamed mid-walk).
+- It doesn't accept a policy like "skip permission-denied entries".
+
+You need a recursive remove that is *best-effort*: it removes what it can, survives concurrent mutation, and never throws.
+
+## Steps
+1. **Top-level existence check via `error_code` overload.** Never throw:
+   ```cpp
+   std::error_code ec;
+   if (not std::filesystem::exists(path, ec) or ec) return;  // gone, or peer raced
+   ```
+2. **Fast-path single-file case.** `remove(path, ec)` and return. No need to recurse for a plain file.
+3. **For directories, iterate with `skip_permission_denied`.**
+   ```cpp
+   auto it = std::filesystem::directory_iterator(path,
+       std::filesystem::directory_options::skip_permission_denied, ec);
+   ```
+   This prevents a single unreadable child from stopping the whole cleanup.
+4. **Pre-increment before using the entry.** This is the load-bearing trick:
+   ```cpp
+   for (auto end = std::filesystem::directory_iterator(); it != end and not ec;) {
+       const auto entry_path = it->path();
+       it.increment(ec);       // advance first
+       if (ec) break;          // iterator blew up (concurrent mutation)
+       safe_remove_all(entry_path);  // recurse — safe even if the dir vanishes mid-walk
+   }
+   ```
+   If you don't pre-increment, calling `safe_remove_all` on `it->path()` and then `++it` can crash because the iterator is now pointing at a deleted inode.
+5. **Remove the now-empty directory.** `remove(path, ec)` — again, error-code overload. If it's already empty, this succeeds; if a peer recreated files, leave them.
+6. **No retries.** A best-effort cleanup that silently fails is better than a loop that races with the peer that actually owns the directory now.
+
+## Evidence (from DeepGEMM)
+- `csrc/utils/system.hpp:100-126`: full `safe_remove_all` — pre-incremented iterator, `skip_permission_denied`, all paths use `error_code` overloads.
+- `csrc/jit/compiler.hpp:137-143`: the use site — after a failed directory rename (peer beat us), clean up our tmp dir:
+  ```cpp
+  // NOTES: avoid `std::filesystem::remove_all` here — it can segfault on
+  // distributed filesystems, when concurrent processes operate
+  // on the same parent directory
+  safe_remove_all(tmp_dir_path);
+  ```
+  The comment explicitly documents the segfault this pattern avoids.
+
+## Counter / Caveats
+- **`skip_permission_denied` in `directory_options`** was added in a later libstdc++ — check your toolchain if you see `no type named 'directory_options'`.
+- **Not atomic.** If another process is *creating* files while you're deleting, you'll leave some behind. Accept this — the contract is "best effort", not "definitely empty after".
+- **This is for trustworthy shared filesystems.** On a user-writable path, a symlink-race attack could delete outside the directory. DeepGEMM's path is inside the user's own `~/.deep_gemm/tmp/`, so this is not an issue — but worth noting for general use.

--- a/skills/linux-sandbox/sandbox-backend-pluggable-architecture/SKILL.md
+++ b/skills/linux-sandbox/sandbox-backend-pluggable-architecture/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: sandbox-backend-pluggable-architecture
+description: Three-backend dispatcher (Host/Bwrap/KVM) with auto-detection priority and env override. Abstract base class defines the interface; concrete implementations handle isolation. Used to run untrusted subprocess workloads on Linux with progressive isolation.
+category: linux-sandbox
+version: 1.0.0
+tags: [sandbox, bubblewrap, bwrap, kvm, linux, isolation, pluggable, daemon]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+# Sandbox Backend Pluggable Architecture
+
+## When to use
+
+Use this pattern when:
+- You need to run user-submitted or untrusted code with varying isolation levels depending on available system capabilities.
+- You want progressive isolation: strongest available sandbox by default, graceful fallback when tools are missing.
+- You want a single interface that callers use regardless of which backend is active.
+- You need runtime override for testing or power users (`SANDBOX_BACKEND=host` to disable isolation).
+
+## Pattern
+
+### Backend priority order (auto-detection)
+
+```
+1. bwrap  — if bwrap binary exists AND a test invocation succeeds
+2. kvm    — if /dev/kvm accessible + qemu + vsock all present
+3. host   — fallback (no isolation, always available)
+```
+
+### Interface (abstract base)
+
+All backends implement the same async interface. The dispatcher creates the right backend instance and the caller never sees which one is running.
+
+```
+BackendBase
+  ├── init(config)
+  ├── startVM(params) → void
+  ├── stopVM()
+  ├── isRunning() → { running: bool }
+  ├── isGuestConnected() → { connected: bool }
+  ├── spawn(params) → { id }
+  ├── kill(params)
+  ├── writeStdin(params)
+  ├── isProcessRunning(params) → { running: bool }
+  ├── mountPath(params) → { path }
+  ├── readFile(params) → { content }
+  ├── installSdk(params)
+  └── addApprovedOauthToken(params)
+```
+
+## Minimal example
+
+```javascript
+// backends/base.js
+class BackendBase {
+    constructor(emitEvent) {
+        this.emitEvent = emitEvent;  // callback to push events to subscribers
+    }
+    async init(config)              { throw new Error('Not implemented: init'); }
+    async startVM(params)           { throw new Error('Not implemented: startVM'); }
+    async stopVM()                  { throw new Error('Not implemented: stopVM'); }
+    isRunning()                     { throw new Error('Not implemented: isRunning'); }
+    isGuestConnected()              { throw new Error('Not implemented: isGuestConnected'); }
+    async spawn(params)             { throw new Error('Not implemented: spawn'); }
+    async kill(params)              { throw new Error('Not implemented: kill'); }
+    async writeStdin(params)        { throw new Error('Not implemented: writeStdin'); }
+    isProcessRunning(params)        { throw new Error('Not implemented: isProcessRunning'); }
+    async mountPath(params)         { throw new Error('Not implemented: mountPath'); }
+    async readFile(params)          { throw new Error('Not implemented: readFile'); }
+    async installSdk(params)        { throw new Error('Not implemented: installSdk'); }
+    async addApprovedOauthToken(p)  { throw new Error('Not implemented: addApprovedOauthToken'); }
+}
+
+// backends/host.js
+class HostBackend extends BackendBase {
+    constructor(emitEvent) {
+        super(emitEvent);
+        this.running = false;
+        this.processes = new Map();
+    }
+    isRunning() { return { running: this.running }; }
+    isGuestConnected() { return { connected: this.running }; }
+    async startVM(params) { this.running = true; }
+    async stopVM() {
+        this.running = false;
+        for (const [, proc] of this.processes) {
+            try { proc.kill(); } catch (_) {}
+        }
+        this.processes.clear();
+    }
+    async spawn(params) {
+        const { spawn } = require('child_process');
+        const id = require('crypto').randomUUID();
+        const child = spawn(params.command, params.args || [], {
+            cwd: params.cwd || process.env.HOME,
+            env: { ...process.env, ...params.env },
+        });
+        this.processes.set(id, child);
+        child.stdout.on('data', d => this.emitEvent({ type: 'stdout', id, data: d.toString() }));
+        child.stderr.on('data', d => this.emitEvent({ type: 'stderr', id, data: d.toString() }));
+        child.on('exit', code => {
+            this.processes.delete(id);
+            this.emitEvent({ type: 'exit', id, code });
+        });
+        return { id };
+    }
+    // ... other methods
+}
+
+// dispatcher.js — auto-detect the best available backend
+const { execSync } = require('child_process');
+const fs = require('fs');
+
+function detectBackend(override) {
+    if (override) {
+        switch (override.toLowerCase()) {
+            case 'bwrap': return 'bwrap';
+            case 'kvm':   return 'kvm';
+            case 'host':  return 'host';
+        }
+    }
+    // Try bwrap
+    try {
+        execSync('which bwrap', { stdio: 'ignore' });
+        execSync('bwrap --ro-bind / / true', { stdio: 'ignore' });
+        return 'bwrap';
+    } catch (_) {}
+    // Try KVM
+    if (fs.existsSync('/dev/kvm')) {
+        try {
+            fs.accessSync('/dev/kvm', fs.constants.R_OK | fs.constants.W_OK);
+            execSync('which qemu-system-x86_64', { stdio: 'ignore' });
+            if (fs.existsSync('/dev/vhost-vsock')) return 'kvm';
+        } catch (_) {}
+    }
+    return 'host';
+}
+
+function createBackend(emitEvent) {
+    const override = process.env.SANDBOX_BACKEND || null;
+    const name = detectBackend(override);
+    switch (name) {
+        case 'bwrap': return new BwrapBackend(emitEvent);
+        case 'kvm':   return new KvmBackend(emitEvent);
+        default:      return new HostBackend(emitEvent);
+    }
+}
+```
+
+## Why this works
+
+### Auto-detection with functional test for bwrap
+
+Checking `which bwrap` alone is insufficient — on some systems bwrap is installed but the kernel user namespace feature is disabled. Running `bwrap --ro-bind / / true` as a smoke test confirms that bwrap actually works. The `{ stdio: 'ignore' }` option prevents output pollution. If the test throws, fall through to the next backend.
+
+### `emitEvent` callback decouples event routing from backend logic
+
+Each backend receives an `emitEvent` function at construction time. This inversion of control means:
+- The backend does not need to know how events are delivered (WebSocket, IPC, file, etc.).
+- Tests can pass a mock `emitEvent` and assert on its calls.
+- Multiple subscribers can be supported by wrapping `emitEvent` in the dispatcher.
+
+### Env override for testing and power users
+
+`SANDBOX_BACKEND=host` lets developers test without bwrap and lets power users opt out of sandboxing for compatibility. The override is checked first in `detectBackend`, before any capability detection, so it is always honored.
+
+### Consistent interface regardless of backend
+
+All three backends implement the same interface. The caller (typically a JSON-RPC dispatcher) does `await backend.spawn(params)` without knowing or caring which backend is active. This is the classic Strategy pattern.
+
+## Pitfalls
+
+- **`bwrap --ro-bind / / true` as a test is a process spawn** — this adds latency to daemon startup. Run it once at startup, cache the result; do not run it per-request.
+- **KVM access requires group membership** — `/dev/kvm` may be readable only by the `kvm` group. `fs.accessSync` checks the effective uid/gid. If the user is not in the `kvm` group, fall through to bwrap.
+- **Backend state is stateful** — `isRunning()` and `isGuestConnected()` return state set by `startVM`/`stopVM`. If the backend process crashes externally, this state can become stale. Consider a health-check heartbeat for production use.
+- **`processes` Map grows without bound if exit events are missed** — always remove entries in the `exit` handler. If the process is killed externally (SIGKILL), the exit event may not fire. Consider a periodic cleanup pass for zombied entries.
+- **Do not use `throw` from interface base class on production** — callers expect a promise rejection, not a synchronous throw. Wrap in `return Promise.reject(new Error(...))` for consistent async error handling.
+
+## Source reference
+
+`scripts/cowork-vm-service.js` — `BackendBase`, `LocalBackend`, `BwrapBackend`, and `detectBackend` function

--- a/skills/mcp/response-pagination-with-metadata/SKILL.md
+++ b/skills/mcp/response-pagination-with-metadata/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: response-pagination-with-metadata
+description: Expose pageSize/pageIdx in MCP tool schemas and return pagination metadata (currentPage, totalPages, hasNextPage, startIndex, endIndex) in both the text and structured response so agents can iterate large result sets deterministically.
+category: mcp
+version: 1.0.0
+version_origin: extracted
+tags: [mcp, pagination, token-budget, response-design, agent-ux]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/ChromeDevTools/chrome-devtools-mcp.git
+source_ref: main
+source_commit: 0a6aaa52ebacb2db834ffa437863e5844aa3730b
+source_project: chrome-devtools-mcp
+source_path: src/utils/pagination.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Tool Response Pagination
+
+## When to use
+
+- An MCP tool can return a list whose size you cannot bound (network requests, console messages, heap aggregates, search hits).
+- Without pagination a single call could blow the agent's context window or truncate mid-entry.
+- You want agents to be able to say "give me the next page" naturally.
+
+## How it works
+
+- Add `pageSize?: number` and `pageIdx?: number` to every list-returning tool's schema with `zod.number().int().positive()` / `.min(0)`. Default page size is a sensible 20; omitting both returns everything (back-compat).
+- Implement a generic `paginate<T>(items, opts)` that returns `{items, currentPage, totalPages, hasNextPage, hasPreviousPage, startIndex, endIndex, invalidPage}`. If `pageIdx` is out of range, coerce to page 0 but set `invalidPage: true`.
+- In the response builder, add a short human-readable line — `"Showing 1-20 of 173 (Page 1 of 9). Next page: 1"` — and put the full pagination object in `structuredContent.pagination` for programmatic consumers.
+- On invalid page input, prepend `"Invalid page number provided. Showing first page."` before the summary so the agent learns to use `totalPages` as the bound.
+
+## Example
+
+```ts
+export function paginate<T>(items, options) {
+  const total = items.length;
+  if (!options || (options.pageSize === undefined && options.pageIdx === undefined)) {
+    return {items, currentPage: 0, totalPages: 1, hasNextPage: false, hasPreviousPage: false, startIndex: 0, endIndex: total, invalidPage: false};
+  }
+  const pageSize = options.pageSize ?? 20;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const {currentPage, invalidPage} = resolvePageIndex(options.pageIdx, totalPages);
+  const startIndex = currentPage * pageSize;
+  const pageItems = items.slice(startIndex, startIndex + pageSize);
+  return {items: pageItems, currentPage, totalPages, hasNextPage: currentPage < totalPages - 1, hasPreviousPage: currentPage > 0, startIndex, endIndex: startIndex + pageItems.length, invalidPage};
+}
+
+// in response format:
+response.push(`Showing ${startIndex+1}-${endIndex} of ${data.length} (Page ${currentPage+1} of ${totalPages}).`);
+if (result.hasNextPage) response.push(`Next page: ${currentPage + 1}`);
+if (result.hasPreviousPage) response.push(`Previous page: ${currentPage - 1}`);
+structuredContent.pagination = result;
+```
+
+## Gotchas
+
+- Emit `totalPages` even when `pageSize` is unset — the agent needs the *bound* before it can ask for page N.
+- The "Next page: N" hint is absolute page index, not relative. Make sure the hint is unambiguous; early drafts wrote "Next page: current+1" and agents paged off the end.
+- Return an empty `items` array, not `null`, when the list is legitimately empty. Agents branch poorly on null in JSON.
+- If filters are applied (e.g. `resourceTypes`), paginate *after* filtering so the page index matches what the agent sees. This is load-bearing for agent mental models.
+- Keep `pageSize` optional. A tool that *requires* it drives up input verbosity on every call.

--- a/skills/model-architecture/rope-dynamic-ntk-scaling/SKILL.md
+++ b/skills/model-architecture/rope-dynamic-ntk-scaling/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: rope-dynamic-ntk-scaling
+description: RoPE with Dynamic NTK scaling to extend context beyond training max position length
+category: model-architecture
+version: 1.0.0
+tags: [rope, positional-encoding, context-extension, transformer, attention]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/OpenBMB/VoxCPM.git
+source_ref: main
+source_commit: 13605c5a0e6b99d6d3527a43bd1a4e0e69c8800e
+source_project: VoxCPM
+source_paths:
+  - src/voxcpm/modules/minicpm4/model.py
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+---
+
+# RoPE with Dynamic NTK scaling for extended sequence support
+
+## When to use
+Use this pattern when a transformer trained with a fixed max context length (e.g., 4096) needs to handle longer sequences (e.g., 8192+) at inference time without fine-tuning. Dynamic NTK scaling adjusts the RoPE frequency basis on-the-fly based on the ratio of actual sequence length to training max, reducing positional aliasing on out-of-distribution lengths.
+
+## Pattern
+
+### Standard RoPE frequencies (baseline)
+```python
+import math
+import torch
+import torch.nn as nn
+
+class RotaryEmbedding(nn.Module):
+    def __init__(self, dim: int, max_position_embeddings: int = 4096, base: float = 10000.0):
+        super().__init__()
+        self.dim = dim
+        self.max_position_embeddings = max_position_embeddings
+        self.base = base
+        self._build_cache(max_position_embeddings)
+
+    def _build_cache(self, seq_len: int):
+        inv_freq = 1.0 / (self.base ** (torch.arange(0, self.dim, 2).float() / self.dim))
+        self.register_buffer("inv_freq", inv_freq)
+        t = torch.arange(seq_len, device=inv_freq.device).float()
+        freqs = torch.outer(t, inv_freq)
+        emb = torch.cat([freqs, freqs], dim=-1)
+        self.register_buffer("cos_cached", emb.cos()[None, None, :, :])
+        self.register_buffer("sin_cached", emb.sin()[None, None, :, :])
+        self._seq_len_cached = seq_len
+```
+
+### Dynamic NTK scaling extension
+When `seq_len > orig_max_pos`, recompute `inv_freq` with a scaled base:
+```python
+    def _maybe_rescale(self, seq_len: int, device):
+        if seq_len <= self._seq_len_cached:
+            return  # cache is still valid
+
+        orig_max_pos = self.max_position_embeddings
+
+        if seq_len > orig_max_pos:
+            # Dynamic NTK: scale the frequency base
+            scale = seq_len / orig_max_pos
+            scaling_factor = math.sqrt(1 + math.log(scale) / math.log(orig_max_pos))
+            new_base = self.base * scaling_factor
+        else:
+            new_base = self.base
+
+        inv_freq = 1.0 / (new_base ** (torch.arange(0, self.dim, 2, device=device).float() / self.dim))
+        self.inv_freq = inv_freq  # update in place
+
+        t = torch.arange(seq_len, device=device).float()
+        freqs = torch.outer(t, inv_freq)
+        emb = torch.cat([freqs, freqs], dim=-1)
+        self.cos_cached = emb.cos()[None, None, :, :]
+        self.sin_cached = emb.sin()[None, None, :, :]
+        self._seq_len_cached = seq_len
+
+    def forward(self, x: torch.Tensor, seq_len: int):
+        self._maybe_rescale(seq_len, x.device)
+        return (
+            self.cos_cached[:, :, :seq_len, :].to(x.dtype),
+            self.sin_cached[:, :, :seq_len, :].to(x.dtype),
+        )
+```
+
+### Apply RoPE in attention
+```python
+def rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1, x2 = x.chunk(2, dim=-1)
+    return torch.cat([-x2, x1], dim=-1)
+
+def apply_rotary_emb(q, k, cos, sin):
+    q_embed = q * cos + rotate_half(q) * sin
+    k_embed = k * cos + rotate_half(k) * sin
+    return q_embed, k_embed
+
+# In attention forward:
+cos, sin = self.rotary_emb(q, seq_len=q.shape[-2])
+q, k = apply_rotary_emb(q, k, cos, sin)
+```
+
+## Source reference
+- Upstream: `OpenBMB/VoxCPM` @ `main` / `13605c5a`
+- Key files:
+  - `src/voxcpm/modules/minicpm4/model.py:28-77` — full Dynamic NTK RoPE implementation including `scaling_factor` computation and cache invalidation
+
+## Notes
+- The scaling formula `sqrt(1 + log(scale) / log(orig_max_pos))` is specific to the Dynamic NTK variant used in MiniCPM4; other variants (Linear, YaRN) use different scaling functions.
+- Cache invalidation is seq_len-based, not step-based; the cache grows monotonically during a session, which is memory-safe.
+- At `seq_len == orig_max_pos`, `scale=1` and `log(scale)=0`, so `scaling_factor=1` and the formula degenerates to standard RoPE — no discontinuity.

--- a/skills/production/release-checklist/SKILL.md
+++ b/skills/production/release-checklist/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: release-checklist
+description: "Generates a comprehensive pre-release validation checklist covering build verification, certification requirements, store metadata, and launch readiness."
+argument-hint: "[platform: pc|console|mobile|all]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version: 1.0.0
+version_origin: extracted
+---
+
+> **Explicit invocation only**: This skill should only run when the user explicitly requests it with `/release-checklist`. Do not auto-invoke based on context matching.
+
+## Phase 1: Parse Arguments
+
+Read the argument for the target platform (`pc`, `console`, `mobile`, or `all`). If no platform is specified, default to `all`.
+
+---
+
+## Phase 2: Load Project Context
+
+- Read `CLAUDE.md` for project context, version information, and platform targets.
+- Read the current milestone from `production/milestones/` to understand what features and content should be included in this release.
+
+---
+
+## Phase 3: Scan Codebase
+
+Scan for outstanding issues:
+
+- Count `TODO` comments
+- Count `FIXME` comments
+- Count `HACK` comments
+- Note their locations and severity
+
+Check for test results in any test output directories or CI logs if available.
+
+---
+
+## Phase 4: Generate the Release Checklist
+
+```markdown
+## Release Checklist: [Version] -- [Platform]
+Generated: [Date]
+
+### Codebase Health
+- TODO count: [N] ([list top 5 if many])
+- FIXME count: [N] ([list all -- these are potential blockers])
+- HACK count: [N] ([list all -- these need review])
+
+### Build Verification
+- [ ] Clean build succeeds on all target platforms
+- [ ] No compiler warnings (zero-warning policy)
+- [ ] All assets included and loading correctly
+- [ ] Build size within budget ([target size])
+- [ ] Build version number correctly set ([version])
+- [ ] Build is reproducible from tagged commit
+
+### Quality Gates
+- [ ] Zero S1 (Critical) bugs
+- [ ] Zero S2 (Major) bugs -- or documented exceptions with producer approval
+- [ ] All critical path features tested and signed off by QA
+- [ ] Performance within budgets:
+  - [ ] Target FPS met on minimum spec hardware
+  - [ ] Memory usage within budget
+  - [ ] Load times within budget
+  - [ ] No memory leaks over extended play sessions
+- [ ] No regression from previous build
+- [ ] Soak test passed (4+ hours continuous play)
+
+### Content Complete
+- [ ] All placeholder assets replaced with final versions
+- [ ] All TODO/FIXME in content files resolved or documented
+- [ ] All player-facing text proofread
+- [ ] All text localization-ready (no hardcoded strings)
+- [ ] Audio mix finalized and approved
+- [ ] Credits complete and accurate
+```
+
+Add platform-specific sections based on the argument:
+
+**For `pc`:**
+```markdown
+### Platform Requirements: PC
+- [ ] Minimum and recommended specs verified and documented
+- [ ] Keyboard+mouse controls fully functional
+- [ ] Controller support tested (Xbox, PlayStation, generic)
+- [ ] Resolution scaling tested (1080p, 1440p, 4K, ultrawide)
+- [ ] Windowed, borderless, and fullscreen modes working
+- [ ] Graphics settings save and load correctly
+- [ ] Steam/Epic/GOG SDK integrated and tested
+- [ ] Achievements functional
+- [ ] Cloud saves functional
+- [ ] Steam Deck compatibility verified (if targeting)
+```
+
+**For `console`:**
+```markdown
+### Platform Requirements: Console
+- [ ] TRC/TCR/Lotcheck requirements checklist complete
+- [ ] Platform-specific controller prompts display correctly
+- [ ] Suspend/resume works correctly
+- [ ] User switching handled properly
+- [ ] Network connectivity loss handled gracefully
+- [ ] Storage full scenario handled
+- [ ] Parental controls respected
+- [ ] Platform-specific achievement/trophy integration tested
+- [ ] First-party certification submission prepared
+```
+
+**For `mobile`:**
+```markdown
+### Platform Requirements: Mobile
+- [ ] App store guidelines compliance verified
+- [ ] All required device permissions justified and documented
+- [ ] Privacy policy linked and accurate
+- [ ] Data safety/nutrition labels completed
+- [ ] Touch controls tested on multiple screen sizes
+- [ ] Battery usage within acceptable range
+- [ ] Background behavior correct (pause, resume, terminate)
+- [ ] Push notification permissions handled correctly
+- [ ] In-app purchase flow tested (if applicable)
+- [ ] App size within store limits
+```
+
+**Store and launch sections (all platforms):**
+```markdown
+### Store / Distribution
+- [ ] Store page metadata complete and proofread
+  - [ ] Short description
+  - [ ] Long description
+  - [ ] Feature list
+  - [ ] System requirements (PC)
+- [ ] Screenshots up to date and per-platform resolution requirements met
+- [ ] Trailers up to date
+- [ ] Key art and capsule images current
+- [ ] Age rating obtained and configured:
+  - [ ] ESRB
+  - [ ] PEGI
+  - [ ] Other regional ratings as required
+- [ ] Legal notices, EULA, and privacy policy in place
+- [ ] Third-party license attributions complete
+- [ ] Pricing configured for all regions
+
+### Launch Readiness
+- [ ] Analytics / telemetry verified and receiving data
+- [ ] Crash reporting configured and dashboard accessible
+- [ ] Day-one patch prepared and tested (if needed)
+- [ ] On-call team schedule set for first 72 hours
+- [ ] Community launch announcements drafted
+- [ ] Press/influencer keys prepared for distribution
+- [ ] Support team briefed on known issues and FAQ
+- [ ] Rollback plan documented (if critical issues found post-launch)
+
+### Go / No-Go: [READY / NOT READY]
+
+**Rationale:**
+[Summary of readiness assessment. List any blocking items that must be
+resolved before launch. If NOT READY, list the specific items that need
+resolution and estimated time to address them.]
+
+**Sign-offs Required:**
+- [ ] QA Lead
+- [ ] Technical Director
+- [ ] Producer
+- [ ] Creative Director
+```
+
+---
+
+## Phase 5: Save Checklist
+
+Present the checklist to the user with: total checklist items, number of known blockers (FIXME/HACK counts, known bugs).
+
+Ask: "May I write this to `production/releases/release-checklist-[version].md`?"
+
+If yes, write the file, creating the directory if needed.
+
+---
+
+## Phase 6: Next Steps
+
+- Run `/gate-check` for a formal phase gate verdict before proceeding to release.
+- Coordinate final sign-offs via `/team-release`.

--- a/skills/production/retrospective/SKILL.md
+++ b/skills/production/retrospective/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: retrospective
+description: "Generates a sprint or milestone retrospective by analyzing completed work, velocity, blockers, and patterns. Produces actionable insights for the next iteration."
+argument-hint: "[sprint-N|milestone-name]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write
+context: |
+  !git log --oneline --since="2 weeks ago" 2>/dev/null
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version: 1.0.0
+version_origin: extracted
+---
+
+## Phase 1: Parse Arguments
+
+Determine whether this is a sprint retrospective (`sprint-N`) or a milestone retrospective (`milestone-name`).
+
+---
+
+## Phase 1b: Check for Existing Retrospective
+
+Before loading any data, glob for an existing retrospective file:
+
+- For sprint retrospectives: `production/retrospectives/retro-[sprint-slug]-*.md`
+  (also check `production/sprints/sprint-[N]-retrospective.md` as an alternate location)
+- For milestone retrospectives: `production/retrospectives/retro-[milestone-name]-*.md`
+
+If a matching file is found, present the user with:
+
+```
+An existing retrospective was found: [filename]
+
+[A] Update existing retrospective — load it and add/revise sections
+[B] Start fresh — generate a new retrospective, archiving the old one
+```
+
+Wait for user selection before continuing. If updating, read the existing file and
+carry its content forward into the generation phase, revising sections with new data.
+
+---
+
+## Phase 2: Load Sprint or Milestone Data
+
+Read the sprint or milestone plan from the appropriate location:
+
+- Sprint plans: `production/sprints/`
+- Milestone definitions: `production/milestones/`
+
+**If the file does not exist or is empty**, output:
+
+> "No sprint data found for [sprint/milestone]. Run `/sprint-status` to generate
+> sprint data first, or provide the sprint details manually."
+
+Then use `AskUserQuestion` to present two options:
+
+- **[A] Provide data manually** — ask the user to paste or describe the sprint
+  tasks, dates, and outcomes; use that as the source of truth for the retrospective.
+- **[B] Stop** — abort the skill. Verdict: **BLOCKED** — no sprint data available.
+
+If the user chooses [A], collect the data and continue to Phase 3 using what they provide.
+If the user chooses [B], stop here.
+
+Extract: planned tasks, estimated effort, owners, and goals.
+
+Read the git log for the period covered by the sprint or milestone to understand what was actually committed and when.
+
+---
+
+## Phase 3: Analyze Completion and Trends
+
+Scan for completed and incomplete tasks by comparing the plan against actual deliverables. Check for:
+
+- Tasks completed as planned
+- Tasks completed but modified from the plan
+- Tasks carried over (not completed)
+- Tasks added mid-sprint (unplanned work)
+- Tasks removed or descoped
+
+Scan the codebase for TODO/FIXME trends:
+
+- Count current TODO/FIXME/HACK comments
+- Compare to previous sprint counts if available (check previous retrospectives)
+- Note whether technical debt is growing or shrinking
+
+Read previous retrospectives (if any) from `production/sprints/` or `production/milestones/` to check:
+
+- Were previous action items addressed?
+- Are the same problems recurring?
+- How has velocity trended?
+
+---
+
+## Phase 4: Generate the Retrospective
+
+```markdown
+## Retrospective: [Sprint N / Milestone Name]
+Period: [Start Date] -- [End Date]
+Generated: [Date]
+
+### Metrics
+
+| Metric | Planned | Actual | Delta |
+|--------|---------|--------|-------|
+| Tasks | [X] | [Y] | [+/- Z] |
+| Completion Rate | -- | [Z%] | -- |
+| Story Points / Effort Days | [X] | [Y] | [+/- Z] |
+| Bugs Found | -- | [N] | -- |
+| Bugs Fixed | -- | [N] | -- |
+| Unplanned Tasks Added | -- | [N] | -- |
+| Commits | -- | [N] | -- |
+
+### Velocity Trend
+
+| Sprint | Planned | Completed | Rate |
+|--------|---------|-----------|------|
+| [N-2] | [X] | [Y] | [Z%] |
+| [N-1] | [X] | [Y] | [Z%] |
+| [N] (current) | [X] | [Y] | [Z%] |
+
+**Trend**: [Increasing / Stable / Decreasing]
+[One sentence explaining the trend]
+
+### What Went Well
+- [Observation backed by specific data or examples]
+- [Another positive observation]
+- [Recognize specific contributions or decisions that paid off]
+
+### What Went Poorly
+- [Specific issue with measurable impact -- e.g., "Feature X took 5 days
+  instead of estimated 2, blocking tasks Y and Z"]
+- [Another issue with impact]
+- [Do not assign blame -- focus on systemic causes]
+
+### Blockers Encountered
+
+| Blocker | Duration | Resolution | Prevention |
+|---------|----------|------------|------------|
+| [What blocked progress] | [How long] | [How it was resolved] | [How to prevent recurrence] |
+
+### Estimation Accuracy
+
+| Task | Estimated | Actual | Variance | Likely Cause |
+|------|-----------|--------|----------|--------------|
+| [Most overestimated task] | [X] | [Y] | [+Z] | [Why] |
+| [Most underestimated task] | [X] | [Y] | [-Z] | [Why] |
+
+**Overall estimation accuracy**: [X%] of tasks within +/- 20% of estimate
+
+[Analysis: Are we consistently over- or under-estimating? For which types of
+tasks? What adjustment should we apply?]
+
+### Carryover Analysis
+
+| Task | Original Sprint | Times Carried | Reason | Action |
+|------|----------------|---------------|--------|--------|
+| [Task that was not completed] | [Sprint N-X] | [N] | [Why] | [Complete / Descope / Redesign] |
+
+### Technical Debt Status
+- Current TODO count: [N] (previous: [N])
+- Current FIXME count: [N] (previous: [N])
+- Current HACK count: [N] (previous: [N])
+- Trend: [Growing / Stable / Shrinking]
+- [Note any areas of concern]
+
+### Previous Action Items Follow-Up
+
+| Action Item (from Sprint N-1) | Status | Notes |
+|-------------------------------|--------|-------|
+| [Previous action] | [Done / In Progress / Not Started] | [Context] |
+
+### Action Items for Next Iteration
+
+| # | Action | Owner | Priority | Deadline |
+|---|--------|-------|----------|----------|
+| 1 | [Specific, measurable action] | [Who] | [High/Med/Low] | [When] |
+| 2 | [Another action] | [Who] | [Priority] | [When] |
+
+### Process Improvements
+- [Specific change to how we work, with expected benefit]
+- [Another improvement -- keep it to 2-3 actionable items, not a wish list]
+
+### Summary
+[2-3 sentence overall assessment: Was this a good sprint/milestone? What is
+the single most important thing to change going forward?]
+```
+
+---
+
+## Phase 5: Save Retrospective
+
+Present the retrospective and top findings to the user (completion rate, velocity trend, top blocker, most important action item).
+
+Ask: "May I write this to `production/sprints/sprint-[N]-retrospective.md`?" (or the milestone path if applicable)
+
+If yes, write the file, creating the directory if needed. Verdict: **COMPLETE** — retrospective saved.
+
+If no, stop here. Verdict: **BLOCKED** — user declined write.
+
+---
+
+## Phase 6: Next Steps
+
+- Run `/sprint-plan` to incorporate the action items and velocity data into the next sprint.
+- If this was a milestone retrospective, run `/gate-check` to formally assess readiness for the next phase.
+
+### Guidelines
+
+- Be honest and specific. Vague retrospectives ("communication could be better") produce vague improvements. Use data and examples.
+- Focus on systemic issues, not individual blame.
+- Limit action items to 3-5. More than that dilutes focus.
+- Every action item must have an owner and a deadline.
+- Check whether previous action items were completed. Recurring unaddressed items are a process smell.
+- If this is a milestone retrospective, also evaluate whether the milestone goals were achieved and what that means for the overall project timeline.

--- a/skills/production/scope-check/SKILL.md
+++ b/skills/production/scope-check/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: scope-check
+description: "Analyze a feature or sprint for scope creep by comparing current scope against the original plan. Flags additions, quantifies bloat, and recommends cuts. Use when user says 'any scope creep', 'scope review', 'are we staying in scope'."
+argument-hint: "[feature-name or sprint-N]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Bash
+model: haiku
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version: 1.0.0
+version_origin: extracted
+---
+
+# Scope Check
+
+This skill is read-only — it reports findings but writes no files.
+
+Compares original planned scope against current state to detect, quantify, and triage
+scope creep.
+
+**Argument:** `$ARGUMENTS[0]` — feature name, sprint number, or milestone name.
+
+---
+
+## Phase 1: Find the Original Plan
+
+Locate the baseline scope document for the given argument:
+
+- **Feature name** → read `design/gdd/[feature].md` or matching file in `design/`
+- **Sprint number** (e.g., `sprint-3`) → read `production/sprints/sprint-03.md` or similar
+- **Milestone** → read `production/milestones/[name].md`
+
+If the document is not found, report the missing file and stop. Do not proceed without
+a baseline to compare against.
+
+---
+
+## Phase 2: Read the Current State
+
+Check what has actually been implemented or is in progress:
+
+- Scan the codebase for files related to the feature/sprint
+- Read git log for commits related to this work (`git log --oneline --since=[start-date]`)
+- Check for TODO/FIXME comments that indicate unfinished scope additions
+- Check active sprint plan if the feature is mid-sprint
+
+---
+
+## Phase 3: Compare Original vs Current Scope
+
+Produce the comparison report:
+
+```markdown
+## Scope Check: [Feature/Sprint Name]
+Generated: [Date]
+
+### Original Scope
+[List of items from the original plan]
+
+### Current Scope
+[List of items currently implemented or in progress]
+
+### Scope Additions (not in original plan)
+| Addition | Source | When | Justified? | Effort |
+|----------|--------|------|------------|--------|
+| [item] | [commit/person] | [date] | [Yes/No/Unclear] | [S/M/L] |
+
+### Scope Removals (in original but dropped)
+| Removed Item | Reason | Impact |
+|-------------|--------|--------|
+| [item] | [why removed] | [what's affected] |
+
+### Bloat Score
+- Original items: [N]
+- Current items: [N]
+- Items added: [N] (+[X]%)
+- Items removed: [N]
+- Net scope change: [+/-N] ([X]%)
+
+### Risk Assessment
+- **Schedule Risk**: [Low/Medium/High] — [explanation]
+- **Quality Risk**: [Low/Medium/High] — [explanation]
+- **Integration Risk**: [Low/Medium/High] — [explanation]
+
+### Recommendations
+1. **Cut**: [Items that should be removed to stay on schedule]
+2. **Defer**: [Items that can move to a future sprint/version]
+3. **Keep**: [Additions that are genuinely necessary]
+4. **Flag**: [Items that need a decision from producer/creative-director]
+```
+
+---
+
+## Phase 4: Verdict
+
+Assign a canonical verdict based on net scope change:
+
+| Net Change | Verdict | Meaning |
+|-----------|---------|---------|
+| ≤10% | **PASS** | On Track — within acceptable variance |
+| 10–25% | **CONCERNS** | Minor Creep — manageable with targeted cuts |
+| 25–50% | **FAIL** | Significant Creep — must cut or formally extend timeline |
+| >50% | **FAIL** | Out of Control — stop, re-plan, escalate to producer |
+
+Output the verdict prominently:
+
+```
+**Scope Verdict: [PASS / CONCERNS / FAIL]**
+Net change: [+X%] — [On Track / Minor Creep / Significant Creep / Out of Control]
+```
+
+---
+
+## Phase 5: Next Steps
+
+After presenting the report, offer concrete follow-up:
+
+- **PASS** → no action required. Suggest re-running before next milestone.
+- **CONCERNS** → offer to identify the 2–3 additions with best cut ratio. Reference `/sprint-plan update` to formally re-scope.
+- **FAIL** → recommend escalating to producer. Reference `/sprint-plan update` for re-planning or `/estimate` to re-baseline timeline.
+
+Always end with:
+> "Run `/scope-check [name]` again after cuts are made to verify the verdict improves."
+
+---
+
+### Rules
+
+- Scope creep is additions without corresponding cuts or timeline extensions
+- Not all additions are bad — some are discovered requirements. But they must be acknowledged and accounted for
+- When recommending cuts, prioritize preserving the core player experience over nice-to-haves
+- Always quantify scope changes — "it feels bigger" is not actionable, "+35% items" is

--- a/skills/qa/regression-suite/SKILL.md
+++ b/skills/qa/regression-suite/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: regression-suite
+description: "Map test coverage to GDD critical paths, identify fixed bugs without regression tests, flag coverage drift from new features, and maintain tests/regression-suite.md. Run after implementing a bug fix or before a release gate."
+argument-hint: "[update | audit | report]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write, Edit
+source_type: extracted-from-git
+source_url: https://github.com/Donchitos/Claude-Code-Game-Studios.git
+source_ref: main
+source_commit: 666e0fcb5ad3f5f0f56e1219e8cf03d44e62a49a
+source_project: Claude-Code-Game-Studios
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version: 1.0.0
+version_origin: extracted
+---
+
+# Regression Suite
+
+This skill ensures that every bug fix is backed by a test that would have
+caught the original bug — and that the regression suite stays current as the
+game evolves. It also detects when new features have been added without
+corresponding regression coverage.
+
+A regression suite is not a new test category — it is a **curated list of
+tests already in `tests/`** that collectively cover the game's critical paths
+and known failure points. This skill maintains that list.
+
+**Output:** `tests/regression-suite.md`
+
+**When to run:**
+- After fixing a bug (confirm a regression test was written or identify gap)
+- Before a release gate (`/gate-check polish` requires regression suite exists)
+- As part of sprint close to detect coverage drift
+
+---
+
+## 1. Parse Arguments
+
+**Modes:**
+- `/regression-suite update` — scan new bug fixes this sprint and check
+  for regression test presence; add new tests to the suite manifest
+- `/regression-suite audit` — full audit of all GDD critical paths vs.
+  existing test coverage; flag paths with no regression test
+- `/regression-suite report` — read-only status report (no writes); suitable
+  for sprint reviews
+- No argument — run `update` if a sprint is active, else `audit`
+
+---
+
+## 2. Load Context
+
+### Step 2a — Load existing regression suite
+
+Read `tests/regression-suite.md` if it exists. Extract:
+- Total registered regression tests
+- Last updated date
+- Any tests flagged as `STALE` or `QUARANTINED`
+
+If it does not exist: note "No regression suite found — will create one."
+
+### Step 2b — Load test inventory
+
+Glob all test files:
+```
+tests/unit/**/*_test.*
+tests/integration/**/*_test.*
+tests/regression/**/*
+```
+
+For each file, note the system (from directory path) and file name.
+Do not read test file contents unless needed for name-to-test mapping.
+
+### Step 2c — Load GDD critical paths
+
+For `audit` mode: read `design/gdd/systems-index.md` to get all systems.
+For each MVP-tier system, read its GDD and extract:
+- Acceptance Criteria (these define the critical paths)
+- Formulas section (formulas must have regression tests)
+- Edge Cases section (known edge cases should have regression tests)
+
+For `update` mode: skip full GDD scan. Instead read the current sprint plan
+and story files to find stories with Status: Complete this sprint.
+
+### Step 2d — Load closed bugs
+
+Glob `production/qa/bugs/*.md` and filter for bugs with a `Status: Closed`
+or `Status: Fixed` field. Note:
+- Which story or system the bug was in
+- Whether a regression test was mentioned in the fix description
+
+---
+
+## 3. Map Coverage — Critical Paths
+
+For `audit` mode only:
+
+For each GDD acceptance criterion, determine whether a test exists:
+
+1. Grep `tests/unit/[system]/` and `tests/integration/[system]/` for file names
+   and function names related to the criterion's key noun/verb
+2. Assign coverage:
+
+| Status | Meaning |
+|--------|---------|
+| **COVERED** | A test file exists that targets this criterion's logic |
+| **PARTIAL** | A test exists but doesn't cover all cases (e.g. happy path only) |
+| **MISSING** | No test found for this critical path |
+| **EXEMPT** | Visual/Feel or UI criterion — not automatable by design |
+
+3. Elevate MISSING items that correspond to formulas or state machines to
+   **HIGH PRIORITY** gap — these are the most likely regression sources.
+
+---
+
+## 4. Map Coverage — Fixed Bugs
+
+For each closed bug:
+
+1. Extract the system slug from the bug's metadata
+2. Grep `tests/unit/[system]/` and `tests/integration/[system]/` for a test
+   that references the bug ID or the specific failure scenario
+3. Assign:
+   - **HAS REGRESSION TEST** — a test was found that would catch this bug
+   - **MISSING REGRESSION TEST** — bug was fixed but no test guards against recurrence
+
+For MISSING REGRESSION TEST items:
+- Flag them as regression gaps
+- Suggest the test file path: `tests/unit/[system]/[bug-slug]_regression_test.[ext]`
+- Note: "Without this test, this bug can silently return in a future sprint."
+
+---
+
+## 5. Detect Coverage Drift
+
+Coverage drift occurs when the game grows but the regression suite doesn't.
+
+Check for drift indicators:
+- Stories completed this sprint with no corresponding test files in `tests/`
+- New systems added to `systems-index.md` since the last regression-suite update
+- GDD sections added or revised since the regression suite was last updated
+  (use Grep on GDD file modification hints if available, or ask the user)
+- `tests/regression-suite.md` last-updated date vs. current date — if gap >
+  2 sprints, flag as likely stale
+
+---
+
+## 6. Generate Report and Suite Manifest
+
+### Report format (in conversation)
+
+```
+## Regression Suite Status
+
+**Mode**: [update | audit | report]
+**Existing registered tests**: [N]
+**Test files scanned**: [N]
+
+### Critical Path Coverage (audit mode only)
+| System | Total ACs | Covered | Partial | Missing | Exempt |
+|--------|-----------|---------|---------|---------|--------|
+| [name] | [N] | [N] | [N] | [N] | [N] |
+
+**Coverage rate (non-exempt)**: [N]%
+
+### Bug Regression Coverage
+| Bug ID | System | Severity | Has Regression Test? |
+|--------|--------|----------|----------------------|
+| BUG-NNN | [system] | S[N] | YES / NO ⚠ |
+
+**Bugs without regression tests**: [N]
+
+### Coverage Drift Indicators
+[List new systems or stories with no test coverage, or "None detected."]
+
+### Recommended New Regression Tests
+| Priority | System | Suggested Test File | Covers |
+|----------|--------|---------------------|--------|
+| HIGH | [system] | `tests/unit/[system]/[slug]_regression_test.[ext]` | BUG-NNN / AC-[N] |
+| MEDIUM | [system] | `tests/unit/[system]/[slug]_test.[ext]` | [criterion] |
+```
+
+### Suite manifest format (`tests/regression-suite.md`)
+
+The manifest is a curated index — not the tests themselves, but a registry
+of which tests should always pass before a release:
+
+```markdown
+# Regression Suite Manifest
+
+> Last Updated: [date]
+> Total registered tests: [N]
+> Coverage: [N]% of GDD critical paths
+
+## How to run
+
+[Engine-specific command to run all regression tests]
+
+## Registered Regression Tests
+
+### [System Name]
+
+| Test File | Test Function (if known) | Covers | Added |
+|-----------|--------------------------|--------|-------|
+| `tests/unit/[system]/[file]_test.[ext]` | `test_[scenario]` | AC-N / BUG-NNN | [date] |
+
+## Known Gaps
+
+Tests that should exist but don't yet:
+
+| Priority | System | Suggested Path | Covers | Reason Not Yet Written |
+|----------|--------|----------------|--------|------------------------|
+| HIGH | [system] | `tests/unit/[system]/[path]` | BUG-NNN | Bug fixed without test |
+
+## Quarantined Tests
+
+Tests that are flaky or disabled (do not run in CI):
+
+| Test File | Function | Reason | Quarantined Since |
+|-----------|----------|--------|-------------------|
+| (none) | | | |
+```
+
+---
+
+## 7. Write Output
+
+Ask: "May I write/update `tests/regression-suite.md` with the current
+regression suite manifest?"
+
+For `update` mode: append new entries; never remove existing entries
+(use `Edit` with targeted insertions).
+For `audit` mode: rewrite the full manifest with updated coverage data.
+For `report` mode: do not write anything.
+
+After writing (if approved):
+
+- For each HIGH priority gap: "Consider creating the missing regression test
+  before the next sprint. Run `/test-helpers` to scaffold the test file."
+- If bug regression gaps > 0: "These bugs can silently return without regression
+  tests. The next sprint should include a story to write the missing tests."
+- If coverage drift detected: "Regression suite may be drifting. Consider
+  running `/regression-suite audit` at the next sprint boundary."
+
+Verdict: **COMPLETE** — regression suite updated. (If user declined write: Verdict: **BLOCKED**.)
+
+---
+
+## Collaborative Protocol
+
+- **Never remove existing regression tests from the manifest** without
+  explicit user approval — removing a test that was deliberately written is a
+  regression risk itself
+- **Gaps are advisory, not blocking** — surface them clearly but do not prevent
+  other work from proceeding (except at release gate where regression suite is required)
+- **Quarantine is not deletion** — tests with intermittent failures should be
+  quarantined (noted in manifest) but not removed; they should be fixed by
+  `/test-flakiness`
+- **Ask before writing** — always confirm before creating or updating the manifest

--- a/skills/reverse-engineering/retrofit-okhttp-api-endpoint-extraction/SKILL.md
+++ b/skills/reverse-engineering/retrofit-okhttp-api-endpoint-extraction/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: retrofit-okhttp-api-endpoint-extraction
+description: Enumerate and document all HTTP endpoints from decompiled Android code by grepping annotation/builder signatures (Retrofit @GET/@POST, OkHttp Request.Builder, Volley request classes) then capturing method, path, headers, body, response type, and call site for each hit.
+category: reverse-engineering
+version: 1.0.0
+tags: [android, reverse-engineering, retrofit, okhttp, volley, api-extraction, http]
+source_type: extracted-from-git
+source_url: https://github.com/SimoneAvogadro/android-reverse-engineering-skill.git
+source_ref: master
+source_commit: ddeb9bc33272db1e34107fd286098bb1e9896e51
+source_project: android-reverse-engineering-skill
+source_path: plugins/android-reverse-engineering/skills/android-reverse-engineering/references/api-extraction-patterns.md
+imported_at: 2026-04-18T03:36:29Z
+confidence: medium
+version_origin: extracted
+---
+
+# Retrofit / OkHttp / Volley API Endpoint Extraction
+
+After decompiling an Android app, enumerate every HTTP endpoint it calls by running a fixed set of grep patterns against the `sources/` tree. The patterns target the **public library API surface**, which survives obfuscation — annotation names and Retrofit/OkHttp method calls are never renamed by ProGuard/R8.
+
+## Search strategy (ordered)
+
+1. **Base URL constants** — find where the API root is configured before anything else. It anchors every subsequent endpoint.
+2. **Retrofit interfaces** — cleanest enumeration; one annotated method per endpoint.
+3. **Interceptors** — reveal auth headers and common request modifiers.
+4. **Hardcoded URLs** — catch one-off calls outside the main client.
+5. **WebView URLs** — some hybrid apps route API calls through JavaScript bridges.
+
+## Retrofit patterns
+
+```bash
+# HTTP method annotations
+grep -rn '@GET\|@POST\|@PUT\|@DELETE\|@PATCH\|@HEAD' sources/
+
+# Parameter annotations
+grep -rn '@Query\|@QueryMap\|@Path\|@Body\|@Field\|@FieldMap\|@Part\|@Header\|@HeaderMap' sources/
+
+# Static headers + base URL
+grep -rn '@Headers' sources/
+grep -rn 'baseUrl\|\.baseUrl(' sources/
+```
+
+## OkHttp patterns
+
+```bash
+grep -rn 'Request\.Builder\|Request.Builder\|\.url(\|\.post(\|\.put(\|\.delete(\|\.patch(' sources/
+grep -rn 'HttpUrl\|\.addQueryParameter\|\.addPathSegment' sources/
+grep -rn 'Interceptor\|addInterceptor\|addNetworkInterceptor\|intercept(' sources/
+grep -rn '\.execute()\|\.enqueue(' sources/
+```
+
+## Volley / HttpURLConnection / WebView
+
+```bash
+grep -rn 'StringRequest\|JsonObjectRequest\|JsonArrayRequest\|Volley\.newRequestQueue\|RequestQueue' sources/
+grep -rn 'HttpURLConnection\|HttpsURLConnection\|openConnection\|setRequestMethod\|setRequestProperty' sources/
+grep -rn 'loadUrl\|evaluateJavascript\|addJavascriptInterface\|WebViewClient\|shouldOverrideUrlLoading' sources/
+```
+
+## Hardcoded URL + secret sweep
+
+```bash
+grep -rn '"https\?://[^"]*"' sources/
+grep -rni 'api[_-]\?key\|api[_-]\?secret\|auth[_-]\?token\|bearer\|access[_-]\?token\|client[_-]\?secret' sources/
+grep -rni 'BASE_URL\|API_URL\|SERVER_URL\|ENDPOINT\|API_BASE' sources/
+```
+
+## Endpoint documentation template
+
+For every hit that resolves to a real endpoint, write one block:
+
+```markdown
+### `METHOD /path/to/endpoint`
+
+- **Source**: `com.example.api.ApiService` (ApiService.java:42)
+- **Base URL**: `https://api.example.com/v1`
+- **Full URL**: `https://api.example.com/v1/path/to/endpoint`
+- **Path params**: `id` (String)
+- **Query params**: `page` (int), `limit` (int)
+- **Headers**: `Authorization: Bearer <token>`, `Content-Type: application/json`
+- **Request body**: `LoginRequest { email: String, password: String }`
+- **Response**: `ApiResponse<User>`
+- **Called from**: `LoginActivity → LoginViewModel → UserRepository → ApiService`
+```
+
+The "Called from" field is the payoff — it connects the endpoint back to user-facing UI and reveals the full request path.
+
+## Why this pattern survives obfuscation
+
+Retrofit annotations (`@GET`, `@POST`, `@Path`, etc.) are part of the library's public ABI. ProGuard/R8 cannot rename them without breaking the Retrofit runtime's reflection lookups. String literals (URLs, header names) are also preserved. So even in a fully obfuscated app with single-letter class names, the annotation grep still lands on every endpoint — you just have to trace the anchor class back through obfuscated callers.

--- a/skills/rpm/rpm-package-from-electron-no-hyphens/SKILL.md
+++ b/skills/rpm/rpm-package-from-electron-no-hyphens/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: rpm-package-from-electron-no-hyphens
+description: Generate an RPM spec file for an Electron app that correctly splits hyphenated version strings into Version/Release fields, maps Debian architecture names (amd64→x86_64, arm64→aarch64), and disables binary stripping and debug package generation.
+category: rpm
+version: 1.0.0
+tags: [rpm, fedora, packaging, electron, spec, arch-mapping, version-string]
+source_type: extracted-from-git
+source_url: https://github.com/aaddrick/claude-desktop-debian.git
+source_ref: main
+source_commit: 2fd9faf9db4eaa409b88310bdce397f8bdb0e916
+source_project: claude-desktop-debian
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+# RPM Package from Electron App (No Hyphens in Version)
+
+## When to use
+
+Use this pattern when:
+- You are building an RPM package for an Electron app from a CI/CD script.
+- Your version string may contain hyphens (e.g., `1.1.799-1.3.3`) because it encodes both an upstream app version and a wrapper/packaging version.
+- You are producing packages on both Debian-family and RPM-family systems from the same build pipeline and want consistent version semantics.
+- You need to suppress automatic dependency detection, binary stripping, and debug package generation (all of which are incompatible with pre-built Electron binaries).
+
+## Pattern
+
+### Version splitting
+
+```
+Input:  version="1.1.799-1.3.3"
+Output: rpm_version="1.1.799"   (before first hyphen)
+        rpm_release="1.3.3"      (after first hyphen)
+
+Input:  version="1.1.799"        (no hyphen)
+Output: rpm_version="1.1.799"
+        rpm_release="1"           (default release)
+```
+
+### Architecture mapping
+
+| Input (Debian) | Output (RPM) |
+|---|---|
+| `amd64` | `x86_64` |
+| `arm64` | `aarch64` |
+
+### Critical spec directives for Electron binaries
+
+```spec
+AutoReqProv:    no          # disable automatic dependency scanning
+%define debug_package %{nil} # disable debug package
+%define __strip /bin/true   # disable binary stripping
+%define _build_id_links none # disable build ID generation
+```
+
+## Minimal example
+
+```bash
+#!/usr/bin/env bash
+version="$1"; architecture="$2"; work_dir="$3"
+app_staging_dir="$4"; package_name="$5"
+description="${7:-My Electron App}"
+
+# Split version on first hyphen
+if [[ $version == *-* ]]; then
+    rpm_version="${version%%-*}"
+    rpm_release="${version#*-}"
+else
+    rpm_version="$version"
+    rpm_release="1"
+fi
+
+# Map architecture names
+case "$architecture" in
+    amd64) rpm_arch='x86_64' ;;
+    arm64) rpm_arch='aarch64' ;;
+    *) echo "Unsupported arch: $architecture" >&2; exit 1 ;;
+esac
+
+rpmbuild_dir="$work_dir/rpmbuild"
+rm -rf "$rpmbuild_dir"
+mkdir -p "$rpmbuild_dir"/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+# Create launcher script
+launcher="$work_dir/rpm-staging/$package_name"
+mkdir -p "$(dirname "$launcher")"
+cat > "$launcher" << LAUNCHER
+#!/usr/bin/env bash
+source "/usr/lib/$package_name/launcher-common.sh"
+setup_logging || exit 1
+setup_electron_env
+cleanup_stale_lock
+detect_display_backend
+electron_exec="/usr/lib/$package_name/node_modules/electron/dist/electron"
+app_path="/usr/lib/$package_name/node_modules/electron/dist/resources/app.asar"
+build_electron_args 'deb'
+electron_args+=("\$app_path")
+cd "/usr/lib/$package_name" || exit 1
+exec "\$electron_exec" "\${electron_args[@]}" "\$@"
+LAUNCHER
+chmod +x "$launcher"
+
+# Create desktop entry
+desktop_file="$work_dir/rpm-staging/$package_name.desktop"
+cat > "$desktop_file" << EOF
+[Desktop Entry]
+Name=My App
+Exec=/usr/bin/$package_name %u
+Icon=$package_name
+Type=Application
+Terminal=false
+Categories=Office;Utility;
+MimeType=x-scheme-handler/myapp;
+StartupWMClass=MyApp
+EOF
+
+# Write RPM spec
+cat > "$rpmbuild_dir/SPECS/$package_name.spec" << SPECEOF
+Name:           $package_name
+Version:        $rpm_version
+Release:        $rpm_release%{?dist}
+Summary:        $description
+
+License:        Proprietary
+URL:            https://example.com
+
+AutoReqProv:    no
+%define debug_package %{nil}
+%define __strip /bin/true
+%define _build_id_links none
+
+%description
+$description
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}/usr/lib/$package_name
+mkdir -p %{buildroot}/usr/share/applications
+mkdir -p %{buildroot}/usr/bin
+
+# Install icons
+for size in 16 24 32 48 64 256; do
+    icon_dir=%{buildroot}/usr/share/icons/hicolor/\${size}x\${size}/apps
+    mkdir -p "\$icon_dir"
+    icon_src="$work_dir/app_\${size}x\${size}.png"
+    [ -f "\$icon_src" ] && install -Dm 644 "\$icon_src" "\$icon_dir/$package_name.png"
+done
+
+# Install app files
+cp -r $app_staging_dir/node_modules %{buildroot}/usr/lib/$package_name/
+cp    $app_staging_dir/app.asar     %{buildroot}/usr/lib/$package_name/node_modules/electron/dist/resources/
+cp -r $app_staging_dir/app.asar.unpacked \
+      %{buildroot}/usr/lib/$package_name/node_modules/electron/dist/resources/
+cp scripts/launcher-common.sh %{buildroot}/usr/lib/$package_name/
+
+install -Dm 644 $desktop_file  %{buildroot}/usr/share/applications/$package_name.desktop
+install -Dm 755 $launcher      %{buildroot}/usr/bin/$package_name
+
+%post
+update-desktop-database /usr/share/applications >/dev/null 2>&1 || true
+SANDBOX="/usr/lib/$package_name/node_modules/electron/dist/chrome-sandbox"
+if [ -f "\$SANDBOX" ]; then
+    chown root:root "\$SANDBOX" || true
+    chmod 4755 "\$SANDBOX" || true
+fi
+
+%postun
+update-desktop-database /usr/share/applications >/dev/null 2>&1 || true
+
+%files
+%defattr(-, root, root, 0755)
+%attr(755, root, root) /usr/bin/$package_name
+/usr/lib/$package_name
+/usr/share/applications/$package_name.desktop
+/usr/share/icons/hicolor/*/apps/$package_name.png
+SPECEOF
+
+# Build RPM
+rpmbuild --define "_topdir $rpmbuild_dir" \
+         --define "_rpmdir $work_dir" \
+         --target "$rpm_arch" \
+         -bb "$rpmbuild_dir/SPECS/$package_name.spec"
+
+# Find and rename to consistent filename
+rpm_file=$(find "$work_dir" -name "${package_name}-${rpm_version}*.rpm" -type f | head -1)
+final_rpm="$work_dir/${package_name}-${version}-1.${rpm_arch}.rpm"
+[[ "$rpm_file" != "$final_rpm" ]] && mv "$rpm_file" "$final_rpm"
+echo "Built: $final_rpm"
+```
+
+## Why this works
+
+### Hyphen prohibition in RPM `Version:`
+
+RPM's `rpmvercmp` algorithm uses hyphens as field separators between `Version`, `Release`, and `Epoch`. A hyphen in the `Version:` field is a parse error. You must split `1.1.799-1.3.3` into `Version: 1.1.799` and `Release: 1.3.3` before writing the spec.
+
+### `%{?dist}` suffix in Release
+
+The `%{?dist}` macro expands to the distribution tag (e.g., `.fc40`, `.el9`) when built on that distro. If the macro is undefined (e.g., in a container without rpm macros), it expands to nothing. This makes the resulting filename correct on each target distro without hardcoding.
+
+### `AutoReqProv: no`
+
+RPM automatically scans ELF binaries for shared library dependencies and generates `Requires:` entries. Electron's bundled binaries reference many system libraries. On Fedora 40, some of these may differ from the host's library versions. `AutoReqProv: no` suppresses this scanner for the whole package, preventing spurious unresolvable dependency errors.
+
+### `%define __strip /bin/true`
+
+RPM's build process strips debug symbols from binaries by default. Stripping Electron's pre-built ELF files can corrupt them (Electron embeds important data in sections that `strip` considers debug-only). Replacing `__strip` with `/bin/true` is a no-op strip that preserves the binaries.
+
+### Architecture file renaming
+
+`rpmbuild` places output files in `$_rpmdir/$rpm_arch/package-version.rpm`. The final filename uses the RPM arch (`x86_64`), but the build pipeline convention uses Debian arch (`amd64`). Renaming the output file after build gives consistent filenames across all package formats.
+
+## Pitfalls
+
+- **`%install` section uses absolute source paths** — unlike debhelper, RPM specs do not have an implicit source tree. Use absolute paths to staging directories (passed from the build script). Relative paths in `%install` are relative to the rpmbuild `BUILD/` directory, not the project root.
+- **`%files` glob for icons requires actual files to exist** — `/usr/share/icons/hicolor/*/apps/$package_name.png` will cause build failure if no icon files are installed. Guard icon installation with `[ -f "$icon_src" ]`.
+- **`%post` chrome-sandbox requires `chown root:root` at runtime** — the sandbox file is installed as the build user. Only the `%post` scriptlet runs as root during installation. Do not attempt setuid in `%install`.
+- **SRPMS directory must exist** — `rpmbuild` expects the full `{BUILD,RPMS,SOURCES,SPECS,SRPMS}` hierarchy even when building binary-only (`-bb`). Creating all five subdirectories avoids `No such file or directory` errors.
+- **Embedded paths in spec file** — the spec file interpolates shell variables at write time. If `$app_staging_dir` contains spaces, the spec will be malformed. Use paths without spaces in staging directories.
+
+## Source reference
+
+`scripts/build-rpm-package.sh` — full implementation

--- a/skills/safety/reversible-pii-masking-context/SKILL.md
+++ b/skills/safety/reversible-pii-masking-context/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: reversible-pii-masking-context
+description: Replace sensitive identifiers with stable placeholders before LLM calls and reverse-map them on the way out, using a per-investigation context that survives node-to-node state transitions in a graph pipeline.
+category: safety
+version: 1.0.0
+version_origin: extracted
+tags: [masking, pii, llm, reversible, langgraph]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/Tracer-Cloud/opensre.git
+source_ref: main
+source_commit: fb5ba0a1b4ef511d16c56a80f1f126b1f581d724
+source_project: opensre
+source_path: app/masking/context.py
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Reversible PII Masking Context
+
+## When to use
+You need to send logs/evidence to an LLM but must keep raw identifiers (pod names, namespaces, IPs, account IDs, emails) out of the prompt. After the LLM responds, you want the original identifiers restored in the output so users still see real names. The placeholder map needs to survive across multiple LangGraph nodes.
+
+## How it works
+- A `MaskingContext` carries a placeholder map (`<NS_0> -> "kube-system"`) plus a counter per identifier kind so successive calls reuse the same placeholder for the same value.
+- `mask_value` recurses into dicts/lists/tuples; same for `unmask_value`.
+- `MaskingContext.from_state(state)` reconstructs the context from `state["masking_map"]`; `to_state()` serializes it back. Each node masks evidence before LLM input, then unmasks the LLM's output before storing it back to state.
+- A regex-based `MaskingPolicy` (built from env vars per-investigation, no singleton) decides which identifier kinds are enabled.
+
+## Example
+```python
+class MaskingContext:
+    @classmethod
+    def from_state(cls, state):
+        policy = MaskingPolicy.from_env()
+        existing = state.get("masking_map") or {}
+        return cls(policy=policy, placeholder_map=dict(existing))
+
+    def _ensure_placeholder(self, kind, value):
+        if value in self._reverse_map:
+            return self._reverse_map[value]
+        index = self._counters.get(kind, 0)
+        self._counters[kind] = index + 1
+        placeholder = f"<{kind.upper()}_{index}>"
+        self._placeholder_map[placeholder] = value
+        self._reverse_map[value] = placeholder
+        return placeholder
+
+    def mask_value(self, value):
+        if isinstance(value, str):  return self.mask(value)
+        if isinstance(value, dict): return {k: self.mask_value(v) for k, v in value.items()}
+        if isinstance(value, list): return [self.mask_value(v) for v in value]
+        return value
+
+# Usage in a node:
+masking_ctx = MaskingContext.from_state(dict(state))
+masked_evidence = masking_ctx.mask_value(evidence)
+result["masking_map"] = masking_ctx.to_state()
+# ...later, on LLM output:
+display_root_cause = masking_ctx.unmask(llm_response)
+```
+
+## Gotchas
+- Apply replacements in **reverse order of position** so earlier indices stay valid.
+- Resolve overlapping detector matches by keeping the longest/earliest one — overlapping spans corrupt the output.
+- Build the policy fresh per investigation (`MaskingPolicy.from_env()`) so toggling env vars between calls works without restarting the process.
+- Compile extra regex patterns once per context, not per `mask()` call.

--- a/skills/security/reject-insecure-bind-without-tls/SKILL.md
+++ b/skills/security/reject-insecure-bind-without-tls/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: reject-insecure-bind-without-tls
+description: Refuse to bind a token-authenticated WebSocket/HTTP server to a non-loopback address unless TLS is configured, with an explicit --allow-insecure-bind escape hatch.
+category: security
+version: 1.0.0
+version_origin: extracted
+tags: [websocket, tls, tokens, bind-safety]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: packages/server/src/index.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Reject insecure network bind without TLS
+
+## When to use
+- Any server that carries a bearer token or session cookie over TCP (headless RPC, admin UI, etc.).
+- You expect most users to run on `127.0.0.1` but some will want remote access.
+- Want secure-by-default: users only hit the insecure path if they *explicitly* acknowledge.
+
+## How it works
+1. After successfully starting the listener, check:
+   ```ts
+   const isLocalBind = host === '127.0.0.1' || host === 'localhost' || host === '::1';
+   if (!isLocalBind && protocol === 'ws') { /* insecure */ }
+   ```
+2. If insecure, look for a CLI escape hatch flag, e.g. `--allow-insecure-bind`.
+3. If not granted: print a multi-line actionable error (show TLS env vars, show the override flag), call `await server.stop()`, `process.exit(1)`.
+4. If granted: print a warning but continue.
+5. Pair with TLS setup: `CRAFT_RPC_TLS_CERT` + `CRAFT_RPC_TLS_KEY` paths are `readFileSync`d and passed to `createHttpsServer({ cert, key, ca? })` before the WebSocket server wraps it.
+
+## Example
+```ts
+const isLocal = host === '127.0.0.1' || host === 'localhost' || host === '::1';
+if (!isLocal && protocol === 'ws') {
+  if (!process.argv.includes('--allow-insecure-bind')) {
+    console.error(
+      '\nRefusing to bind to a network address without TLS.\n' +
+      '  1. Set CRAFT_RPC_TLS_CERT and CRAFT_RPC_TLS_KEY to enable wss://\n' +
+      '  2. Pass --allow-insecure-bind to override (NOT recommended)\n');
+    await instance.stop(); process.exit(1);
+  }
+  console.warn('WARNING: binding to a network address without TLS; tokens in cleartext.');
+}
+```
+
+## Gotchas
+- Don't just warn and keep going - users will never read warnings and production will end up in plaintext.
+- `--allow-insecure-bind` is strictly better than an env var because it has to be typed for every run.
+- Consider also rejecting `0.0.0.0` without TLS even in Docker - set the env variable `CRAFT_RPC_HOST=0.0.0.0` as a default ONLY in Docker where the container network is the isolation boundary.
+- Show the user HOW to fix it (env vars, script path) in the error message, not just what's wrong.

--- a/skills/telemetry/sanitize-tool-params-for-metrics/SKILL.md
+++ b/skills/telemetry/sanitize-tool-params-for-metrics/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: sanitize-tool-params-for-metrics
+description: When logging tool-invocation metrics, record only privacy-safe derivatives of arguments — string lengths, array counts, enum values — never raw values; drive the transformation from the tool's zod schema.
+category: telemetry
+version: 1.0.0
+version_origin: extracted
+tags: [telemetry, privacy, zod, schema, metrics]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/ChromeDevTools/chrome-devtools-mcp.git
+source_ref: main
+source_commit: 0a6aaa52ebacb2db834ffa437863e5844aa3730b
+source_project: chrome-devtools-mcp
+source_path: src/telemetry/flagUtils.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Sanitize Tool Parameters for Metrics
+
+## When to use
+
+- You want to log "how often and with what shape tools are called" without leaking user data (URLs, selectors, search queries, file paths).
+- You already have typed schemas (zod, JSON schema, etc.) for every tool's params.
+
+## How it works
+
+- Walk the tool's schema once per invocation. For each param:
+  - `ZodString` → emit `<snake_case_name>_length: value.length` (number).
+  - `ZodArray` → emit `<snake_case_name>_count: value.length` (number).
+  - `ZodNumber`/`ZodBoolean` → emit the raw value (these are safe in context).
+  - `ZodEnum` → emit the enum string as-is (finite set, known values).
+  - Anything else (`ZodObject`, etc.) → refuse to log (throw at tool-authoring time, not runtime).
+- Unwrap `ZodOptional`, `ZodDefault`, `ZodNullable`, `ZodEffects` recursively to get at the inner type — schemas commonly layer modifiers.
+- Keep a `PARAM_BLOCKLIST` (e.g. `uid`, `reqid`, `msgid` — any internal opaque handle) to strip entirely regardless of type.
+- Type-check value against declared type before transform; log mismatches as errors so drift is detected.
+
+## Example
+
+```ts
+export function sanitizeParams(params, schema) {
+  const out = {};
+  for (const [name, value] of Object.entries(params)) {
+    if (PARAM_BLOCKLIST.has(name)) continue;
+    const zodType = getZodType(schema[name]); // unwraps Optional/Default/Nullable/Effects
+    if (!hasEquivalentType(zodType, value)) throw new Error(`type mismatch for ${name}`);
+    const key = transformArgName(zodType, name); // foo → foo_length for strings
+    out[key] = transformValue(zodType, value);   // "hello" → 5
+  }
+  return out;
+}
+
+function getZodType(t) {
+  const def = t._def;
+  if (['ZodOptional','ZodDefault','ZodNullable'].includes(def.typeName)) return getZodType(def.innerType);
+  if (def.typeName === 'ZodEffects') return getZodType(def.schema);
+  if (SUPPORTED.includes(def.typeName)) return def.typeName;
+  throw new Error(`Unsupported zod type ${def.typeName}`);
+}
+```
+
+## Gotchas
+
+- Refuse (throw at startup / in a test) when a tool's schema uses unsupported types for logged params. Otherwise the first time someone adds a `ZodObject` input to a tool, telemetry silently ships the raw object.
+- `ZodEnum` with sensitive values (URLs, IDs) isn't actually enum-like — audit enum definitions, they should be finite categorical choices.
+- Always snake_case the param name for emitted metric keys. Metrics backends expect consistent casing; `foo_length` beats `fooLength` in querying.
+- Maintain the blocklist per project; `uid`/`reqid`/`msgid` are common but yours will differ.
+- Ship a flag like `USAGE_STATISTICS=false` as the environment kill switch, and check it *before* constructing the telemetry client at all — not inside `sanitizeParams`.

--- a/skills/workflow/run-messages-incremental-polling/SKILL.md
+++ b/skills/workflow/run-messages-incremental-polling/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: run-messages-incremental-polling
+description: Monotonic sequence numbers on streamed task messages enable cheap incremental polling (--since seq) so live UI fetches only the tail, not the whole log.
+category: workflow
+version: 1.0.0
+tags: [polling, streaming, task-messages, cli, pagination]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: medium
+---
+
+## When to use
+
+- An agent execution streams many messages (tool calls, thinking blocks, text) and a UI wants a live view.
+- WebSocket is overkill or not available (CLI polling).
+
+## Steps
+
+1. Schema: each message row on a task has a monotonic `seq` (BIGSERIAL per-task is fine):
+   ```sql
+   CREATE TABLE task_messages (
+     id UUID PRIMARY KEY,
+     task_id UUID NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+     seq BIGSERIAL,
+     type TEXT NOT NULL,   -- text | thinking | tool_use | tool_result | error | log
+     payload JSONB NOT NULL,
+     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+     UNIQUE (task_id, seq)
+   );
+   ```
+2. API endpoint accepts `?since=<seq>`:
+   ```
+   GET /api/tasks/:taskId/messages?since=42
+   → 200 { messages: [{ seq: 43, type: "text", ... }, { seq: 44, ... }], has_more: false }
+   ```
+   Limit page size (e.g. 500) and return `has_more` if truncated.
+3. CLI surface:
+   ```
+   multica issue run-messages <task-id>              # full log
+   multica issue run-messages <task-id> --since 42   # incremental
+   ```
+4. Caller (UI, CLI watcher) keeps local `maxSeq`; each poll sends `since=<maxSeq>`, appends returned messages, updates `maxSeq`.
+
+## Example
+
+In a CLI "watch this run" command:
+```bash
+last_seq=0
+while :; do
+  payload=$(multica issue run-messages $TASK --since $last_seq --output json)
+  echo "$payload" | jq -r '.messages[] | "\(.seq)\t\(.type)\t\(.payload.text // .payload.tool_name)"'
+  last_seq=$(echo "$payload" | jq '.messages[-1].seq // '$last_seq)
+  [ "$(echo "$payload" | jq '.status')" = '"completed"' ] && break
+  sleep 1
+done
+```
+
+## Caveats
+
+- `BIGSERIAL` per-task is easiest, but on insert-heavy systems may become a sequence-bottleneck — measure before switching to a ULID + timestamp index.
+- Clients should tolerate gaps in the seq sequence (cleanup jobs, rare races). Treat returned `seq` as authoritative "what I've seen"; don't assume contiguous.
+- On task completion, emit a sentinel message (or set a terminal status the client can observe) so watchers know to stop polling.

--- a/skills/zod/registeropenapiroute-wrapper/SKILL.md
+++ b/skills/zod/registeropenapiroute-wrapper/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: registeropenapiroute-wrapper
+description: Thin wrapper around `@hono/zod-openapi`'s `app.openapi(route, handler)` that casts the handler to `never`, bypassing the TypedResponse constraint while keeping runtime Zod validation of inputs.
+category: zod
+version: 1.0.0
+version_origin: extracted
+tags: [zod, hono, openapi, typed-response, route-registration]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/coleam00/Archon.git
+source_ref: dev
+source_commit: d89bc767d291f52687beea91c9fcf155459be0d9
+source_project: Archon
+imported_at: 2026-04-18T00:00:00Z
+linked_knowledge: [zod-openapi-schema-conventions]
+---
+
+# `registerOpenApiRoute` Wrapper for `@hono/zod-openapi` Handlers
+
+## When to use
+
+- You use `@hono/zod-openapi` for API routes and want the OpenAPI spec generation + runtime Zod validation.
+- Your handlers return `Response` built via `c.json(...)` / `c.text(...)` etc., but TypeScript's `TypedResponse` constraints from `app.openapi(route, handler)` keep fighting you (nested generics, conditional types, never-unions).
+- You accept that response schemas are used for **spec only** — runtime validation is only on inputs — and you want a one-line escape hatch to declare that intent.
+
+## Steps
+
+1. **Define a local helper that casts the handler**:
+
+   ```ts
+   function registerOpenApiRoute(
+     route: ReturnType<typeof createRoute>,
+     handler: (c: Context) => Response | Promise<Response>,
+   ): void {
+     app.openapi(route, handler as never);
+   }
+   ```
+
+   The `as never` cast is explicit; TypeScript's structural checker accepts `never` for anything. You've made the tradeoff visible.
+
+2. **Add a second helper for validated body access** to keep handlers readable:
+
+   ```ts
+   function getValidatedBody<T>(c: Context, _schema: z.ZodType<T>): T {
+     return (c.req as unknown as { valid(k: 'json'): T }).valid('json');
+   }
+   ```
+
+   Handlers then call `const body = getValidatedBody(c, createCodebaseBodySchema);` and get typed, validated data.
+
+3. **Register every route through the wrapper**, not `app.openapi(...)` directly. Makes it easy to grep:
+
+   ```ts
+   registerOpenApiRoute(createConversationRoute, async c => {
+     const body = getValidatedBody(c, createConversationBodySchema);
+     …
+     return c.json({ conversation }, 201);
+   });
+   ```
+
+4. **Document the tradeoff with a comment** next to the wrapper: "Zod validates inputs (query, params, body) at runtime via defaultHook. Response schemas are used for OpenAPI spec generation only — output is not validated at runtime. The `as never` cast bypasses TypedResponse constraints." (Archon's actual comment is at `api.ts:1638-1643`.)
+
+5. **Use `z` from `@hono/zod-openapi`, not from `zod` directly.** The wrapper's re-export includes extension methods (`openapi()`) needed for spec generation. Root `CLAUDE.md` codifies this in the Zod Schema Conventions section.
+
+6. **Route schemas per domain.** Archon's layout: `packages/server/src/routes/schemas/` with one file per domain (conversations, codebases, workflows). Engine schemas live elsewhere. Keep route contracts separate from engine/internal schemas.
+
+7. **Serve the OpenAPI spec** in one line:
+
+   ```ts
+   app.doc('/api/openapi.json', {
+     openapi: '3.0.0',
+     info: { title: 'Archon API', version: '1.0.0' },
+   });
+   ```
+
+## Counter / Caveats
+
+- **Inputs are validated, outputs are not.** This is a feature for developer ergonomics, but it means a bug that returns the wrong shape will silently ship wrong data to clients. Pair this with OpenAPI-driven client code generation (`@hey-api/openapi-ts` in Archon's case) so consumers see mismatches at their compile time.
+- **Don't** extend the wrapper to accept arbitrary middleware — keep it minimal. If you need Hono-level middleware, use `app.use()` separately.
+- `as never` is pragmatic, not principled. If a future `@hono/zod-openapi` release ships better TypedResponse inference, drop the wrapper.
+- Inside handlers, **never** access `c.req.json()` directly for a validated route — always use `getValidatedBody`. Bypassing the helper bypasses the validated type.
+- If you need response-shape enforcement, add a separate test layer that boots the app and exercises each route; runtime validation is overkill in Hono for high-QPS endpoints.
+
+## Evidence
+
+- `packages/server/src/routes/api.ts:1638-1654`: both helpers with inline comments.
+  ```ts
+  function registerOpenApiRoute(route: ReturnType<typeof createRoute>, handler: (c: Context) => Response | Promise<Response>): void {
+    app.openapi(route, handler as never);
+  }
+  function getValidatedBody<T>(c: Context, _schema: z.ZodType<T>): T {
+    return (c.req as unknown as { valid(k: 'json'): T }).valid('json');
+  }
+  ```
+- Spec serving at `api.ts:1657-1660`: `app.doc('/api/openapi.json', { openapi: '3.0.0', info: { title: 'Archon API', version: '1.0.0' } });`
+- ~40+ handler registrations across `api.ts` all go through the wrapper (greppable via `registerOpenApiRoute(`).
+- Root `CLAUDE.md` Zod Schema Conventions section (lines 21-30) codifies "All new/modified API routes must use `registerOpenApiRoute(createRoute({...}), handler)` — the local wrapper handles the TypedResponse bypass."
+- Commit SHA: d89bc767d291f52687beea91c9fcf155459be0d9.


### PR DESCRIPTION
## Batch
- batch 18/24

## Knowledge (21)
- `input/relative-mouse-mode-flutter-only`
- `devops/release-auto-update-publish-url`
- `domain/repository-identity-vs-project-vs-thread`
- `engineering/reproduce-bug-with-failing-test-first`
- `domain/research-paper-published-icse-2025`
- `inference/retry-badcase-token-ratio-heuristic`
- `workflow/reverse-document-workflow-example`
- `llm-fundamentals/rlhf-ppo-trl`
- `safety/rollback-strategy-git-based-three-modes`
- `engineering/root-cause-tracing`
- `reference/rpc-channel-namespaces`
- `rpm/rpm-version-field-hyphen-constraint`
- `llm-agents/run-context-and-shared-state`
- `api/runtime-mode-approval-policy-and-sandbox-mode`
- `model-loading/safetensors-pth-fallback`
- `safety/sandbox-soft-vs-hard-trade-off`
- `security/sanitized-environment-fingerprint-for-auto-report`
- `automation/scheduler-and-cron-task-execution-model`
- `flutter/sciter-ui-deprecation-path`
- `codecs/screen-capture-api-evolution-macos`
- _... and 1 more_

## Skills (29)
- `zod/registeropenapiroute-wrapper`
- `qa/regression-suite`
- `security/reject-insecure-bind-without-tls`
- `input/relative-mouse-mode-state-machine`
- `production/release-checklist`
- `electron-packaging/repackage-electron-asar-with-patterns`
- `engineering/requesting-code-review`
- `architecture/reserved-slugs-coordinated-list`
- `automation/resolve-cloudflare-protected-download-url`
- `mcp/response-pagination-with-metadata`
- `reverse-engineering/retrofit-okhttp-api-endpoint-extraction`
- `production/retrospective`
- `design/reverse-document`
- `safety/reversible-pii-masking-context`
- `design/review-all-gdds`
- `model-architecture/rope-dynamic-ntk-scaling`
- `rpm/rpm-package-from-electron-no-hyphens`
- `agents/run-config-global-settings`
- `agents/run-context-shared-state`
- `workflow/run-messages-incremental-polling`
- _... and 9 more_

## Source
- project: F:/workspace/tool (bulk extract)
- batch plan: .omc/batch-plan.json

## Post-merge
After squash-merge, run step 7 to re-anchor skill tags at the merge commit.