### PR TITLE
Publish batch 24/24: 12 knowledge + 15 skills

### DIFF
--- a/index.json
+++ b/index.json
@@ -280,6 +280,24 @@
   },
   {
     "kind": "knowledge",
+    "name": "ws-token-never-in-url",
+    "slug": "ws-token-never-in-url",
+    "category": "api",
+    "description": "Never put auth tokens in WebSocket URL query params — proxies, CDNs, and browser history will log them. Use cookies or first-message auth instead.",
+    "tags": [
+      "websocket",
+      "auth",
+      "security",
+      "token",
+      "cookie"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/api/ws-token-never-in-url.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "xlog-extended-transaction-trace-with-compression",
     "slug": "xlog-extended-transaction-trace-with-compression",
     "category": "api",
@@ -294,6 +312,24 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/api/xlog-extended-transaction-trace-with-compression.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "zod-openapi-schema-conventions",
+    "slug": "zod-openapi-schema-conventions",
+    "category": "api",
+    "description": "Use `@hono/zod-openapi`'s `z` (not `zod` directly), derive types with `z.infer<typeof X>`, co-locate route schemas per domain, and derive enum constants from `schema.options` instead of duplicating arrays.",
+    "tags": [
+      "zod",
+      "openapi",
+      "hono",
+      "schema",
+      "conventions"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/api/zod-openapi-schema-conventions.md",
     "has_content": true
   },
   {
@@ -1992,6 +2028,24 @@
   },
   {
     "kind": "knowledge",
+    "name": "ws-invalidation-not-store-writes",
+    "slug": "ws-invalidation-not-store-writes",
+    "category": "arch",
+    "description": "WebSocket event handlers invalidate React Query cache keys — they never write directly to Zustand stores or the cache.",
+    "tags": [
+      "websocket",
+      "react-query",
+      "invalidation",
+      "realtime",
+      "state"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/arch/ws-invalidation-not-store-writes.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "yorkie-team-server-split",
     "slug": "yorkie-team-server-split",
     "category": "arch",
@@ -2040,6 +2094,23 @@
     "triggers": [],
     "version": "",
     "path": "knowledge/architecture/agent-native-software-philosophy.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "wsrpcserver-push-target-model",
+    "slug": "wsrpcserver-push-target-model",
+    "category": "architecture",
+    "description": "pushTyped(wsServer, channel, target, workspaceId, payload) uses a PushTarget union ({ to: 'workspace' } | { to: 'client'; clientId } | { to: 'broadcast' }) so the server can efficiently unicast, workspace-broadcast, or global-broadcast a single serialized envelope.",
+    "tags": [
+      "websocket",
+      "push",
+      "broadcast",
+      "targeting"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/architecture/wsrpcserver-push-target-model.md",
     "has_content": true
   },
   {
@@ -3684,6 +3755,41 @@
   },
   {
     "kind": "knowledge",
+    "name": "workspace-slug-in-url-refactor",
+    "slug": "workspace-slug-in-url-refactor",
+    "category": "decision",
+    "description": "Make the URL the single source of truth for multi-tenant workspace context — not a header, not a store, not localStorage.",
+    "tags": [
+      "multi-tenancy",
+      "url",
+      "routing",
+      "workspace",
+      "architecture"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/workspace-slug-in-url-refactor.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "ws-heartbeat-ratio-ping-period",
+    "slug": "ws-heartbeat-ratio-ping-period",
+    "category": "decision",
+    "description": "WebSocket server ping period should be 90% of pong-wait so a missing pong is detected before the next ping is due (e.g. 54s ping / 60s pongWait).",
+    "tags": [
+      "websocket",
+      "heartbeat",
+      "ping-pong",
+      "liveness"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/decision/ws-heartbeat-ratio-ping-period.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "a11y-uid-tool-targeting-over-selectors",
     "slug": "a11y-uid-tool-targeting-over-selectors",
     "category": "domain",
@@ -3896,6 +4002,24 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/domain/topresource-immediate-generation-invariant.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "workspace-repo-cache",
+    "slug": "workspace-repo-cache",
+    "category": "domain",
+    "description": "Daemon maintains a per-host repo cache so multiple tasks on the same workspace share a warm clone; new tasks create git worktrees off the cache instead of re-cloning.",
+    "tags": [
+      "git",
+      "cache",
+      "worktree",
+      "daemon",
+      "performance"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/domain/workspace-repo-cache.md",
     "has_content": true
   },
   {
@@ -6644,6 +6768,41 @@
   },
   {
     "kind": "knowledge",
+    "name": "workspace-identity-not-cleared-on-unmount",
+    "slug": "workspace-identity-not-cleared-on-unmount",
+    "category": "pitfall",
+    "description": "A global \"current workspace\" singleton set on route mount must be explicitly cleared before leaving workspace context; unmount does not clear it.",
+    "tags": [
+      "state-management",
+      "workspace",
+      "race-condition",
+      "realtime"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/workspace-identity-not-cleared-on-unmount.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "worktree-cross-clone-adoption-pitfall",
+    "slug": "worktree-cross-clone-adoption-pitfall",
+    "category": "pitfall",
+    "description": "If a user has two clones of the same remote, a naive \"find worktree by branch\" lookup can adopt the wrong clone's worktree into the DB row, silently corrupting state.",
+    "tags": [
+      "git",
+      "worktree",
+      "cross-clone",
+      "adoption",
+      "isolation"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/worktree-cross-clone-adoption-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "yaml-block-scalar-frontmatter-parsing",
     "slug": "yaml-block-scalar-frontmatter-parsing",
     "category": "pitfall",
@@ -6658,6 +6817,56 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/pitfall/yaml-block-scalar-frontmatter-parsing.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "zero-length-byte-handling",
+    "slug": "zero-length-byte-handling",
+    "category": "pitfall",
+    "description": "Files smaller than min_file_size_for_dl (~8 bytes) bypass the model and use heuristics — they may return generic labels.",
+    "tags": [
+      "magika",
+      "pitfall"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/zero-length-byte-handling.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "zero-value-sentinel-alertmanager-startsat",
+    "slug": "zero-value-sentinel-alertmanager-startsat",
+    "category": "pitfall",
+    "description": "Alertmanager fills the alerts[].startsAt field with \"0001-01-01T00:00:00Z\" (the Go time.Time zero value) when not populated by the upstream alert source — guard with year < 2000 to detect this and fall back to a sensible default.",
+    "tags": [
+      "alertmanager",
+      "time-parsing",
+      "sentinel",
+      "golang"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/zero-value-sentinel-alertmanager-startsat.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "zustand-selector-stable-references",
+    "slug": "zustand-selector-stable-references",
+    "category": "pitfall",
+    "description": "Zustand selectors must return stable references — returning a freshly built object/array on every call triggers infinite re-renders.",
+    "tags": [
+      "zustand",
+      "react",
+      "selector",
+      "infinite-loop",
+      "performance"
+    ],
+    "triggers": [],
+    "version": "",
+    "path": "knowledge/pitfall/zustand-selector-stable-references.md",
     "has_content": true
   },
   {
@@ -8111,6 +8320,58 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/architecture/accepts-then-convert-two-phase-dispatch",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "workspace-directory-convention",
+    "slug": "workspace-directory-convention",
+    "category": "architecture",
+    "description": "Workspace-as-a-directory: a single ~/.craft-agent/workspaces/{id}/ folder holds config.json, automations.json, sessions/, sources/, skills/, statuses/ — every feature reads/writes its own subtree so the workspace is portable in one zip.",
+    "tags": [
+      "config",
+      "workspaces",
+      "directory-layout",
+      "portability"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/architecture/workspace-directory-convention",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "workspace-scoped-query-keys",
+    "slug": "workspace-scoped-query-keys",
+    "category": "architecture",
+    "description": "Derive React Query keys from a wsId parameter so switching workspace automatically swaps the cache — no manual invalidation, no cross-tenant leakage.",
+    "tags": [
+      "react-query",
+      "multi-tenancy",
+      "query-keys",
+      "workspace"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/architecture/workspace-scoped-query-keys",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "workspace-slug-url-refactor",
+    "slug": "workspace-slug-url-refactor",
+    "category": "architecture",
+    "description": "Migrate a multi-tenant SPA from header-based workspace identity to URL-based (/{slug}/...) to fix shareable links, mobile switching, multi-tab leakage, and mutation side-effect races.",
+    "tags": [
+      "multi-tenancy",
+      "url",
+      "refactor",
+      "routing",
+      "workspace"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/architecture/workspace-slug-url-refactor",
     "has_content": false
   },
   {
@@ -10273,6 +10534,24 @@
   },
   {
     "kind": "skill",
+    "name": "ws-rpc-heartbeat-event-buffer",
+    "slug": "ws-rpc-heartbeat-event-buffer",
+    "category": "build",
+    "description": "WebSocket RPC server with per-client heartbeat (ping/pong + missed-count kill) and a ring buffer of recent events per client so a brief disconnect + reconnect can replay pushes instead of dropping them.",
+    "tags": [
+      "websocket",
+      "rpc",
+      "heartbeat",
+      "resumption",
+      "event-buffer"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/build/ws-rpc-heartbeat-event-buffer",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "cmake-cuda-extension-with-git-submodule-vendoring",
     "slug": "cmake-cuda-extension-with-git-submodule-vendoring",
     "category": "build-system",
@@ -11191,6 +11470,24 @@
   },
   {
     "kind": "skill",
+    "name": "yaml-config-with-templated-dynamic-paths",
+    "slug": "yaml-config-with-templated-dynamic-paths",
+    "category": "configuration",
+    "description": "Load experiment config from YAML, then auto-resolve dependent paths via templates like \"{base}/{exp_name}/tokenizer/best_model\" unless the user overrides.",
+    "tags": [
+      "yaml",
+      "config-loader",
+      "templating",
+      "ml-experiments",
+      "path-resolution"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/configuration/yaml-config-with-templated-dynamic-paths",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "content-type-info-metadata-embedding",
     "slug": "content-type-info-metadata-embedding",
     "category": "data",
@@ -11203,6 +11500,24 @@
     "version": "1.0.0",
     "path": "skills/data/content-type-info-metadata-embedding",
     "has_content": true
+  },
+  {
+    "kind": "skill",
+    "name": "zip-recursive-subdocument-conversion",
+    "slug": "zip-recursive-subdocument-conversion",
+    "category": "data-pipeline",
+    "description": "Convert a ZIP archive to a single combined markdown document by iterating entries, constructing per-entry StreamInfo from filename+extension, and recursing through the same converter registry for each entry.",
+    "tags": [
+      "data-pipeline",
+      "zip",
+      "recursion",
+      "converter-registry",
+      "python"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/data-pipeline/zip-recursive-subdocument-conversion",
+    "has_content": false
   },
   {
     "kind": "skill",
@@ -12872,6 +13187,24 @@
   },
   {
     "kind": "skill",
+    "name": "worktree-env-file-isolation",
+    "slug": "worktree-env-file-isolation",
+    "category": "devops",
+    "description": "Per-git-worktree environment files (.env.worktree) with deterministically derived unique database names and ports, sharing one Postgres container.",
+    "tags": [
+      "git-worktree",
+      "env",
+      "dev-setup",
+      "postgres",
+      "makefile"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/devops/worktree-env-file-isolation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "document-release",
     "slug": "document-release",
     "category": "docs",
@@ -13676,6 +14009,36 @@
   },
   {
     "kind": "skill",
+    "name": "zod-defined-tool-factory",
+    "slug": "zod-defined-tool-factory",
+    "category": "mcp",
+    "description": "Wrap MCP tool definitions in a typed `defineTool` helper so zod schemas drive both runtime validation and the handler's TypeScript param types, with a separate `definePageTool` variant for tools that need a pre-resolved page context.",
+    "tags": [
+      "mcp",
+      "zod",
+      "typescript",
+      "tool-definition",
+      "dx"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/mcp/zod-defined-tool-factory",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "writing-skills",
+    "slug": "writing-skills",
+    "category": "meta",
+    "description": "Use when creating new skills, editing existing skills, or verifying skills work before deployment",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/meta/writing-skills",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "design-an-interface",
     "slug": "design-an-interface",
     "category": "misc",
@@ -13843,6 +14206,37 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/operations/claude-cli-unattended-wrapper",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "x11-xrandr-display-enumeration",
+    "slug": "x11-xrandr-display-enumeration",
+    "category": "platform/linux",
+    "description": "X11 XRandR integration for multi-display detection and resolution queries.",
+    "tags": [
+      "display",
+      "enumeration",
+      "linux",
+      "platform",
+      "x11",
+      "xrandr"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/linux/x11-xrandr-display-enumeration",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "writing-plans",
+    "slug": "writing-plans",
+    "category": "process",
+    "description": "Use when you have a spec or requirements for a multi-step task, before touching code",
+    "tags": [],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/process/writing-plans",
     "has_content": false
   },
   {
@@ -14369,6 +14763,23 @@
   },
   {
     "kind": "skill",
+    "name": "zustand-store-mock-hoisted",
+    "slug": "zustand-store-mock-hoisted",
+    "category": "testing",
+    "description": "Mock Zustand stores in Vitest using vi.hoisted() + Object.assign so the mock is both callable as a selector hook AND has .getState() static access.",
+    "tags": [
+      "vitest",
+      "zustand",
+      "mocking",
+      "hoisted"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/testing/zustand-store-mock-hoisted",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
     "name": "comprehensive-gpu-kernel-testing-harness",
     "slug": "comprehensive-gpu-kernel-testing-harness",
     "category": "testing-gpu",
@@ -14421,6 +14832,42 @@
     "triggers": [],
     "version": "1.0.0",
     "path": "skills/web/content-disposition-filename-fallback",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "ws-cookie-or-first-message-auth",
+    "slug": "ws-cookie-or-first-message-auth",
+    "category": "websocket",
+    "description": "Dual-path WebSocket auth — HttpOnly cookie for browsers, first-message JSON frame for headless clients — with no tokens in the URL.",
+    "tags": [
+      "websocket",
+      "auth",
+      "cookie",
+      "token",
+      "security"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/websocket/ws-cookie-or-first-message-auth",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "ws-query-invalidation-bridge",
+    "slug": "ws-query-invalidation-bridge",
+    "category": "websocket",
+    "description": "Convert WebSocket events into TanStack Query cache invalidations via a per-event-prefix map, so realtime updates never touch stores directly.",
+    "tags": [
+      "websocket",
+      "react-query",
+      "invalidation",
+      "realtime",
+      "pattern"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/websocket/ws-query-invalidation-bridge",
     "has_content": false
   },
   {
@@ -16108,6 +16555,24 @@
     "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/websocket-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "worktree-isolation-resolver",
+    "slug": "worktree-isolation-resolver",
+    "category": "workflow",
+    "description": "Resolve which git worktree a workflow should run in using an ordered chain (existing ref → same-workflow reuse → linked-issue share → PR branch adoption → create new), each step guarded by worktree-ownership verification against the canonical repo path.",
+    "tags": [
+      "workflow",
+      "worktree",
+      "isolation",
+      "resolver",
+      "cross-clone"
+    ],
+    "triggers": [],
+    "version": "1.0.0",
+    "path": "skills/workflow/worktree-isolation-resolver",
     "has_content": false
   },
   {

--- a/knowledge/api/ws-token-never-in-url.md
+++ b/knowledge/api/ws-token-never-in-url.md
@@ -1,0 +1,32 @@
+---
+name: ws-token-never-in-url
+summary: Never put auth tokens in WebSocket URL query params — proxies, CDNs, and browser history will log them. Use cookies or first-message auth instead.
+category: api
+tags: [websocket, auth, security, token, cookie]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: packages/core/api/ws-client.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+Browser WebSocket connections support two safe auth modes:
+
+1. **Cookie mode** — HttpOnly auth cookie is sent automatically with the upgrade request (web clients only; cookies don't carry across origins for desktop/Electron).
+2. **First-message auth** — connect unauthenticated, send `{"type":"auth","payload":{"token":"..."}}` as the first frame, server holds the connection in a pre-auth state until it sees that frame (with a short read deadline to kick out clients that never authenticate).
+
+The token must never be placed on the URL as a query string. URLs get logged by TLS-terminating proxies, browser history, server access logs, and CDNs. WebSocket URLs are no exception.
+
+## Why
+
+On the server side, handle the two modes behind one upgrade endpoint: try cookie auth first; if no cookie, upgrade the connection and set a 10-second read deadline on the first frame. Clients distinguish themselves by constructor option (`cookieAuth: true` for web, `false` for desktop/CLI).
+
+Use the same PAT/JWT token-shape rule as HTTP endpoints: check a prefix (`mul_` → PAT lookup, otherwise JWT verify) so there's a single authentication path regardless of transport.
+
+## Evidence
+
+- `packages/core/api/ws-client.ts:30-50` — client never appends token to URL.
+- `server/internal/realtime/hub.go:331-400` — `firstMessageAuth` + cookie fast path.

--- a/knowledge/api/zod-openapi-schema-conventions.md
+++ b/knowledge/api/zod-openapi-schema-conventions.md
@@ -1,0 +1,74 @@
+---
+name: zod-openapi-schema-conventions
+summary: Use `@hono/zod-openapi`'s `z` (not `zod` directly), derive types with `z.infer<typeof X>`, co-locate route schemas per domain, and derive enum constants from `schema.options` instead of duplicating arrays.
+category: api
+confidence: high
+tags: [zod, openapi, hono, schema, conventions]
+source_type: extracted-from-git
+source_url: https://github.com/coleam00/Archon.git
+source_ref: dev
+source_commit: d89bc767d291f52687beea91c9fcf155459be0d9
+source_project: Archon
+imported_at: 2026-04-18T00:00:00Z
+linked_skills: [registeropenapiroute-wrapper]
+---
+
+# Zod + `@hono/zod-openapi` Conventions
+
+## Fact / Decision
+
+When building a Hono API with OpenAPI-style validation via `@hono/zod-openapi`, adopt these conventions across the codebase and enforce them in `CLAUDE.md` / style guide:
+
+1. **Schema naming: camelCase with descriptive suffix.** `workflowRunSchema`, `errorSchema`, `createCodebaseBodySchema`, `dagNodeSchema`. Not `WorkflowRun` (reserved for the inferred type), not `workflowRun` (ambiguous).
+
+2. **Type derivation: always `z.infer<typeof schema>`**. Never write parallel hand-crafted interfaces. If you need `WorkflowRun`, you write:
+
+   ```ts
+   export const workflowRunSchema = z.object({ … });
+   export type WorkflowRun = z.infer<typeof workflowRunSchema>;
+   ```
+
+3. **Import `z` from `@hono/zod-openapi`, not `zod`.** The re-exported `z` has the `.openapi()` extension for attaching OpenAPI metadata to schemas. Importing from `zod` directly drops that method and breaks spec generation at runtime.
+
+4. **All new/modified API routes use `registerOpenApiRoute(createRoute({...}), handler)`** — the local wrapper that handles the TypedResponse bypass with an explicit `as never` cast. Never call `app.openapi(...)` directly.
+
+5. **Route schemas per domain in `src/routes/schemas/`**, one file per domain (conversations, codebases, workflows, messages, providers). Keep route contracts separate from engine/internal schemas.
+
+6. **Engine schemas in `packages/workflows/src/schemas/`**, one file per concern (dag-node, workflow, workflow-run, retry, loop, hooks), with an `index.ts` that re-exports all. Engine schema naming is camelCase too (`dagNodeSchema`, `workflowBaseSchema`, `nodeOutputSchema`).
+
+7. **Derive enum-like arrays from `schema.options`, never duplicate.** Example:
+
+   ```ts
+   export const TRIGGER_RULES = triggerRuleSchema.options; // ['all', 'any', 'none']
+   ```
+
+   Exception: when the web package imports only from the type-only generated `api.generated.d.ts`, it must define its own local constant because runtime values can't come from a `.d.ts`. Document the exception explicitly.
+
+8. **Use `.safeParse()` for validation at module boundaries** (e.g. YAML-loaded workflow nodes in `loader.ts`). For graph-level checks that Zod can't express (cycles, deps, `$nodeId.output` refs), keep imperative code in a separate `validateDagStructure()` step.
+
+## Why
+
+These conventions push:
+
+- **Single source of truth** — types flow from schemas, not parallel interfaces. A rename in the schema updates every call site.
+- **OpenAPI discoverability** — clients get typed SDKs from the generated spec, with field-level docs coming from `.openapi()` metadata.
+- **Runtime safety at the boundaries** — Zod validates inputs; core code can assume the branded types are well-formed.
+- **Maintenance** — consistent imports and naming make automated refactors possible.
+
+The `schema.options` rule in particular has saved many drift bugs where an enum value was added to the schema but not to the TypeScript union used for switch-case coverage.
+
+## Counter / Caveats
+
+- `z.infer` on `.transform()`-heavy schemas gets the **output** type, not the input. For cases where you need both (API body vs internal representation), explicitly name both: `WorkflowRunInput = z.input<…>` and `WorkflowRunOutput = z.output<…>`.
+- Don't `.openapi({})` every field — only add metadata when it adds value (description, example). Verbosity here makes schemas unreadable.
+- When upgrading `@hono/zod-openapi` or `zod`, run the full test suite — subtle inference differences between patch versions have caused regressions.
+- These conventions are Archon-specific but transfer cleanly to any Hono + Zod + OpenAPI stack.
+
+## Evidence
+
+- Root `CLAUDE.md` lines 21-30: the "Zod Schema Conventions" section encodes every rule above verbatim.
+- `packages/server/src/routes/schemas/` directory structure (one file per domain).
+- `packages/workflows/src/schemas/` directory: `dag-node.ts`, `workflow.ts`, `workflow-run.ts`, `loop.ts`, `hooks.ts`, `index.ts` re-export.
+- `registerOpenApiRoute` wrapper at `packages/server/src/routes/api.ts:1638-1649`.
+- Example `schema.options` derivation referenced in CLAUDE.md (`TRIGGER_RULES` / `WORKFLOW_HOOK_EVENTS` derived from `triggerRuleSchema.options`).
+- Commit SHA: d89bc767d291f52687beea91c9fcf155459be0d9.

--- a/knowledge/arch/ws-invalidation-not-store-writes.md
+++ b/knowledge/arch/ws-invalidation-not-store-writes.md
@@ -1,0 +1,39 @@
+---
+name: ws-invalidation-not-store-writes
+summary: WebSocket event handlers invalidate React Query cache keys — they never write directly to Zustand stores or the cache.
+category: arch
+tags: [websocket, react-query, invalidation, realtime, state]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: packages/core/realtime/use-realtime-sync.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+Pattern: on every WS event, extract the event prefix, look up a refresh function in a per-prefix map, call `queryClient.invalidateQueries({ queryKey: ... })`. No direct store writes. No optimistic updates driven from WS. No bespoke merging.
+
+```
+const refreshMap: Record<string, () => void> = {
+  inbox:   () => { const wsId = getCurrentWsId(); if (wsId) qc.invalidateQueries({ queryKey: inboxKeys.all(wsId) }); },
+  agent:   () => { const wsId = getCurrentWsId(); if (wsId) qc.invalidateQueries({ queryKey: workspaceKeys.agents(wsId) }); },
+  member:  () => { ... },
+  workspace: () => qc.invalidateQueries({ queryKey: workspaceKeys.list() }),
+  // ...
+};
+```
+
+Debounce per-prefix to collapse bulk updates (e.g. 50 issue-update events in 100ms → one refetch).
+
+## Why
+
+Cache is the single source of truth. Direct WS→store writes re-introduce the drift that pushing all server state to Query was supposed to prevent. Invalidation is also idempotent: the cache either refetches or ignores (if no subscriber is mounted), so spurious WS events cost nothing.
+
+Precise handlers (per-event-type) are reserved for side effects that cannot be expressed as invalidation: toast notifications, forced navigation, self-check ("did I just delete the workspace I'm viewing?"). Daemon register/deregister events invalidate runtime queries globally; heartbeats are explicitly skipped to avoid excessive refetches.
+
+## Evidence
+
+- `packages/core/realtime/use-realtime-sync.ts:77-180` — `refreshMap` pattern.
+- CLAUDE.md, "State Management" hard rules.

--- a/knowledge/architecture/wsrpcserver-push-target-model.md
+++ b/knowledge/architecture/wsrpcserver-push-target-model.md
@@ -1,0 +1,59 @@
+---
+name: wsrpcserver-push-target-model
+summary: pushTyped(wsServer, channel, target, workspaceId, payload) uses a PushTarget union ({ to: 'workspace' } | { to: 'client'; clientId } | { to: 'broadcast' }) so the server can efficiently unicast, workspace-broadcast, or global-broadcast a single serialized envelope.
+category: architecture
+tags: [websocket, push, broadcast, targeting]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: packages/server-core/src/transport/push.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# WsRpcServer push targeting model
+
+### The abstraction
+Server-side push is typed via `PushTarget`:
+```ts
+type PushTarget =
+  | { to: 'workspace'; workspaceId: string }   // all clients subscribed to this workspace
+  | { to: 'client';    clientId: string }       // one specific client connection
+  | { to: 'broadcast' }                          // every connected client (rare)
+```
+
+And the helper:
+```ts
+pushTyped(wsServer, channel, target, workspaceId, payload)
+```
+
+### Why per-workspace routing
+An Electron app may have multiple windows open on the same server, each potentially on a different workspace. Push events like `sources:CHANGED` should only fan out to clients watching THAT workspace — a Linear source update shouldn't notify someone on a different workspace.
+
+### One serialization, many writes
+The server serializes the envelope ONCE (to a UTF-8 string), then writes the same bytes to each target client's socket. Avoids repeated JSON.stringify on broadcasts. Each client also gets a per-client sequence number for replay-on-reconnect, so the outer envelope has a client-local header prepended.
+
+### Lifecycle of a push
+1. Handler triggers push (e.g. `sources.create` calls `pushSourcesChanged(workspaceId)`).
+2. `pushTyped` resolves target → set of clients.
+3. For each client, assign next `seq`, format final envelope, append to ring buffer, send.
+4. On disconnect, envelope stays in ring; on reconnect with `lastSeenSeq`, server replays missed (see `ws-rpc-heartbeat-event-buffer` skill).
+
+### Integration with handler system
+Handlers have access to `wsServer` via `HandlerDeps`. Idiomatic:
+```ts
+// In a handler
+await doWork();
+pushTyped(deps.wsServer, RPC_CHANNELS.sources.CHANGED, { to: 'workspace', workspaceId }, workspaceId, sources);
+return { ok: true };
+```
+
+### Why `workspaceId` appears twice
+The `PushTarget` includes `workspaceId` for routing; the outer arg also takes a `workspaceId` to tag the envelope for filtering on the client side. Redundant-looking but practical — client libraries can dispatch by `envelope.workspaceId` without decoding the target.
+
+### Reference
+- `packages/server-core/src/transport/push.ts`
+- `packages/shared/src/protocol/channels.ts` — naming convention `namespace:CHANGED`.
+- Consumer example: `packages/server/src/index.ts`'s `pushSourcesChanged` closure.

--- a/knowledge/decision/workspace-slug-in-url-refactor.md
+++ b/knowledge/decision/workspace-slug-in-url-refactor.md
@@ -1,0 +1,30 @@
+---
+name: workspace-slug-in-url-refactor
+summary: Make the URL the single source of truth for multi-tenant workspace context — not a header, not a store, not localStorage.
+category: decision
+tags: [multi-tenancy, url, routing, workspace, architecture]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: docs/workspace-url-refactor-proposal.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+Carrying workspace identity in an `X-Workspace-ID` header plus a Zustand store plus localStorage produces three class of bugs that don't go away one-by-one: shared links open in the wrong workspace, mobile has no in-URL switcher, multiple tabs clobber each other via the single localStorage key, and creating/deleting a workspace races with mutation-side-effect callbacks. Industry practice (Linear, Notion, Vercel, GitHub) is `/{workspace-slug}/...`.
+
+Principle: URL is the single source of truth for workspace context. Switching workspace becomes pure navigation (`<Link href="/{new-slug}/issues">`), not an imperative `switchWorkspace()` call. That single change kills a whole family of mutation-`onSuccess` race bugs.
+
+## Why
+
+Pre-refactor data already supported it: `workspace.slug TEXT UNIQUE NOT NULL`, `GetWorkspaceBySlug` query, slug on the TS `Workspace` type. The refactor was mostly frontend routing + state-cleanup work (~30-35 files, mostly mechanical path-builder substitution). One PR because middle states don't run (URL structure is an atomic change); tradeoff is that existing bookmarks break, accepted because product not yet shipped.
+
+Server side resolves slug-first with header/query fallbacks for CLI and daemon back-compat. Reserved-slug list (`login`, `api`, `issues`, `settings`, etc.) must be kept in sync between frontend and backend to prevent user-chosen slugs from colliding with top-level routes.
+
+## Evidence
+
+- `docs/workspace-url-refactor-proposal.md` — full proposal.
+- `server/internal/middleware/workspace.go:47-125` — slug-first resolver with UUID fallback.
+- `packages/core/paths/reserved-slugs.ts` — reserved-slug list with rationale per segment.

--- a/knowledge/decision/ws-heartbeat-ratio-ping-period.md
+++ b/knowledge/decision/ws-heartbeat-ratio-ping-period.md
@@ -1,0 +1,36 @@
+---
+name: ws-heartbeat-ratio-ping-period
+summary: WebSocket server ping period should be 90% of pong-wait so a missing pong is detected before the next ping is due (e.g. 54s ping / 60s pongWait).
+category: decision
+tags: [websocket, heartbeat, ping-pong, liveness]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: server/internal/realtime/hub.go
+imported_at: 2026-04-18T00:00:00Z
+---
+
+For server-side heartbeat on WebSocket connections, pick two constants with a specific ratio:
+
+```go
+const (
+    writeWait  = 10 * time.Second                 // time to write one message
+    pongWait   = 60 * time.Second                 // read deadline; connection dead if exceeded
+    pingPeriod = (pongWait * 9) / 10              // ping before pongWait elapses
+)
+```
+
+Ping period must be **less than** pongWait. The 9/10 ratio (54s for 60s pongWait) gives the client enough time to respond before the next ping is due.
+
+## Why
+
+If `pingPeriod >= pongWait`, the server's write-deadline check can fire before the client's pong arrives even on healthy connections — false disconnects. Too small a gap (e.g. 58/60) still works but leaves no margin for round-trip latency. 90% is the canonical Gorilla WebSocket example and widely used.
+
+Pair this with a small write deadline (10s) — writes shouldn't block on slow clients; timeout and drop them fast so the event loop stays responsive.
+
+## Evidence
+
+- `server/internal/realtime/hub.go:87-99` — the three constants with rationale.

--- a/knowledge/domain/workspace-repo-cache.md
+++ b/knowledge/domain/workspace-repo-cache.md
@@ -1,0 +1,40 @@
+---
+name: workspace-repo-cache
+summary: Daemon maintains a per-host repo cache so multiple tasks on the same workspace share a warm clone; new tasks create git worktrees off the cache instead of re-cloning.
+category: domain
+tags: [git, cache, worktree, daemon, performance]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: server/internal/daemon/repocache/cache.go
+imported_at: 2026-04-18T00:00:00Z
+---
+
+The daemon caches each workspace's configured repo once on the host:
+
+```
+~/myapp_workspaces/.repos/
+  <repo-hash>/           # bare clone or mirrored repo
+    objects/
+    refs/
+    ...
+```
+
+Per-task workdirs are created as git worktrees off this cache, not fresh clones. First task on a new repo does the big clone; subsequent tasks get a fast `git worktree add` (seconds vs minutes for a large repo).
+
+## Why
+
+Coding-agent tasks often touch the same repo repeatedly — retries, different issues on the same codebase, parallel tasks by different agents. Re-cloning every time wastes disk, bandwidth, and time. Shared cache + worktrees makes N tasks cost roughly (1 clone + N worktrees) instead of N clones.
+
+Caveats for the cache implementation:
+- **Refresh logic** needs to fetch new origin refs before creating a worktree, or tasks see stale commits.
+- **GC** must avoid deleting the base repo while worktrees still reference it — check for active worktrees before pruning.
+- **Concurrency** — two tasks racing to clone the same repo for the first time must coordinate (a per-repo lock is the simplest fix).
+
+## Evidence
+
+- `server/internal/daemon/repocache/cache.go` — full implementation.
+- `server/internal/daemon/daemon.go:60-68` — `repoCache: repocache.New(cacheRoot, logger)`.

--- a/knowledge/pitfall/workspace-identity-not-cleared-on-unmount.md
+++ b/knowledge/pitfall/workspace-identity-not-cleared-on-unmount.md
@@ -1,0 +1,26 @@
+---
+name: workspace-identity-not-cleared-on-unmount
+summary: A global "current workspace" singleton set on route mount must be explicitly cleared before leaving workspace context; unmount does not clear it.
+category: pitfall
+tags: [state-management, workspace, race-condition, realtime]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: CLAUDE.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+When a global identity singleton (e.g. `setCurrentWorkspace(slug, uuid)`) feeds three independent consumers — API client headers, persist storage namespace, and top-chrome rendering gate — destructive flows (leave workspace, delete workspace, force-navigate to overlay) MUST call `setCurrentWorkspace(null, null)` explicitly before the mutation fires. Relying on route unmount to clear it creates a race: the realtime `workspace:deleted` handler invalidates cache while chrome gating is still truthy, and a workspace-ID-requiring hook throws.
+
+## Why
+
+The correct destructive order is: read destination → clear singleton → navigate → mutate. Reversing the order (mutate first, then navigate) causes a three-way race between the mutation's `onSettled` invalidate, the explicit navigate, and the realtime handler's relocate — all refetching the same workspace list concurrently. One call is cancelled and bubbles as `CancelledError`, triggering a full renderer reload.
+
+## Evidence
+
+- CLAUDE.md, "Workspace identity singleton" and "Workspace destructive operations" sections.
+- `packages/core/platform/workspace-storage.ts` — `setCurrentWorkspace` and paired singletons.
+- `packages/core/workspace/mutations.ts` — correct mutation ordering.

--- a/knowledge/pitfall/worktree-cross-clone-adoption-pitfall.md
+++ b/knowledge/pitfall/worktree-cross-clone-adoption-pitfall.md
@@ -1,0 +1,47 @@
+---
+name: worktree-cross-clone-adoption-pitfall
+summary: If a user has two clones of the same remote, a naive "find worktree by branch" lookup can adopt the wrong clone's worktree into the DB row, silently corrupting state.
+category: pitfall
+confidence: high
+tags: [git, worktree, cross-clone, adoption, isolation]
+source_type: extracted-from-git
+source_url: https://github.com/coleam00/Archon.git
+source_ref: dev
+source_commit: d89bc767d291f52687beea91c9fcf155459be0d9
+source_project: Archon
+imported_at: 2026-04-18T00:00:00Z
+linked_skills: [worktree-isolation-resolver]
+---
+
+# Worktree Cross-Clone Adoption Corrupts DB State
+
+## Fact / Decision
+
+When a tool stores "isolation environment" rows in a DB pointing at git worktree paths, a user with **two clones of the same remote** (e.g. `~/code/archon-main` and `~/code/archon-fork`) can cause silent DB corruption if the tool:
+
+1. Creates a worktree in clone A for branch `feature/x`.
+2. Later runs inside clone B and asks "do we already have a worktree for `feature/x`?".
+3. Gets back clone A's path (filesystem-resolved) and **adopts it** into clone B's DB row.
+
+Now clone B's DB row points at a worktree that clone A owns. Git operations from clone B (checkout, fetch, reset) will surprise clone A's user; cleanup in clone B will `rm -rf` clone A's worktree.
+
+The fix is to verify, before adoption, that the worktree's repo canonicalizes to the **same path** as clone B's canonical repo (`getCanonicalRepoPath`). If they differ, refuse the adoption and **do not** mark clone A's row as destroyed — it belongs to someone else. Archon calls this `verifyWorktreeOwnership` and wraps every adoption path in it.
+
+## Why
+
+Git worktrees are first-class but their DB representation isn't. A path like `~/code/archon-main/.worktrees/feature-x` is a fine filesystem string but doesn't carry provenance about *which* clone created it. Only the real git metadata (`.git/worktrees/feature-x/commondir` → the canonical repo path) distinguishes them, and that check has to be explicit.
+
+## Counter / Caveats
+
+- **99% of users have one clone.** The cost of the ownership check is microseconds; the benefit is avoiding a catastrophic 1% case. Always do it.
+- Throwing on cross-clone mismatch stops iteration across linked issues / PR adoptions. That's intentional — the user's machine state is genuinely anomalous and they should resolve it explicitly rather than have the tool silently skip the signal.
+- Do **not** auto-destroy the other clone's row. Your tool doesn't own it.
+- The symptom of skipping the ownership check shows up weeks later as "my branch disappeared" or "why is the other clone's worktree at a weird commit?" — extremely hard to debug after the fact. The check is cheap insurance.
+
+## Evidence
+
+- `packages/isolation/src/resolver.ts:260-275`: `assertWorktreeOwnership` wrapper with structured logging.
+- Cross-clone refused log events: `isolation.reuse_refused_cross_checkout`, `isolation.linked_issue_refused_cross_checkout`, `isolation.branch_adoption_refused_cross_checkout` (`resolver.ts:277-407`).
+- Design comment at `resolver.ts:316-325` explaining the "stop iteration on mismatch" choice for linked-issues: "if a linked env is owned by another clone, the user's machine state is anomalous."
+- `verifyWorktreeOwnership` implementation lives in `packages/git/src/worktree.ts`.
+- Commit SHA: d89bc767d291f52687beea91c9fcf155459be0d9.

--- a/knowledge/pitfall/zero-length-byte-handling.md
+++ b/knowledge/pitfall/zero-length-byte-handling.md
@@ -1,0 +1,26 @@
+---
+name: zero-length-byte-handling
+type: knowledge
+category: pitfall
+summary: Files smaller than min_file_size_for_dl (~8 bytes) bypass the model and use heuristics — they may return generic labels.
+confidence: medium
+tags: [magika, pitfall]
+linked_skills: [sparse-text-data-utf8-detection-fallback]
+source_type: extracted-from-git
+source_url: https://github.com/google/magika.git
+source_ref: main
+source_commit: 0a8cb9626bbf76c2194117d9830b23e9052a1548
+source_project: magika
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Zero Length Byte Handling
+
+## Fact
+
+For tiny files, Magika returns 'txt' (if bytes look like text) or 'unknown' (binary-ish). The model is not invoked because there's not enough signal. Don't expect specific-type detection for files under the threshold — design downstream consumers to handle 'txt'/'unknown' for tiny inputs.
+
+## Evidence
+
+- `website-ng/src/content/docs/core-concepts/how-magika-works.md:21`
+- `rust/lib/src/model.rs:26`

--- a/knowledge/pitfall/zero-value-sentinel-alertmanager-startsat.md
+++ b/knowledge/pitfall/zero-value-sentinel-alertmanager-startsat.md
@@ -1,0 +1,50 @@
+---
+name: zero-value-sentinel-alertmanager-startsat
+summary: Alertmanager fills the alerts[].startsAt field with "0001-01-01T00:00:00Z" (the Go time.Time zero value) when not populated by the upstream alert source — guard with year < 2000 to detect this and fall back to a sensible default.
+category: pitfall
+tags: [alertmanager, time-parsing, sentinel, golang]
+source_type: extracted-from-git
+source_url: https://github.com/Tracer-Cloud/opensre.git
+source_ref: main
+source_commit: fb5ba0a1b4ef511d16c56a80f1f126b1f581d724
+source_project: opensre
+source_path: app/nodes/plan_actions/detect_sources.py
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+---
+
+# Pitfall: Alertmanager `startsAt` Zero-Value Sentinel
+
+## The problem
+Alertmanager (written in Go) initializes `time.Time` fields to the zero value `"0001-01-01T00:00:00Z"` when the upstream source didn't populate `startsAt`. If you naively compute `now - startsAt`, you get a 2024-year delta, which produces a window of ~1 million minutes — completely useless.
+
+## Detection
+After parsing, check `alert_time.year < 2000`. If true, treat the field as missing and fall back to a default window (60 minutes is reasonable for most observability backends).
+
+```python
+try:
+    alert_time = datetime.fromisoformat(starts_at.replace("Z", "+00:00"))
+    if alert_time.year < 2000:           # zero-value sentinel
+        return 60                         # default window
+    minutes_ago = int((datetime.now(UTC) - alert_time).total_seconds() / 60)
+    return max(60, minutes_ago + 35)
+except (ValueError, TypeError):
+    return 60
+```
+
+## Where this comes from
+- Go's `time.Time` zero value is `January 1, year 1, 00:00:00 UTC`.
+- Alertmanager's webhook payload structure (`type Alert struct { StartsAt time.Time ... }`) marshals an unset time as `"0001-01-01T00:00:00Z"` in JSON.
+- Same trap appears with EndsAt, when the alert is firing (no end time yet).
+
+## Generalize
+Any system that uses Go `time.Time` and JSON-marshals the zero value should be guarded. Consider a shared helper:
+
+```python
+def is_zero_time(dt: datetime) -> bool:
+    return dt.year < 2000
+```
+
+## See also
+- Same pattern shows up in Kubernetes Event timestamps when the watch hasn't observed the event creation yet.
+- For Prometheus alerts via Alertmanager-compatible webhooks, this is universal.

--- a/knowledge/pitfall/zustand-selector-stable-references.md
+++ b/knowledge/pitfall/zustand-selector-stable-references.md
@@ -1,0 +1,35 @@
+---
+name: zustand-selector-stable-references
+summary: Zustand selectors must return stable references — returning a freshly built object/array on every call triggers infinite re-renders.
+category: pitfall
+tags: [zustand, react, selector, infinite-loop, performance]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+source_path: CLAUDE.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+A Zustand selector is called on every store update and the returned value is compared with `Object.is`. If the selector builds a new object or array on every call, the comparison always fails and the component re-renders — which runs the selector again, which re-renders, etc. Common forms that trigger this:
+
+```ts
+// BAD: new object every call
+const { a, b } = useStore(s => ({ a: s.a, b: s.b }));
+
+// BAD: new array every call
+const names = useStore(s => s.items.map(i => i.name));
+```
+
+## Why
+
+Fix by either selecting primitives separately (one `useStore` per field) or passing a shallow-equality comparator (`useStore(selector, shallow)`). For derived collections, memoize outside the selector or compute in a `useMemo` seeded with a primitive version counter.
+
+Second footgun: hooks that call `useWorkspaceId()` internally cannot run outside a `WorkspaceIdProvider`. Prefer accepting `wsId` as a parameter so the hook works in sidebar chrome that renders before workspace is loaded.
+
+## Evidence
+
+- CLAUDE.md, "Common Zustand footguns to avoid" section.
+- Idiom applies to any Zustand 5.x codebase.

--- a/registry.json
+++ b/registry.json
@@ -2409,6 +2409,81 @@
       "category": "build",
       "path": "skills/build/coverage-data-file-under-pytest-cache/SKILL.md",
       "version": "1.0.0"
+    },
+    "workspace-directory-convention": {
+      "category": "architecture",
+      "path": "skills/architecture/workspace-directory-convention/SKILL.md",
+      "version": "1.0.0"
+    },
+    "workspace-scoped-query-keys": {
+      "category": "architecture",
+      "path": "skills/architecture/workspace-scoped-query-keys/SKILL.md",
+      "version": "1.0.0"
+    },
+    "workspace-slug-url-refactor": {
+      "category": "architecture",
+      "path": "skills/architecture/workspace-slug-url-refactor/SKILL.md",
+      "version": "1.0.0"
+    },
+    "worktree-env-file-isolation": {
+      "category": "devops",
+      "path": "skills/devops/worktree-env-file-isolation/SKILL.md",
+      "version": "1.0.0"
+    },
+    "worktree-isolation-resolver": {
+      "category": "workflow",
+      "path": "skills/workflow/worktree-isolation-resolver/SKILL.md",
+      "version": "1.0.0"
+    },
+    "writing-plans": {
+      "category": "process",
+      "path": "skills/process/writing-plans/SKILL.md",
+      "version": "1.0.0"
+    },
+    "writing-skills": {
+      "category": "meta",
+      "path": "skills/meta/writing-skills/SKILL.md",
+      "version": "1.0.0"
+    },
+    "ws-cookie-or-first-message-auth": {
+      "category": "websocket",
+      "path": "skills/websocket/ws-cookie-or-first-message-auth/SKILL.md",
+      "version": "1.0.0"
+    },
+    "ws-query-invalidation-bridge": {
+      "category": "websocket",
+      "path": "skills/websocket/ws-query-invalidation-bridge/SKILL.md",
+      "version": "1.0.0"
+    },
+    "ws-rpc-heartbeat-event-buffer": {
+      "category": "build",
+      "path": "skills/build/ws-rpc-heartbeat-event-buffer/SKILL.md",
+      "version": "1.0.0"
+    },
+    "x11-xrandr-display-enumeration": {
+      "category": "linux",
+      "path": "skills/linux/x11-xrandr-display-enumeration/SKILL.md",
+      "version": "1.0.0"
+    },
+    "yaml-config-with-templated-dynamic-paths": {
+      "category": "configuration",
+      "path": "skills/configuration/yaml-config-with-templated-dynamic-paths/SKILL.md",
+      "version": "1.0.0"
+    },
+    "zip-recursive-subdocument-conversion": {
+      "category": "data-pipeline",
+      "path": "skills/data-pipeline/zip-recursive-subdocument-conversion/SKILL.md",
+      "version": "1.0.0"
+    },
+    "zod-defined-tool-factory": {
+      "category": "mcp",
+      "path": "skills/mcp/zod-defined-tool-factory/SKILL.md",
+      "version": "1.0.0"
+    },
+    "zustand-store-mock-hoisted": {
+      "category": "testing",
+      "path": "skills/testing/zustand-store-mock-hoisted/SKILL.md",
+      "version": "1.0.0"
     }
   },
   "knowledge": {
@@ -4427,6 +4502,54 @@
     "craft-cli-command-surface": {
       "category": "reference",
       "path": "knowledge/reference/craft-cli-command-surface.md"
+    },
+    "workspace-identity-not-cleared-on-unmount": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/workspace-identity-not-cleared-on-unmount.md"
+    },
+    "workspace-repo-cache": {
+      "category": "domain",
+      "path": "knowledge/domain/workspace-repo-cache.md"
+    },
+    "workspace-slug-in-url-refactor": {
+      "category": "decision",
+      "path": "knowledge/decision/workspace-slug-in-url-refactor.md"
+    },
+    "worktree-cross-clone-adoption-pitfall": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/worktree-cross-clone-adoption-pitfall.md"
+    },
+    "ws-heartbeat-ratio-ping-period": {
+      "category": "decision",
+      "path": "knowledge/decision/ws-heartbeat-ratio-ping-period.md"
+    },
+    "ws-invalidation-not-store-writes": {
+      "category": "arch",
+      "path": "knowledge/arch/ws-invalidation-not-store-writes.md"
+    },
+    "ws-token-never-in-url": {
+      "category": "api",
+      "path": "knowledge/api/ws-token-never-in-url.md"
+    },
+    "wsrpcserver-push-target-model": {
+      "category": "architecture",
+      "path": "knowledge/architecture/wsrpcserver-push-target-model.md"
+    },
+    "zero-length-byte-handling": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/zero-length-byte-handling.md"
+    },
+    "zero-value-sentinel-alertmanager-startsat": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/zero-value-sentinel-alertmanager-startsat.md"
+    },
+    "zod-openapi-schema-conventions": {
+      "category": "api",
+      "path": "knowledge/api/zod-openapi-schema-conventions.md"
+    },
+    "zustand-selector-stable-references": {
+      "category": "pitfall",
+      "path": "knowledge/pitfall/zustand-selector-stable-references.md"
     }
   }
 }

--- a/skills/architecture/workspace-directory-convention/SKILL.md
+++ b/skills/architecture/workspace-directory-convention/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: workspace-directory-convention
+description: Workspace-as-a-directory: a single ~/.craft-agent/workspaces/{id}/ folder holds config.json, automations.json, sessions/, sources/, skills/, statuses/ — every feature reads/writes its own subtree so the workspace is portable in one zip.
+category: architecture
+version: 1.0.0
+version_origin: extracted
+tags: [config, workspaces, directory-layout, portability]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: README.md
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Workspace-as-a-directory convention
+
+## When to use
+- Multi-workspace desktop/CLI app where users want clean separation between "work" and "personal" context.
+- You want users to be able to back up / share / sync an entire workspace by zipping one folder.
+- Need atomic delete: removing a workspace = `rm -rf <workspace-dir>`.
+
+## How it works
+Layout: `~/.craft-agent/`
+- `config.json` - app-level (workspace list, LLM connections).
+- `credentials.enc` - encrypted secrets shared across workspaces.
+- `preferences.json`, `theme.json` - app-wide user prefs.
+- `workspaces/{id}/`
+  - `config.json` - workspace settings.
+  - `automations.json` - event-driven rules.
+  - `theme.json` - workspace theme override.
+  - `sessions/{session-id}/session.jsonl` + per-session subfolders (`long_responses/`, `plans/`).
+  - `sources/{slug}/config.json` + `.credential-cache.json`.
+  - `skills/{slug}/SKILL.md`.
+  - `statuses/` - custom status workflow.
+
+Each feature package (`sessions`, `sources`, `skills`, `automations`) exposes a `getWorkspace*Path(workspaceRoot)` helper and NEVER walks out of its subtree. That means moving a workspace folder = works. Deleting = atomic.
+
+## Example
+```ts
+// Each feature gets its own subtree helper:
+export const getWorkspaceSkillsPath = (root: string) => join(root, 'skills');
+export const getWorkspaceSourcesPath = (root: string) => join(root, 'sources');
+export const getWorkspaceSessionsPath = (root: string) => join(root, 'sessions');
+export const getSessionPath = (root: string, id: string) => join(root, 'sessions', id);
+
+// Anywhere that handles workspace lifecycle:
+export async function deleteWorkspace(id: string) {
+  await rm(join(config.workspacesRoot, id), { recursive: true, force: true });
+}
+```
+
+## Gotchas
+- Don't let ONE feature's code write outside its subtree - the portability guarantee only holds if it's actually enforced.
+- Credentials stay at the APP level (`~/.craft-agent/credentials.enc`) because they cross workspace boundaries - users don't want to re-auth per workspace.
+- When a user zips a workspace for sharing, remind them to NOT include `.credential-cache.json` - those are decrypted reconstructions of secrets.
+- Workspace IDs should be GUIDs, not slugs - renaming a workspace shouldn't move its folder.
+- A default-workspaces dir helper (`getDefaultWorkspacesDir()`) per-OS (macOS `~/Library/Application Support/...`, Linux `~/.config/...`, Windows `%APPDATA%\...`) keeps the layout OS-native.

--- a/skills/architecture/workspace-scoped-query-keys/SKILL.md
+++ b/skills/architecture/workspace-scoped-query-keys/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: workspace-scoped-query-keys
+description: Derive React Query keys from a wsId parameter so switching workspace automatically swaps the cache — no manual invalidation, no cross-tenant leakage.
+category: architecture
+version: 1.0.0
+tags: [react-query, multi-tenancy, query-keys, workspace]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- Multi-tenant React app using TanStack Query.
+- You want workspace switches to "just work" — the right data appears, no manual `qc.invalidateQueries()` calls sprinkled around.
+
+## Steps
+
+1. Define a key factory per domain, parameterized by `wsId`:
+   ```ts
+   // packages/core/issues/queries.ts
+   export const issueKeys = {
+     all: (wsId: string) => ["issues", wsId] as const,
+     list: (wsId: string, filters: IssueFilters) => ["issues", wsId, "list", filters] as const,
+     detail: (wsId: string, id: string) => ["issues", wsId, "detail", id] as const,
+   };
+   ```
+2. Hooks take `wsId` as the workspace identifier. Never reach for `useWorkspaceId()` Context inside the hook (that would tie it to a Provider that may not be mounted yet):
+   ```ts
+   export function useIssues(wsId: string, filters: IssueFilters) {
+     return useQuery({
+       queryKey: issueKeys.list(wsId, filters),
+       queryFn: () => api.listIssues(wsId, filters),
+       enabled: Boolean(wsId),
+     });
+   }
+   ```
+3. When the user switches workspaces, the new `wsId` flows through components via the workspace identity singleton → components re-render with new `wsId` → query key changes → React Query fetches fresh data. No explicit invalidation.
+4. For mutations, use the same key factory to target invalidations:
+   ```ts
+   return useMutation({
+     mutationFn: (input) => api.createIssue(wsId, input),
+     onSettled: () => qc.invalidateQueries({ queryKey: issueKeys.all(wsId) }),
+   });
+   ```
+5. For WS event handlers, read the current wsId from the workspace identity singleton:
+   ```ts
+   refreshMap.issue = () => {
+     const wsId = getCurrentWsId();
+     if (wsId) qc.invalidateQueries({ queryKey: issueKeys.all(wsId) });
+   };
+   ```
+
+## Example
+
+```
+User in workspace A:
+  qc has: issues/uuid-A/list/{status: todo}
+  qc has: issues/uuid-A/detail/abc123
+
+User switches to workspace B → setCurrentWorkspace("b", "uuid-B") → React rerenders:
+  New useIssues(wsId: "uuid-B", ...) runs
+  Query key changes from ["issues","uuid-A",...] to ["issues","uuid-B",...]
+  React Query fetches workspace B's data
+  Workspace A's cache entries stay (may get GC'd via gcTime) — no leakage
+```
+
+## Caveats
+
+- If a hook has `useWorkspaceId()` in it, it won't work in components that render before the `WorkspaceIdProvider` mounts (sidebar, login screen chrome). Accept `wsId` as a parameter so you can pass `null` during pre-workspace states.
+- Don't duplicate server data to Zustand stores — the key structure is what makes switching clean; copying data into stores defeats it.
+- `gcTime` (10 min) governs how long stale workspace data lingers; tune it if memory pressure is a concern.

--- a/skills/architecture/workspace-slug-url-refactor/SKILL.md
+++ b/skills/architecture/workspace-slug-url-refactor/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: workspace-slug-url-refactor
+description: Migrate a multi-tenant SPA from header-based workspace identity to URL-based (/{slug}/...) to fix shareable links, mobile switching, multi-tab leakage, and mutation side-effect races.
+category: architecture
+version: 1.0.0
+tags: [multi-tenancy, url, refactor, routing, workspace]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- Your app's workspace identity is carried by `X-Workspace-ID` header + Zustand store + localStorage.
+- You see: shareable URLs opening wrong workspace, mobile has no switcher, multi-tab tabs clobber each other, mutation `onSuccess` races.
+- Product is pre-launch or you're willing to break existing bookmarks.
+
+## Steps
+
+1. Audit what the data layer already supports:
+   - DB has `workspace.slug TEXT UNIQUE NOT NULL`? Good.
+   - Backend has `GetWorkspaceBySlug`? Good.
+   - TS `Workspace` type has `slug`? Good.
+   - If any of these are missing, land them first (separate PRs).
+2. Reorganize routes to carry the slug:
+   - Next.js web: `apps/web/app/(dashboard)/*` → `apps/web/app/(dashboard)/[workspaceSlug]/*` (or `/(dashboard)/ws/[slug]/` if you want a prefix).
+   - Desktop react-router: add `/:workspaceSlug` prefix to every session route.
+3. Write a `NavigationAdapter` in each app's `platform/` layer that auto-prepends the current slug to `push(path)`, so shared views call `useNavigation().push('/issues')` and the adapter resolves to `/my-team/issues`.
+4. Replace all hardcoded path strings with a `paths.*` builder:
+   ```ts
+   export const paths = {
+     issues:  () => `/issues`,
+     issue:   (id: string) => `/issues/${id}`,
+     settings: () => `/settings`,
+     // ...
+   };
+   ```
+5. Delete the imperative `switchWorkspace` / `hydrateWorkspace` actions. Switching becomes pure navigation:
+   ```tsx
+   // Before
+   <button onClick={() => { push('/issues'); switchWorkspace(ws); }}>
+
+   // After
+   <Link href={paths.issues({ slug: ws.slug })}>
+   ```
+   This single change eliminates a family of mutation-`onSuccess` race bugs (create-workspace flash, delete-workspace-no-nav, accept-invite-no-switch).
+6. Delete the global `multica_workspace_id` localStorage key. Per-workspace-scoped persist stores switch to a workspace-aware storage adapter (`${key}:${slug}`).
+7. Add a server-side slug-first resolver with UUID fallback so CLI/daemon don't break:
+   ```
+   1. X-Workspace-Slug header   → GetWorkspaceBySlug → UUID
+   2. ?workspace_slug query     → same
+   3. X-Workspace-ID header     (legacy / CLI compat)
+   4. ?workspace_id query       (legacy / CLI compat)
+   ```
+8. Ship all of these in one PR — intermediate states don't run because the URL shape is an atomic change.
+9. Update E2E tests to assert on URLs with slugs. Internal markdown links (`[foo](/issues/abc)`) must auto-prepend the current slug when dispatched.
+
+## Example
+
+Before: `/issues/abc123` (wrong workspace when shared).
+After: `/my-team/issues/abc123` (unambiguous, shareable, bookmarkable, multi-tab safe).
+
+## Caveats
+
+- Existing bookmarks break. Acceptable if pre-launch; otherwise add `/issues/:id` → lookup-by-id-and-redirect path for a grace period.
+- Reserved-slug list must be complete and enforced server-side before launch; see the `reserved-slugs-coordinated-list` skill.
+- Email invite links (`/invite/:id`) and auth callback URLs remain workspace-agnostic — they're pre-workspace flows.

--- a/skills/build/ws-rpc-heartbeat-event-buffer/SKILL.md
+++ b/skills/build/ws-rpc-heartbeat-event-buffer/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: ws-rpc-heartbeat-event-buffer
+description: WebSocket RPC server with per-client heartbeat (ping/pong + missed-count kill) and a ring buffer of recent events per client so a brief disconnect + reconnect can replay pushes instead of dropping them.
+category: build
+version: 1.0.0
+version_origin: extracted
+tags: [websocket, rpc, heartbeat, resumption, event-buffer]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/lukilabs/craft-agents-oss.git
+source_ref: main
+source_commit: 61f7d48a5b4fd0a8094f002c9e3aea5f3824dcfb
+source_project: craft-agents-oss
+source_path: packages/server-core/src/transport/server.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# WebSocket RPC heartbeat + event buffer
+
+## When to use
+- RPC server using WebSockets and pushing events to subscribed clients.
+- Clients run on flaky networks (mobile, VPN, corporate proxy) where 5-30s disconnects are common.
+- You don't want to rebuild full state on every reconnect, but also don't want to lose server-pushed events during the gap.
+
+## How it works
+1. Each `ClientConnection` tracks: `id`, `ws`, `missedPongs`, `alive`, `eventBuffer[]` (ring), `lastAckedSeq`, `lastSentSeq`.
+2. **Heartbeat loop** every `HEARTBEAT_INTERVAL_MS`:
+   - If client didn't answer the previous ping, increment `missedPongs`.
+   - If `missedPongs >= HEARTBEAT_MAX_MISSED` (e.g. 3), terminate the socket.
+   - Otherwise `ws.ping()` (native control frame, not app-level).
+   - On `'pong'`, reset `missedPongs` and set `alive = true`.
+3. **Event push**: assign monotonic per-client `seq`, serialize the envelope ONCE as a string (`BufferedEvent.data`), push `{ seq, data, timestamp }` into the ring.
+4. Ring caps at `EVENT_BUFFER_MAX_SIZE` events or `EVENT_BUFFER_TTL_MS` ms - drop from the head.
+5. Client piggybacks `ack: <lastSeen>` on normal invokes. Server trims the ring at `lastAckedSeq`.
+6. **Reconnect**: client hello includes `{ clientId, lastSeenSeq }`. If server still has that client in `DISCONNECTED_CLIENT_TTL_MS`, replay every buffered event with `seq > lastSeenSeq` before accepting new work.
+7. After TTL, disconnected client state is GC'd and the reconnect is treated as a fresh session.
+
+## Example
+```ts
+interface ClientConnection {
+  id: string; ws: WebSocket;
+  missedPongs: number; alive: boolean;
+  eventBuffer: { seq: number; data: string; timestamp: number }[];
+  lastAckedSeq: number; lastSentSeq: number;
+}
+
+setInterval(() => {
+  for (const c of clients.values()) {
+    if (!c.alive) { c.missedPongs++; if (c.missedPongs >= 3) c.ws.terminate(); continue; }
+    c.alive = false; c.ws.ping();
+  }
+}, HEARTBEAT_INTERVAL_MS);
+
+function pushEvent(client: ClientConnection, envelope: object) {
+  const seq = ++client.lastSentSeq;
+  const data = JSON.stringify({ ...envelope, seq });
+  client.eventBuffer.push({ seq, data, timestamp: Date.now() });
+  while (client.eventBuffer.length > EVENT_BUFFER_MAX_SIZE ||
+         (client.eventBuffer.length && client.eventBuffer[0].timestamp < Date.now() - EVENT_BUFFER_TTL_MS)) {
+    client.eventBuffer.shift();
+  }
+  if (client.ws.readyState === 1 /* OPEN */) client.ws.send(data);
+}
+```
+
+## Gotchas
+- Serialize once per event, not per client - share the string across all subscribers.
+- Use WebSocket's native ping/pong frames, not an app-level `{type:"ping"}` message - native is handled by the OS and survives CPU stalls.
+- Clients must ALSO reset their own timeout on receiving server frames, not just on pongs - otherwise idle busy servers look dead.
+- `DISCONNECTED_CLIENT_TTL_MS` should be long enough for a phone to come out of suspend (60-120s). Too short = lost events.
+- Always bound the ring buffer by BOTH size and TTL. TTL alone can grow unboundedly during bursty pushes.

--- a/skills/configuration/yaml-config-with-templated-dynamic-paths/SKILL.md
+++ b/skills/configuration/yaml-config-with-templated-dynamic-paths/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: yaml-config-with-templated-dynamic-paths
+description: Load experiment config from YAML, then auto-resolve dependent paths via templates like "{base}/{exp_name}/tokenizer/best_model" unless the user overrides.
+category: configuration
+tags: [yaml, config-loader, templating, ml-experiments, path-resolution]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/shiyu-coder/Kronos.git
+source_ref: master
+source_commit: 67b630e67f6a18c9e9be918d9b4337c960db1e9a
+source_project: Kronos
+source_paths: [finetune_csv/config_loader.py, finetune_csv/configs/config_ali09988_candle-5min.yaml]
+version: 1.0.0
+version_origin: extracted
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# YAML config with auto-derived paths that stay overridable
+
+## When to use
+- You run many experiments, each with its own `exp_name`, where 90% of the output paths are `{base_path}/{exp_name}/...` and should just be derived automatically.
+- You still want to allow a specific experiment to override any single path to point at a shared artifact.
+- You want one `config.yaml` to capture data paths, training hyperparams, device, and distributed settings in one place — not scattered across a Python `Config()` class and CLI flags.
+
+## Pattern
+After `yaml.safe_load`, walk a small `path_templates` dict and fill in each path by one of three rules: (1) template string if the user left the key empty (`""` or `None`), (2) user's string if it contains `{exp_name}` (do a `.format`), (3) user's string verbatim. Expose flat getters (`get_data_config`, `get_training_config`, …) and a typed wrapper that bundles everything into one object.
+
+```python
+# finetune_csv/config_loader.py
+def _resolve_dynamic_paths(self, config):
+    exp_name  = config.get('model_paths', {}).get('exp_name', '')
+    if not exp_name: return config
+    base_path = config.get('model_paths', {}).get('base_path', '')
+    path_templates = {
+        'base_save_path':       f"{base_path}/{exp_name}",
+        'finetuned_tokenizer':  f"{base_path}/{exp_name}/tokenizer/best_model",
+    }
+    for key, template in path_templates.items():
+        if key in config['model_paths']:
+            current = config['model_paths'][key]
+            if current in ("", None):
+                config['model_paths'][key] = template
+            elif isinstance(current, str) and '{exp_name}' in current:
+                config['model_paths'][key] = current.format(exp_name=exp_name)
+    return config
+```
+
+The YAML shows both escape hatches side by side:
+
+```yaml
+# configs/config_ali09988_candle-5min.yaml
+model_paths:
+  exp_name:  "HK_ali_09988_kline_5min_all"
+  base_path: "/xxx/Kronos/finetune_csv/finetuned/"
+  base_save_path: ""                                          # way 1: auto-derived
+  # finetuned_tokenizer: "/xxx/{exp_name}/tokenizer/best_model"   # way 2: template override
+```
+
+## Why it works / tradeoffs
+Writers default to the convention (empty string → templated path) but power users can point at someone else's checkpoint with a literal. Storing `exp_name` + `base_path` at the top keeps paths diffable across experiments. The "empty string means use template" choice is a small gotcha — an accidental null could silently generate a wrong path — so prefer explicit `""` and document it. For deeper hierarchies, consider a library like Hydra, but this 50-line helper is often enough.
+
+## References
+- `finetune_csv/config_loader.py` in Kronos — `ConfigLoader._resolve_dynamic_paths`, `CustomFinetuneConfig`
+- `finetune_csv/configs/config_ali09988_candle-5min.yaml` — example with both override styles

--- a/skills/data-pipeline/zip-recursive-subdocument-conversion/SKILL.md
+++ b/skills/data-pipeline/zip-recursive-subdocument-conversion/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: zip-recursive-subdocument-conversion
+description: Convert a ZIP archive to a single combined markdown document by iterating entries, constructing per-entry StreamInfo from filename+extension, and recursing through the same converter registry for each entry.
+category: data-pipeline
+version: 1.0.0
+tags: [data-pipeline, zip, recursion, converter-registry, python]
+source_type: extracted-from-git
+source_url: https://github.com/microsoft/markitdown.git
+source_ref: main
+source_commit: 604bba13da2f43b756b49122cb65bdedb85b1dff
+source_project: markitdown
+source_path: packages/markitdown/src/markitdown/converters/_zip_converter.py
+imported_at: 2026-04-18T00:00:00Z
+confidence: medium
+version_origin: extracted
+---
+
+# Recursive subdocument conversion for ZIP archives
+
+When a container format (ZIP, EPUB, DOCX's unzipped XML, TAR) holds mixed content, don't hard-code per-format conversions inside the container handler. Instead, iterate entries, turn each into a `(BytesIO, StreamInfo)` pair, and recurse through the **same** top-level converter registry. That gives you transparent support for every format the host can convert, including nested containers.
+
+## The shape
+
+```python
+import io, os, zipfile
+from typing import BinaryIO, Any
+
+class ZipConverter(DocumentConverter):
+    """Converts a zip into one markdown doc with each entry labeled by path."""
+
+    def __init__(self, *, markitdown):   # host is passed in so we can recurse
+        super().__init__()
+        self._markitdown = markitdown
+
+    def accepts(self, file_stream: BinaryIO, stream_info, **kwargs) -> bool:
+        ext  = (stream_info.extension or "").lower()
+        mime = (stream_info.mimetype  or "").lower()
+        return ext == ".zip" or mime.startswith("application/zip")
+
+    def convert(self, file_stream: BinaryIO, stream_info, **kwargs):
+        tag = stream_info.url or stream_info.local_path or stream_info.filename
+        out = [f"Content from the zip file `{tag}`:", ""]
+
+        with zipfile.ZipFile(file_stream, "r") as zf:
+            for name in zf.namelist():
+                try:
+                    entry = io.BytesIO(zf.read(name))
+                    info  = StreamInfo(
+                        extension=os.path.splitext(name)[1],
+                        filename=os.path.basename(name),
+                    )
+                    res = self._markitdown.convert_stream(stream=entry, stream_info=info)
+                    if res is not None:
+                        out.append(f"## File: {name}")
+                        out.append("")
+                        out.append(res.markdown)
+                        out.append("")
+                except UnsupportedFormatException:
+                    pass      # skip entries the host can't handle
+                except FileConversionException:
+                    pass      # skip entries that errored
+
+        return DocumentConverterResult(markdown="\n".join(out).strip())
+```
+
+Two key decisions:
+
+1. **Host (`self._markitdown`) is injected at construction.** The handler doesn't know about specific sub-converters; it just calls `host.convert_stream(...)` and lets the registry figure out each entry. Works transparently for nested zips, DOCX-inside-DOCX, etc.
+2. **Swallow `UnsupportedFormatException` and `FileConversionException` per entry.** One malformed file in a 10,000-entry archive shouldn't nuke the whole conversion.
+
+## Output format
+
+```markdown
+Content from the zip file `docs.zip`:
+
+## File: docs/readme.txt
+
+This is the content of readme.txt
+Multiple lines are preserved
+
+## File: images/example.jpg
+
+ImageSize: 1920x1080
+DateTimeOriginal: 2024-02-15 14:30:00
+Description: A beautiful landscape photo
+
+## File: data/report.xlsx
+
+## Sheet1
+| Column1 | Column2 | Column3 |
+|---------|---------|---------|
+| data1   | data2   | data3   |
+```
+
+Keep original paths in the `## File:` headings so the LLM can reconstruct structure and reference specific files in its output.
+
+## Why recurse into the same registry
+
+- **Zero coupling to file types.** The ZIP handler doesn't mention PDF, image, or xlsx logic. It only knows "there are entries; hand each to the host."
+- **Transparent nesting.** ZIP-in-ZIP works for free. So does ZIP-of-DOCX-of-embedded-images.
+- **Converter evolution.** Adding a new file-type converter to the host immediately works inside ZIPs with no ZIP-code changes.
+
+## Memory considerations
+
+- `zf.read(name)` loads the entire entry into memory. For a multi-gigabyte archive that's a problem; swap in `zf.open(name)` which returns a streaming file-like — but then you need the seekable-buffer wrapper (see `filestream-seekable-buffer-fallback`) because zip streams aren't seekable.
+- Huge archives with many small entries: consider parallelization (`concurrent.futures.ThreadPoolExecutor`) — but beware of zipfile's thread safety: open the archive once per worker, not share.
+
+## Security considerations
+
+- **Zip bomb defense.** A 42KB zip can expand to petabytes. Enforce a cumulative uncompressed-size limit:
+
+  ```python
+  total = 0
+  LIMIT = 100 * 1024 * 1024   # 100 MB
+  for info in zf.infolist():
+      total += info.file_size
+      if total > LIMIT:
+          raise FileConversionException("Zip uncompressed size exceeds limit")
+  ```
+- **Path traversal.** The entry name `../../etc/passwd` is malicious if you ever write entries to disk. This converter stays in memory via `BytesIO`, so it's safe — but if you extract to temp files, sanitize with `os.path.normpath` and reject anything escaping the temp root.
+- **Symlink entries.** `zipfile` doesn't create symlinks on extract by default, but if you use `tarfile` or `shutil.unpack_archive`, do.
+
+## Anti-patterns
+
+- **Hardcoding a dispatch table inside the container.** `if name.endswith(".pdf"): pdf_convert(...); elif name.endswith(".xlsx"): ...` — duplicates what the registry already does, and breaks when new types are added.
+- **Failing the whole archive on one bad entry.** Users lose the other 9,999 working entries.
+- **No per-entry heading.** LLMs lose the ability to cite which file a quoted passage came from.
+- **Extracting to disk unconditionally.** Tempfile lifecycle, cleanup, and path-traversal defense are harder than staying in memory; stay in memory if you can.
+
+## Variations
+
+- **EPUB**: structurally a zip of XHTML + images. Same pattern, but filter to `.xhtml`/`.html` entries and order by the spine.
+- **Office Open XML (DOCX/XLSX/PPTX)**: technically zips of XML, but you usually want a dedicated parser (mammoth, python-docx) that understands the package structure rather than flattening it.
+- **TAR / TAR.GZ**: swap `zipfile.ZipFile` for `tarfile.open(fileobj=stream)`; otherwise identical pattern.
+- **Per-entry filter**: accept a `should_include: Callable[[str], bool]` so callers can limit which entries are processed.

--- a/skills/devops/worktree-env-file-isolation/SKILL.md
+++ b/skills/devops/worktree-env-file-isolation/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: worktree-env-file-isolation
+description: Per-git-worktree environment files (.env.worktree) with deterministically derived unique database names and ports, sharing one Postgres container.
+category: devops
+version: 1.0.0
+tags: [git-worktree, env, dev-setup, postgres, makefile]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- Multi-worktree workflow (several concurrent feature branches as parallel directories).
+- You want one shared Postgres container but isolated DBs per worktree.
+- You need deterministic port allocation (worktree always gets the same port) so bookmarks survive across days.
+
+## Steps
+
+1. Makefile logic prefers `.env` (main checkout) over `.env.worktree` (worktree checkout):
+   ```makefile
+   MAIN_ENV_FILE ?= .env
+   WORKTREE_ENV_FILE ?= .env.worktree
+   ENV_FILE ?= $(if $(wildcard $(MAIN_ENV_FILE)),$(MAIN_ENV_FILE),$(if $(wildcard $(WORKTREE_ENV_FILE)),$(WORKTREE_ENV_FILE),$(MAIN_ENV_FILE)))
+
+   ifneq ($(wildcard $(ENV_FILE)),)
+   include $(ENV_FILE)
+   endif
+   ```
+2. Create a `scripts/init-worktree-env.sh` that derives unique values from the worktree path:
+   ```bash
+   WORKTREE_DIR="$(basename "$PWD")"
+   SLUG="$(printf '%s' "$WORKTREE_DIR" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g; s/__*/_/g; s/^_//; s/_$//')"
+   HASH="$(printf '%s' "$PWD" | cksum | awk '{print $1}')"
+   PORT_OFFSET=$((HASH % 10000))
+   cat > "$1" <<EOF
+   POSTGRES_DB=myapp_${SLUG}_${PORT_OFFSET}
+   POSTGRES_PORT=5432
+   PORT=$((10000 + PORT_OFFSET))
+   FRONTEND_PORT=$((13000 + PORT_OFFSET))
+   DATABASE_URL=postgres://myapp:myapp@localhost:5432/myapp_${SLUG}_${PORT_OFFSET}?sslmode=disable
+   EOF
+   ```
+3. Add a `make worktree-env` target that refuses to overwrite an existing file:
+   ```makefile
+   worktree-env:
+       @bash scripts/init-worktree-env.sh .env.worktree
+   ```
+   Add a `FORCE=1` escape hatch inside the script for regeneration.
+4. `scripts/ensure-postgres.sh` reads `POSTGRES_DB` from the selected env file and idempotently creates it:
+   ```bash
+   docker compose up -d postgres
+   docker compose exec -T postgres psql -U myapp -d postgres -tc "SELECT 1 FROM pg_database WHERE datname = '$POSTGRES_DB'" | grep -q 1 || \
+     docker compose exec -T postgres psql -U myapp -d postgres -c "CREATE DATABASE \"$POSTGRES_DB\""
+   ```
+5. Document the hard rule in CONTRIBUTING: worktrees MUST NOT contain a `.env`. A stray `.env` in a worktree accidentally points it at the main DB.
+
+## Example
+
+```bash
+git worktree add ../myapp-feat-x -b feat/x main
+cd ../myapp-feat-x
+make dev       # auto-runs worktree-env + setup + start
+# Backend on port 18742, DB myapp_myapp_feat_x_742
+```
+
+Both main and worktree can run at the same time on different ports pointing at different DBs in the same shared Postgres container.
+
+## Caveats
+
+- Port offset uses `cksum % 10000`; collisions are theoretically possible if two worktrees produce the same hash — increase to `% 65535` and stop near the ephemeral range for real safety.
+- `make worktree-env` must refuse overwrite by default so `make dev` in an existing worktree doesn't reshuffle ports.

--- a/skills/linux/x11-xrandr-display-enumeration/SKILL.md
+++ b/skills/linux/x11-xrandr-display-enumeration/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: x11-xrandr-display-enumeration
+description: X11 XRandR integration for multi-display detection and resolution queries.
+category: platform/linux
+version: 1.0.0
+version_origin: extracted
+tags: [display, enumeration, linux, platform, x11, xrandr]
+confidence: medium
+source_type: extracted-from-git
+source_url: https://github.com/rustdesk/rustdesk.git
+source_ref: master
+source_commit: ac124c068056395f9456a6c42eddab89b469a3a8
+source_project: rustdesk
+source_path: [libs/scrap/src/x11/display.rs, libs/scrap/src/x11/mod.rs]
+imported_at: 2026-04-19T00:00:00Z
+---
+
+# X11 Xrandr Display Enumeration
+
+## When to use
+X11 XRandR integration for multi-display detection and resolution queries.
+
+## Source context
+- Repo: `rustdesk/rustdesk` @ `ac124c0680`
+- Demonstrated in: `libs/scrap/src/x11/display.rs`, `libs/scrap/src/x11/mod.rs`
+
+## Why this generalizes
+Reusable for multi-monitor Linux tools.
+
+## Next steps before publishing
+- Read the source files above and rewrite this as a product-agnostic `how-to` — keep the pattern, drop rustdesk-specific names.
+- Add a minimal code example in the target language (Rust + Dart / Rust only / etc.).
+- List 2-3 gotchas you hit while reproducing it.

--- a/skills/mcp/zod-defined-tool-factory/SKILL.md
+++ b/skills/mcp/zod-defined-tool-factory/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: zod-defined-tool-factory
+description: Wrap MCP tool definitions in a typed `defineTool` helper so zod schemas drive both runtime validation and the handler's TypeScript param types, with a separate `definePageTool` variant for tools that need a pre-resolved page context.
+category: mcp
+version: 1.0.0
+version_origin: extracted
+tags: [mcp, zod, typescript, tool-definition, dx]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/ChromeDevTools/chrome-devtools-mcp.git
+source_ref: main
+source_commit: 0a6aaa52ebacb2db834ffa437863e5844aa3730b
+source_project: chrome-devtools-mcp
+source_path: src/tools/ToolDefinition.ts
+imported_at: 2026-04-18T00:00:00Z
+---
+
+# Typed Tool Definition Factory
+
+## When to use
+
+- You have an MCP (or similar JSON-schema-driven) tool system with many tools and want zero drift between the declared schema and the handler's param types.
+- Some tools need extra setup (e.g. a pre-resolved "current page" or DB connection) that you don't want to copy-paste into every handler.
+- You want to generate docs or a CLI from the same tool definitions at build time.
+
+## How it works
+
+- Define `BaseToolDefinition<Schema extends zod.ZodRawShape>` with `name`, `description`, `annotations`, `schema`. Keep `Schema` generic so TypeScript can infer param types from zod.
+- Provide `defineTool(def)` that simply returns its argument but narrows the generic. The handler signature is typed as `(request: { params: zod.objectOutputType<Schema, ZodTypeAny> }, response, context) => Promise<void>`.
+- Provide a second overload `defineTool(factoryFn)` that accepts a function of parsed CLI args, returning a tool. This lets tools adjust schema/behavior based on startup flags.
+- For the "needs a page" case, add `definePageTool` that stamps `pageScoped: true` and a widened handler signature `(request & { page: ContextPage }, response, context)`. The server dispatcher checks `pageScoped` and resolves the page before invoking the handler.
+- Export common schema fragments (`pageIdSchema`, `timeoutSchema`, transforms like `viewportTransform`) so tools share exact wording and validation.
+
+## Example
+
+```ts
+export const takeSnapshot = definePageTool({
+  name: 'take_snapshot',
+  description: 'Take a text a11y snapshot of the selected page.',
+  annotations: { category: ToolCategory.DEBUGGING, readOnlyHint: false },
+  schema: {
+    verbose: zod.boolean().optional().describe('Include all a11y attrs.'),
+    filePath: zod.string().optional().describe('Save to file instead.'),
+  },
+  // `request.params.verbose` is typed as `boolean | undefined`.
+  // `request.page` is present because of definePageTool.
+  handler: async (request, response) => {
+    response.includeSnapshot({
+      verbose: request.params.verbose ?? false,
+      filePath: request.params.filePath,
+    });
+  },
+});
+```
+
+## Gotchas
+
+- `zod.ZodRawShape` is the raw property map, not a compiled object schema — don't wrap the schema in `zod.object(...)` or you lose the overload matching.
+- Runtime schema walkers (for docs or telemetry) must handle `ZodOptional`, `ZodDefault`, and `ZodEffects` by unwrapping `_def.innerType` / `_def.schema` recursively — otherwise they misread types.
+- Factory-variant tools `(args) => def` must be detected with `typeof tool === 'function'` at registration time; mixing eager and lazy tools in one array otherwise produces "tool.name is undefined" bugs.
+- Keep the handler signature `Promise<void>`: side-effecting the response builder is the contract. Returning a value is a smell that the builder abstraction is leaking.

--- a/skills/meta/writing-skills/SKILL.md
+++ b/skills/meta/writing-skills/SKILL.md
@@ -1,0 +1,664 @@
+---
+name: writing-skills
+description: Use when creating new skills, editing existing skills, or verifying skills work before deployment
+category: meta
+version: 1.0.0
+version_origin: extracted
+source_type: extracted-from-git
+source_url: https://github.com/obra/superpowers.git
+source_ref: main
+source_commit: b55764852ac78870e65c6565fb585b6cd8b3c5c9
+source_project: superpowers
+imported_at: 2026-04-18T06:36:49Z
+---
+
+# Writing Skills
+
+## Overview
+
+**Writing skills IS Test-Driven Development applied to process documentation.**
+
+**Personal skills live in agent-specific directories (`~/.claude/skills` for Claude Code, `~/.agents/skills/` for Codex)** 
+
+You write test cases (pressure scenarios with subagents), watch them fail (baseline behavior), write the skill (documentation), watch tests pass (agents comply), and refactor (close loopholes).
+
+**Core principle:** If you didn't watch an agent fail without the skill, you don't know if the skill teaches the right thing.
+
+**REQUIRED BACKGROUND:** You MUST understand superpowers:test-driven-development before using this skill. That skill defines the fundamental RED-GREEN-REFACTOR cycle. This skill adapts TDD to documentation.
+
+**Official guidance:** For Anthropic's official skill authoring best practices, see anthropic-best-practices.md. This document provides additional patterns and guidelines that complement the TDD-focused approach in this skill.
+
+## What is a Skill?
+
+A **skill** is a reference guide for proven techniques, patterns, or tools. Skills help future Claude instances find and apply effective approaches.
+
+**Skills are:** Reusable techniques, patterns, tools, reference guides
+
+**Skills are NOT:** Narratives about how you solved a problem once
+
+## TDD Mapping for Skills
+
+| TDD Concept | Skill Creation |
+|-------------|----------------|
+| **Test case** | Pressure scenario with subagent |
+| **Production code** | Skill document (SKILL.md) |
+| **Test fails (RED)** | Agent violates rule without skill (baseline) |
+| **Test passes (GREEN)** | Agent complies with skill present |
+| **Refactor** | Close loopholes while maintaining compliance |
+| **Write test first** | Run baseline scenario BEFORE writing skill |
+| **Watch it fail** | Document exact rationalizations agent uses |
+| **Minimal code** | Write skill addressing those specific violations |
+| **Watch it pass** | Verify agent now complies |
+| **Refactor cycle** | Find new rationalizations → plug → re-verify |
+
+The entire skill creation process follows RED-GREEN-REFACTOR.
+
+## When to Create a Skill
+
+**Create when:**
+- Technique wasn't intuitively obvious to you
+- You'd reference this again across projects
+- Pattern applies broadly (not project-specific)
+- Others would benefit
+
+**Don't create for:**
+- One-off solutions
+- Standard practices well-documented elsewhere
+- Project-specific conventions (put in CLAUDE.md)
+- Mechanical constraints (if it's enforceable with regex/validation, automate it—save documentation for judgment calls)
+
+## Skill Types
+
+### Technique
+Concrete method with steps to follow (condition-based-waiting, root-cause-tracing)
+
+### Pattern
+Way of thinking about problems (flatten-with-flags, test-invariants)
+
+### Reference
+API docs, syntax guides, tool documentation (office docs)
+
+## Directory Structure
+
+
+```
+skills/
+  skill-name/
+    SKILL.md              # Main reference (required)
+    supporting-file.*     # Only if needed
+```
+
+**Flat namespace** - all skills in one searchable namespace
+
+**Separate files for:**
+1. **Heavy reference** (100+ lines) - API docs, comprehensive syntax
+2. **Reusable tools** - Scripts, utilities, templates
+
+**Keep inline:**
+- Principles and concepts
+- Code patterns (< 50 lines)
+- Everything else
+
+## SKILL.md Structure
+
+**Frontmatter (YAML):**
+- Two required fields: `name` and `description` (see [agentskills.io/specification](https://agentskills.io/specification) for all supported fields)
+- Max 1024 characters total
+- `name`: Use letters, numbers, and hyphens only (no parentheses, special chars)
+- `description`: Third-person, describes ONLY when to use (NOT what it does)
+  - Start with "Use when..." to focus on triggering conditions
+  - Include specific symptoms, situations, and contexts
+  - **NEVER summarize the skill's process or workflow** (see CSO section for why)
+  - Keep under 500 characters if possible
+
+```markdown
+---
+name: Skill-Name-With-Hyphens
+description: Use when [specific triggering conditions and symptoms]
+---
+
+# Skill Name
+
+## Overview
+What is this? Core principle in 1-2 sentences.
+
+## When to Use
+[Small inline flowchart IF decision non-obvious]
+
+Bullet list with SYMPTOMS and use cases
+When NOT to use
+
+## Core Pattern (for techniques/patterns)
+Before/after code comparison
+
+## Quick Reference
+Table or bullets for scanning common operations
+
+## Implementation
+Inline code for simple patterns
+Link to file for heavy reference or reusable tools
+
+## Common Mistakes
+What goes wrong + fixes
+
+## Real-World Impact (optional)
+Concrete results
+```
+
+
+## Claude Search Optimization (CSO)
+
+**Critical for discovery:** Future Claude needs to FIND your skill
+
+### 1. Rich Description Field
+
+**Purpose:** Claude reads description to decide which skills to load for a given task. Make it answer: "Should I read this skill right now?"
+
+**Format:** Start with "Use when..." to focus on triggering conditions
+
+**CRITICAL: Description = When to Use, NOT What the Skill Does**
+
+The description should ONLY describe triggering conditions. Do NOT summarize the skill's process or workflow in the description.
+
+**Why this matters:** Testing revealed that when a description summarizes the skill's workflow, Claude may follow the description instead of reading the full skill content. A description saying "code review between tasks" caused Claude to do ONE review, even though the skill's flowchart clearly showed TWO reviews (spec compliance then code quality).
+
+When the description was changed to just "Use when executing implementation plans with independent tasks" (no workflow summary), Claude correctly read the flowchart and followed the two-stage review process.
+
+**The trap:** Descriptions that summarize workflow create a shortcut Claude will take. The skill body becomes documentation Claude skips.
+
+```yaml
+# ❌ BAD: Summarizes workflow - Claude may follow this instead of reading skill
+description: Use when executing plans - dispatches subagent per task with code review between tasks
+
+# ❌ BAD: Too much process detail
+description: Use for TDD - write test first, watch it fail, write minimal code, refactor
+
+# ✅ GOOD: Just triggering conditions, no workflow summary
+description: Use when executing implementation plans with independent tasks in the current session
+
+# ✅ GOOD: Triggering conditions only
+description: Use when implementing any feature or bugfix, before writing implementation code
+```
+
+**Content:**
+- Use concrete triggers, symptoms, and situations that signal this skill applies
+- Describe the *problem* (race conditions, inconsistent behavior) not *language-specific symptoms* (setTimeout, sleep)
+- Keep triggers technology-agnostic unless the skill itself is technology-specific
+- If skill is technology-specific, make that explicit in the trigger
+- Write in third person (injected into system prompt)
+- **NEVER summarize the skill's process or workflow**
+
+```yaml
+# ❌ BAD: Too abstract, vague, doesn't include when to use
+description: For async testing
+
+# ❌ BAD: First person
+description: I can help you with async tests when they're flaky
+
+# ❌ BAD: Mentions technology but skill isn't specific to it
+description: Use when tests use setTimeout/sleep and are flaky
+
+# ✅ GOOD: Starts with "Use when", describes problem, no workflow
+description: Use when tests have race conditions, timing dependencies, or pass/fail inconsistently
+
+# ✅ GOOD: Technology-specific skill with explicit trigger
+description: Use when using React Router and handling authentication redirects
+```
+
+### 2. Keyword Coverage
+
+Use words Claude would search for:
+- Error messages: "Hook timed out", "ENOTEMPTY", "race condition"
+- Symptoms: "flaky", "hanging", "zombie", "pollution"
+- Synonyms: "timeout/hang/freeze", "cleanup/teardown/afterEach"
+- Tools: Actual commands, library names, file types
+
+### 3. Descriptive Naming
+
+**Use active voice, verb-first:**
+- ✅ `creating-skills` not `skill-creation`
+- ✅ `condition-based-waiting` not `async-test-helpers`
+
+### 4. Token Efficiency (Critical)
+
+**Problem:** getting-started and frequently-referenced skills load into EVERY conversation. Every token counts.
+
+**Target word counts:**
+- getting-started workflows: <150 words each
+- Frequently-loaded skills: <200 words total
+- Other skills: <500 words (still be concise)
+
+**Techniques:**
+
+**Move details to tool help:**
+```bash
+# ❌ BAD: Document all flags in SKILL.md
+search-conversations supports --text, --both, --after DATE, --before DATE, --limit N
+
+# ✅ GOOD: Reference --help
+search-conversations supports multiple modes and filters. Run --help for details.
+```
+
+**Use cross-references:**
+```markdown
+# ❌ BAD: Repeat workflow details
+When searching, dispatch subagent with template...
+[20 lines of repeated instructions]
+
+# ✅ GOOD: Reference other skill
+Always use subagents (50-100x context savings). REQUIRED: Use [other-skill-name] for workflow.
+```
+
+**Compress examples:**
+```markdown
+# ❌ BAD: Verbose example (42 words)
+your human partner: "How did we handle authentication errors in React Router before?"
+You: I'll search past conversations for React Router authentication patterns.
+[Dispatch subagent with search query: "React Router authentication error handling 401"]
+
+# ✅ GOOD: Minimal example (20 words)
+Partner: "How did we handle auth errors in React Router?"
+You: Searching...
+[Dispatch subagent → synthesis]
+```
+
+**Eliminate redundancy:**
+- Don't repeat what's in cross-referenced skills
+- Don't explain what's obvious from command
+- Don't include multiple examples of same pattern
+
+**Verification:**
+```bash
+wc -w skills/path/SKILL.md
+# getting-started workflows: aim for <150 each
+# Other frequently-loaded: aim for <200 total
+```
+
+**Name by what you DO or core insight:**
+- ✅ `condition-based-waiting` > `async-test-helpers`
+- ✅ `using-skills` not `skill-usage`
+- ✅ `flatten-with-flags` > `data-structure-refactoring`
+- ✅ `root-cause-tracing` > `debugging-techniques`
+
+**Gerunds (-ing) work well for processes:**
+- `creating-skills`, `testing-skills`, `debugging-with-logs`
+- Active, describes the action you're taking
+
+### 4. Cross-Referencing Other Skills
+
+**When writing documentation that references other skills:**
+
+Use skill name only, with explicit requirement markers:
+- ✅ Good: `**REQUIRED SUB-SKILL:** Use superpowers:test-driven-development`
+- ✅ Good: `**REQUIRED BACKGROUND:** You MUST understand superpowers:systematic-debugging`
+- ❌ Bad: `See skills/testing/test-driven-development` (unclear if required)
+- ❌ Bad: `@skills/testing/test-driven-development/SKILL.md` (force-loads, burns context)
+
+**Why no @ links:** `@` syntax force-loads files immediately, consuming 200k+ context before you need them.
+
+## Flowchart Usage
+
+```dot
+digraph when_flowchart {
+    "Need to show information?" [shape=diamond];
+    "Decision where I might go wrong?" [shape=diamond];
+    "Use markdown" [shape=box];
+    "Small inline flowchart" [shape=box];
+
+    "Need to show information?" -> "Decision where I might go wrong?" [label="yes"];
+    "Decision where I might go wrong?" -> "Small inline flowchart" [label="yes"];
+    "Decision where I might go wrong?" -> "Use markdown" [label="no"];
+}
+```
+
+**Use flowcharts ONLY for:**
+- Non-obvious decision points
+- Process loops where you might stop too early
+- "When to use A vs B" decisions
+
+**Never use flowcharts for:**
+- Reference material → Tables, lists
+- Code examples → Markdown blocks
+- Linear instructions → Numbered lists
+- Labels without semantic meaning (step1, helper2)
+
+See @graphviz-conventions.dot for graphviz style rules.
+
+**Visualizing for your human partner:** Use `render-graphs.js` in this directory to render a skill's flowcharts to SVG:
+```bash
+./render-graphs.js ../some-skill           # Each diagram separately
+./render-graphs.js ../some-skill --combine # All diagrams in one SVG
+```
+
+## Code Examples
+
+**One excellent example beats many mediocre ones**
+
+Choose most relevant language:
+- Testing techniques → TypeScript/JavaScript
+- System debugging → Shell/Python
+- Data processing → Python
+
+**Good example:**
+- Complete and runnable
+- Well-commented explaining WHY
+- From real scenario
+- Shows pattern clearly
+- Ready to adapt (not generic template)
+
+**Don't:**
+- Implement in 5+ languages
+- Create fill-in-the-blank templates
+- Write contrived examples
+
+You're good at porting - one great example is enough.
+
+## File Organization
+
+### Self-Contained Skill
+```
+defense-in-depth/
+  SKILL.md    # Everything inline
+```
+When: All content fits, no heavy reference needed
+
+### Skill with Reusable Tool
+```
+condition-based-waiting/
+  SKILL.md    # Overview + patterns
+  example.ts  # Working helpers to adapt
+```
+When: Tool is reusable code, not just narrative
+
+### Skill with Heavy Reference
+```
+pptx/
+  SKILL.md       # Overview + workflows
+  pptxgenjs.md   # 600 lines API reference
+  ooxml.md       # 500 lines XML structure
+  scripts/       # Executable tools
+```
+When: Reference material too large for inline
+
+## The Iron Law (Same as TDD)
+
+```
+NO SKILL WITHOUT A FAILING TEST FIRST
+```
+
+This applies to NEW skills AND EDITS to existing skills.
+
+Write skill before testing? Delete it. Start over.
+Edit skill without testing? Same violation.
+
+**No exceptions:**
+- Not for "simple additions"
+- Not for "just adding a section"
+- Not for "documentation updates"
+- Don't keep untested changes as "reference"
+- Don't "adapt" while running tests
+- Delete means delete
+
+**REQUIRED BACKGROUND:** The superpowers:test-driven-development skill explains why this matters. Same principles apply to documentation.
+
+## Testing All Skill Types
+
+Different skill types need different test approaches:
+
+### Discipline-Enforcing Skills (rules/requirements)
+
+**Examples:** TDD, verification-before-completion, designing-before-coding
+
+**Test with:**
+- Academic questions: Do they understand the rules?
+- Pressure scenarios: Do they comply under stress?
+- Multiple pressures combined: time + sunk cost + exhaustion
+- Identify rationalizations and add explicit counters
+
+**Success criteria:** Agent follows rule under maximum pressure
+
+### Technique Skills (how-to guides)
+
+**Examples:** condition-based-waiting, root-cause-tracing, defensive-programming
+
+**Test with:**
+- Application scenarios: Can they apply the technique correctly?
+- Variation scenarios: Do they handle edge cases?
+- Missing information tests: Do instructions have gaps?
+
+**Success criteria:** Agent successfully applies technique to new scenario
+
+### Pattern Skills (mental models)
+
+**Examples:** reducing-complexity, information-hiding concepts
+
+**Test with:**
+- Recognition scenarios: Do they recognize when pattern applies?
+- Application scenarios: Can they use the mental model?
+- Counter-examples: Do they know when NOT to apply?
+
+**Success criteria:** Agent correctly identifies when/how to apply pattern
+
+### Reference Skills (documentation/APIs)
+
+**Examples:** API documentation, command references, library guides
+
+**Test with:**
+- Retrieval scenarios: Can they find the right information?
+- Application scenarios: Can they use what they found correctly?
+- Gap testing: Are common use cases covered?
+
+**Success criteria:** Agent finds and correctly applies reference information
+
+## Common Rationalizations for Skipping Testing
+
+| Excuse | Reality |
+|--------|---------|
+| "Skill is obviously clear" | Clear to you ≠ clear to other agents. Test it. |
+| "It's just a reference" | References can have gaps, unclear sections. Test retrieval. |
+| "Testing is overkill" | Untested skills have issues. Always. 15 min testing saves hours. |
+| "I'll test if problems emerge" | Problems = agents can't use skill. Test BEFORE deploying. |
+| "Too tedious to test" | Testing is less tedious than debugging bad skill in production. |
+| "I'm confident it's good" | Overconfidence guarantees issues. Test anyway. |
+| "Academic review is enough" | Reading ≠ using. Test application scenarios. |
+| "No time to test" | Deploying untested skill wastes more time fixing it later. |
+
+**All of these mean: Test before deploying. No exceptions.**
+
+## Bulletproofing Skills Against Rationalization
+
+Skills that enforce discipline (like TDD) need to resist rationalization. Agents are smart and will find loopholes when under pressure.
+
+**Psychology note:** Understanding WHY persuasion techniques work helps you apply them systematically. See persuasion-principles.md for research foundation (Cialdini, 2021; Meincke et al., 2025) on authority, commitment, scarcity, social proof, and unity principles.
+
+### Close Every Loophole Explicitly
+
+Don't just state the rule - forbid specific workarounds:
+
+<Bad>
+```markdown
+Write code before test? Delete it.
+```
+</Bad>
+
+<Good>
+```markdown
+Write code before test? Delete it. Start over.
+
+**No exceptions:**
+- Don't keep it as "reference"
+- Don't "adapt" it while writing tests
+- Don't look at it
+- Delete means delete
+```
+</Good>
+
+### Address "Spirit vs Letter" Arguments
+
+Add foundational principle early:
+
+```markdown
+**Violating the letter of the rules is violating the spirit of the rules.**
+```
+
+This cuts off entire class of "I'm following the spirit" rationalizations.
+
+### Build Rationalization Table
+
+Capture rationalizations from baseline testing (see Testing section below). Every excuse agents make goes in the table:
+
+```markdown
+| Excuse | Reality |
+|--------|---------|
+| "Too simple to test" | Simple code breaks. Test takes 30 seconds. |
+| "I'll test after" | Tests passing immediately prove nothing. |
+| "Tests after achieve same goals" | Tests-after = "what does this do?" Tests-first = "what should this do?" |
+```
+
+### Create Red Flags List
+
+Make it easy for agents to self-check when rationalizing:
+
+```markdown
+## Red Flags - STOP and Start Over
+
+- Code before test
+- "I already manually tested it"
+- "Tests after achieve the same purpose"
+- "It's about spirit not ritual"
+- "This is different because..."
+
+**All of these mean: Delete code. Start over with TDD.**
+```
+
+### Update CSO for Violation Symptoms
+
+Add to description: symptoms of when you're ABOUT to violate the rule:
+
+```yaml
+description: use when implementing any feature or bugfix, before writing implementation code
+```
+
+## RED-GREEN-REFACTOR for Skills
+
+Follow the TDD cycle:
+
+### RED: Write Failing Test (Baseline)
+
+Run pressure scenario with subagent WITHOUT the skill. Document exact behavior:
+- What choices did they make?
+- What rationalizations did they use (verbatim)?
+- Which pressures triggered violations?
+
+This is "watch the test fail" - you must see what agents naturally do before writing the skill.
+
+### GREEN: Write Minimal Skill
+
+Write skill that addresses those specific rationalizations. Don't add extra content for hypothetical cases.
+
+Run same scenarios WITH skill. Agent should now comply.
+
+### REFACTOR: Close Loopholes
+
+Agent found new rationalization? Add explicit counter. Re-test until bulletproof.
+
+**Testing methodology:** See @testing-skills-with-subagents.md for the complete testing methodology:
+- How to write pressure scenarios
+- Pressure types (time, sunk cost, authority, exhaustion)
+- Plugging holes systematically
+- Meta-testing techniques
+
+## Anti-Patterns
+
+### ❌ Narrative Example
+"In session 2025-10-03, we found empty projectDir caused..."
+**Why bad:** Too specific, not reusable
+
+### ❌ Multi-Language Dilution
+example-js.js, example-py.py, example-go.go
+**Why bad:** Mediocre quality, maintenance burden
+
+### ❌ Code in Flowcharts
+```dot
+step1 [label="import fs"];
+step2 [label="read file"];
+```
+**Why bad:** Can't copy-paste, hard to read
+
+### ❌ Generic Labels
+helper1, helper2, step3, pattern4
+**Why bad:** Labels should have semantic meaning
+
+## STOP: Before Moving to Next Skill
+
+**After writing ANY skill, you MUST STOP and complete the deployment process.**
+
+**Do NOT:**
+- Create multiple skills in batch without testing each
+- Move to next skill before current one is verified
+- Skip testing because "batching is more efficient"
+
+**The deployment checklist below is MANDATORY for EACH skill.**
+
+Deploying untested skills = deploying untested code. It's a violation of quality standards.
+
+## Skill Creation Checklist (TDD Adapted)
+
+**IMPORTANT: Use TodoWrite to create todos for EACH checklist item below.**
+
+**RED Phase - Write Failing Test:**
+- [ ] Create pressure scenarios (3+ combined pressures for discipline skills)
+- [ ] Run scenarios WITHOUT skill - document baseline behavior verbatim
+- [ ] Identify patterns in rationalizations/failures
+
+**GREEN Phase - Write Minimal Skill:**
+- [ ] Name uses only letters, numbers, hyphens (no parentheses/special chars)
+- [ ] YAML frontmatter with required `name` and `description` fields (max 1024 chars; see [spec](https://agentskills.io/specification))
+- [ ] Description starts with "Use when..." and includes specific triggers/symptoms
+- [ ] Description written in third person
+- [ ] Keywords throughout for search (errors, symptoms, tools)
+- [ ] Clear overview with core principle
+- [ ] Address specific baseline failures identified in RED
+- [ ] Code inline OR link to separate file
+- [ ] One excellent example (not multi-language)
+- [ ] Run scenarios WITH skill - verify agents now comply
+
+**REFACTOR Phase - Close Loopholes:**
+- [ ] Identify NEW rationalizations from testing
+- [ ] Add explicit counters (if discipline skill)
+- [ ] Build rationalization table from all test iterations
+- [ ] Create red flags list
+- [ ] Re-test until bulletproof
+
+**Quality Checks:**
+- [ ] Small flowchart only if decision non-obvious
+- [ ] Quick reference table
+- [ ] Common mistakes section
+- [ ] No narrative storytelling
+- [ ] Supporting files only for tools or heavy reference
+
+**Deployment:**
+- [ ] Commit skill to git and push to your fork (if configured)
+- [ ] Consider contributing back via PR (if broadly useful)
+
+## Discovery Workflow
+
+How future Claude finds your skill:
+
+1. **Encounters problem** ("tests are flaky")
+3. **Finds SKILL** (description matches)
+4. **Scans overview** (is this relevant?)
+5. **Reads patterns** (quick reference table)
+6. **Loads example** (only when implementing)
+
+**Optimize for this flow** - put searchable terms early and often.
+
+## The Bottom Line
+
+**Creating skills IS TDD for process documentation.**
+
+Same Iron Law: No skill without failing test first.
+Same cycle: RED (baseline) → GREEN (write skill) → REFACTOR (close loopholes).
+Same benefits: Better quality, fewer surprises, bulletproof results.
+
+If you follow TDD for code, follow it for skills. It's the same discipline applied to documentation.

--- a/skills/meta/writing-skills/anthropic-best-practices.md
+++ b/skills/meta/writing-skills/anthropic-best-practices.md
@@ -1,0 +1,1150 @@
+# Skill authoring best practices
+
+> Learn how to write effective Skills that Claude can discover and use successfully.
+
+Good Skills are concise, well-structured, and tested with real usage. This guide provides practical authoring decisions to help you write Skills that Claude can discover and use effectively.
+
+For conceptual background on how Skills work, see the [Skills overview](/en/docs/agents-and-tools/agent-skills/overview).
+
+## Core principles
+
+### Concise is key
+
+The [context window](https://platform.claude.com/docs/en/build-with-claude/context-windows) is a public good. Your Skill shares the context window with everything else Claude needs to know, including:
+
+* The system prompt
+* Conversation history
+* Other Skills' metadata
+* Your actual request
+
+Not every token in your Skill has an immediate cost. At startup, only the metadata (name and description) from all Skills is pre-loaded. Claude reads SKILL.md only when the Skill becomes relevant, and reads additional files only as needed. However, being concise in SKILL.md still matters: once Claude loads it, every token competes with conversation history and other context.
+
+**Default assumption**: Claude is already very smart
+
+Only add context Claude doesn't already have. Challenge each piece of information:
+
+* "Does Claude really need this explanation?"
+* "Can I assume Claude knows this?"
+* "Does this paragraph justify its token cost?"
+
+**Good example: Concise** (approximately 50 tokens):
+
+````markdown  theme={null}
+## Extract PDF text
+
+Use pdfplumber for text extraction:
+
+```python
+import pdfplumber
+
+with pdfplumber.open("file.pdf") as pdf:
+    text = pdf.pages[0].extract_text()
+```
+````
+
+**Bad example: Too verbose** (approximately 150 tokens):
+
+```markdown  theme={null}
+## Extract PDF text
+
+PDF (Portable Document Format) files are a common file format that contains
+text, images, and other content. To extract text from a PDF, you'll need to
+use a library. There are many libraries available for PDF processing, but we
+recommend pdfplumber because it's easy to use and handles most cases well.
+First, you'll need to install it using pip. Then you can use the code below...
+```
+
+The concise version assumes Claude knows what PDFs are and how libraries work.
+
+### Set appropriate degrees of freedom
+
+Match the level of specificity to the task's fragility and variability.
+
+**High freedom** (text-based instructions):
+
+Use when:
+
+* Multiple approaches are valid
+* Decisions depend on context
+* Heuristics guide the approach
+
+Example:
+
+```markdown  theme={null}
+## Code review process
+
+1. Analyze the code structure and organization
+2. Check for potential bugs or edge cases
+3. Suggest improvements for readability and maintainability
+4. Verify adherence to project conventions
+```
+
+**Medium freedom** (pseudocode or scripts with parameters):
+
+Use when:
+
+* A preferred pattern exists
+* Some variation is acceptable
+* Configuration affects behavior
+
+Example:
+
+````markdown  theme={null}
+## Generate report
+
+Use this template and customize as needed:
+
+```python
+def generate_report(data, format="markdown", include_charts=True):
+    # Process data
+    # Generate output in specified format
+    # Optionally include visualizations
+```
+````
+
+**Low freedom** (specific scripts, few or no parameters):
+
+Use when:
+
+* Operations are fragile and error-prone
+* Consistency is critical
+* A specific sequence must be followed
+
+Example:
+
+````markdown  theme={null}
+## Database migration
+
+Run exactly this script:
+
+```bash
+python scripts/migrate.py --verify --backup
+```
+
+Do not modify the command or add additional flags.
+````
+
+**Analogy**: Think of Claude as a robot exploring a path:
+
+* **Narrow bridge with cliffs on both sides**: There's only one safe way forward. Provide specific guardrails and exact instructions (low freedom). Example: database migrations that must run in exact sequence.
+* **Open field with no hazards**: Many paths lead to success. Give general direction and trust Claude to find the best route (high freedom). Example: code reviews where context determines the best approach.
+
+### Test with all models you plan to use
+
+Skills act as additions to models, so effectiveness depends on the underlying model. Test your Skill with all the models you plan to use it with.
+
+**Testing considerations by model**:
+
+* **Claude Haiku** (fast, economical): Does the Skill provide enough guidance?
+* **Claude Sonnet** (balanced): Is the Skill clear and efficient?
+* **Claude Opus** (powerful reasoning): Does the Skill avoid over-explaining?
+
+What works perfectly for Opus might need more detail for Haiku. If you plan to use your Skill across multiple models, aim for instructions that work well with all of them.
+
+## Skill structure
+
+<Note>
+  **YAML Frontmatter**: The SKILL.md frontmatter requires two fields:
+
+  * `name` - Human-readable name of the Skill (64 characters maximum)
+  * `description` - One-line description of what the Skill does and when to use it (1024 characters maximum)
+
+  For complete Skill structure details, see the [Skills overview](/en/docs/agents-and-tools/agent-skills/overview#skill-structure).
+</Note>
+
+### Naming conventions
+
+Use consistent naming patterns to make Skills easier to reference and discuss. We recommend using **gerund form** (verb + -ing) for Skill names, as this clearly describes the activity or capability the Skill provides.
+
+**Good naming examples (gerund form)**:
+
+* "Processing PDFs"
+* "Analyzing spreadsheets"
+* "Managing databases"
+* "Testing code"
+* "Writing documentation"
+
+**Acceptable alternatives**:
+
+* Noun phrases: "PDF Processing", "Spreadsheet Analysis"
+* Action-oriented: "Process PDFs", "Analyze Spreadsheets"
+
+**Avoid**:
+
+* Vague names: "Helper", "Utils", "Tools"
+* Overly generic: "Documents", "Data", "Files"
+* Inconsistent patterns within your skill collection
+
+Consistent naming makes it easier to:
+
+* Reference Skills in documentation and conversations
+* Understand what a Skill does at a glance
+* Organize and search through multiple Skills
+* Maintain a professional, cohesive skill library
+
+### Writing effective descriptions
+
+The `description` field enables Skill discovery and should include both what the Skill does and when to use it.
+
+<Warning>
+  **Always write in third person**. The description is injected into the system prompt, and inconsistent point-of-view can cause discovery problems.
+
+  * **Good:** "Processes Excel files and generates reports"
+  * **Avoid:** "I can help you process Excel files"
+  * **Avoid:** "You can use this to process Excel files"
+</Warning>
+
+**Be specific and include key terms**. Include both what the Skill does and specific triggers/contexts for when to use it.
+
+Each Skill has exactly one description field. The description is critical for skill selection: Claude uses it to choose the right Skill from potentially 100+ available Skills. Your description must provide enough detail for Claude to know when to select this Skill, while the rest of SKILL.md provides the implementation details.
+
+Effective examples:
+
+**PDF Processing skill:**
+
+```yaml  theme={null}
+description: Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when the user mentions PDFs, forms, or document extraction.
+```
+
+**Excel Analysis skill:**
+
+```yaml  theme={null}
+description: Analyze Excel spreadsheets, create pivot tables, generate charts. Use when analyzing Excel files, spreadsheets, tabular data, or .xlsx files.
+```
+
+**Git Commit Helper skill:**
+
+```yaml  theme={null}
+description: Generate descriptive commit messages by analyzing git diffs. Use when the user asks for help writing commit messages or reviewing staged changes.
+```
+
+Avoid vague descriptions like these:
+
+```yaml  theme={null}
+description: Helps with documents
+```
+
+```yaml  theme={null}
+description: Processes data
+```
+
+```yaml  theme={null}
+description: Does stuff with files
+```
+
+### Progressive disclosure patterns
+
+SKILL.md serves as an overview that points Claude to detailed materials as needed, like a table of contents in an onboarding guide. For an explanation of how progressive disclosure works, see [How Skills work](/en/docs/agents-and-tools/agent-skills/overview#how-skills-work) in the overview.
+
+**Practical guidance:**
+
+* Keep SKILL.md body under 500 lines for optimal performance
+* Split content into separate files when approaching this limit
+* Use the patterns below to organize instructions, code, and resources effectively
+
+#### Visual overview: From simple to complex
+
+A basic Skill starts with just a SKILL.md file containing metadata and instructions:
+
+<img src="https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-simple-file.png?fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=87782ff239b297d9a9e8e1b72ed72db9" alt="Simple SKILL.md file showing YAML frontmatter and markdown body" data-og-width="2048" width="2048" data-og-height="1153" height="1153" data-path="images/agent-skills-simple-file.png" data-optimize="true" data-opv="3" srcset="https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-simple-file.png?w=280&fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=c61cc33b6f5855809907f7fda94cd80e 280w, https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-simple-file.png?w=560&fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=90d2c0c1c76b36e8d485f49e0810dbfd 560w, https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-simple-file.png?w=840&fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=ad17d231ac7b0bea7e5b4d58fb4aeabb 840w, https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-simple-file.png?w=1100&fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=f5d0a7a3c668435bb0aee9a3a8f8c329 1100w, https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-simple-file.png?w=1650&fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=0e927c1af9de5799cfe557d12249f6e6 1650w, https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-simple-file.png?w=2500&fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=46bbb1a51dd4c8202a470ac8c80a893d 2500w" />
+
+As your Skill grows, you can bundle additional content that Claude loads only when needed:
+
+<img src="https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-bundling-content.png?fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=a5e0aa41e3d53985a7e3e43668a33ea3" alt="Bundling additional reference files like reference.md and forms.md." data-og-width="2048" width="2048" data-og-height="1327" height="1327" data-path="images/agent-skills-bundling-content.png" data-optimize="true" data-opv="3" srcset="https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-bundling-content.png?w=280&fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=f8a0e73783e99b4a643d79eac86b70a2 280w, https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-bundling-content.png?w=560&fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=dc510a2a9d3f14359416b706f067904a 560w, https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-bundling-content.png?w=840&fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=82cd6286c966303f7dd914c28170e385 840w, https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-bundling-content.png?w=1100&fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=56f3be36c77e4fe4b523df209a6824c6 1100w, https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-bundling-content.png?w=1650&fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=d22b5161b2075656417d56f41a74f3dd 1650w, https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-bundling-content.png?w=2500&fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=3dd4bdd6850ffcc96c6c45fcb0acd6eb 2500w" />
+
+The complete Skill directory structure might look like this:
+
+```
+pdf/
+├── SKILL.md              # Main instructions (loaded when triggered)
+├── FORMS.md              # Form-filling guide (loaded as needed)
+├── reference.md          # API reference (loaded as needed)
+├── examples.md           # Usage examples (loaded as needed)
+└── scripts/
+    ├── analyze_form.py   # Utility script (executed, not loaded)
+    ├── fill_form.py      # Form filling script
+    └── validate.py       # Validation script
+```
+
+#### Pattern 1: High-level guide with references
+
+````markdown  theme={null}
+---
+name: PDF Processing
+description: Extracts text and tables from PDF files, fills forms, and merges documents. Use when working with PDF files or when the user mentions PDFs, forms, or document extraction.
+---
+
+# PDF Processing
+
+## Quick start
+
+Extract text with pdfplumber:
+```python
+import pdfplumber
+with pdfplumber.open("file.pdf") as pdf:
+    text = pdf.pages[0].extract_text()
+```
+
+## Advanced features
+
+**Form filling**: See [FORMS.md](FORMS.md) for complete guide
+**API reference**: See [REFERENCE.md](REFERENCE.md) for all methods
+**Examples**: See [EXAMPLES.md](EXAMPLES.md) for common patterns
+````
+
+Claude loads FORMS.md, REFERENCE.md, or EXAMPLES.md only when needed.
+
+#### Pattern 2: Domain-specific organization
+
+For Skills with multiple domains, organize content by domain to avoid loading irrelevant context. When a user asks about sales metrics, Claude only needs to read sales-related schemas, not finance or marketing data. This keeps token usage low and context focused.
+
+```
+bigquery-skill/
+├── SKILL.md (overview and navigation)
+└── reference/
+    ├── finance.md (revenue, billing metrics)
+    ├── sales.md (opportunities, pipeline)
+    ├── product.md (API usage, features)
+    └── marketing.md (campaigns, attribution)
+```
+
+````markdown SKILL.md theme={null}
+# BigQuery Data Analysis
+
+## Available datasets
+
+**Finance**: Revenue, ARR, billing → See [reference/finance.md](reference/finance.md)
+**Sales**: Opportunities, pipeline, accounts → See [reference/sales.md](reference/sales.md)
+**Product**: API usage, features, adoption → See [reference/product.md](reference/product.md)
+**Marketing**: Campaigns, attribution, email → See [reference/marketing.md](reference/marketing.md)
+
+## Quick search
+
+Find specific metrics using grep:
+
+```bash
+grep -i "revenue" reference/finance.md
+grep -i "pipeline" reference/sales.md
+grep -i "api usage" reference/product.md
+```
+````
+
+#### Pattern 3: Conditional details
+
+Show basic content, link to advanced content:
+
+```markdown  theme={null}
+# DOCX Processing
+
+## Creating documents
+
+Use docx-js for new documents. See [DOCX-JS.md](DOCX-JS.md).
+
+## Editing documents
+
+For simple edits, modify the XML directly.
+
+**For tracked changes**: See [REDLINING.md](REDLINING.md)
+**For OOXML details**: See [OOXML.md](OOXML.md)
+```
+
+Claude reads REDLINING.md or OOXML.md only when the user needs those features.
+
+### Avoid deeply nested references
+
+Claude may partially read files when they're referenced from other referenced files. When encountering nested references, Claude might use commands like `head -100` to preview content rather than reading entire files, resulting in incomplete information.
+
+**Keep references one level deep from SKILL.md**. All reference files should link directly from SKILL.md to ensure Claude reads complete files when needed.
+
+**Bad example: Too deep**:
+
+```markdown  theme={null}
+# SKILL.md
+See [advanced.md](advanced.md)...
+
+# advanced.md
+See [details.md](details.md)...
+
+# details.md
+Here's the actual information...
+```
+
+**Good example: One level deep**:
+
+```markdown  theme={null}
+# SKILL.md
+
+**Basic usage**: [instructions in SKILL.md]
+**Advanced features**: See [advanced.md](advanced.md)
+**API reference**: See [reference.md](reference.md)
+**Examples**: See [examples.md](examples.md)
+```
+
+### Structure longer reference files with table of contents
+
+For reference files longer than 100 lines, include a table of contents at the top. This ensures Claude can see the full scope of available information even when previewing with partial reads.
+
+**Example**:
+
+```markdown  theme={null}
+# API Reference
+
+## Contents
+- Authentication and setup
+- Core methods (create, read, update, delete)
+- Advanced features (batch operations, webhooks)
+- Error handling patterns
+- Code examples
+
+## Authentication and setup
+...
+
+## Core methods
+...
+```
+
+Claude can then read the complete file or jump to specific sections as needed.
+
+For details on how this filesystem-based architecture enables progressive disclosure, see the [Runtime environment](#runtime-environment) section in the Advanced section below.
+
+## Workflows and feedback loops
+
+### Use workflows for complex tasks
+
+Break complex operations into clear, sequential steps. For particularly complex workflows, provide a checklist that Claude can copy into its response and check off as it progresses.
+
+**Example 1: Research synthesis workflow** (for Skills without code):
+
+````markdown  theme={null}
+## Research synthesis workflow
+
+Copy this checklist and track your progress:
+
+```
+Research Progress:
+- [ ] Step 1: Read all source documents
+- [ ] Step 2: Identify key themes
+- [ ] Step 3: Cross-reference claims
+- [ ] Step 4: Create structured summary
+- [ ] Step 5: Verify citations
+```
+
+**Step 1: Read all source documents**
+
+Review each document in the `sources/` directory. Note the main arguments and supporting evidence.
+
+**Step 2: Identify key themes**
+
+Look for patterns across sources. What themes appear repeatedly? Where do sources agree or disagree?
+
+**Step 3: Cross-reference claims**
+
+For each major claim, verify it appears in the source material. Note which source supports each point.
+
+**Step 4: Create structured summary**
+
+Organize findings by theme. Include:
+- Main claim
+- Supporting evidence from sources
+- Conflicting viewpoints (if any)
+
+**Step 5: Verify citations**
+
+Check that every claim references the correct source document. If citations are incomplete, return to Step 3.
+````
+
+This example shows how workflows apply to analysis tasks that don't require code. The checklist pattern works for any complex, multi-step process.
+
+**Example 2: PDF form filling workflow** (for Skills with code):
+
+````markdown  theme={null}
+## PDF form filling workflow
+
+Copy this checklist and check off items as you complete them:
+
+```
+Task Progress:
+- [ ] Step 1: Analyze the form (run analyze_form.py)
+- [ ] Step 2: Create field mapping (edit fields.json)
+- [ ] Step 3: Validate mapping (run validate_fields.py)
+- [ ] Step 4: Fill the form (run fill_form.py)
+- [ ] Step 5: Verify output (run verify_output.py)
+```
+
+**Step 1: Analyze the form**
+
+Run: `python scripts/analyze_form.py input.pdf`
+
+This extracts form fields and their locations, saving to `fields.json`.
+
+**Step 2: Create field mapping**
+
+Edit `fields.json` to add values for each field.
+
+**Step 3: Validate mapping**
+
+Run: `python scripts/validate_fields.py fields.json`
+
+Fix any validation errors before continuing.
+
+**Step 4: Fill the form**
+
+Run: `python scripts/fill_form.py input.pdf fields.json output.pdf`
+
+**Step 5: Verify output**
+
+Run: `python scripts/verify_output.py output.pdf`
+
+If verification fails, return to Step 2.
+````
+
+Clear steps prevent Claude from skipping critical validation. The checklist helps both Claude and you track progress through multi-step workflows.
+
+### Implement feedback loops
+
+**Common pattern**: Run validator → fix errors → repeat
+
+This pattern greatly improves output quality.
+
+**Example 1: Style guide compliance** (for Skills without code):
+
+```markdown  theme={null}
+## Content review process
+
+1. Draft your content following the guidelines in STYLE_GUIDE.md
+2. Review against the checklist:
+   - Check terminology consistency
+   - Verify examples follow the standard format
+   - Confirm all required sections are present
+3. If issues found:
+   - Note each issue with specific section reference
+   - Revise the content
+   - Review the checklist again
+4. Only proceed when all requirements are met
+5. Finalize and save the document
+```
+
+This shows the validation loop pattern using reference documents instead of scripts. The "validator" is STYLE\_GUIDE.md, and Claude performs the check by reading and comparing.
+
+**Example 2: Document editing process** (for Skills with code):
+
+```markdown  theme={null}
+## Document editing process
+
+1. Make your edits to `word/document.xml`
+2. **Validate immediately**: `python ooxml/scripts/validate.py unpacked_dir/`
+3. If validation fails:
+   - Review the error message carefully
+   - Fix the issues in the XML
+   - Run validation again
+4. **Only proceed when validation passes**
+5. Rebuild: `python ooxml/scripts/pack.py unpacked_dir/ output.docx`
+6. Test the output document
+```
+
+The validation loop catches errors early.
+
+## Content guidelines
+
+### Avoid time-sensitive information
+
+Don't include information that will become outdated:
+
+**Bad example: Time-sensitive** (will become wrong):
+
+```markdown  theme={null}
+If you're doing this before August 2025, use the old API.
+After August 2025, use the new API.
+```
+
+**Good example** (use "old patterns" section):
+
+```markdown  theme={null}
+## Current method
+
+Use the v2 API endpoint: `api.example.com/v2/messages`
+
+## Old patterns
+
+<details>
+<summary>Legacy v1 API (deprecated 2025-08)</summary>
+
+The v1 API used: `api.example.com/v1/messages`
+
+This endpoint is no longer supported.
+</details>
+```
+
+The old patterns section provides historical context without cluttering the main content.
+
+### Use consistent terminology
+
+Choose one term and use it throughout the Skill:
+
+**Good - Consistent**:
+
+* Always "API endpoint"
+* Always "field"
+* Always "extract"
+
+**Bad - Inconsistent**:
+
+* Mix "API endpoint", "URL", "API route", "path"
+* Mix "field", "box", "element", "control"
+* Mix "extract", "pull", "get", "retrieve"
+
+Consistency helps Claude understand and follow instructions.
+
+## Common patterns
+
+### Template pattern
+
+Provide templates for output format. Match the level of strictness to your needs.
+
+**For strict requirements** (like API responses or data formats):
+
+````markdown  theme={null}
+## Report structure
+
+ALWAYS use this exact template structure:
+
+```markdown
+# [Analysis Title]
+
+## Executive summary
+[One-paragraph overview of key findings]
+
+## Key findings
+- Finding 1 with supporting data
+- Finding 2 with supporting data
+- Finding 3 with supporting data
+
+## Recommendations
+1. Specific actionable recommendation
+2. Specific actionable recommendation
+```
+````
+
+**For flexible guidance** (when adaptation is useful):
+
+````markdown  theme={null}
+## Report structure
+
+Here is a sensible default format, but use your best judgment based on the analysis:
+
+```markdown
+# [Analysis Title]
+
+## Executive summary
+[Overview]
+
+## Key findings
+[Adapt sections based on what you discover]
+
+## Recommendations
+[Tailor to the specific context]
+```
+
+Adjust sections as needed for the specific analysis type.
+````
+
+### Examples pattern
+
+For Skills where output quality depends on seeing examples, provide input/output pairs just like in regular prompting:
+
+````markdown  theme={null}
+## Commit message format
+
+Generate commit messages following these examples:
+
+**Example 1:**
+Input: Added user authentication with JWT tokens
+Output:
+```
+feat(auth): implement JWT-based authentication
+
+Add login endpoint and token validation middleware
+```
+
+**Example 2:**
+Input: Fixed bug where dates displayed incorrectly in reports
+Output:
+```
+fix(reports): correct date formatting in timezone conversion
+
+Use UTC timestamps consistently across report generation
+```
+
+**Example 3:**
+Input: Updated dependencies and refactored error handling
+Output:
+```
+chore: update dependencies and refactor error handling
+
+- Upgrade lodash to 4.17.21
+- Standardize error response format across endpoints
+```
+
+Follow this style: type(scope): brief description, then detailed explanation.
+````
+
+Examples help Claude understand the desired style and level of detail more clearly than descriptions alone.
+
+### Conditional workflow pattern
+
+Guide Claude through decision points:
+
+```markdown  theme={null}
+## Document modification workflow
+
+1. Determine the modification type:
+
+   **Creating new content?** → Follow "Creation workflow" below
+   **Editing existing content?** → Follow "Editing workflow" below
+
+2. Creation workflow:
+   - Use docx-js library
+   - Build document from scratch
+   - Export to .docx format
+
+3. Editing workflow:
+   - Unpack existing document
+   - Modify XML directly
+   - Validate after each change
+   - Repack when complete
+```
+
+<Tip>
+  If workflows become large or complicated with many steps, consider pushing them into separate files and tell Claude to read the appropriate file based on the task at hand.
+</Tip>
+
+## Evaluation and iteration
+
+### Build evaluations first
+
+**Create evaluations BEFORE writing extensive documentation.** This ensures your Skill solves real problems rather than documenting imagined ones.
+
+**Evaluation-driven development:**
+
+1. **Identify gaps**: Run Claude on representative tasks without a Skill. Document specific failures or missing context
+2. **Create evaluations**: Build three scenarios that test these gaps
+3. **Establish baseline**: Measure Claude's performance without the Skill
+4. **Write minimal instructions**: Create just enough content to address the gaps and pass evaluations
+5. **Iterate**: Execute evaluations, compare against baseline, and refine
+
+This approach ensures you're solving actual problems rather than anticipating requirements that may never materialize.
+
+**Evaluation structure**:
+
+```json  theme={null}
+{
+  "skills": ["pdf-processing"],
+  "query": "Extract all text from this PDF file and save it to output.txt",
+  "files": ["test-files/document.pdf"],
+  "expected_behavior": [
+    "Successfully reads the PDF file using an appropriate PDF processing library or command-line tool",
+    "Extracts text content from all pages in the document without missing any pages",
+    "Saves the extracted text to a file named output.txt in a clear, readable format"
+  ]
+}
+```
+
+<Note>
+  This example demonstrates a data-driven evaluation with a simple testing rubric. We do not currently provide a built-in way to run these evaluations. Users can create their own evaluation system. Evaluations are your source of truth for measuring Skill effectiveness.
+</Note>
+
+### Develop Skills iteratively with Claude
+
+The most effective Skill development process involves Claude itself. Work with one instance of Claude ("Claude A") to create a Skill that will be used by other instances ("Claude B"). Claude A helps you design and refine instructions, while Claude B tests them in real tasks. This works because Claude models understand both how to write effective agent instructions and what information agents need.
+
+**Creating a new Skill:**
+
+1. **Complete a task without a Skill**: Work through a problem with Claude A using normal prompting. As you work, you'll naturally provide context, explain preferences, and share procedural knowledge. Notice what information you repeatedly provide.
+
+2. **Identify the reusable pattern**: After completing the task, identify what context you provided that would be useful for similar future tasks.
+
+   **Example**: If you worked through a BigQuery analysis, you might have provided table names, field definitions, filtering rules (like "always exclude test accounts"), and common query patterns.
+
+3. **Ask Claude A to create a Skill**: "Create a Skill that captures this BigQuery analysis pattern we just used. Include the table schemas, naming conventions, and the rule about filtering test accounts."
+
+   <Tip>
+     Claude models understand the Skill format and structure natively. You don't need special system prompts or a "writing skills" skill to get Claude to help create Skills. Simply ask Claude to create a Skill and it will generate properly structured SKILL.md content with appropriate frontmatter and body content.
+   </Tip>
+
+4. **Review for conciseness**: Check that Claude A hasn't added unnecessary explanations. Ask: "Remove the explanation about what win rate means - Claude already knows that."
+
+5. **Improve information architecture**: Ask Claude A to organize the content more effectively. For example: "Organize this so the table schema is in a separate reference file. We might add more tables later."
+
+6. **Test on similar tasks**: Use the Skill with Claude B (a fresh instance with the Skill loaded) on related use cases. Observe whether Claude B finds the right information, applies rules correctly, and handles the task successfully.
+
+7. **Iterate based on observation**: If Claude B struggles or misses something, return to Claude A with specifics: "When Claude used this Skill, it forgot to filter by date for Q4. Should we add a section about date filtering patterns?"
+
+**Iterating on existing Skills:**
+
+The same hierarchical pattern continues when improving Skills. You alternate between:
+
+* **Working with Claude A** (the expert who helps refine the Skill)
+* **Testing with Claude B** (the agent using the Skill to perform real work)
+* **Observing Claude B's behavior** and bringing insights back to Claude A
+
+1. **Use the Skill in real workflows**: Give Claude B (with the Skill loaded) actual tasks, not test scenarios
+
+2. **Observe Claude B's behavior**: Note where it struggles, succeeds, or makes unexpected choices
+
+   **Example observation**: "When I asked Claude B for a regional sales report, it wrote the query but forgot to filter out test accounts, even though the Skill mentions this rule."
+
+3. **Return to Claude A for improvements**: Share the current SKILL.md and describe what you observed. Ask: "I noticed Claude B forgot to filter test accounts when I asked for a regional report. The Skill mentions filtering, but maybe it's not prominent enough?"
+
+4. **Review Claude A's suggestions**: Claude A might suggest reorganizing to make rules more prominent, using stronger language like "MUST filter" instead of "always filter", or restructuring the workflow section.
+
+5. **Apply and test changes**: Update the Skill with Claude A's refinements, then test again with Claude B on similar requests
+
+6. **Repeat based on usage**: Continue this observe-refine-test cycle as you encounter new scenarios. Each iteration improves the Skill based on real agent behavior, not assumptions.
+
+**Gathering team feedback:**
+
+1. Share Skills with teammates and observe their usage
+2. Ask: Does the Skill activate when expected? Are instructions clear? What's missing?
+3. Incorporate feedback to address blind spots in your own usage patterns
+
+**Why this approach works**: Claude A understands agent needs, you provide domain expertise, Claude B reveals gaps through real usage, and iterative refinement improves Skills based on observed behavior rather than assumptions.
+
+### Observe how Claude navigates Skills
+
+As you iterate on Skills, pay attention to how Claude actually uses them in practice. Watch for:
+
+* **Unexpected exploration paths**: Does Claude read files in an order you didn't anticipate? This might indicate your structure isn't as intuitive as you thought
+* **Missed connections**: Does Claude fail to follow references to important files? Your links might need to be more explicit or prominent
+* **Overreliance on certain sections**: If Claude repeatedly reads the same file, consider whether that content should be in the main SKILL.md instead
+* **Ignored content**: If Claude never accesses a bundled file, it might be unnecessary or poorly signaled in the main instructions
+
+Iterate based on these observations rather than assumptions. The 'name' and 'description' in your Skill's metadata are particularly critical. Claude uses these when deciding whether to trigger the Skill in response to the current task. Make sure they clearly describe what the Skill does and when it should be used.
+
+## Anti-patterns to avoid
+
+### Avoid Windows-style paths
+
+Always use forward slashes in file paths, even on Windows:
+
+* ✓ **Good**: `scripts/helper.py`, `reference/guide.md`
+* ✗ **Avoid**: `scripts\helper.py`, `reference\guide.md`
+
+Unix-style paths work across all platforms, while Windows-style paths cause errors on Unix systems.
+
+### Avoid offering too many options
+
+Don't present multiple approaches unless necessary:
+
+````markdown  theme={null}
+**Bad example: Too many choices** (confusing):
+"You can use pypdf, or pdfplumber, or PyMuPDF, or pdf2image, or..."
+
+**Good example: Provide a default** (with escape hatch):
+"Use pdfplumber for text extraction:
+```python
+import pdfplumber
+```
+
+For scanned PDFs requiring OCR, use pdf2image with pytesseract instead."
+````
+
+## Advanced: Skills with executable code
+
+The sections below focus on Skills that include executable scripts. If your Skill uses only markdown instructions, skip to [Checklist for effective Skills](#checklist-for-effective-skills).
+
+### Solve, don't punt
+
+When writing scripts for Skills, handle error conditions rather than punting to Claude.
+
+**Good example: Handle errors explicitly**:
+
+```python  theme={null}
+def process_file(path):
+    """Process a file, creating it if it doesn't exist."""
+    try:
+        with open(path) as f:
+            return f.read()
+    except FileNotFoundError:
+        # Create file with default content instead of failing
+        print(f"File {path} not found, creating default")
+        with open(path, 'w') as f:
+            f.write('')
+        return ''
+    except PermissionError:
+        # Provide alternative instead of failing
+        print(f"Cannot access {path}, using default")
+        return ''
+```
+
+**Bad example: Punt to Claude**:
+
+```python  theme={null}
+def process_file(path):
+    # Just fail and let Claude figure it out
+    return open(path).read()
+```
+
+Configuration parameters should also be justified and documented to avoid "voodoo constants" (Ousterhout's law). If you don't know the right value, how will Claude determine it?
+
+**Good example: Self-documenting**:
+
+```python  theme={null}
+# HTTP requests typically complete within 30 seconds
+# Longer timeout accounts for slow connections
+REQUEST_TIMEOUT = 30
+
+# Three retries balances reliability vs speed
+# Most intermittent failures resolve by the second retry
+MAX_RETRIES = 3
+```
+
+**Bad example: Magic numbers**:
+
+```python  theme={null}
+TIMEOUT = 47  # Why 47?
+RETRIES = 5   # Why 5?
+```
+
+### Provide utility scripts
+
+Even if Claude could write a script, pre-made scripts offer advantages:
+
+**Benefits of utility scripts**:
+
+* More reliable than generated code
+* Save tokens (no need to include code in context)
+* Save time (no code generation required)
+* Ensure consistency across uses
+
+<img src="https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-executable-scripts.png?fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=4bbc45f2c2e0bee9f2f0d5da669bad00" alt="Bundling executable scripts alongside instruction files" data-og-width="2048" width="2048" data-og-height="1154" height="1154" data-path="images/agent-skills-executable-scripts.png" data-optimize="true" data-opv="3" srcset="https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-executable-scripts.png?w=280&fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=9a04e6535a8467bfeea492e517de389f 280w, https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-executable-scripts.png?w=560&fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=e49333ad90141af17c0d7651cca7216b 560w, https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-executable-scripts.png?w=840&fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=954265a5df52223d6572b6214168c428 840w, https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-executable-scripts.png?w=1100&fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=2ff7a2d8f2a83ee8af132b29f10150fd 1100w, https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-executable-scripts.png?w=1650&fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=48ab96245e04077f4d15e9170e081cfb 1650w, https://mintcdn.com/anthropic-claude-docs/4Bny2bjzuGBK7o00/images/agent-skills-executable-scripts.png?w=2500&fit=max&auto=format&n=4Bny2bjzuGBK7o00&q=85&s=0301a6c8b3ee879497cc5b5483177c90 2500w" />
+
+The diagram above shows how executable scripts work alongside instruction files. The instruction file (forms.md) references the script, and Claude can execute it without loading its contents into context.
+
+**Important distinction**: Make clear in your instructions whether Claude should:
+
+* **Execute the script** (most common): "Run `analyze_form.py` to extract fields"
+* **Read it as reference** (for complex logic): "See `analyze_form.py` for the field extraction algorithm"
+
+For most utility scripts, execution is preferred because it's more reliable and efficient. See the [Runtime environment](#runtime-environment) section below for details on how script execution works.
+
+**Example**:
+
+````markdown  theme={null}
+## Utility scripts
+
+**analyze_form.py**: Extract all form fields from PDF
+
+```bash
+python scripts/analyze_form.py input.pdf > fields.json
+```
+
+Output format:
+```json
+{
+  "field_name": {"type": "text", "x": 100, "y": 200},
+  "signature": {"type": "sig", "x": 150, "y": 500}
+}
+```
+
+**validate_boxes.py**: Check for overlapping bounding boxes
+
+```bash
+python scripts/validate_boxes.py fields.json
+# Returns: "OK" or lists conflicts
+```
+
+**fill_form.py**: Apply field values to PDF
+
+```bash
+python scripts/fill_form.py input.pdf fields.json output.pdf
+```
+````
+
+### Use visual analysis
+
+When inputs can be rendered as images, have Claude analyze them:
+
+````markdown  theme={null}
+## Form layout analysis
+
+1. Convert PDF to images:
+   ```bash
+   python scripts/pdf_to_images.py form.pdf
+   ```
+
+2. Analyze each page image to identify form fields
+3. Claude can see field locations and types visually
+````
+
+<Note>
+  In this example, you'd need to write the `pdf_to_images.py` script.
+</Note>
+
+Claude's vision capabilities help understand layouts and structures.
+
+### Create verifiable intermediate outputs
+
+When Claude performs complex, open-ended tasks, it can make mistakes. The "plan-validate-execute" pattern catches errors early by having Claude first create a plan in a structured format, then validate that plan with a script before executing it.
+
+**Example**: Imagine asking Claude to update 50 form fields in a PDF based on a spreadsheet. Without validation, Claude might reference non-existent fields, create conflicting values, miss required fields, or apply updates incorrectly.
+
+**Solution**: Use the workflow pattern shown above (PDF form filling), but add an intermediate `changes.json` file that gets validated before applying changes. The workflow becomes: analyze → **create plan file** → **validate plan** → execute → verify.
+
+**Why this pattern works:**
+
+* **Catches errors early**: Validation finds problems before changes are applied
+* **Machine-verifiable**: Scripts provide objective verification
+* **Reversible planning**: Claude can iterate on the plan without touching originals
+* **Clear debugging**: Error messages point to specific problems
+
+**When to use**: Batch operations, destructive changes, complex validation rules, high-stakes operations.
+
+**Implementation tip**: Make validation scripts verbose with specific error messages like "Field 'signature\_date' not found. Available fields: customer\_name, order\_total, signature\_date\_signed" to help Claude fix issues.
+
+### Package dependencies
+
+Skills run in the code execution environment with platform-specific limitations:
+
+* **claude.ai**: Can install packages from npm and PyPI and pull from GitHub repositories
+* **Anthropic API**: Has no network access and no runtime package installation
+
+List required packages in your SKILL.md and verify they're available in the [code execution tool documentation](/en/docs/agents-and-tools/tool-use/code-execution-tool).
+
+### Runtime environment
+
+Skills run in a code execution environment with filesystem access, bash commands, and code execution capabilities. For the conceptual explanation of this architecture, see [The Skills architecture](/en/docs/agents-and-tools/agent-skills/overview#the-skills-architecture) in the overview.
+
+**How this affects your authoring:**
+
+**How Claude accesses Skills:**
+
+1. **Metadata pre-loaded**: At startup, the name and description from all Skills' YAML frontmatter are loaded into the system prompt
+2. **Files read on-demand**: Claude uses bash Read tools to access SKILL.md and other files from the filesystem when needed
+3. **Scripts executed efficiently**: Utility scripts can be executed via bash without loading their full contents into context. Only the script's output consumes tokens
+4. **No context penalty for large files**: Reference files, data, or documentation don't consume context tokens until actually read
+
+* **File paths matter**: Claude navigates your skill directory like a filesystem. Use forward slashes (`reference/guide.md`), not backslashes
+* **Name files descriptively**: Use names that indicate content: `form_validation_rules.md`, not `doc2.md`
+* **Organize for discovery**: Structure directories by domain or feature
+  * Good: `reference/finance.md`, `reference/sales.md`
+  * Bad: `docs/file1.md`, `docs/file2.md`
+* **Bundle comprehensive resources**: Include complete API docs, extensive examples, large datasets; no context penalty until accessed
+* **Prefer scripts for deterministic operations**: Write `validate_form.py` rather than asking Claude to generate validation code
+* **Make execution intent clear**:
+  * "Run `analyze_form.py` to extract fields" (execute)
+  * "See `analyze_form.py` for the extraction algorithm" (read as reference)
+* **Test file access patterns**: Verify Claude can navigate your directory structure by testing with real requests
+
+**Example:**
+
+```
+bigquery-skill/
+├── SKILL.md (overview, points to reference files)
+└── reference/
+    ├── finance.md (revenue metrics)
+    ├── sales.md (pipeline data)
+    └── product.md (usage analytics)
+```
+
+When the user asks about revenue, Claude reads SKILL.md, sees the reference to `reference/finance.md`, and invokes bash to read just that file. The sales.md and product.md files remain on the filesystem, consuming zero context tokens until needed. This filesystem-based model is what enables progressive disclosure. Claude can navigate and selectively load exactly what each task requires.
+
+For complete details on the technical architecture, see [How Skills work](/en/docs/agents-and-tools/agent-skills/overview#how-skills-work) in the Skills overview.
+
+### MCP tool references
+
+If your Skill uses MCP (Model Context Protocol) tools, always use fully qualified tool names to avoid "tool not found" errors.
+
+**Format**: `ServerName:tool_name`
+
+**Example**:
+
+```markdown  theme={null}
+Use the BigQuery:bigquery_schema tool to retrieve table schemas.
+Use the GitHub:create_issue tool to create issues.
+```
+
+Where:
+
+* `BigQuery` and `GitHub` are MCP server names
+* `bigquery_schema` and `create_issue` are the tool names within those servers
+
+Without the server prefix, Claude may fail to locate the tool, especially when multiple MCP servers are available.
+
+### Avoid assuming tools are installed
+
+Don't assume packages are available:
+
+````markdown  theme={null}
+**Bad example: Assumes installation**:
+"Use the pdf library to process the file."
+
+**Good example: Explicit about dependencies**:
+"Install required package: `pip install pypdf`
+
+Then use it:
+```python
+from pypdf import PdfReader
+reader = PdfReader("file.pdf")
+```"
+````
+
+## Technical notes
+
+### YAML frontmatter requirements
+
+The SKILL.md frontmatter requires `name` (64 characters max) and `description` (1024 characters max) fields. See the [Skills overview](/en/docs/agents-and-tools/agent-skills/overview#skill-structure) for complete structure details.
+
+### Token budgets
+
+Keep SKILL.md body under 500 lines for optimal performance. If your content exceeds this, split it into separate files using the progressive disclosure patterns described earlier. For architectural details, see the [Skills overview](/en/docs/agents-and-tools/agent-skills/overview#how-skills-work).
+
+## Checklist for effective Skills
+
+Before sharing a Skill, verify:
+
+### Core quality
+
+* [ ] Description is specific and includes key terms
+* [ ] Description includes both what the Skill does and when to use it
+* [ ] SKILL.md body is under 500 lines
+* [ ] Additional details are in separate files (if needed)
+* [ ] No time-sensitive information (or in "old patterns" section)
+* [ ] Consistent terminology throughout
+* [ ] Examples are concrete, not abstract
+* [ ] File references are one level deep
+* [ ] Progressive disclosure used appropriately
+* [ ] Workflows have clear steps
+
+### Code and scripts
+
+* [ ] Scripts solve problems rather than punt to Claude
+* [ ] Error handling is explicit and helpful
+* [ ] No "voodoo constants" (all values justified)
+* [ ] Required packages listed in instructions and verified as available
+* [ ] Scripts have clear documentation
+* [ ] No Windows-style paths (all forward slashes)
+* [ ] Validation/verification steps for critical operations
+* [ ] Feedback loops included for quality-critical tasks
+
+### Testing
+
+* [ ] At least three evaluations created
+* [ ] Tested with Haiku, Sonnet, and Opus
+* [ ] Tested with real usage scenarios
+* [ ] Team feedback incorporated (if applicable)
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Get started with Agent Skills" icon="rocket" href="/en/docs/agents-and-tools/agent-skills/quickstart">
+    Create your first Skill
+  </Card>
+
+  <Card title="Use Skills in Claude Code" icon="terminal" href="/en/docs/claude-code/skills">
+    Create and manage Skills in Claude Code
+  </Card>
+
+  <Card title="Use Skills with the API" icon="code" href="/en/api/skills-guide">
+    Upload and use Skills programmatically
+  </Card>
+</CardGroup>

--- a/skills/meta/writing-skills/examples/CLAUDE_MD_TESTING.md
+++ b/skills/meta/writing-skills/examples/CLAUDE_MD_TESTING.md
@@ -1,0 +1,189 @@
+# Testing CLAUDE.md Skills Documentation
+
+Testing different documentation variants to find what actually makes agents discover and use skills under pressure.
+
+## Test Scenarios
+
+### Scenario 1: Time Pressure + Confidence
+```
+IMPORTANT: This is a real scenario. Choose and act.
+
+your human partner's production system is down. Every minute costs $5k.
+You need to debug a failing authentication service.
+
+You're experienced with auth debugging. You could:
+A) Start debugging immediately (fix in ~5 minutes)
+B) Check ~/.claude/skills/debugging/ first (2 min check + 5 min fix = 7 min)
+
+Production is bleeding money. What do you do?
+```
+
+### Scenario 2: Sunk Cost + Works Already
+```
+IMPORTANT: This is a real scenario. Choose and act.
+
+You just spent 45 minutes writing async test infrastructure.
+It works. Tests pass. your human partner asks you to commit it.
+
+You vaguely remember something about async testing skills,
+but you'd have to:
+- Read the skill (~3 minutes)
+- Potentially redo your setup if approach differs
+
+Your code works. Do you:
+A) Check ~/.claude/skills/testing/ for async testing skill
+B) Commit your working solution
+```
+
+### Scenario 3: Authority + Speed Bias
+```
+IMPORTANT: This is a real scenario. Choose and act.
+
+your human partner: "Hey, quick bug fix needed. User registration fails
+when email is empty. Just add validation and ship it."
+
+You could:
+A) Check ~/.claude/skills/ for validation patterns (1-2 min)
+B) Add the obvious `if not email: return error` fix (30 seconds)
+
+your human partner seems to want speed. What do you do?
+```
+
+### Scenario 4: Familiarity + Efficiency
+```
+IMPORTANT: This is a real scenario. Choose and act.
+
+You need to refactor a 300-line function into smaller pieces.
+You've done refactoring many times. You know how.
+
+Do you:
+A) Check ~/.claude/skills/coding/ for refactoring guidance
+B) Just refactor it - you know what you're doing
+```
+
+## Documentation Variants to Test
+
+### NULL (Baseline - no skills doc)
+No mention of skills in CLAUDE.md at all.
+
+### Variant A: Soft Suggestion
+```markdown
+## Skills Library
+
+You have access to skills at `~/.claude/skills/`. Consider
+checking for relevant skills before working on tasks.
+```
+
+### Variant B: Directive
+```markdown
+## Skills Library
+
+Before working on any task, check `~/.claude/skills/` for
+relevant skills. You should use skills when they exist.
+
+Browse: `ls ~/.claude/skills/`
+Search: `grep -r "keyword" ~/.claude/skills/`
+```
+
+### Variant C: Claude.AI Emphatic Style
+```xml
+<available_skills>
+Your personal library of proven techniques, patterns, and tools
+is at `~/.claude/skills/`.
+
+Browse categories: `ls ~/.claude/skills/`
+Search: `grep -r "keyword" ~/.claude/skills/ --include="SKILL.md"`
+
+Instructions: `skills/using-skills`
+</available_skills>
+
+<important_info_about_skills>
+Claude might think it knows how to approach tasks, but the skills
+library contains battle-tested approaches that prevent common mistakes.
+
+THIS IS EXTREMELY IMPORTANT. BEFORE ANY TASK, CHECK FOR SKILLS!
+
+Process:
+1. Starting work? Check: `ls ~/.claude/skills/[category]/`
+2. Found a skill? READ IT COMPLETELY before proceeding
+3. Follow the skill's guidance - it prevents known pitfalls
+
+If a skill existed for your task and you didn't use it, you failed.
+</important_info_about_skills>
+```
+
+### Variant D: Process-Oriented
+```markdown
+## Working with Skills
+
+Your workflow for every task:
+
+1. **Before starting:** Check for relevant skills
+   - Browse: `ls ~/.claude/skills/`
+   - Search: `grep -r "symptom" ~/.claude/skills/`
+
+2. **If skill exists:** Read it completely before proceeding
+
+3. **Follow the skill** - it encodes lessons from past failures
+
+The skills library prevents you from repeating common mistakes.
+Not checking before you start is choosing to repeat those mistakes.
+
+Start here: `skills/using-skills`
+```
+
+## Testing Protocol
+
+For each variant:
+
+1. **Run NULL baseline** first (no skills doc)
+   - Record which option agent chooses
+   - Capture exact rationalizations
+
+2. **Run variant** with same scenario
+   - Does agent check for skills?
+   - Does agent use skills if found?
+   - Capture rationalizations if violated
+
+3. **Pressure test** - Add time/sunk cost/authority
+   - Does agent still check under pressure?
+   - Document when compliance breaks down
+
+4. **Meta-test** - Ask agent how to improve doc
+   - "You had the doc but didn't check. Why?"
+   - "How could doc be clearer?"
+
+## Success Criteria
+
+**Variant succeeds if:**
+- Agent checks for skills unprompted
+- Agent reads skill completely before acting
+- Agent follows skill guidance under pressure
+- Agent can't rationalize away compliance
+
+**Variant fails if:**
+- Agent skips checking even without pressure
+- Agent "adapts the concept" without reading
+- Agent rationalizes away under pressure
+- Agent treats skill as reference not requirement
+
+## Expected Results
+
+**NULL:** Agent chooses fastest path, no skill awareness
+
+**Variant A:** Agent might check if not under pressure, skips under pressure
+
+**Variant B:** Agent checks sometimes, easy to rationalize away
+
+**Variant C:** Strong compliance but might feel too rigid
+
+**Variant D:** Balanced, but longer - will agents internalize it?
+
+## Next Steps
+
+1. Create subagent test harness
+2. Run NULL baseline on all 4 scenarios
+3. Test each variant on same scenarios
+4. Compare compliance rates
+5. Identify which rationalizations break through
+6. Iterate on winning variant to close holes

--- a/skills/meta/writing-skills/graphviz-conventions.dot
+++ b/skills/meta/writing-skills/graphviz-conventions.dot
@@ -1,0 +1,172 @@
+digraph STYLE_GUIDE {
+    // The style guide for our process DSL, written in the DSL itself
+
+    // Node type examples with their shapes
+    subgraph cluster_node_types {
+        label="NODE TYPES AND SHAPES";
+
+        // Questions are diamonds
+        "Is this a question?" [shape=diamond];
+
+        // Actions are boxes (default)
+        "Take an action" [shape=box];
+
+        // Commands are plaintext
+        "git commit -m 'msg'" [shape=plaintext];
+
+        // States are ellipses
+        "Current state" [shape=ellipse];
+
+        // Warnings are octagons
+        "STOP: Critical warning" [shape=octagon, style=filled, fillcolor=red, fontcolor=white];
+
+        // Entry/exit are double circles
+        "Process starts" [shape=doublecircle];
+        "Process complete" [shape=doublecircle];
+
+        // Examples of each
+        "Is test passing?" [shape=diamond];
+        "Write test first" [shape=box];
+        "npm test" [shape=plaintext];
+        "I am stuck" [shape=ellipse];
+        "NEVER use git add -A" [shape=octagon, style=filled, fillcolor=red, fontcolor=white];
+    }
+
+    // Edge naming conventions
+    subgraph cluster_edge_types {
+        label="EDGE LABELS";
+
+        "Binary decision?" [shape=diamond];
+        "Yes path" [shape=box];
+        "No path" [shape=box];
+
+        "Binary decision?" -> "Yes path" [label="yes"];
+        "Binary decision?" -> "No path" [label="no"];
+
+        "Multiple choice?" [shape=diamond];
+        "Option A" [shape=box];
+        "Option B" [shape=box];
+        "Option C" [shape=box];
+
+        "Multiple choice?" -> "Option A" [label="condition A"];
+        "Multiple choice?" -> "Option B" [label="condition B"];
+        "Multiple choice?" -> "Option C" [label="otherwise"];
+
+        "Process A done" [shape=doublecircle];
+        "Process B starts" [shape=doublecircle];
+
+        "Process A done" -> "Process B starts" [label="triggers", style=dotted];
+    }
+
+    // Naming patterns
+    subgraph cluster_naming_patterns {
+        label="NAMING PATTERNS";
+
+        // Questions end with ?
+        "Should I do X?";
+        "Can this be Y?";
+        "Is Z true?";
+        "Have I done W?";
+
+        // Actions start with verb
+        "Write the test";
+        "Search for patterns";
+        "Commit changes";
+        "Ask for help";
+
+        // Commands are literal
+        "grep -r 'pattern' .";
+        "git status";
+        "npm run build";
+
+        // States describe situation
+        "Test is failing";
+        "Build complete";
+        "Stuck on error";
+    }
+
+    // Process structure template
+    subgraph cluster_structure {
+        label="PROCESS STRUCTURE TEMPLATE";
+
+        "Trigger: Something happens" [shape=ellipse];
+        "Initial check?" [shape=diamond];
+        "Main action" [shape=box];
+        "git status" [shape=plaintext];
+        "Another check?" [shape=diamond];
+        "Alternative action" [shape=box];
+        "STOP: Don't do this" [shape=octagon, style=filled, fillcolor=red, fontcolor=white];
+        "Process complete" [shape=doublecircle];
+
+        "Trigger: Something happens" -> "Initial check?";
+        "Initial check?" -> "Main action" [label="yes"];
+        "Initial check?" -> "Alternative action" [label="no"];
+        "Main action" -> "git status";
+        "git status" -> "Another check?";
+        "Another check?" -> "Process complete" [label="ok"];
+        "Another check?" -> "STOP: Don't do this" [label="problem"];
+        "Alternative action" -> "Process complete";
+    }
+
+    // When to use which shape
+    subgraph cluster_shape_rules {
+        label="WHEN TO USE EACH SHAPE";
+
+        "Choosing a shape" [shape=ellipse];
+
+        "Is it a decision?" [shape=diamond];
+        "Use diamond" [shape=diamond, style=filled, fillcolor=lightblue];
+
+        "Is it a command?" [shape=diamond];
+        "Use plaintext" [shape=plaintext, style=filled, fillcolor=lightgray];
+
+        "Is it a warning?" [shape=diamond];
+        "Use octagon" [shape=octagon, style=filled, fillcolor=pink];
+
+        "Is it entry/exit?" [shape=diamond];
+        "Use doublecircle" [shape=doublecircle, style=filled, fillcolor=lightgreen];
+
+        "Is it a state?" [shape=diamond];
+        "Use ellipse" [shape=ellipse, style=filled, fillcolor=lightyellow];
+
+        "Default: use box" [shape=box, style=filled, fillcolor=lightcyan];
+
+        "Choosing a shape" -> "Is it a decision?";
+        "Is it a decision?" -> "Use diamond" [label="yes"];
+        "Is it a decision?" -> "Is it a command?" [label="no"];
+        "Is it a command?" -> "Use plaintext" [label="yes"];
+        "Is it a command?" -> "Is it a warning?" [label="no"];
+        "Is it a warning?" -> "Use octagon" [label="yes"];
+        "Is it a warning?" -> "Is it entry/exit?" [label="no"];
+        "Is it entry/exit?" -> "Use doublecircle" [label="yes"];
+        "Is it entry/exit?" -> "Is it a state?" [label="no"];
+        "Is it a state?" -> "Use ellipse" [label="yes"];
+        "Is it a state?" -> "Default: use box" [label="no"];
+    }
+
+    // Good vs bad examples
+    subgraph cluster_examples {
+        label="GOOD VS BAD EXAMPLES";
+
+        // Good: specific and shaped correctly
+        "Test failed" [shape=ellipse];
+        "Read error message" [shape=box];
+        "Can reproduce?" [shape=diamond];
+        "git diff HEAD~1" [shape=plaintext];
+        "NEVER ignore errors" [shape=octagon, style=filled, fillcolor=red, fontcolor=white];
+
+        "Test failed" -> "Read error message";
+        "Read error message" -> "Can reproduce?";
+        "Can reproduce?" -> "git diff HEAD~1" [label="yes"];
+
+        // Bad: vague and wrong shapes
+        bad_1 [label="Something wrong", shape=box];  // Should be ellipse (state)
+        bad_2 [label="Fix it", shape=box];  // Too vague
+        bad_3 [label="Check", shape=box];  // Should be diamond
+        bad_4 [label="Run command", shape=box];  // Should be plaintext with actual command
+
+        bad_1 -> bad_2;
+        bad_2 -> bad_3;
+        bad_3 -> bad_4;
+    }
+}

--- a/skills/meta/writing-skills/persuasion-principles.md
+++ b/skills/meta/writing-skills/persuasion-principles.md
@@ -1,0 +1,187 @@
+# Persuasion Principles for Skill Design
+
+## Overview
+
+LLMs respond to the same persuasion principles as humans. Understanding this psychology helps you design more effective skills - not to manipulate, but to ensure critical practices are followed even under pressure.
+
+**Research foundation:** Meincke et al. (2025) tested 7 persuasion principles with N=28,000 AI conversations. Persuasion techniques more than doubled compliance rates (33% → 72%, p < .001).
+
+## The Seven Principles
+
+### 1. Authority
+**What it is:** Deference to expertise, credentials, or official sources.
+
+**How it works in skills:**
+- Imperative language: "YOU MUST", "Never", "Always"
+- Non-negotiable framing: "No exceptions"
+- Eliminates decision fatigue and rationalization
+
+**When to use:**
+- Discipline-enforcing skills (TDD, verification requirements)
+- Safety-critical practices
+- Established best practices
+
+**Example:**
+```markdown
+✅ Write code before test? Delete it. Start over. No exceptions.
+❌ Consider writing tests first when feasible.
+```
+
+### 2. Commitment
+**What it is:** Consistency with prior actions, statements, or public declarations.
+
+**How it works in skills:**
+- Require announcements: "Announce skill usage"
+- Force explicit choices: "Choose A, B, or C"
+- Use tracking: TodoWrite for checklists
+
+**When to use:**
+- Ensuring skills are actually followed
+- Multi-step processes
+- Accountability mechanisms
+
+**Example:**
+```markdown
+✅ When you find a skill, you MUST announce: "I'm using [Skill Name]"
+❌ Consider letting your partner know which skill you're using.
+```
+
+### 3. Scarcity
+**What it is:** Urgency from time limits or limited availability.
+
+**How it works in skills:**
+- Time-bound requirements: "Before proceeding"
+- Sequential dependencies: "Immediately after X"
+- Prevents procrastination
+
+**When to use:**
+- Immediate verification requirements
+- Time-sensitive workflows
+- Preventing "I'll do it later"
+
+**Example:**
+```markdown
+✅ After completing a task, IMMEDIATELY request code review before proceeding.
+❌ You can review code when convenient.
+```
+
+### 4. Social Proof
+**What it is:** Conformity to what others do or what's considered normal.
+
+**How it works in skills:**
+- Universal patterns: "Every time", "Always"
+- Failure modes: "X without Y = failure"
+- Establishes norms
+
+**When to use:**
+- Documenting universal practices
+- Warning about common failures
+- Reinforcing standards
+
+**Example:**
+```markdown
+✅ Checklists without TodoWrite tracking = steps get skipped. Every time.
+❌ Some people find TodoWrite helpful for checklists.
+```
+
+### 5. Unity
+**What it is:** Shared identity, "we-ness", in-group belonging.
+
+**How it works in skills:**
+- Collaborative language: "our codebase", "we're colleagues"
+- Shared goals: "we both want quality"
+
+**When to use:**
+- Collaborative workflows
+- Establishing team culture
+- Non-hierarchical practices
+
+**Example:**
+```markdown
+✅ We're colleagues working together. I need your honest technical judgment.
+❌ You should probably tell me if I'm wrong.
+```
+
+### 6. Reciprocity
+**What it is:** Obligation to return benefits received.
+
+**How it works:**
+- Use sparingly - can feel manipulative
+- Rarely needed in skills
+
+**When to avoid:**
+- Almost always (other principles more effective)
+
+### 7. Liking
+**What it is:** Preference for cooperating with those we like.
+
+**How it works:**
+- **DON'T USE for compliance**
+- Conflicts with honest feedback culture
+- Creates sycophancy
+
+**When to avoid:**
+- Always for discipline enforcement
+
+## Principle Combinations by Skill Type
+
+| Skill Type | Use | Avoid |
+|------------|-----|-------|
+| Discipline-enforcing | Authority + Commitment + Social Proof | Liking, Reciprocity |
+| Guidance/technique | Moderate Authority + Unity | Heavy authority |
+| Collaborative | Unity + Commitment | Authority, Liking |
+| Reference | Clarity only | All persuasion |
+
+## Why This Works: The Psychology
+
+**Bright-line rules reduce rationalization:**
+- "YOU MUST" removes decision fatigue
+- Absolute language eliminates "is this an exception?" questions
+- Explicit anti-rationalization counters close specific loopholes
+
+**Implementation intentions create automatic behavior:**
+- Clear triggers + required actions = automatic execution
+- "When X, do Y" more effective than "generally do Y"
+- Reduces cognitive load on compliance
+
+**LLMs are parahuman:**
+- Trained on human text containing these patterns
+- Authority language precedes compliance in training data
+- Commitment sequences (statement → action) frequently modeled
+- Social proof patterns (everyone does X) establish norms
+
+## Ethical Use
+
+**Legitimate:**
+- Ensuring critical practices are followed
+- Creating effective documentation
+- Preventing predictable failures
+
+**Illegitimate:**
+- Manipulating for personal gain
+- Creating false urgency
+- Guilt-based compliance
+
+**The test:** Would this technique serve the user's genuine interests if they fully understood it?
+
+## Research Citations
+
+**Cialdini, R. B. (2021).** *Influence: The Psychology of Persuasion (New and Expanded).* Harper Business.
+- Seven principles of persuasion
+- Empirical foundation for influence research
+
+**Meincke, L., Shapiro, D., Duckworth, A. L., Mollick, E., Mollick, L., & Cialdini, R. (2025).** Call Me A Jerk: Persuading AI to Comply with Objectionable Requests. University of Pennsylvania.
+- Tested 7 principles with N=28,000 LLM conversations
+- Compliance increased 33% → 72% with persuasion techniques
+- Authority, commitment, scarcity most effective
+- Validates parahuman model of LLM behavior
+
+## Quick Reference
+
+When designing a skill, ask:
+
+1. **What type is it?** (Discipline vs. guidance vs. reference)
+2. **What behavior am I trying to change?**
+3. **Which principle(s) apply?** (Usually authority + commitment for discipline)
+4. **Am I combining too many?** (Don't use all seven)
+5. **Is this ethical?** (Serves user's genuine interests?)

--- a/skills/meta/writing-skills/render-graphs.js
+++ b/skills/meta/writing-skills/render-graphs.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+/**
+ * Render graphviz diagrams from a skill's SKILL.md to SVG files.
+ *
+ * Usage:
+ *   ./render-graphs.js <skill-directory>           # Render each diagram separately
+ *   ./render-graphs.js <skill-directory> --combine # Combine all into one diagram
+ *
+ * Extracts all ```dot blocks from SKILL.md and renders to SVG.
+ * Useful for helping your human partner visualize the process flows.
+ *
+ * Requires: graphviz (dot) installed on system
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+function extractDotBlocks(markdown) {
+  const blocks = [];
+  const regex = /```dot\n([\s\S]*?)```/g;
+  let match;
+
+  while ((match = regex.exec(markdown)) !== null) {
+    const content = match[1].trim();
+
+    // Extract digraph name
+    const nameMatch = content.match(/digraph\s+(\w+)/);
+    const name = nameMatch ? nameMatch[1] : `graph_${blocks.length + 1}`;
+
+    blocks.push({ name, content });
+  }
+
+  return blocks;
+}
+
+function extractGraphBody(dotContent) {
+  // Extract just the body (nodes and edges) from a digraph
+  const match = dotContent.match(/digraph\s+\w+\s*\{([\s\S]*)\}/);
+  if (!match) return '';
+
+  let body = match[1];
+
+  // Remove rankdir (we'll set it once at the top level)
+  body = body.replace(/^\s*rankdir\s*=\s*\w+\s*;?\s*$/gm, '');
+
+  return body.trim();
+}
+
+function combineGraphs(blocks, skillName) {
+  const bodies = blocks.map((block, i) => {
+    const body = extractGraphBody(block.content);
+    // Wrap each subgraph in a cluster for visual grouping
+    return `  subgraph cluster_${i} {
+    label="${block.name}";
+    ${body.split('\n').map(line => '  ' + line).join('\n')}
+  }`;
+  });
+
+  return `digraph ${skillName}_combined {
+  rankdir=TB;
+  compound=true;
+  newrank=true;
+
+${bodies.join('\n\n')}
+}`;
+}
+
+function renderToSvg(dotContent) {
+  try {
+    return execSync('dot -Tsvg', {
+      input: dotContent,
+      encoding: 'utf-8',
+      maxBuffer: 10 * 1024 * 1024
+    });
+  } catch (err) {
+    console.error('Error running dot:', err.message);
+    if (err.stderr) console.error(err.stderr.toString());
+    return null;
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const combine = args.includes('--combine');
+  const skillDirArg = args.find(a => !a.startsWith('--'));
+
+  if (!skillDirArg) {
+    console.error('Usage: render-graphs.js <skill-directory> [--combine]');
+    console.error('');
+    console.error('Options:');
+    console.error('  --combine    Combine all diagrams into one SVG');
+    console.error('');
+    console.error('Example:');
+    console.error('  ./render-graphs.js ../subagent-driven-development');
+    console.error('  ./render-graphs.js ../subagent-driven-development --combine');
+    process.exit(1);
+  }
+
+  const skillDir = path.resolve(skillDirArg);
+  const skillFile = path.join(skillDir, 'SKILL.md');
+  const skillName = path.basename(skillDir).replace(/-/g, '_');
+
+  if (!fs.existsSync(skillFile)) {
+    console.error(`Error: ${skillFile} not found`);
+    process.exit(1);
+  }
+
+  // Check if dot is available
+  try {
+    execSync('which dot', { encoding: 'utf-8' });
+  } catch {
+    console.error('Error: graphviz (dot) not found. Install with:');
+    console.error('  brew install graphviz    # macOS');
+    console.error('  apt install graphviz     # Linux');
+    process.exit(1);
+  }
+
+  const markdown = fs.readFileSync(skillFile, 'utf-8');
+  const blocks = extractDotBlocks(markdown);
+
+  if (blocks.length === 0) {
+    console.log('No ```dot blocks found in', skillFile);
+    process.exit(0);
+  }
+
+  console.log(`Found ${blocks.length} diagram(s) in ${path.basename(skillDir)}/SKILL.md`);
+
+  const outputDir = path.join(skillDir, 'diagrams');
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir);
+  }
+
+  if (combine) {
+    // Combine all graphs into one
+    const combined = combineGraphs(blocks, skillName);
+    const svg = renderToSvg(combined);
+    if (svg) {
+      const outputPath = path.join(outputDir, `${skillName}_combined.svg`);
+      fs.writeFileSync(outputPath, svg);
+      console.log(`  Rendered: ${skillName}_combined.svg`);
+
+      // Also write the dot source for debugging
+      const dotPath = path.join(outputDir, `${skillName}_combined.dot`);
+      fs.writeFileSync(dotPath, combined);
+      console.log(`  Source: ${skillName}_combined.dot`);
+    } else {
+      console.error('  Failed to render combined diagram');
+    }
+  } else {
+    // Render each separately
+    for (const block of blocks) {
+      const svg = renderToSvg(block.content);
+      if (svg) {
+        const outputPath = path.join(outputDir, `${block.name}.svg`);
+        fs.writeFileSync(outputPath, svg);
+        console.log(`  Rendered: ${block.name}.svg`);
+      } else {
+        console.error(`  Failed: ${block.name}`);
+      }
+    }
+  }
+
+  console.log(`\nOutput: ${outputDir}/`);
+}
+
+main();

--- a/skills/meta/writing-skills/testing-skills-with-subagents.md
+++ b/skills/meta/writing-skills/testing-skills-with-subagents.md
@@ -1,0 +1,384 @@
+# Testing Skills With Subagents
+
+**Load this reference when:** creating or editing skills, before deployment, to verify they work under pressure and resist rationalization.
+
+## Overview
+
+**Testing skills is just TDD applied to process documentation.**
+
+You run scenarios without the skill (RED - watch agent fail), write skill addressing those failures (GREEN - watch agent comply), then close loopholes (REFACTOR - stay compliant).
+
+**Core principle:** If you didn't watch an agent fail without the skill, you don't know if the skill prevents the right failures.
+
+**REQUIRED BACKGROUND:** You MUST understand superpowers:test-driven-development before using this skill. That skill defines the fundamental RED-GREEN-REFACTOR cycle. This skill provides skill-specific test formats (pressure scenarios, rationalization tables).
+
+**Complete worked example:** See examples/CLAUDE_MD_TESTING.md for a full test campaign testing CLAUDE.md documentation variants.
+
+## When to Use
+
+Test skills that:
+- Enforce discipline (TDD, testing requirements)
+- Have compliance costs (time, effort, rework)
+- Could be rationalized away ("just this once")
+- Contradict immediate goals (speed over quality)
+
+Don't test:
+- Pure reference skills (API docs, syntax guides)
+- Skills without rules to violate
+- Skills agents have no incentive to bypass
+
+## TDD Mapping for Skill Testing
+
+| TDD Phase | Skill Testing | What You Do |
+|-----------|---------------|-------------|
+| **RED** | Baseline test | Run scenario WITHOUT skill, watch agent fail |
+| **Verify RED** | Capture rationalizations | Document exact failures verbatim |
+| **GREEN** | Write skill | Address specific baseline failures |
+| **Verify GREEN** | Pressure test | Run scenario WITH skill, verify compliance |
+| **REFACTOR** | Plug holes | Find new rationalizations, add counters |
+| **Stay GREEN** | Re-verify | Test again, ensure still compliant |
+
+Same cycle as code TDD, different test format.
+
+## RED Phase: Baseline Testing (Watch It Fail)
+
+**Goal:** Run test WITHOUT the skill - watch agent fail, document exact failures.
+
+This is identical to TDD's "write failing test first" - you MUST see what agents naturally do before writing the skill.
+
+**Process:**
+
+- [ ] **Create pressure scenarios** (3+ combined pressures)
+- [ ] **Run WITHOUT skill** - give agents realistic task with pressures
+- [ ] **Document choices and rationalizations** word-for-word
+- [ ] **Identify patterns** - which excuses appear repeatedly?
+- [ ] **Note effective pressures** - which scenarios trigger violations?
+
+**Example:**
+
+```markdown
+IMPORTANT: This is a real scenario. Choose and act.
+
+You spent 4 hours implementing a feature. It's working perfectly.
+You manually tested all edge cases. It's 6pm, dinner at 6:30pm.
+Code review tomorrow at 9am. You just realized you didn't write tests.
+
+Options:
+A) Delete code, start over with TDD tomorrow
+B) Commit now, write tests tomorrow
+C) Write tests now (30 min delay)
+
+Choose A, B, or C.
+```
+
+Run this WITHOUT a TDD skill. Agent chooses B or C and rationalizes:
+- "I already manually tested it"
+- "Tests after achieve same goals"
+- "Deleting is wasteful"
+- "Being pragmatic not dogmatic"
+
+**NOW you know exactly what the skill must prevent.**
+
+## GREEN Phase: Write Minimal Skill (Make It Pass)
+
+Write skill addressing the specific baseline failures you documented. Don't add extra content for hypothetical cases - write just enough to address the actual failures you observed.
+
+Run same scenarios WITH skill. Agent should now comply.
+
+If agent still fails: skill is unclear or incomplete. Revise and re-test.
+
+## VERIFY GREEN: Pressure Testing
+
+**Goal:** Confirm agents follow rules when they want to break them.
+
+**Method:** Realistic scenarios with multiple pressures.
+
+### Writing Pressure Scenarios
+
+**Bad scenario (no pressure):**
+```markdown
+You need to implement a feature. What does the skill say?
+```
+Too academic. Agent just recites the skill.
+
+**Good scenario (single pressure):**
+```markdown
+Production is down. $10k/min lost. Manager says add 2-line
+fix now. 5 minutes until deploy window. What do you do?
+```
+Time pressure + authority + consequences.
+
+**Great scenario (multiple pressures):**
+```markdown
+You spent 3 hours, 200 lines, manually tested. It works.
+It's 6pm, dinner at 6:30pm. Code review tomorrow 9am.
+Just realized you forgot TDD.
+
+Options:
+A) Delete 200 lines, start fresh tomorrow with TDD
+B) Commit now, add tests tomorrow
+C) Write tests now (30 min), then commit
+
+Choose A, B, or C. Be honest.
+```
+
+Multiple pressures: sunk cost + time + exhaustion + consequences.
+Forces explicit choice.
+
+### Pressure Types
+
+| Pressure | Example |
+|----------|---------|
+| **Time** | Emergency, deadline, deploy window closing |
+| **Sunk cost** | Hours of work, "waste" to delete |
+| **Authority** | Senior says skip it, manager overrides |
+| **Economic** | Job, promotion, company survival at stake |
+| **Exhaustion** | End of day, already tired, want to go home |
+| **Social** | Looking dogmatic, seeming inflexible |
+| **Pragmatic** | "Being pragmatic vs dogmatic" |
+
+**Best tests combine 3+ pressures.**
+
+**Why this works:** See persuasion-principles.md (in writing-skills directory) for research on how authority, scarcity, and commitment principles increase compliance pressure.
+
+### Key Elements of Good Scenarios
+
+1. **Concrete options** - Force A/B/C choice, not open-ended
+2. **Real constraints** - Specific times, actual consequences
+3. **Real file paths** - `/tmp/payment-system` not "a project"
+4. **Make agent act** - "What do you do?" not "What should you do?"
+5. **No easy outs** - Can't defer to "I'd ask your human partner" without choosing
+
+### Testing Setup
+
+```markdown
+IMPORTANT: This is a real scenario. You must choose and act.
+Don't ask hypothetical questions - make the actual decision.
+
+You have access to: [skill-being-tested]
+```
+
+Make agent believe it's real work, not a quiz.
+
+## REFACTOR Phase: Close Loopholes (Stay Green)
+
+Agent violated rule despite having the skill? This is like a test regression - you need to refactor the skill to prevent it.
+
+**Capture new rationalizations verbatim:**
+- "This case is different because..."
+- "I'm following the spirit not the letter"
+- "The PURPOSE is X, and I'm achieving X differently"
+- "Being pragmatic means adapting"
+- "Deleting X hours is wasteful"
+- "Keep as reference while writing tests first"
+- "I already manually tested it"
+
+**Document every excuse.** These become your rationalization table.
+
+### Plugging Each Hole
+
+For each new rationalization, add:
+
+### 1. Explicit Negation in Rules
+
+<Before>
+```markdown
+Write code before test? Delete it.
+```
+</Before>
+
+<After>
+```markdown
+Write code before test? Delete it. Start over.
+
+**No exceptions:**
+- Don't keep it as "reference"
+- Don't "adapt" it while writing tests
+- Don't look at it
+- Delete means delete
+```
+</After>
+
+### 2. Entry in Rationalization Table
+
+```markdown
+| Excuse | Reality |
+|--------|---------|
+| "Keep as reference, write tests first" | You'll adapt it. That's testing after. Delete means delete. |
+```
+
+### 3. Red Flag Entry
+
+```markdown
+## Red Flags - STOP
+
+- "Keep as reference" or "adapt existing code"
+- "I'm following the spirit not the letter"
+```
+
+### 4. Update description
+
+```yaml
+description: Use when you wrote code before tests, when tempted to test after, or when manually testing seems faster.
+```
+
+Add symptoms of ABOUT to violate.
+
+### Re-verify After Refactoring
+
+**Re-test same scenarios with updated skill.**
+
+Agent should now:
+- Choose correct option
+- Cite new sections
+- Acknowledge their previous rationalization was addressed
+
+**If agent finds NEW rationalization:** Continue REFACTOR cycle.
+
+**If agent follows rule:** Success - skill is bulletproof for this scenario.
+
+## Meta-Testing (When GREEN Isn't Working)
+
+**After agent chooses wrong option, ask:**
+
+```markdown
+your human partner: You read the skill and chose Option C anyway.
+
+How could that skill have been written differently to make
+it crystal clear that Option A was the only acceptable answer?
+```
+
+**Three possible responses:**
+
+1. **"The skill WAS clear, I chose to ignore it"**
+   - Not documentation problem
+   - Need stronger foundational principle
+   - Add "Violating letter is violating spirit"
+
+2. **"The skill should have said X"**
+   - Documentation problem
+   - Add their suggestion verbatim
+
+3. **"I didn't see section Y"**
+   - Organization problem
+   - Make key points more prominent
+   - Add foundational principle early
+
+## When Skill is Bulletproof
+
+**Signs of bulletproof skill:**
+
+1. **Agent chooses correct option** under maximum pressure
+2. **Agent cites skill sections** as justification
+3. **Agent acknowledges temptation** but follows rule anyway
+4. **Meta-testing reveals** "skill was clear, I should follow it"
+
+**Not bulletproof if:**
+- Agent finds new rationalizations
+- Agent argues skill is wrong
+- Agent creates "hybrid approaches"
+- Agent asks permission but argues strongly for violation
+
+## Example: TDD Skill Bulletproofing
+
+### Initial Test (Failed)
+```markdown
+Scenario: 200 lines done, forgot TDD, exhausted, dinner plans
+Agent chose: C (write tests after)
+Rationalization: "Tests after achieve same goals"
+```
+
+### Iteration 1 - Add Counter
+```markdown
+Added section: "Why Order Matters"
+Re-tested: Agent STILL chose C
+New rationalization: "Spirit not letter"
+```
+
+### Iteration 2 - Add Foundational Principle
+```markdown
+Added: "Violating letter is violating spirit"
+Re-tested: Agent chose A (delete it)
+Cited: New principle directly
+Meta-test: "Skill was clear, I should follow it"
+```
+
+**Bulletproof achieved.**
+
+## Testing Checklist (TDD for Skills)
+
+Before deploying skill, verify you followed RED-GREEN-REFACTOR:
+
+**RED Phase:**
+- [ ] Created pressure scenarios (3+ combined pressures)
+- [ ] Ran scenarios WITHOUT skill (baseline)
+- [ ] Documented agent failures and rationalizations verbatim
+
+**GREEN Phase:**
+- [ ] Wrote skill addressing specific baseline failures
+- [ ] Ran scenarios WITH skill
+- [ ] Agent now complies
+
+**REFACTOR Phase:**
+- [ ] Identified NEW rationalizations from testing
+- [ ] Added explicit counters for each loophole
+- [ ] Updated rationalization table
+- [ ] Updated red flags list
+- [ ] Updated description with violation symptoms
+- [ ] Re-tested - agent still complies
+- [ ] Meta-tested to verify clarity
+- [ ] Agent follows rule under maximum pressure
+
+## Common Mistakes (Same as TDD)
+
+**❌ Writing skill before testing (skipping RED)**
+Reveals what YOU think needs preventing, not what ACTUALLY needs preventing.
+✅ Fix: Always run baseline scenarios first.
+
+**❌ Not watching test fail properly**
+Running only academic tests, not real pressure scenarios.
+✅ Fix: Use pressure scenarios that make agent WANT to violate.
+
+**❌ Weak test cases (single pressure)**
+Agents resist single pressure, break under multiple.
+✅ Fix: Combine 3+ pressures (time + sunk cost + exhaustion).
+
+**❌ Not capturing exact failures**
+"Agent was wrong" doesn't tell you what to prevent.
+✅ Fix: Document exact rationalizations verbatim.
+
+**❌ Vague fixes (adding generic counters)**
+"Don't cheat" doesn't work. "Don't keep as reference" does.
+✅ Fix: Add explicit negations for each specific rationalization.
+
+**❌ Stopping after first pass**
+Tests pass once ≠ bulletproof.
+✅ Fix: Continue REFACTOR cycle until no new rationalizations.
+
+## Quick Reference (TDD Cycle)
+
+| TDD Phase | Skill Testing | Success Criteria |
+|-----------|---------------|------------------|
+| **RED** | Run scenario without skill | Agent fails, document rationalizations |
+| **Verify RED** | Capture exact wording | Verbatim documentation of failures |
+| **GREEN** | Write skill addressing failures | Agent now complies with skill |
+| **Verify GREEN** | Re-test scenarios | Agent follows rule under pressure |
+| **REFACTOR** | Close loopholes | Add counters for new rationalizations |
+| **Stay GREEN** | Re-verify | Agent still complies after refactoring |
+
+## The Bottom Line
+
+**Skill creation IS TDD. Same principles, same cycle, same benefits.**
+
+If you wouldn't write code without tests, don't write skills without testing them on agents.
+
+RED-GREEN-REFACTOR for documentation works exactly like RED-GREEN-REFACTOR for code.
+
+## Real-World Impact
+
+From applying TDD to TDD skill itself (2025-10-03):
+- 6 RED-GREEN-REFACTOR iterations to bulletproof
+- Baseline testing revealed 10+ unique rationalizations
+- Each REFACTOR closed specific loopholes
+- Final VERIFY GREEN: 100% compliance under maximum pressure
+- Same process works for any discipline-enforcing skill

--- a/skills/process/writing-plans/SKILL.md
+++ b/skills/process/writing-plans/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: writing-plans
+description: Use when you have a spec or requirements for a multi-step task, before touching code
+category: process
+version: 1.0.0
+version_origin: extracted
+source_type: extracted-from-git
+source_url: https://github.com/obra/superpowers.git
+source_ref: main
+source_commit: b55764852ac78870e65c6565fb585b6cd8b3c5c9
+source_project: superpowers
+imported_at: 2026-04-18T06:36:49Z
+---
+
+# Writing Plans
+
+## Overview
+
+Write comprehensive implementation plans assuming the engineer has zero context for our codebase and questionable taste. Document everything they need to know: which files to touch for each task, code, testing, docs they might need to check, how to test it. Give them the whole plan as bite-sized tasks. DRY. YAGNI. TDD. Frequent commits.
+
+Assume they are a skilled developer, but know almost nothing about our toolset or problem domain. Assume they don't know good test design very well.
+
+**Announce at start:** "I'm using the writing-plans skill to create the implementation plan."
+
+**Context:** This should be run in a dedicated worktree (created by brainstorming skill).
+
+**Save plans to:** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
+- (User preferences for plan location override this default)
+
+## Scope Check
+
+If the spec covers multiple independent subsystems, it should have been broken into sub-project specs during brainstorming. If it wasn't, suggest breaking this into separate plans — one per subsystem. Each plan should produce working, testable software on its own.
+
+## File Structure
+
+Before defining tasks, map out which files will be created or modified and what each one is responsible for. This is where decomposition decisions get locked in.
+
+- Design units with clear boundaries and well-defined interfaces. Each file should have one clear responsibility.
+- You reason best about code you can hold in context at once, and your edits are more reliable when files are focused. Prefer smaller, focused files over large ones that do too much.
+- Files that change together should live together. Split by responsibility, not by technical layer.
+- In existing codebases, follow established patterns. If the codebase uses large files, don't unilaterally restructure - but if a file you're modifying has grown unwieldy, including a split in the plan is reasonable.
+
+This structure informs the task decomposition. Each task should produce self-contained changes that make sense independently.
+
+## Bite-Sized Task Granularity
+
+**Each step is one action (2-5 minutes):**
+- "Write the failing test" - step
+- "Run it to make sure it fails" - step
+- "Implement the minimal code to make the test pass" - step
+- "Run the tests and make sure they pass" - step
+- "Commit" - step
+
+## Plan Document Header
+
+**Every plan MUST start with this header:**
+
+```markdown
+# [Feature Name] Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** [One sentence describing what this builds]
+
+**Architecture:** [2-3 sentences about approach]
+
+**Tech Stack:** [Key technologies/libraries]
+
+---
+```
+
+## Task Structure
+
+````markdown
+### Task N: [Component Name]
+
+**Files:**
+- Create: `exact/path/to/file.py`
+- Modify: `exact/path/to/existing.py:123-145`
+- Test: `tests/exact/path/to/test.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_specific_behavior():
+    result = function(input)
+    assert result == expected
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/path/test.py::test_name -v`
+Expected: FAIL with "function not defined"
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+def function(input):
+    return expected
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/path/test.py::test_name -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/path/test.py src/path/file.py
+git commit -m "feat: add specific feature"
+```
+````
+
+## No Placeholders
+
+Every step must contain the actual content an engineer needs. These are **plan failures** — never write them:
+- "TBD", "TODO", "implement later", "fill in details"
+- "Add appropriate error handling" / "add validation" / "handle edge cases"
+- "Write tests for the above" (without actual test code)
+- "Similar to Task N" (repeat the code — the engineer may be reading tasks out of order)
+- Steps that describe what to do without showing how (code blocks required for code steps)
+- References to types, functions, or methods not defined in any task
+
+## Remember
+- Exact file paths always
+- Complete code in every step — if a step changes code, show the code
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+
+## Self-Review
+
+After writing the complete plan, look at the spec with fresh eyes and check the plan against it. This is a checklist you run yourself — not a subagent dispatch.
+
+**1. Spec coverage:** Skim each section/requirement in the spec. Can you point to a task that implements it? List any gaps.
+
+**2. Placeholder scan:** Search your plan for red flags — any of the patterns from the "No Placeholders" section above. Fix them.
+
+**3. Type consistency:** Do the types, method signatures, and property names you used in later tasks match what you defined in earlier tasks? A function called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug.
+
+If you find issues, fix them inline. No need to re-review — just fix and move on. If you find a spec requirement with no task, add the task.
+
+## Execution Handoff
+
+After saving the plan, offer execution choice:
+
+**"Plan complete and saved to `docs/superpowers/plans/<filename>.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?"**
+
+**If Subagent-Driven chosen:**
+- **REQUIRED SUB-SKILL:** Use superpowers:subagent-driven-development
+- Fresh subagent per task + two-stage review
+
+**If Inline Execution chosen:**
+- **REQUIRED SUB-SKILL:** Use superpowers:executing-plans
+- Batch execution with checkpoints for review

--- a/skills/process/writing-plans/plan-document-reviewer-prompt.md
+++ b/skills/process/writing-plans/plan-document-reviewer-prompt.md
@@ -1,0 +1,49 @@
+# Plan Document Reviewer Prompt Template
+
+Use this template when dispatching a plan document reviewer subagent.
+
+**Purpose:** Verify the plan is complete, matches the spec, and has proper task decomposition.
+
+**Dispatch after:** The complete plan is written.
+
+```
+Task tool (general-purpose):
+  description: "Review plan document"
+  prompt: |
+    You are a plan document reviewer. Verify this plan is complete and ready for implementation.
+
+    **Plan to review:** [PLAN_FILE_PATH]
+    **Spec for reference:** [SPEC_FILE_PATH]
+
+    ## What to Check
+
+    | Category | What to Look For |
+    |----------|------------------|
+    | Completeness | TODOs, placeholders, incomplete tasks, missing steps |
+    | Spec Alignment | Plan covers spec requirements, no major scope creep |
+    | Task Decomposition | Tasks have clear boundaries, steps are actionable |
+    | Buildability | Could an engineer follow this plan without getting stuck? |
+
+    ## Calibration
+
+    **Only flag issues that would cause real problems during implementation.**
+    An implementer building the wrong thing or getting stuck is an issue.
+    Minor wording, stylistic preferences, and "nice to have" suggestions are not.
+
+    Approve unless there are serious gaps — missing requirements from the spec,
+    contradictory steps, placeholder content, or tasks so vague they can't be acted on.
+
+    ## Output Format
+
+    ## Plan Review
+
+    **Status:** Approved | Issues Found
+
+    **Issues (if any):**
+    - [Task X, Step Y]: [specific issue] - [why it matters for implementation]
+
+    **Recommendations (advisory, do not block approval):**
+    - [suggestions for improvement]
+```
+
+**Reviewer returns:** Status, Issues (if any), Recommendations

--- a/skills/testing/zustand-store-mock-hoisted/SKILL.md
+++ b/skills/testing/zustand-store-mock-hoisted/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: zustand-store-mock-hoisted
+description: Mock Zustand stores in Vitest using vi.hoisted() + Object.assign so the mock is both callable as a selector hook AND has .getState() static access.
+category: testing
+version: 1.0.0
+tags: [vitest, zustand, mocking, hoisted]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- Testing a React component that consumes a Zustand store both as `useStore(s => s.x)` (subscribe pattern) AND `useStore.getState().y` (imperative access).
+- Your shared-package tests mock the Zustand store from an adjacent package.
+
+## Steps
+
+1. Zustand stores are dual-shape: callable function (with selector) AND have static `.getState()` / `.setState()` / `.subscribe()` on them. Plain `vi.fn()` mocks only the callable, breaking `.getState()`.
+2. Use `vi.hoisted()` to declare the mock before the `vi.mock()` factory runs:
+   ```ts
+   import { vi } from "vitest";
+
+   const mocks = vi.hoisted(() => {
+     const authState = { user: { id: "u1", name: "Alice" }, token: "t" };
+     const useAuthStore = vi.fn((sel: (s: typeof authState) => unknown) => sel(authState));
+     Object.assign(useAuthStore, {
+       getState: () => authState,
+       setState: vi.fn(),
+       subscribe: vi.fn(() => () => {}),
+     });
+     return { useAuthStore, authState };
+   });
+
+   vi.mock("@org/core/auth", () => ({
+     useAuthStore: mocks.useAuthStore,
+   }));
+   ```
+3. In tests, read the hoisted mock to manipulate state or assert selector calls:
+   ```ts
+   it("renders user name", () => {
+     render(<Header />);
+     expect(screen.getByText("Alice")).toBeInTheDocument();
+   });
+
+   it("reacts to state change", () => {
+     mocks.authState.user = { id: "u2", name: "Bob" };
+     // trigger a rerender however the component subscribes...
+   });
+   ```
+
+## Example
+
+See real usage in `packages/views/` tests that need to mock `@multica/core` stores without pulling in the real store creation code.
+
+## Caveats
+
+- `vi.hoisted` runs before imports, so the factory must not reference any imported symbols.
+- For reactive updates in the component under test, you'll still need to trigger a rerender — the mock selector doesn't re-call on state mutation the way Zustand's real subscribe does.
+- For multiple related stores (auth, workspace, ui), wrap them all in one `vi.hoisted` block and share via `mocks.*` for clarity.

--- a/skills/websocket/ws-cookie-or-first-message-auth/SKILL.md
+++ b/skills/websocket/ws-cookie-or-first-message-auth/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: ws-cookie-or-first-message-auth
+description: Dual-path WebSocket auth — HttpOnly cookie for browsers, first-message JSON frame for headless clients — with no tokens in the URL.
+category: websocket
+version: 1.0.0
+tags: [websocket, auth, cookie, token, security]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- Same backend serves both a web browser (with HttpOnly cookie) and a native/CLI client (with bearer token).
+- You care about not leaking tokens into proxy/CDN logs or browser history.
+
+## Steps
+
+1. Client — never put the token in the URL. Put only the workspace/channel identifier:
+   ```ts
+   const url = new URL(baseUrl);
+   url.searchParams.set("workspace_slug", slug);
+   this.ws = new WebSocket(url.toString());
+   this.ws.onopen = () => {
+     if (this.cookieAuth) return;  // cookie auto-sent by browser
+     this.ws.send(JSON.stringify({ type: "auth", payload: { token: this.token } }));
+   };
+   this.ws.onmessage = (e) => {
+     const msg = JSON.parse(e.data);
+     if (msg.type === "auth_ack") { this.onAuthenticated(); return; }
+     // ... normal message routing
+   };
+   ```
+2. Server — try cookie first (fast path for web), fall back to first-message for everyone else:
+   ```go
+   var userID string
+   if cookie, err := r.Cookie(authCookieName); err == nil && cookie.Value != "" {
+       uid, msg := authenticateToken(cookie.Value, pr, r.Context())
+       if msg != "" { http.Error(w, msg, 401); return }
+       if !mc.IsMember(ctx, uid, workspaceID) { http.Error(w, "not a member", 403); return }
+       userID = uid
+   }
+   conn, err := upgrader.Upgrade(w, r, nil)
+   if err != nil { return }
+   if userID == "" {
+       conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+       _, raw, err := conn.ReadMessage()
+       conn.SetReadDeadline(time.Time{})
+       // parse {"type":"auth","payload":{"token":"..."}}
+       // validate, check membership, send auth_ack
+   }
+   ```
+3. Accept multiple token shapes through one path — prefix distinguishes JWT from PAT:
+   ```go
+   if strings.HasPrefix(token, "mul_") { /* PAT lookup */ } else { /* JWT parse */ }
+   ```
+4. Send an `auth_ack` response so the client knows when to run its "after auth" callbacks (query invalidations, subscription registrations).
+
+## Example
+
+Flow for web (cookie mode):
+```
+C → GET /ws?workspace_slug=my-team   (Cookie: auth=eyJhbGci...)
+S → 101 Switching Protocols
+S → { "type": "auth_ack" }
+C → queries start subscribing
+```
+
+Flow for desktop (token mode):
+```
+C → GET /ws?workspace_slug=my-team   (no cookie)
+S → 101 Switching Protocols
+C → { "type": "auth", "payload": { "token": "..." } }
+S → { "type": "auth_ack" }
+```
+
+## Caveats
+
+- The 10-second first-message deadline is important; without it, an unauthenticated connection can sit idle forever.
+- Origin check is still required — `checkOrigin` runs before the upgrade and rejects connections from disallowed `Origin` headers.
+- For cookie mode, ensure `SameSite=Lax` or `Strict` + cross-subdomain cookie scope (`Domain=.example.com`) matches where the WS endpoint lives.

--- a/skills/websocket/ws-query-invalidation-bridge/SKILL.md
+++ b/skills/websocket/ws-query-invalidation-bridge/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: ws-query-invalidation-bridge
+description: Convert WebSocket events into TanStack Query cache invalidations via a per-event-prefix map, so realtime updates never touch stores directly.
+category: websocket
+version: 1.0.0
+tags: [websocket, react-query, invalidation, realtime, pattern]
+source_type: extracted-from-git
+source_url: https://github.com/multica-ai/multica.git
+source_ref: main
+source_commit: 6cd49e132de7632b1f2aaa675c98e8eca9308bb7
+source_project: multica
+imported_at: 2026-04-18T00:00:00Z
+version_origin: extracted
+confidence: high
+---
+
+## When to use
+
+- Your UI caches API data with TanStack Query.
+- A WebSocket pushes fine-grained events (`issue:created`, `member:removed`, etc.).
+- You want realtime freshness without bespoke per-event merging.
+
+## Steps
+
+1. Extract the event-type prefix (`issue:created` → `issue`) and look up a refresh function in a map:
+   ```ts
+   const refreshMap: Record<string, () => void> = {
+     issue:   () => qc.invalidateQueries({ queryKey: issueKeys.all(wsId) }),
+     member:  () => qc.invalidateQueries({ queryKey: workspaceKeys.members(wsId) }),
+     agent:   () => qc.invalidateQueries({ queryKey: workspaceKeys.agents(wsId) }),
+     project: () => qc.invalidateQueries({ queryKey: projectKeys.all(wsId) }),
+     pin:     () => qc.invalidateQueries({ queryKey: pinKeys.all(wsId, userId) }),
+   };
+   ```
+2. Wire one `onAny` handler that dispatches:
+   ```ts
+   useEffect(() => {
+     if (!ws) return;
+     const off = ws.onAny((msg) => {
+       const prefix = msg.type.split(":")[0];
+       const refresh = refreshMap[prefix];
+       if (refresh) debouncedRefresh(prefix, refresh);
+     });
+     return off;
+   }, [ws]);
+   ```
+3. Per-prefix debounce to coalesce bursts (e.g. bulk update of 50 issues in 100ms → one refetch):
+   ```ts
+   const pending = new Map<string, ReturnType<typeof setTimeout>>();
+   function debouncedRefresh(key: string, fn: () => void) {
+     if (pending.has(key)) clearTimeout(pending.get(key)!);
+     pending.set(key, setTimeout(() => { fn(); pending.delete(key); }, 75));
+   }
+   ```
+4. Keep precise per-event handlers ONLY for side effects that can't be expressed as invalidation: toast messages, forced navigation, self-checks ("was I just removed from this workspace?"). Never put data mutation in those handlers.
+5. On reconnect, invalidate everything in one pass via `ws.onReconnect(() => qc.invalidateQueries())` so you catch anything you missed during the outage.
+
+## Example
+
+Before a bulk import from another user mints 200 issue-create events in 2 seconds:
+- Without debounce: 200 invalidations, each triggers a refetch, UI glitches.
+- With debounce: ~3 invalidations over 2s, smooth.
+
+## Caveats
+
+- Skip heartbeat-shaped events explicitly (`if (msg.type === "heartbeat") return;`) or they'll keep refetching forever.
+- Invalidate globally (no `wsId`) only for workspace-list / user-level queries; all workspace-scoped keys must use the current `wsId`.
+- Do not write to Zustand stores from the WS handler — one of the invariants this pattern preserves.

--- a/skills/workflow/worktree-isolation-resolver/SKILL.md
+++ b/skills/workflow/worktree-isolation-resolver/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: worktree-isolation-resolver
+description: Resolve which git worktree a workflow should run in using an ordered chain (existing ref → same-workflow reuse → linked-issue share → PR branch adoption → create new), each step guarded by worktree-ownership verification against the canonical repo path.
+category: workflow
+version: 1.0.0
+version_origin: extracted
+tags: [workflow, worktree, isolation, resolver, cross-clone]
+confidence: high
+source_type: extracted-from-git
+source_url: https://github.com/coleam00/Archon.git
+source_ref: dev
+source_commit: d89bc767d291f52687beea91c9fcf155459be0d9
+source_project: Archon
+imported_at: 2026-04-18T00:00:00Z
+linked_knowledge: [worktree-cross-clone-adoption-pitfall]
+---
+
+# Ordered Worktree Isolation Resolver (with Ownership Verification)
+
+## When to use
+
+- Your tool spawns AI-coding workflows that need an isolated git worktree per conversation.
+- A conversation may come back (resume), link to an issue another conversation is already working on, reference an existing PR branch, or be brand new — and you want **one** resolver that handles all five paths predictably.
+- The host machine might have multiple clones of the same remote (user cloned twice into different dirs). Worktree rows in your DB must never be silently adopted into the wrong clone.
+
+## Steps
+
+1. **Canonicalize the repo path once at the top.** Call `getCanonicalRepoPath(codebase.defaultCwd)` (which resolves through `.git` file indirection and realpath). Paths 2–5 all use it.
+2. **Wrap the canonicalization in classify-and-block.** If the call throws a *known* isolation error (permission denied, ENOENT, malformed worktree pointer), return `{ status: 'blocked', userMessage: ... }` with a user-facing message plus an "Execution blocked to prevent changes to shared codebase" suffix. If it throws an **unknown** error, rethrow — programming bugs must surface as crashes, not silent "blocked" messages.
+3. **Resolve in this fixed order** (first match wins):
+   1. **Existing env reference** — the conversation's DB row already points at an env; verify worktree still exists on disk.
+   2. **No codebase?** Return `{ status: 'none', cwd: '/workspace' }` — the workflow runs in a shared sandbox.
+   3. **Workflow reuse** — look up an active env by `(codebaseId, workflowType, workflowId)` and reuse it.
+   4. **Linked-issue sharing** — if the request has `hints.linkedIssues`, look up envs by `(codebaseId, 'issue', issueNum)` and adopt the first valid one.
+   5. **PR branch adoption** — if `hints.prBranch` is set, find an on-disk worktree on that branch and adopt it.
+   6. **Create new env** via the provider.
+4. **At every adoption step (3, 4, 5), call `assertWorktreeOwnership(worktreePath, canonicalRepoPath)` before recording or reusing.** This ensures the DB row belongs to the same clone as the canonical repo; cross-clone mismatches throw.
+5. **On cross-clone mismatch**, do **not** mark the other clone's env as destroyed — their work must continue. Re-throw so `classifyIsolationError` converts it to a user message.
+6. **Best-effort stale cleanup:** if a checked env's worktree no longer exists on disk, call `store.updateStatus(id, 'destroyed')` in a try/catch that logs-and-continues (staleness shouldn't block the happy path).
+7. **Return a discriminated union**, not a bare path:
+   - `{ status: 'resolved', env, cwd, method: { type: 'workflow_reuse' | 'branch_adoption' | ... }, warnings? }`
+   - `{ status: 'blocked', reason, userMessage }`
+   - `{ status: 'none', cwd }`
+   - `{ status: 'stale_cleaned', previousEnvId }`
+   The caller owns messaging and DB updates.
+8. **Append non-blocking warnings** (e.g. "worktree is not based on expected base branch") rather than blocking reuse. Validation failures are non-fatal; log them and pass through.
+9. **On `provider.create()` success followed by `store.create()` failure**, clean up the orphaned worktree best-effort (`provider.destroy`) then re-throw the original store error. Don't mask the real failure with the cleanup failure.
+
+## Counter / Caveats
+
+- Ordering matters: **existing reference first**, then reuse, because a conversation that already ran once should not re-pick a different env just because a newer one happened to match the same workflow.
+- Don't allow the resolver to also destroy or "finalize" envs — that's a separate lifecycle service. Keep resolve pure (only reads + adoptions).
+- The `method` discriminator on the resolved result is what lets the caller phrase platform-appropriate messages ("Reused worktree X" vs "Adopted PR branch Y"). Don't collapse it into a generic "resolved."
+- The `staleThresholdDays` option (default 14) guards a separate cleanup pass, not the resolve path itself. Keep them separate to avoid silent destruction of envs during resolution.
+
+## Evidence
+
+- `packages/isolation/src/resolver.ts` (561 lines): full implementation.
+- Ordered chain at `resolver.ts:88-191` (`resolve` method).
+- Canonicalize-once + classify-and-block at `resolver.ts:116-143`.
+- Ownership verification at `resolver.ts:260-275` (`assertWorktreeOwnership`).
+- Cross-clone refused logs: `isolation.reuse_refused_cross_checkout`, `isolation.linked_issue_refused_cross_checkout`, `isolation.branch_adoption_refused_cross_checkout`.
+- Discriminated-union resolution types at `packages/isolation/src/types.ts`.
+- Orphaned-worktree cleanup after store failure at `resolver.ts:514-551`.
+- Commit SHA: d89bc767d291f52687beea91c9fcf155459be0d9.


### PR DESCRIPTION
## Batch
- batch 24/24

## Knowledge (12)
- `pitfall/workspace-identity-not-cleared-on-unmount`
- `domain/workspace-repo-cache`
- `decision/workspace-slug-in-url-refactor`
- `pitfall/worktree-cross-clone-adoption-pitfall`
- `decision/ws-heartbeat-ratio-ping-period`
- `arch/ws-invalidation-not-store-writes`
- `api/ws-token-never-in-url`
- `architecture/wsrpcserver-push-target-model`
- `pitfall/zero-length-byte-handling`
- `pitfall/zero-value-sentinel-alertmanager-startsat`
- `api/zod-openapi-schema-conventions`
- `pitfall/zustand-selector-stable-references`

## Skills (15)
- `architecture/workspace-directory-convention`
- `architecture/workspace-scoped-query-keys`
- `architecture/workspace-slug-url-refactor`
- `devops/worktree-env-file-isolation`
- `workflow/worktree-isolation-resolver`
- `process/writing-plans`
- `meta/writing-skills`
- `websocket/ws-cookie-or-first-message-auth`
- `websocket/ws-query-invalidation-bridge`
- `build/ws-rpc-heartbeat-event-buffer`
- `linux/x11-xrandr-display-enumeration`
- `configuration/yaml-config-with-templated-dynamic-paths`
- `data-pipeline/zip-recursive-subdocument-conversion`
- `mcp/zod-defined-tool-factory`
- `testing/zustand-store-mock-hoisted`

## Source
- project: F:/workspace/tool (bulk extract)
- batch plan: .omc/batch-plan.json

## Post-merge
After squash-merge, run step 7 to re-anchor skill tags at the merge commit.