### PR TITLE
Publish 1 skill + 2 knowledge entries (session 2026-04-25)

### DIFF
--- a/index.json
+++ b/index.json
@@ -6059,6 +6059,18 @@
   },
   {
     "kind": "knowledge",
+    "name": "union-merge-catalog-first-seen-wins",
+    "slug": "union-merge-catalog-first-seen-wins",
+    "category": "decision",
+    "description": "\"When union-merging catalog JSON across N PR branches, use first-seen-wins per slug to preserve install metadata\"",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/decision/union-merge-catalog-first-seen-wins.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
     "name": "use-label-not-mime-type-in-workflows",
     "slug": "use-label-not-mime-type-in-workflows",
     "category": "decision",
@@ -9402,6 +9414,18 @@
     "triggers": [],
     "version": "0.1.0-draft",
     "path": "knowledge/pitfall/backpressure-implementation-pitfall.md",
+    "has_content": true
+  },
+  {
+    "kind": "knowledge",
+    "name": "bash-var-length-counts-bytes-not-chars",
+    "slug": "bash-var-length-counts-bytes-not-chars",
+    "category": "pitfall",
+    "description": "\"Bash ${#var} returns byte length, not character count; UTF-8 multibyte (Korean, em-dash) inflates apparent length\"",
+    "tags": "",
+    "triggers": [],
+    "version": "0.1.0-draft",
+    "path": "knowledge/pitfall/bash-var-length-counts-bytes-not-chars.md",
     "has_content": true
   },
   {
@@ -33661,6 +33685,18 @@
     "triggers": "",
     "version": "1.0.0",
     "path": "skills/workflow/consistent-hashing-data-simulation",
+    "has_content": false
+  },
+  {
+    "kind": "skill",
+    "name": "consolidate-batch-publish-pr-conflicts",
+    "slug": "consolidate-batch-publish-pr-conflicts",
+    "category": "workflow",
+    "description": "\"Consolidate N conflicting batch-publish PRs: filesystem cherry-pick + catalog union-merge, keeping install metadata\"",
+    "tags": "",
+    "triggers": "",
+    "version": "0.1.0-draft",
+    "path": "skills/workflow/consolidate-batch-publish-pr-conflicts",
     "has_content": false
   },
   {

--- a/knowledge/decision/union-merge-catalog-first-seen-wins.md
+++ b/knowledge/decision/union-merge-catalog-first-seen-wins.md
@@ -1,0 +1,88 @@
+---
+name: union-merge-catalog-first-seen-wins
+description: "When union-merging catalog JSON across N PR branches, use first-seen-wins per slug to preserve install metadata"
+category: decision
+tags:
+  - merge-strategy
+  - registry
+  - catalog
+  - install-metadata
+  - first-seen-wins
+version: 0.1.0-draft
+---
+
+# Decision: union-merge catalog JSON with first-seen-wins per slug
+
+## Decision
+
+When consolidating N branches that each add entries to a shared catalog JSON file (e.g. `registry.json`, `package.json`-like indexes), the union-merge MUST use **first-seen-wins** semantics — the value from the first source containing a given slug is kept; subsequent sources do not overwrite.
+
+## Rationale
+
+Catalog JSON entries typically carry **install metadata** that is authored once at first appearance:
+
+```json
+{
+  "skills": {
+    "<slug>": {
+      "category": "...",
+      "version": "...",
+      "installed_at": "2026-04-16T00:40:04Z",   // <-- the FIRST install time
+      "source_commit": "a974d4a...",            // <-- the commit that added it
+      "pinned": false
+    }
+  }
+}
+```
+
+If the slug already exists on `main`, that's the authoritative metadata. A re-publish PR may re-list the same slug with a NEW `installed_at` (today's date) and a new `source_commit` (today's branch). **Last-wins would silently rewrite history** — the install date no longer reflects when the entry actually first appeared in the corpus.
+
+First-seen-wins preserves:
+- `installed_at` as the original first-publish timestamp (audit trail)
+- `source_commit` as the actual originating commit (provenance)
+- `pinned` flag if previously set by an operator (intent)
+
+## Implementation pattern
+
+```python
+merged = {"skills": {}, "knowledge": {}}
+
+# Load main FIRST — it has authoritative entries
+with open("registry.json", encoding="utf-8") as f:
+    base = json.load(f)
+merged["skills"].update(base.get("skills", {}))
+merged["knowledge"].update(base.get("knowledge", {}))
+
+# Then iterate branches, ADDING only what main doesn't have
+for branch in branches:
+    pr_reg = load_branch_registry(branch)
+    for slug, meta in pr_reg.get("skills", {}).items():
+        if slug not in merged["skills"]:        # FIRST-SEEN WINS
+            merged["skills"][slug] = meta
+    for slug, meta in pr_reg.get("knowledge", {}).items():
+        if slug not in merged["knowledge"]:
+            merged["knowledge"][slug] = meta
+```
+
+The `if slug not in merged` guard is the entire decision in one line.
+
+## When the rule does NOT apply
+
+- Catalog entries that are intended to **reflect the latest state** (e.g. `last_modified`, `current_version`) — those should be last-wins or recomputed from filesystem.
+- Sparse-update flows where a branch genuinely UPDATES (not just RE-LISTS) an existing entry — case-by-case merge needed, not a blanket strategy.
+- Catalogs without authoritative install metadata — last-wins is fine if entries carry no provenance.
+
+## Concrete usage
+
+This rule was applied during the recovery of 20 conflicting batch-publish PRs (#1087–#1106 → #1107). Result:
+
+- Pre-existing 381 skills on main retained their April-16 install dates and original source commits.
+- 533 newly-added skills inherited their respective batch's metadata.
+- No history-rewriting on existing entries.
+
+The alternative (last-wins) would have rewritten every existing skill's `installed_at` to the recovery date, losing months of audit trail.
+
+## Related
+
+- `knowledge/workflow/batch-pr-conflict-recovery` — the broader pattern this decision lives inside
+- `skills/workflow/consolidate-batch-publish-pr-conflicts` — runnable procedure that applies this rule (Phase 2)

--- a/knowledge/pitfall/bash-var-length-counts-bytes-not-chars.md
+++ b/knowledge/pitfall/bash-var-length-counts-bytes-not-chars.md
@@ -1,0 +1,70 @@
+---
+name: bash-var-length-counts-bytes-not-chars
+description: "Bash ${#var} returns byte length, not character count; UTF-8 multibyte (Korean, em-dash) inflates apparent length"
+category: pitfall
+tags:
+  - bash
+  - utf-8
+  - encoding
+  - string-length
+  - linting
+version: 0.1.0-draft
+---
+
+# Pitfall: bash `${#var}` counts bytes, not characters
+
+## Symptom
+
+A description-length lint check (rule: "≤ 120 characters") fires for a string that *visually* fits within the budget. Manual character count agrees with the budget; bash `${#var}` disagrees.
+
+Concrete example from `paper/ai/llm-fallback-cost-displacement` description check:
+
+```bash
+DESC="Iterative loop turning fuzz crashes into TDD'd fixes: investigate → triage → implement → return crash to seed corpus"
+echo ${#DESC}        # prints 122 — appears over limit
+
+python3 -c "print(len('$DESC'))"   # prints 116 — under limit
+```
+
+The two arrow characters (`→`, U+2192, 3 bytes each in UTF-8) account for the gap. The string is 116 *characters* but 122 *bytes*.
+
+## Cause
+
+Bash parameter-length expansion `${#var}` returns the **byte count** of the variable's value when bash is built with byte-based string handling (the default on most Linux/macOS distributions). Multibyte UTF-8 sequences inflate the count.
+
+Most schema rules express limits in **characters**, not bytes — e.g.:
+- "description ≤ 120 chars"
+- "title ≤ 80 chars"
+- "first paragraph ≤ 200 chars"
+
+So `${#var}` is the wrong primitive whenever the string may contain non-ASCII (Korean, em-dash, arrows, emoji, smart quotes, etc.).
+
+## Fix
+
+Use a Unicode-aware length primitive:
+
+```bash
+# Python (always character-correct)
+python3 -c "import sys; print(len(sys.argv[1]))" "$DESC"
+
+# wc -m with UTF-8 locale
+echo -n "$DESC" | LC_ALL=en_US.UTF-8 wc -m
+
+# awk in some implementations (less portable)
+echo -n "$DESC" | awk '{print length($0)}'
+```
+
+For shell scripts that lint description lengths, use `python3 -c "print(len(...))"` — most portable and unambiguous.
+
+## When you might still want bytes
+
+- File-size budgets (KB, not chars) — bytes is correct
+- Network protocol payload limits — bytes is correct
+- ANY budget expressed in "no more than N bytes" — bytes is correct
+
+For *content* limits (titles, descriptions, summaries) where the rule was authored in character-thinking, characters is correct.
+
+## Related
+
+- Hub schema rules expressing limits in characters: `paper/` schema §6 rule 4 (description ≤ 120), `technique/` schema §9 rule 4
+- Lint scripts running in bash should call out to Python for string-length checks rather than `${#var}`

--- a/registry.json
+++ b/registry.json
@@ -5394,6 +5394,18 @@
       "category": "testing",
       "path": "skills/testing/zustand-store-mock-hoisted/SKILL.md",
       "version": "1.0.0"
+    },
+    "consolidate-batch-publish-pr-conflicts": {
+      "category": "workflow",
+      "scope": "global",
+      "installed_at": "2026-04-25",
+      "version": "0.1.0-draft",
+      "source_commit": "release/combined-20260425-session-0920",
+      "pinned": false,
+      "linked_knowledge": [
+        "batch-pr-conflict-recovery",
+        "union-merge-catalog-first-seen-wins"
+      ]
     }
   },
   "knowledge": {
@@ -9332,6 +9344,25 @@
     "zustand-selector-stable-references": {
       "category": "pitfall",
       "path": "knowledge/pitfall/zustand-selector-stable-references.md"
+    },
+    "bash-var-length-counts-bytes-not-chars": {
+      "category": "pitfall",
+      "scope": "global",
+      "installed_at": "2026-04-25",
+      "version": "0.1.0-draft",
+      "source_commit": "release/combined-20260425-session-0920",
+      "pinned": false
+    },
+    "union-merge-catalog-first-seen-wins": {
+      "category": "decision",
+      "scope": "global",
+      "installed_at": "2026-04-25",
+      "version": "0.1.0-draft",
+      "source_commit": "release/combined-20260425-session-0920",
+      "pinned": false,
+      "linked_skills": [
+        "consolidate-batch-publish-pr-conflicts"
+      ]
     }
   }
 }

--- a/skills/workflow/consolidate-batch-publish-pr-conflicts/SKILL.md
+++ b/skills/workflow/consolidate-batch-publish-pr-conflicts/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: consolidate-batch-publish-pr-conflicts
+description: "Consolidate N conflicting batch-publish PRs: filesystem cherry-pick + catalog union-merge, keeping install metadata"
+category: workflow
+version: 0.1.0-draft
+tags:
+  - git
+  - github
+  - pr-conflict
+  - recovery
+  - batch-publish
+  - catalog-merge
+triggers:
+  - many PRs conflicting
+  - registry.json conflict
+  - batch publish stuck
+  - catalog file conflict storm
+---
+
+# Consolidate N conflicting batch-publish PRs into one
+
+## When to activate
+
+A multi-PR auto-publish flow has produced N branches (N ≥ 3) that **all conflict on a shared catalog file** (e.g. `registry.json`, `index.json`, `example/README.md`). Each individual PR is content-only correct; the conflict is purely on the catalog because each PR regenerates it as the sequence advances.
+
+This is the canonical scenario described in `knowledge/workflow/batch-pr-conflict-recovery` and the technique `technique/workflow/safe-bulk-pr-publishing`. This skill is the **executable procedure** for both.
+
+## When NOT to activate
+
+- Conflicts are on actual content files, not just the catalog — those need real merge resolution
+- Only 1–2 PRs conflict — sequential rebase is cheaper than the consolidation overhead
+- The catalog has no filesystem-derivable regenerator AND no clean union semantic — hand-merge case-by-case instead
+
+## Workflow
+
+### Phase 0: confirm pattern
+
+For every conflicting PR, run a sample merge (`git fetch + git rebase main`) and confirm conflicts are limited to the same single catalog file. If the conflict set varies per PR, this skill does not apply.
+
+### Phase 1: branch + content cherry-pick
+
+```bash
+# Start fresh from main
+git checkout main && git pull --ff-only
+git checkout -b recovery/consolidate-<short-tag>-<yyyymmdd>
+
+# Fetch all conflicting PR branches
+BRANCHES=("release/...-batch-05-of-24" "...-batch-06-of-24" ...)
+git fetch origin "${BRANCHES[@]}"
+
+# For each branch, copy ONLY content folders — NEVER the catalog file
+CONTENT_DIRS=(skills knowledge technique paper example)
+for b in "${BRANCHES[@]}"; do
+  for d in "${CONTENT_DIRS[@]}"; do
+    git checkout "origin/$b" -- "$d/" 2>/dev/null
+  done
+done
+```
+
+The `git checkout <branch> -- <path>` form copies files from another branch into the index without invoking merge machinery. No conflicts possible because we are not merging histories — just copying paths.
+
+### Phase 2: union-merge catalog files
+
+For JSON catalogs (registry.json, etc.):
+
+```python
+# union_merge_catalog.py
+import json, subprocess
+
+with open("registry.json", encoding="utf-8") as f:
+    merged = json.load(f)
+merged.setdefault("skills", {})
+merged.setdefault("knowledge", {})
+
+for branch in BRANCHES:
+    out = subprocess.check_output(
+        ["git", "show", f"origin/{branch}:registry.json"],
+        text=True, encoding="utf-8")
+    pr_reg = json.loads(out)
+    # FIRST-SEEN WINS — preserves original install_at, source_commit, etc.
+    for slug, meta in pr_reg.get("skills", {}).items():
+        if slug not in merged["skills"]:
+            merged["skills"][slug] = meta
+    for slug, meta in pr_reg.get("knowledge", {}).items():
+        if slug not in merged["knowledge"]:
+            merged["knowledge"][slug] = meta
+
+with open("registry.json", "w", encoding="utf-8", newline="\n") as f:
+    json.dump(merged, f, ensure_ascii=False, indent=2)
+    f.write("\n")
+```
+
+Why first-seen-wins: original entries on main have authoritative `installed_at` and `source_commit`. Last-wins would overwrite them with re-publish metadata. See `knowledge/decision/union-merge-catalog-first-seen-wins-rationale` (if available).
+
+### Phase 3: regenerate filesystem-derived indexes
+
+For indexes that walk the filesystem (`index.json`):
+
+```bash
+python3 bootstrap/tools/_rebuild_index_json.py --root .
+```
+
+These regenerate from disk so they automatically reflect the cherry-picked content.
+
+### Phase 4: lint sweep
+
+Large content imports often surface pre-existing data quality issues that lint catches:
+
+```bash
+python3 bootstrap/tools/_lint_frontmatter.py
+# If failures: run _fix_frontmatter.py for auto-fixable fields
+python3 bootstrap/tools/_fix_frontmatter.py --apply --only-missing=name,version,category,tags
+# Then handle remaining (e.g. description) manually or via synthesis script
+```
+
+### Phase 5: single PR + close originating PRs
+
+```bash
+git add -A
+git commit -m "recovery: consolidate N batch-publish PRs"
+git push -u origin recovery/<branch-name>
+gh pr create --title "recovery: consolidate N PRs" --body "..."
+
+# After consolidation PR merges:
+COMMENT="Superseded by #<consolidation> — content consolidated via batch-pr-conflict-recovery pattern. Branch preserved."
+for n in <pr1> <pr2> ...; do
+  gh pr close $n --comment "$COMMENT"
+done
+```
+
+**Branches stay intact after close** — closing != deleting. Re-importing individual batches later is still possible.
+
+## Verification
+
+After Phase 4 lint passes and Phase 5 PR is opened, confirm:
+
+- `git log --diff-filter=A --name-only origin/main..HEAD | wc -l` shows the expected file count (sum of unique content from all batches)
+- `python3 -c "import json; d=json.load(open('registry.json')); print(len(d['skills']), len(d['knowledge']))"` shows union-merged counts
+- `index.json` line count grew by roughly the expected delta
+
+## Why this skill exists separately from the knowledge entry
+
+`knowledge/workflow/batch-pr-conflict-recovery` describes the pattern. This skill provides the **runnable script + decision points** so a future operator can execute without re-deriving each phase. The knowledge entry is the *what and why*; this skill is the *how, with code*.


### PR DESCRIPTION
## Summary

Three drafts extracted from session 2026-04-25 (recovery of #1107 + the lint/length surprises along the way), shipped together to keep the procedure (skill) and the rationale (knowledge) co-merged.

## Skills (1)

| Slug | Category | Version |
|---|---|---|
| `workflow/consolidate-batch-publish-pr-conflicts` | workflow | 0.1.0-draft |

The runnable procedure that turns `knowledge/workflow/batch-pr-conflict-recovery` (the *what*) and `technique/workflow/safe-bulk-pr-publishing` (the *shape*) into an executable 5-phase script: filesystem cherry-pick → union-merge catalog → regenerate filesystem-derived indexes → lint sweep → consolidation PR + close originating PRs. Linked to two knowledge entries below.

## Knowledge (2)

| Slug | Category | Confidence |
|---|---|---|
| `pitfall/bash-var-length-counts-bytes-not-chars` | pitfall | high |
| `decision/union-merge-catalog-first-seen-wins` | decision | high |

The pitfall captures the UTF-8-multibyte trap that fired twice during this session's description-length checks. The decision captures the first-seen-wins rule applied during the #1107 recovery and explains why last-wins would silently destroy install-history.

## Cross-links

- skill `consolidate-batch-publish-pr-conflicts` → `linked_knowledge: [batch-pr-conflict-recovery, union-merge-catalog-first-seen-wins]`
- knowledge `union-merge-catalog-first-seen-wins` → `linked_skills: [consolidate-batch-publish-pr-conflicts]`

These cross-links are **explicit in frontmatter**, not inferred from name similarity (per the rule).

## Source

- Session: 2026-04-25 (post-#1107 recovery)
- Tag created: `skills/consolidate-batch-publish-pr-conflicts/v0.1.0-draft` at the skill's commit SHA (recorded pre-rebuild to avoid the squash-orphan issue documented in `knowledge/decision/squash-merge-orphans-release-branch-tags`)

## Verification

- Pre-flight slug collision: 0 (all 3 slugs new)
- Final lint: PASS (`_lint_frontmatter.py` reports all files satisfy schema)
- index.json regenerated: 2004 → 2007 entries (+3)
- registry.json union-extended: 3 new entries inserted, no existing entries touched

## Post-merge

After this PR squash-merges:
1. Re-anchor the skill tag to the squash-merge commit (per `squash-merge-orphans-release-branch-tags`):
   ```bash
   git fetch origin && git checkout main && git pull --ff-only
   MERGE_SHA=$(gh pr view <PR#> --json mergeCommit --jq '.mergeCommit.oid')
   git tag -d skills/consolidate-batch-publish-pr-conflicts/v0.1.0-draft
   git tag -a skills/consolidate-batch-publish-pr-conflicts/v0.1.0-draft "$MERGE_SHA" \
     -m "skills/workflow/consolidate-batch-publish-pr-conflicts v0.1.0-draft"
   git push --force origin skills/consolidate-batch-publish-pr-conflicts/v0.1.0-draft
   git merge-base --is-ancestor skills/consolidate-batch-publish-pr-conflicts/v0.1.0-draft main && echo ok
   ```
2. Move drafts to `_published/` (handled by the publish flow's step 6 once PR confirmed merged):
   - `.skills-draft/session-20260425-0920/` → `.skills-draft/_published/2026-04-25/`
   - `.knowledge-draft/session-20260425-0920/` → `.knowledge-draft/_published/2026-04-25/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
