### PR TITLE
feat(hub): 4-layer discovery + loop-closing flows (citations.json, paper-from-technique, experiment-run)

### DIFF
--- a/bootstrap/commands/hub-paper-experiment-run.md
+++ b/bootstrap/commands/hub-paper-experiment-run.md
@@ -1,0 +1,150 @@
+---
+description: Guided flow to close a planned paper experiment — record result, set supports_premise, suggest outcomes, transition status to implemented (or retracted).
+argument-hint: <paper-slug> [<experiment-name>] [--retract]
+---
+
+# /hub-paper-experiment-run $ARGUMENTS
+
+The paper layer's whole point is closing the loop: a `type: hypothesis` paper transitions `draft → implemented` only when at least one `experiments[]` entry completes with a non-null `result` and `supports_premise`. Writing the paper is easy; running the experiment and updating the frontmatter consistently is where most papers stall.
+
+This command is the guided flow for that step. It walks you from "I have a result" to a verified, lint-passing PAPER.md update — including premise rewriting if the experiment partially refutes the original claim, and `outcomes[]` suggestion if the experiment produced new corpus entries.
+
+## Resolution
+
+- `<paper-slug>` — locate first match in `./.paper-draft/**/<slug>/PAPER.md`, then `~/.claude/skills-hub/remote/paper/**/<slug>/PAPER.md`.
+- `<experiment-name>` (optional) — `experiments[].name` to close. If omitted, list `status: planned` / `status: running` experiments and ask the user to pick one.
+- `--retract` — fast path: skip experiment-result collection, jump directly to retraction (asks `retraction_reason`).
+
+## Steps
+
+1. **Open + parse the PAPER.md frontmatter.**
+   - Validate `type: hypothesis` (other types don't need an experiment to reach `implemented`; warn and ask whether to proceed anyway).
+   - Find the target experiment. Refuse if `status: completed` or `status: abandoned` already (use `--force` to overwrite).
+
+2. **Collect result fields** (interactive, one prompt each):
+
+   | Field | Prompt |
+   |---|---|
+   | `result` | "What did the experiment observe? Multi-line OK; cite numbers, deltas, conditions." (required) |
+   | `supports_premise` | "Does the result support the paper's `premise.then`? `yes` / `no` / `partial`" (required) |
+   | `observed_at` | "When was it observed? ISO date (YYYY-MM-DD). Default = today." |
+   | `built_as` | "Was a build shipped under `example/`? Path like `example/<slug>` or `null`." (optional) |
+
+   Validate `built_as` resolves on disk if given (must point to `example/<slug>/`).
+
+3. **Branch on `supports_premise`:**
+
+   ### `yes`
+   - Show the existing `premise.then` with no edit prompt.
+   - Skip premise rewrite step.
+   - Suggest `status: implemented` transition.
+
+   ### `partial`
+   - Show the existing `premise.then`.
+   - Ask: "What refined claim does the result support? Rewrite `premise.then` to capture it." Multi-line input.
+   - Show side-by-side diff of old vs new `premise.then`. Confirm before applying.
+   - Suggest `status: implemented` transition with the rewritten premise.
+
+   ### `no`
+   - Refusal path. Two options:
+     1. Rewrite `premise.then` to capture what the result *did* show (often "the original claim was wrong because…"), then suggest `status: implemented`.
+     2. Move to `status: retracted` — ask `retraction_reason` (single line) and skip premise rewrite.
+   - User picks. If retracting, jump to step 6.
+
+4. **Suggest `outcomes[]`** (optional, applies to `yes` and `partial`):
+   - Ask: "Did this experiment produce a new corpus entry? Pick one or skip."
+     - `produced_skill <ref>`
+     - `produced_knowledge <ref>`
+     - `produced_technique <ref>`
+     - `produced_pitfall <ref>` (knowledge of kind=pitfall)
+     - `produced_example <ref>`
+     - `updated_skill / updated_knowledge / updated_technique <ref>`
+     - skip
+   - For each picked, validate the ref resolves on disk. Append to `outcomes[]`.
+   - Loop until user types `done`.
+
+5. **Compute new `status`** (advisory, user confirms):
+   - From `draft` / `reviewed` + `supports_premise: yes | partial` → suggest `implemented`.
+   - From `supports_premise: no` + retract path → `retracted`.
+   - From `supports_premise: no` + premise-rewrite path → suggest `implemented` (the rewritten claim is now what's implemented).
+   - Show: `status: <old> → <new>`. Confirm.
+
+6. **Write changes.**
+   - Update the experiment entry in-place: `status`, `result`, `supports_premise`, `observed_at`, `built_as` if any.
+   - Append to `outcomes[]` if any were chosen.
+   - Update top-level `status` and (if `retracted`) `retraction_reason`.
+   - If premise was rewritten: update `premise.then` and append a note to the body's `## Provenance` section: `Premise rewritten <date> after experiment <name> result.`
+   - Diff is shown before write; user confirms once.
+
+7. **Verify.**
+   - Run `/hub-paper-verify <slug>`.
+   - On FAIL: print errors and offer to revert the just-written change, edit the file, or accept the FAIL state.
+   - On PASS: print location and next-step hint:
+     ```
+     EXPERIMENT CLOSED: paper/<category>/<slug>/PAPER.md
+     status: <new>
+     experiment: <name> → completed
+     supports_premise: <yes|partial|no>
+     <if outcomes:> outcomes added: <list>
+
+     Next: review the body, then commit + open PR via /hub-publish --only paper --pr
+     ```
+
+## Rules
+
+- Never overwrite a `completed` experiment without `--force`. The history of a closed loop matters; rewriting silently is a footgun.
+- Never auto-rewrite `premise.then` — always show diff and require explicit confirm. Premise drift without acknowledgment is the failure mode this layer exists to prevent.
+- Refuse on `type: survey` or `type: position` — those don't need experiments. Print: "this paper has type=`<type>`; experiments are not required for `status: implemented`. Use a manual edit if you want to record observations anyway."
+- `--retract` skips steps 2-5 entirely. Step 6 writes only `status: retracted` + `retraction_reason`.
+- Authoring and verification stay separate passes (step 7 is a separate verify call). Do not collapse — the user should see the diff before lint runs.
+
+## Example
+
+```
+/hub-paper-experiment-run parallel-dispatch-breakeven-point coordinator-curve
+
+▶ paper/workflow/parallel-dispatch-breakeven-point (type=hypothesis, status=draft)
+▶ experiment: coordinator-curve (status=planned)
+
+result?
+> Wall-clock improved 38% N=4, plateaued N=6, regressed 12% N=8 vs N=1 baseline.
+  Coverage threshold matters less than task-class — annotate-files broke at N=8,
+  semantic-search held to N=12.
+
+supports_premise? (yes / no / partial)
+> partial
+
+observed_at? [default: 2026-04-25]
+> 
+
+built_as? (path under example/ or null)
+> example/coordinator-overhead-benchmark
+
+[partial] rewrite premise.then?
+old: Coordinator overhead grows with N while parallelism gain saturates past N=4. …
+new: > Coordinator overhead grows with N while parallelism gain saturates past N=4 for
+       I/O-heavy tasks. The break-even N varies by task class (annotate-files inverts at
+       N=8, semantic-search at N≥12), so a single threshold is misleading.
+
+diff:
+- Coordinator overhead grows with N while parallelism gain saturates past N=4.…
++ Coordinator overhead grows with N while parallelism gain saturates past N=4 for I/O-heavy tasks.
++ The break-even N varies by task class.…
+apply? (y/n) > y
+
+outcomes? (e.g. produced_knowledge workflow/parallel-dispatch-task-class-thresholds)
+> produced_knowledge workflow/parallel-dispatch-task-class-thresholds
+> done
+
+status: draft → implemented? (y/n) > y
+
+writing diff to paper/workflow/parallel-dispatch-breakeven-point/PAPER.md … done
+running /hub-paper-verify … PASS
+
+EXPERIMENT CLOSED.
+Next: /hub-publish --only paper --pr
+```
+
+## Why exists
+
+The first paper to close its loop in this hub (`paper/workflow/parallel-dispatch-breakeven-point`) took multiple manual edits across frontmatter sections and a body-section rewrite. That friction explains why so many papers stay at `status: draft` with `experiments[].status: planned` indefinitely. This command makes the closing step deliberate and verified, instead of "remember to update three fields and re-run lint".

--- a/bootstrap/commands/hub-paper-from-technique.md
+++ b/bootstrap/commands/hub-paper-from-technique.md
@@ -1,0 +1,175 @@
+---
+description: Scaffold a paper draft that interrogates an existing technique — premise prompt, examines pre-filled from technique's composes[], perspectives seeded, ready to refine.
+argument-hint: <technique-slug> [--type=hypothesis|survey|position] [--category=<cat>]
+---
+
+# /hub-paper-from-technique $ARGUMENTS
+
+Authoring a paper from scratch is a heavy lift — premise design, multi-perspective framing, picking what to examine, drafting an experiment. Authoring a paper that **interrogates an existing technique** is much lighter: the technique already names the atoms involved (`composes[]`), the binding decisions, and the failure modes implied by its `## When NOT to use` section. This command turns that latent material into a paper draft scaffold.
+
+The goal is to lower the floor for paper authoring against existing techniques, so questions like "is this composition actually load-bearing?" or "what's the cost curve for this pattern at scale?" become 5-minute drafts instead of 1-hour blocks.
+
+## Resolution
+
+- `<technique-slug>` — locate first match in `~/.claude/skills-hub/remote/technique/**/<slug>/TECHNIQUE.md`, then `./.technique-draft/**/<slug>/`. Refuse if not found.
+- `--type=<hypothesis | survey | position>` — paper type, default `hypothesis` (the most common shape for technique interrogation).
+- `--category=<cat>` — paper category, default = technique's category. Override only if the paper's subject is conceptually different from the technique's domain.
+
+## Steps
+
+1. **Read the technique** (read-only):
+   - Frontmatter: `name`, `description`, `category`, `tags`, `composes[]`, `binding`, `verify`.
+   - Body: `## When to use`, `## When NOT to use`, `## Phase sequence`, `## Glue summary`, `## Known limitations`. These sections are mined for the paper scaffold.
+
+2. **Propose a paper slug:**
+   - Default: `<technique-slug>-<type-suffix>` where suffix depends on type:
+     - `hypothesis` → `-cost-curve` / `-breakeven-point` / `-failure-modes` (interactive pick) or user-supplied
+     - `survey` → `-landscape` or `-comparison`
+     - `position` → `-policy` or `-default-rule`
+   - Show the proposal, allow override.
+
+3. **Premise scaffold** (interactive — premise-first, just like `/hub-paper-compose`):
+
+   Show prompts that draw from the technique:
+
+   ```
+   This technique composes <N> atoms: <list>.
+   The technique's "When NOT to use" lists: <list>.
+   Glue summary describes: <one-line>.
+
+   What's your premise.if?
+     (typical patterns:
+      - "When this technique is applied at scale of N >= ..."
+      - "When team X adopts <technique> without <prerequisite>"
+      - "When the composition runs in <constrained-environment>")
+
+   What's your premise.then?
+     (typical patterns:
+      - "<measured-outcome> degrades by X% past threshold Y"
+      - "<silent-failure-mode> occurs in K% of runs"
+      - "Cost displaces from <axis> to <other-axis>")
+   ```
+
+   Both `if` and `then` must be non-empty (≥ 1 char after strip). Refuse to proceed otherwise.
+
+4. **Pre-fill `examines[]`:**
+   - Add the technique itself: `{ kind: technique, ref: <category>/<slug>, role: subject }`. (paper citing technique — the reverse-citation hub will surface this.)
+   - Add each `composes[].ref` from the technique with role: same role as in `composes[]` (e.g. `orchestrator` carries forward).
+   - User can prune (deselect any) or add more via interactive search (`/hub-find` integration).
+
+5. **Seed `perspectives[]`** (≥ 2 required by schema):
+   - Default 4 perspectives drawn from common technique-interrogation angles:
+     1. **Cost Model** — "what does this technique cost in time / tokens / cognitive load?"
+     2. **Failure Modes** — drawn from the technique's `## When NOT to use` and `## Known limitations`
+     3. **Adoption Curve** — "what conditions does the team need to hit before this technique pays for itself?"
+     4. **Counter-Argument** — "what would refute the premise? what's the strongest case for the opposite conclusion?"
+   - User can keep, edit, or replace any of these. Edits inline (name + 1-2 line summary).
+
+6. **Seed `proposed_builds[]`** (typical: 1-3):
+   - Default suggestions based on type:
+     - `hypothesis` → `<slug>-benchmark` (POC measuring the premise's threshold)
+     - `survey` → `<slug>-comparison-matrix` (POC mapping the landscape)
+     - `position` → `<slug>-default-policy` (DEMO codifying the rule)
+   - Each pre-filled with `requires:` listing the technique itself + 1-2 of its composed atoms (so the non-triviality gate, rule 13, doesn't WARN).
+   - User edits / adds / removes.
+
+7. **Seed `experiments[]`** (only for `type: hypothesis`, ≥ 1):
+   - Default skeleton:
+     ```yaml
+     - name: <slug>-curve
+       hypothesis: <one-line restatement of premise.then>
+       method: |
+         (TODO — design measurement; typical shape:
+          replay N representative invocations of <technique> at varying
+          conditions, measure <outcome>, plot curve, identify break-even.)
+       status: planned
+       built_as: null
+       result: null
+       supports_premise: null
+       observed_at: null
+     ```
+   - User fills `method` (the only field that requires real thought at compose time).
+
+8. **Write the draft:**
+   - Target: `.paper-draft/<category>/<slug>/PAPER.md`.
+   - Frontmatter assembled from steps 3-7. Version `0.2.0-draft`. Status `draft`.
+   - Body skeleton (same as `/hub-paper-compose`) with `## Background` pre-filled with a paragraph naming the technique and pointing to its TECHNIQUE.md.
+   - Auto-inject `## References (examines)` and `## Build dependencies` body sections via `_inject_references_section.py`.
+
+9. **Immediate verification:**
+   - Run `/hub-paper-verify <slug>`. PASS / WARN / FAIL handled same as `/hub-paper-compose` step 14.
+   - Print location + next step:
+     ```
+     DRAFT CREATED: .paper-draft/<category>/<slug>/PAPER.md
+     Subject technique: <category>/<slug>
+     Examines pre-filled: <N> entries
+     Perspectives seeded: 4 (edit or replace)
+     Experiment status: planned (run via /hub-paper-experiment-run when ready)
+
+     Next:
+       • Refine perspectives + experiment.method
+       • /hub-publish --only paper --pr
+     ```
+
+## Rules
+
+- Never modify the source TECHNIQUE.md. Read-only on the technique.
+- Refuse if a paper at `<slug>` already exists in either `.paper-draft/` or installed `paper/` — propose appending a suffix (`<slug>-v2`, `<slug>-revisited`).
+- Pre-fill aggressively but do not lock fields. Every seeded `perspective` / `proposed_build` / `experiment` is editable in step 5/6/7. The goal is *acceleration*, not *prescription*.
+- The seeded `examines[]` includes the technique itself (`kind: technique`). The v0 → v0.2.1 schema doesn't restrict this — the only restriction is `proposed_builds[].requires[].kind: paper` (still banned).
+- `type=hypothesis` is the default because it forces the loop-closing path — `/hub-paper-experiment-run` then has work to do later. `type=survey` and `position` are valid but skip step 7.
+
+## Example
+
+```
+/hub-paper-from-technique safe-bulk-pr-publishing
+
+▶ technique: workflow/safe-bulk-pr-publishing
+▶ composes: [orchestrator, rollback-anchor, conflict-recovery]
+▶ when NOT to use: ['atomic operations', 'single PR']
+▶ proposing slug: safe-bulk-pr-publishing-cost-curve
+▶ type: hypothesis (default)
+
+premise.if?
+> When N pull requests are published in one run with this technique
+premise.then?
+> The expected gain over per-PR publishing inverts past N≈30 because
+  conflict-recovery passes scale O(N²) on average and the rollback anchor
+  becomes a single point of contention.
+
+examines (pre-filled, edit/prune):
+  ✓ technique workflow/safe-bulk-pr-publishing  role=subject
+  ✓ skill workflow/parallel-build-sequential-publish  role=orchestrator
+  ✓ skill workflow/rollback-anchor-tag-before-destructive-op  role=failure-recovery
+  ✓ knowledge workflow/batch-pr-conflict-recovery  role=conflict-resolution
+  add more? (n)
+
+perspectives (4 seeded, edit/replace):
+  1. Cost Model
+  2. Failure Modes (drawn from "When NOT to use")
+  3. Adoption Curve
+  4. Counter-Argument
+  edit? (n)
+
+proposed_builds (default seeded):
+  1. safe-bulk-pr-publishing-benchmark — POC measuring per-N runtime + conflict frequency
+     requires: technique:safe-bulk-pr-publishing, skill:parallel-build-sequential-publish
+  edit? (n)
+
+experiment (1 seeded):
+  name: safe-bulk-pr-publishing-curve
+  method: > Replay 50 historical bulk-publish runs at N ∈ {5, 15, 30, 60} and measure
+            wall-clock + conflict-recovery iterations + manual-intervention count.
+  edit method? (n)
+
+writing .paper-draft/workflow/safe-bulk-pr-publishing-cost-curve/PAPER.md … done
+running /hub-paper-verify … PASS
+
+DRAFT CREATED. Next: /hub-publish --only paper --pr
+```
+
+## Why exists
+
+15 papers exist; only 1 has closed its loop. The rest were authored from a blank slate, which takes long enough that running the experiment afterward feels like a separate project. Authoring against an existing technique reuses the technique's structural decisions (atoms, binding, failure cases) so the author can spend their attention on what matters — the premise and the experiment design — instead of the framing scaffold.
+
+The companion command `/hub-paper-experiment-run` then closes the loop. Together: scaffold from technique → run experiment → close loop → produce corpus update.

--- a/bootstrap/commands/hub-show.md
+++ b/bootstrap/commands/hub-show.md
@@ -66,6 +66,19 @@ Tags:        [oauth, token, refresh]
 2. **Resolve** — find the entry per resolution order above.
 3. **Read** — load the file(s) from local path or remote cache.
 4. **Render** — show metadata header + file content (respecting `--raw` and `--section`).
+5. **Append `Cited by` block** (skipped under `--raw`) — open `~/.claude/skills-hub/remote/citations.json`, look up the key `<kind>/<ref>` for the resolved entry, and render the `cited_by` list:
+
+   ```
+   --- Cited by ---
+   technique  workflow/safe-bulk-pr-publishing  · role: orchestrator    · via: composes
+   paper      workflow/parallel-dispatch-breakeven-point  · role: counter-evidence  · via: examines
+   paper      workflow/parallel-dispatch-breakeven-point  · role: gate-input  · via: requires:parallel-dispatch-coverage-gate
+   ```
+
+   - Group by kind (`technique` first, then `paper`); within a kind sort by ref.
+   - Show at most 8 entries; tail the rest as `… and N more`.
+   - If the atom has zero citations, render `--- Cited by ---  (none yet)`. This is informative — uncited atoms are exactly what `paper/arch/technique-layer-roi-after-100-pilots` is measuring.
+   - If `citations.json` is missing or older than the entry's last modification, advise `precheck.py` (the post-merge / post-commit hook regenerates it automatically).
 
 ## Rules
 

--- a/bootstrap/commands/hub-suggest.md
+++ b/bootstrap/commands/hub-suggest.md
@@ -13,32 +13,45 @@ argument-hint: <task description>
    - `$ARGUMENTS` 에서 의미 토큰만 뽑는다. 불용어(은/는/을/를/해줘/구현 등)는 제거.
    - 기술 용어(spring, kafka, jwt, websocket, mongo, react, …)는 원형 유지.
 
-2. **검색 실행**
+2. **검색 실행 (4-layer)**
+   - 핵심: skill/knowledge **그리고** technique/paper 까지 같이 검색해서 사용자가 한 단계 위 추상에서 이미 검토된 패턴이 있는지 알 수 있게 한다.
    ```bash
-   hub-search "<추출된 키워드>" -n 5
+   hub-search "<추출된 키워드>" -n 8
    ```
-   PATH 에 없으면 `py ~/.claude/skills-hub/tools/hub_search.py` 로 대체.
+   결과는 kind 별로 묶어서 본다 (skill / knowledge / technique / paper). PATH 에 없으면 `py ~/.claude/skills-hub/tools/hub_search.py` 로 대체.
 
 3. **강한 매칭 판정**
    - 상위 결과 **score ≥ 10** AND
    - `name` 토큰이 키워드와 겹치거나 `tags` 에 키워드 2개 이상 포함
+   - 우선순위: 같은 점수면 **paper > technique > skill > knowledge** 순. 위 레이어가 더 높은 추상에서 작업을 본다.
    - 미달이면 "허브에서 직접 연관된 항목을 찾지 못했습니다" 리포트 후 종료.
 
 4. **제시 형식**
    ```
-   [kind/category] <name> · <description 한 줄> · <path>
+   [paper/<category>] <slug> · <description 한 줄> · <path> · type=<hypothesis|survey|position> status=<status>
+   [technique/<category>] <slug> · <description 한 줄> · <path> · composes <N> atoms
+   [skill/<category>] <name> · <description 한 줄> · <path>
+   [knowledge/<category>] <slug> · <summary 한 줄> · <path>
    ```
-   상위 1~3 개만. 점수 부여 근거도 한 줄.
+   상위 1~5 개만 (kind 가 섞여있으면 각 1개씩 우선). 점수 부여 근거도 한 줄.
 
-5. **사용자 선택**
-   - **Skills**:
+5. **사용자 선택** (kind 별로 다름)
+   - **Paper** (먼저 보여주는 게 핵심):
+     - ① 읽고 premise/perspectives/limitations 반영 — `/hub-paper-show <slug>` 자동 실행
+     - ② 이 paper 의 `proposed_builds[]` 중 작업과 맞는 게 있으면 `/hub-make` 로 scaffold 시도
+     - ③ 건너뛰기
+   - **Technique**:
+     - ① 참조 — `/hub-technique-show <slug>` 로 composes[] 와 phase sequence 보고 적용
+     - ② composes[] 의 atom 들 일괄 설치 — `/hub-install` 을 atom 마다 호출
+     - ③ 건너뛰기
+   - **Skill**:
      - ① 참조만 — `~/.claude/skills-hub/remote/<path>/SKILL.md` + `content.md` 읽어서 본 작업에 반영
      - ② 설치 — `/hub-install <name>` 호출
      - ③ 건너뛰기
    - **Knowledge** (knowledge 는 설치 개념 없음):
      - ① 읽고 반영 — `~/.claude/skills-hub/remote/<path>` 읽어서 인용
      - ② 건너뛰기
-   - 혼합 결과면 각각 물어본다.
+   - 혼합 결과면 각각 물어본다. paper 가 있으면 먼저 보여줘서 사용자가 "이미 분석된 cost 곡선·threshold·tradeoff" 를 인지한 채로 진행하게 한다.
 
 6. **응답 후 진행**
    - ①/② 선택 시: 해당 MD 를 읽고, 응답 본문에 이름+경로 인용.

--- a/bootstrap/tools/_build_citations_index.py
+++ b/bootstrap/tools/_build_citations_index.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Build citations.json — a reverse-lookup index from atom → entries that cite it.
+
+Walks every TECHNIQUE.md (composes[]) and PAPER.md (examines[] + proposed_builds[].requires[])
+and produces a flat map:
+
+  {
+    "<kind>/<ref>": {
+      "cited_by": [
+        { "kind": "technique" | "paper", "ref": "<category>/<slug>", "role": "<short label>", "via": "composes" | "examines" | "requires" }
+      ]
+    },
+    ...
+  }
+
+The output is consumed by `/hub-show` (and in future `/hub-find`) to surface "this atom
+is cited by N entries" without re-walking the corpus on every command. Regenerated on
+post-commit / post-merge via precheck.py the same way `index.json` is.
+
+Idempotent: deterministic ordering, sorted keys, sorted citation lists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import yaml
+
+HUB_ROOT = Path(__file__).resolve().parents[2]
+PAPER_DIR = HUB_ROOT / "paper"
+TECHNIQUE_DIR = HUB_ROOT / "technique"
+OUTPUT = HUB_ROOT / "citations.json"
+
+
+def split_frontmatter(text: str) -> str:
+    if not text.startswith("---\n"):
+        return ""
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return ""
+    return text[4 : end + 1]
+
+
+def parse_frontmatter(text: str) -> dict:
+    fm = split_frontmatter(text)
+    if not fm:
+        return {}
+    try:
+        return yaml.safe_load(fm) or {}
+    except yaml.YAMLError:
+        return {}
+
+
+def normalize_key(kind: str, ref: str) -> str | None:
+    if not kind or not ref:
+        return None
+    kind = kind.strip()
+    ref = ref.strip()
+    if kind not in ("skill", "knowledge", "technique", "paper"):
+        return None
+    return f"{kind}/{ref}"
+
+
+def collect_paper_citations(citations: dict) -> int:
+    count = 0
+    for paper_md in sorted(PAPER_DIR.glob("**/PAPER.md")):
+        fm = parse_frontmatter(paper_md.read_text(encoding="utf-8"))
+        rel = paper_md.relative_to(PAPER_DIR).parent.as_posix()
+        source = {"kind": "paper", "ref": rel}
+        for entry in fm.get("examines") or []:
+            if not isinstance(entry, dict):
+                continue
+            key = normalize_key(entry.get("kind"), entry.get("ref"))
+            if not key:
+                continue
+            citations[key].append({**source, "role": (entry.get("role") or "").strip(), "via": "examines"})
+            count += 1
+        for build in fm.get("proposed_builds") or []:
+            if not isinstance(build, dict):
+                continue
+            for entry in build.get("requires") or []:
+                if not isinstance(entry, dict):
+                    continue
+                key = normalize_key(entry.get("kind"), entry.get("ref"))
+                if not key:
+                    continue
+                citations[key].append({
+                    **source,
+                    "role": (entry.get("role") or "").strip(),
+                    "via": f"requires:{(build.get('slug') or '').strip()}",
+                })
+                count += 1
+    return count
+
+
+def collect_technique_citations(citations: dict) -> int:
+    count = 0
+    for tech_md in sorted(TECHNIQUE_DIR.glob("**/TECHNIQUE.md")):
+        fm = parse_frontmatter(tech_md.read_text(encoding="utf-8"))
+        rel = tech_md.relative_to(TECHNIQUE_DIR).parent.as_posix()
+        source = {"kind": "technique", "ref": rel}
+        for entry in fm.get("composes") or []:
+            if not isinstance(entry, dict):
+                continue
+            key = normalize_key(entry.get("kind"), entry.get("ref"))
+            if not key:
+                continue
+            citations[key].append({**source, "role": (entry.get("role") or "").strip(), "via": "composes"})
+            count += 1
+    return count
+
+
+def build() -> dict:
+    citations: dict[str, list] = defaultdict(list)
+    paper_count = collect_paper_citations(citations)
+    tech_count = collect_technique_citations(citations)
+
+    sorted_citations: dict[str, dict] = {}
+    for key in sorted(citations.keys()):
+        entries = sorted(citations[key], key=lambda e: (e["kind"], e["ref"], e.get("via", "")))
+        sorted_citations[key] = {"cited_by": entries}
+
+    return {
+        "schema": 1,
+        "totals": {
+            "paper_citations": paper_count,
+            "technique_citations": tech_count,
+            "atoms_cited": len(sorted_citations),
+        },
+        "citations": sorted_citations,
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--output", default=str(OUTPUT), help="Output path (default: <repo>/citations.json)")
+    p.add_argument("--print", action="store_true", help="Print to stdout instead of writing")
+    args = p.parse_args()
+
+    data = build()
+    payload = json.dumps(data, indent=2, ensure_ascii=False, sort_keys=False)
+
+    if args.print:
+        print(payload)
+    else:
+        out = Path(args.output)
+        out.write_text(payload + "\n", encoding="utf-8")
+        print(
+            f"Wrote {out.relative_to(HUB_ROOT) if out.is_relative_to(HUB_ROOT) else out} — "
+            f"{data['totals']['atoms_cited']} atoms cited by "
+            f"{data['totals']['paper_citations']} paper refs + "
+            f"{data['totals']['technique_citations']} technique refs"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bootstrap/tools/precheck.py
+++ b/bootstrap/tools/precheck.py
@@ -53,6 +53,7 @@ def main() -> int:
     steps.append(("master-index", [py, "_build_master_index.py"]))
     steps.append(("master-index-lite", [py, "_build_master_index_lite.py"]))
     steps.append(("category-indexes", [py, "_build_category_indexes.py"]))
+    steps.append(("citations-index", [py, "_build_citations_index.py"]))
 
     for label, cmd in steps:
         rc = run(label, cmd)

--- a/citations.json
+++ b/citations.json
@@ -1,0 +1,1220 @@
+{
+  "schema": 1,
+  "totals": {
+    "paper_citations": 99,
+    "technique_citations": 62,
+    "atoms_cited": 61
+  },
+  "citations": {
+    "knowledge/agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "ai/coordinator-overhead-vs-parallelism",
+          "role": "counter-evidence-from-prior-paper",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "ai/coordinator-overhead-vs-parallelism",
+          "role": "pre-flight-check-pattern",
+          "via": "requires:coordinator-overhead-benchmark"
+        },
+        {
+          "kind": "paper",
+          "ref": "workflow/parallel-dispatch-breakeven-point",
+          "role": "counter-evidence",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "workflow/parallel-dispatch-breakeven-point",
+          "role": "seed-data",
+          "via": "requires:coverage-threshold-decision-table"
+        },
+        {
+          "kind": "paper",
+          "ref": "workflow/parallel-dispatch-breakeven-point",
+          "role": "counter-evidence",
+          "via": "requires:parallel-dispatch-coverage-gate"
+        }
+      ]
+    },
+    "knowledge/decision/caveats-absence-confidence-cap": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "testing/llm-ci-triage-boundary-conditions",
+          "role": "counter-evidence",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "testing/llm-ci-triage-boundary-conditions",
+          "role": "guides-confidence-cap",
+          "via": "requires:llm-triage-confidence-dashboard"
+        },
+        {
+          "kind": "paper",
+          "ref": "testing/llm-ci-triage-boundary-conditions",
+          "role": "seed",
+          "via": "requires:llm-triage-false-known-flake-pitfall"
+        }
+      ]
+    },
+    "knowledge/decision/phi-accrual-failure-detector-over-binary-timeout": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "arch/multi-peer-quorum-decision-loop",
+          "role": "failure-detection-rationale",
+          "via": "composes"
+        }
+      ]
+    },
+    "knowledge/pitfall/ai-guess-mark-and-review-checklist": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "debug/root-cause-to-tdd-plan",
+          "role": "hypothesis-guard",
+          "via": "composes"
+        }
+      ]
+    },
+    "knowledge/pitfall/backpressure-implementation-pitfall": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "data/producer-consumer-backpressure-loop",
+          "role": "feedback-mechanism-counter-evidence",
+          "via": "composes"
+        }
+      ]
+    },
+    "knowledge/pitfall/bulkhead-implementation-pitfall": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "workflow/fan-out-fan-in-with-bulkhead",
+          "role": "counter-evidence",
+          "via": "composes"
+        }
+      ]
+    },
+    "knowledge/pitfall/canary-release-implementation-pitfall": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "arch/feature-flag-flap-prevention-policies",
+          "role": "similar-flap-pattern",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "devops/canary-auto-revert-calibration",
+          "role": "counter-evidence",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "devops/canary-auto-revert-calibration",
+          "role": "failure-modes-to-validate-against",
+          "via": "requires:canary-threshold-calibration-tool"
+        },
+        {
+          "kind": "technique",
+          "ref": "devops/canary-rollout-with-auto-revert",
+          "role": "counter-evidence",
+          "via": "composes"
+        }
+      ]
+    },
+    "knowledge/pitfall/circuit-breaker-implementation-pitfall": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "ai/llm-fallback-cost-displacement",
+          "role": "counter-evidence",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "ai/llm-fallback-cost-displacement",
+          "role": "informs-which",
+          "via": "requires:llm-fallback-latency-cost-dashboard"
+        },
+        {
+          "kind": "paper",
+          "ref": "ai/llm-fallback-cost-displacement",
+          "role": "codifies-silent-failure",
+          "via": "requires:llm-fallback-schema-validator-middleware"
+        },
+        {
+          "kind": "paper",
+          "ref": "arch/feature-flag-flap-prevention-policies",
+          "role": "counter-evidence",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "arch/feature-flag-flap-prevention-policies",
+          "role": "known-bugs-to-avoid",
+          "via": "requires:hysteresis-tuning-tool"
+        },
+        {
+          "kind": "paper",
+          "ref": "devops/canary-auto-revert-calibration",
+          "role": "similar-flap-failure-mode",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "frontend/optimistic-ui-flicker-tolerance",
+          "role": "failure-mode-similarity",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "security/credential-rotation-window-tradeoff",
+          "role": "emergency-revocation-context",
+          "via": "examines"
+        },
+        {
+          "kind": "technique",
+          "ref": "ai/agent-fallback-ladder",
+          "role": "circuit-state-guard",
+          "via": "composes"
+        },
+        {
+          "kind": "technique",
+          "ref": "arch/feature-flag-killswitch-with-circuit-state",
+          "role": "counter-evidence",
+          "via": "composes"
+        }
+      ]
+    },
+    "knowledge/pitfall/dead-letter-queue-implementation-pitfall": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "db/migration-checkpoint-overhead",
+          "role": "failed-row-handling",
+          "via": "examines"
+        },
+        {
+          "kind": "technique",
+          "ref": "data/producer-consumer-backpressure-loop",
+          "role": "overflow-handling-counter-evidence",
+          "via": "composes"
+        }
+      ]
+    },
+    "knowledge/pitfall/finite-state-machine-implementation-pitfall": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "arch/finite-state-machine-monotonic-ratchet",
+          "role": "state-transition-counter-evidence",
+          "via": "composes"
+        }
+      ]
+    },
+    "knowledge/pitfall/gh-pr-create-race-with-auto-merge": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "workflow/safe-bulk-pr-publishing",
+          "role": "known-pitfall",
+          "via": "composes"
+        }
+      ]
+    },
+    "knowledge/pitfall/idempotency-implementation-pitfall": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "arch/saga-vs-2pc-cost-curve",
+          "role": "compensation-safety-concern",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "db/migration-checkpoint-overhead",
+          "role": "counter-evidence",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "frontend/optimistic-ui-flicker-tolerance",
+          "role": "counter-evidence",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "frontend/optimistic-ui-flicker-tolerance",
+          "role": "realistic-failure-shape",
+          "via": "requires:optimistic-ui-rollback-frequency-monitor"
+        },
+        {
+          "kind": "paper",
+          "ref": "testing/contract-test-staleness-curve",
+          "role": "similar-decay-pattern",
+          "via": "examines"
+        },
+        {
+          "kind": "technique",
+          "ref": "arch/saga-with-compensation-chain",
+          "role": "compensation-safety-counter-evidence",
+          "via": "composes"
+        },
+        {
+          "kind": "technique",
+          "ref": "db/idempotent-migration-with-resume-checkpoint",
+          "role": "counter-evidence",
+          "via": "composes"
+        },
+        {
+          "kind": "technique",
+          "ref": "frontend/optimistic-mutation-with-server-reconcile",
+          "role": "counter-evidence",
+          "via": "composes"
+        }
+      ]
+    },
+    "knowledge/pitfall/quorum-visualization-off-by-one": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "arch/multi-peer-quorum-decision-loop",
+          "role": "quorum-math-counter-evidence",
+          "via": "composes"
+        }
+      ]
+    },
+    "knowledge/pitfall/raft-consensus-implementation-pitfall": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "arch/multi-peer-quorum-decision-loop",
+          "role": "consensus-counter-evidence",
+          "via": "composes"
+        }
+      ]
+    },
+    "knowledge/pitfall/rate-limiter-implementation-pitfall": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "data/producer-consumer-backpressure-loop",
+          "role": "rate-vs-buffer-distinction-counter-evidence",
+          "via": "composes"
+        }
+      ]
+    },
+    "knowledge/pitfall/refresh-token-do-not-regenerate": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "security/credential-rotation-window-tradeoff",
+          "role": "rotation-counter-evidence",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "security/credential-rotation-window-tradeoff",
+          "role": "failure-modes-to-account-for",
+          "via": "requires:rotation-window-simulator"
+        },
+        {
+          "kind": "technique",
+          "ref": "security/credential-rotation-overlap-window",
+          "role": "rotation-counter-evidence",
+          "via": "composes"
+        }
+      ]
+    },
+    "knowledge/pitfall/retry-strategy-implementation-pitfall": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "ai/llm-fallback-cost-displacement",
+          "role": "counter-evidence",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "ai/llm-fallback-cost-displacement",
+          "role": "retry-storm",
+          "via": "requires:llm-fallback-cost-budget-governor"
+        },
+        {
+          "kind": "technique",
+          "ref": "ai/agent-fallback-ladder",
+          "role": "retry-pitfall-guard",
+          "via": "composes"
+        }
+      ]
+    },
+    "knowledge/pitfall/saga-pattern-implementation-pitfall": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "arch/saga-vs-2pc-cost-curve",
+          "role": "saga-counter-evidence",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "arch/saga-vs-2pc-cost-curve",
+          "role": "avoid-known-saga-bugs-in-benchmark",
+          "via": "requires:saga-vs-2pc-microbenchmark"
+        },
+        {
+          "kind": "technique",
+          "ref": "arch/saga-with-compensation-chain",
+          "role": "forward-chain-counter-evidence",
+          "via": "composes"
+        }
+      ]
+    },
+    "knowledge/pitfall/strangler-fig-implementation-pitfall": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "arch/strangler-fig-traffic-shifting",
+          "role": "counter-evidence",
+          "via": "composes"
+        }
+      ]
+    },
+    "knowledge/workflow/batch-pr-conflict-recovery": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "workflow/technique-layer-composition-value",
+          "role": "atom-demonstrating",
+          "via": "examines"
+        },
+        {
+          "kind": "technique",
+          "ref": "workflow/safe-bulk-pr-publishing",
+          "role": "failure-recovery",
+          "via": "composes"
+        }
+      ]
+    },
+    "paper/testing/llm-ci-triage-boundary-conditions": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "ai/llm-fallback-cost-displacement",
+          "role": "sibling-paper",
+          "via": "examines"
+        }
+      ]
+    },
+    "paper/workflow/parallel-dispatch-breakeven-point": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "ai/coordinator-overhead-vs-parallelism",
+          "role": "prior-paper",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "ai/llm-fallback-cost-displacement",
+          "role": "prior-paper",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "testing/llm-ci-triage-boundary-conditions",
+          "role": "prior-paper",
+          "via": "examines"
+        }
+      ]
+    },
+    "paper/workflow/technique-layer-composition-value": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "ai/llm-fallback-cost-displacement",
+          "role": "meta paper on layer ROI",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "arch/technique-layer-roi-after-100-pilots",
+          "role": "sister meta paper",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "testing/llm-ci-triage-boundary-conditions",
+          "role": "meta-paper",
+          "via": "examines"
+        }
+      ]
+    },
+    "skill/agents/basic-agent-runner": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "ai/coordinator-overhead-vs-parallelism",
+          "role": "agent-runtime-baseline",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "ai/coordinator-overhead-vs-parallelism",
+          "role": "harness-runtime",
+          "via": "requires:coordinator-overhead-benchmark"
+        },
+        {
+          "kind": "technique",
+          "ref": "ai/multi-agent-fan-out-with-isolation",
+          "role": "agent-runtime-baseline",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/ai/ai-call-with-mock-fallback": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "ai/llm-fallback-cost-displacement",
+          "role": "the simplest fallback shape",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "ai/llm-fallback-cost-displacement",
+          "role": "baseline-call",
+          "via": "requires:llm-fallback-latency-cost-dashboard"
+        },
+        {
+          "kind": "paper",
+          "ref": "ai/llm-fallback-cost-displacement",
+          "role": "tiered-call",
+          "via": "requires:llm-fallback-schema-validator-middleware"
+        },
+        {
+          "kind": "technique",
+          "ref": "ai/agent-fallback-ladder",
+          "role": "primary-call-shape",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/ai/ai-subagent-scope-narrowing": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "ai/coordinator-overhead-vs-parallelism",
+          "role": "scope-discipline-baseline",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "workflow/parallel-dispatch-breakeven-point",
+          "role": "adjacent-pattern",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "workflow/parallel-dispatch-breakeven-point",
+          "role": "adjacent-pattern",
+          "via": "requires:parallel-dispatch-coverage-gate"
+        },
+        {
+          "kind": "technique",
+          "ref": "ai/multi-agent-fan-out-with-isolation",
+          "role": "scope-discipline",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/algorithms/gossip-round-rng-seeded-reproducible-sim": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "arch/multi-peer-quorum-decision-loop",
+          "role": "gossip-alternative-shape",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/architecture/optimistic-mutation-pattern": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "frontend/optimistic-ui-flicker-tolerance",
+          "role": "optimistic-shape",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "frontend/optimistic-ui-flicker-tolerance",
+          "role": "subject-component",
+          "via": "requires:optimistic-ui-rollback-frequency-monitor"
+        },
+        {
+          "kind": "technique",
+          "ref": "frontend/optimistic-mutation-with-server-reconcile",
+          "role": "optimistic-shape-baseline",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/backend/conditional-feature-flag-rollout": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "arch/feature-flag-flap-prevention-policies",
+          "role": "feature-flag-shape",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "arch/feature-flag-flap-prevention-policies",
+          "role": "flag-control-baseline",
+          "via": "requires:hysteresis-tuning-tool"
+        },
+        {
+          "kind": "paper",
+          "ref": "devops/canary-auto-revert-calibration",
+          "role": "traffic-control-implementation",
+          "via": "examines"
+        },
+        {
+          "kind": "technique",
+          "ref": "arch/feature-flag-killswitch-with-circuit-state",
+          "role": "feature-flag-shape",
+          "via": "composes"
+        },
+        {
+          "kind": "technique",
+          "ref": "devops/canary-rollout-with-auto-revert",
+          "role": "traffic-control-implementation",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/backend/kafka-consumer-semaphore-chunking": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "data/producer-consumer-backpressure-loop",
+          "role": "bounded-buffer-implementation-example",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/backend/migration-processor-pipeline": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "db/migration-checkpoint-overhead",
+          "role": "migration-shape",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "db/migration-checkpoint-overhead",
+          "role": "migration-pipeline-baseline",
+          "via": "requires:migration-checkpoint-granularity-benchmark"
+        },
+        {
+          "kind": "technique",
+          "ref": "arch/strangler-fig-traffic-shifting",
+          "role": "data-migration-shape",
+          "via": "composes"
+        },
+        {
+          "kind": "technique",
+          "ref": "db/idempotent-migration-with-resume-checkpoint",
+          "role": "migration-shape-baseline",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/backend/service-discovery-replica-leader-tracking": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "arch/multi-peer-quorum-decision-loop",
+          "role": "leader-tracking-implementation",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/cli/graceful-version-fallback-tier-order": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "ai/llm-fallback-cost-displacement",
+          "role": "tier-ordering",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "ai/llm-fallback-cost-displacement",
+          "role": "tier-ordering",
+          "via": "requires:llm-fallback-cost-budget-governor"
+        },
+        {
+          "kind": "technique",
+          "ref": "ai/agent-fallback-ladder",
+          "role": "tier-ordering-rule",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/debug/build-error-triage": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "debug/root-cause-to-tdd-plan",
+          "role": "branch-build-error",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/debug/investigate": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "testing/llm-ci-triage-boundary-conditions",
+          "role": "baseline",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "testing/llm-ci-triage-boundary-conditions",
+          "role": "human-systematic",
+          "via": "requires:hybrid-llm-human-triage-router"
+        },
+        {
+          "kind": "technique",
+          "ref": "debug/root-cause-to-tdd-plan",
+          "role": "phase-orchestrator",
+          "via": "composes"
+        },
+        {
+          "kind": "technique",
+          "ref": "testing/fuzz-crash-to-fix-loop",
+          "role": "root-cause-per-crash",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/debug/triage-issue": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "testing/llm-ci-triage-boundary-conditions",
+          "role": "downstream consumer",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "testing/llm-ci-triage-boundary-conditions",
+          "role": "shared-downstream",
+          "via": "requires:hybrid-llm-human-triage-router"
+        },
+        {
+          "kind": "technique",
+          "ref": "debug/root-cause-to-tdd-plan",
+          "role": "artifact-producer",
+          "via": "composes"
+        },
+        {
+          "kind": "technique",
+          "ref": "testing/fuzz-crash-to-fix-loop",
+          "role": "issue-and-plan",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/design/bulkhead-visualization-pattern": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "workflow/fan-out-fan-in-with-bulkhead",
+          "role": "visualization-reference",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/input/relative-mouse-mode-state-machine": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "arch/finite-state-machine-monotonic-ratchet",
+          "role": "concrete-state-machine-example",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/llm-agents/hermes-credential-pool-failover": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "security/credential-rotation-window-tradeoff",
+          "role": "rotation-with-failover-shape",
+          "via": "examines"
+        },
+        {
+          "kind": "technique",
+          "ref": "security/credential-rotation-overlap-window",
+          "role": "rotation-with-failover-shape",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/safety/interface-contract-validation": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "testing/contract-test-staleness-curve",
+          "role": "contract-validation-shape",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "testing/contract-test-staleness-curve",
+          "role": "contract-shape-to-instrument",
+          "via": "requires:contract-test-staleness-detector"
+        },
+        {
+          "kind": "technique",
+          "ref": "testing/contract-test-with-consumer-verification",
+          "role": "schema-validation-shape",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/security/aes256gcm-machineid-credential-store": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "security/credential-rotation-window-tradeoff",
+          "role": "credential-store-shape",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "security/credential-rotation-window-tradeoff",
+          "role": "realistic-credential-shape",
+          "via": "requires:rotation-window-simulator"
+        },
+        {
+          "kind": "technique",
+          "ref": "security/credential-rotation-overlap-window",
+          "role": "credential-storage-baseline",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/testing/fuzz-corpus-seed-management": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "testing/fuzz-crash-to-fix-loop",
+          "role": "crash-source",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/testing/llm-integration-test-failure-diagnosis": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "testing/llm-ci-triage-boundary-conditions",
+          "role": "the subject",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "testing/llm-ci-triage-boundary-conditions",
+          "role": "the LLM step the router gates",
+          "via": "requires:hybrid-llm-human-triage-router"
+        },
+        {
+          "kind": "paper",
+          "ref": "testing/llm-ci-triage-boundary-conditions",
+          "role": "llm-triager",
+          "via": "requires:llm-triage-confidence-dashboard"
+        },
+        {
+          "kind": "paper",
+          "ref": "testing/llm-ci-triage-boundary-conditions",
+          "role": "source-pattern",
+          "via": "requires:llm-triage-false-known-flake-pitfall"
+        }
+      ]
+    },
+    "skill/testing/tdd": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "testing/contract-test-staleness-curve",
+          "role": "test-discipline-baseline",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "testing/contract-test-staleness-curve",
+          "role": "test-execution-discipline",
+          "via": "requires:contract-test-staleness-detector"
+        },
+        {
+          "kind": "technique",
+          "ref": "testing/contract-test-with-consumer-verification",
+          "role": "test-discipline",
+          "via": "composes"
+        },
+        {
+          "kind": "technique",
+          "ref": "testing/fuzz-crash-to-fix-loop",
+          "role": "fix-implementation",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/workflow/backpressure-data-simulation": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "data/producer-consumer-backpressure-loop",
+          "role": "backpressure-shape-baseline",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/workflow/bucket-parallel-java-annotation-dispatch": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "workflow/parallel-dispatch-breakeven-point",
+          "role": "specific-variant",
+          "via": "examines"
+        }
+      ]
+    },
+    "skill/workflow/bulkhead-data-simulation": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "ai/coordinator-overhead-vs-parallelism",
+          "role": "isolation-baseline",
+          "via": "examines"
+        },
+        {
+          "kind": "technique",
+          "ref": "ai/multi-agent-fan-out-with-isolation",
+          "role": "isolation-shape",
+          "via": "composes"
+        },
+        {
+          "kind": "technique",
+          "ref": "workflow/fan-out-fan-in-with-bulkhead",
+          "role": "isolation-shape-baseline",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/workflow/canary-release-data-simulation": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "devops/canary-auto-revert-calibration",
+          "role": "canary-shape",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "devops/canary-auto-revert-calibration",
+          "role": "replay-harness",
+          "via": "requires:canary-threshold-calibration-tool"
+        },
+        {
+          "kind": "technique",
+          "ref": "devops/canary-rollout-with-auto-revert",
+          "role": "canary-shape-baseline",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/workflow/circuit-breaker-data-simulation": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "arch/feature-flag-flap-prevention-policies",
+          "role": "circuit-state-shape",
+          "via": "examines"
+        },
+        {
+          "kind": "technique",
+          "ref": "arch/feature-flag-killswitch-with-circuit-state",
+          "role": "circuit-state-shape",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/workflow/finite-state-machine-data-simulation": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "arch/finite-state-machine-monotonic-ratchet",
+          "role": "state-machine-baseline",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/workflow/idempotency-data-simulation": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "db/migration-checkpoint-overhead",
+          "role": "idempotency-discipline",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "db/migration-checkpoint-overhead",
+          "role": "idempotency-pattern",
+          "via": "requires:migration-checkpoint-granularity-benchmark"
+        },
+        {
+          "kind": "paper",
+          "ref": "frontend/optimistic-ui-flicker-tolerance",
+          "role": "idempotency-discipline",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "testing/contract-test-staleness-curve",
+          "role": "replay-safety-pattern",
+          "via": "examines"
+        },
+        {
+          "kind": "technique",
+          "ref": "arch/saga-with-compensation-chain",
+          "role": "per-step-idempotency-shape",
+          "via": "composes"
+        },
+        {
+          "kind": "technique",
+          "ref": "db/idempotent-migration-with-resume-checkpoint",
+          "role": "per-step-idempotency-pattern",
+          "via": "composes"
+        },
+        {
+          "kind": "technique",
+          "ref": "frontend/optimistic-mutation-with-server-reconcile",
+          "role": "server-side-idempotency",
+          "via": "composes"
+        },
+        {
+          "kind": "technique",
+          "ref": "testing/contract-test-with-consumer-verification",
+          "role": "replay-safety-pattern",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/workflow/parallel-build-sequential-publish": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "workflow/technique-layer-composition-value",
+          "role": "atom-whose",
+          "via": "examines"
+        },
+        {
+          "kind": "technique",
+          "ref": "workflow/safe-bulk-pr-publishing",
+          "role": "orchestrator",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/workflow/parallel-bulk-annotation": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "workflow/parallel-dispatch-breakeven-point",
+          "role": "canonical-how-to",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "workflow/parallel-dispatch-breakeven-point",
+          "role": "the skill being edited",
+          "via": "requires:parallel-bulk-annotation-preflight-section"
+        },
+        {
+          "kind": "paper",
+          "ref": "workflow/parallel-dispatch-breakeven-point",
+          "role": "baseline-how-to",
+          "via": "requires:parallel-dispatch-coverage-gate"
+        }
+      ]
+    },
+    "skill/workflow/raft-consensus-data-simulation": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "arch/multi-peer-quorum-decision-loop",
+          "role": "consensus-baseline",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/workflow/rollback-anchor-tag-before-destructive-op": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "arch/saga-with-compensation-chain",
+          "role": "pre-flight-audit-anchor",
+          "via": "composes"
+        },
+        {
+          "kind": "technique",
+          "ref": "workflow/safe-bulk-pr-publishing",
+          "role": "pre-flight-safety",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/workflow/saga-pattern-data-simulation": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "arch/saga-vs-2pc-cost-curve",
+          "role": "saga-shape",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "arch/saga-vs-2pc-cost-curve",
+          "role": "saga-implementation-baseline",
+          "via": "requires:saga-vs-2pc-microbenchmark"
+        },
+        {
+          "kind": "technique",
+          "ref": "arch/saga-with-compensation-chain",
+          "role": "forward-chain-baseline",
+          "via": "composes"
+        }
+      ]
+    },
+    "skill/workflow/strangler-fig-data-simulation": {
+      "cited_by": [
+        {
+          "kind": "technique",
+          "ref": "arch/strangler-fig-traffic-shifting",
+          "role": "shape-baseline",
+          "via": "composes"
+        }
+      ]
+    },
+    "technique/ai/agent-fallback-ladder": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "arch/technique-layer-roi-after-100-pilots",
+          "role": "example-of-uncited-technique",
+          "via": "examines"
+        }
+      ]
+    },
+    "technique/debug/root-cause-to-tdd-plan": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "arch/technique-layer-roi-after-100-pilots",
+          "role": "example-of-cited-technique",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "arch/technique-layer-roi-after-100-pilots",
+          "role": "starting-node-for-graph-walk",
+          "via": "requires:technique-citation-graph-builder"
+        },
+        {
+          "kind": "paper",
+          "ref": "workflow/technique-layer-composition-value",
+          "role": "pilot-decision",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "workflow/technique-layer-composition-value",
+          "role": "second shape template",
+          "via": "requires:hub-paper-commands"
+        },
+        {
+          "kind": "paper",
+          "ref": "workflow/technique-layer-composition-value",
+          "role": "reference-shape",
+          "via": "requires:security-domain-technique-3"
+        }
+      ]
+    },
+    "technique/testing/fuzz-crash-to-fix-loop": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "arch/technique-layer-roi-after-100-pilots",
+          "role": "example-of-uncited-technique",
+          "via": "examines"
+        }
+      ]
+    },
+    "technique/workflow/safe-bulk-pr-publishing": {
+      "cited_by": [
+        {
+          "kind": "paper",
+          "ref": "arch/saga-vs-2pc-cost-curve",
+          "role": "shape-comparison-baseline-for-multi-step",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "arch/technique-layer-roi-after-100-pilots",
+          "role": "example-of-cited-technique",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "arch/technique-layer-roi-after-100-pilots",
+          "role": "starting-node-for-graph-walk",
+          "via": "requires:technique-citation-graph-builder"
+        },
+        {
+          "kind": "paper",
+          "ref": "workflow/technique-layer-composition-value",
+          "role": "pilot-linear",
+          "via": "examines"
+        },
+        {
+          "kind": "paper",
+          "ref": "workflow/technique-layer-composition-value",
+          "role": "shape-template",
+          "via": "requires:hub-paper-commands"
+        },
+        {
+          "kind": "paper",
+          "ref": "workflow/technique-layer-composition-value",
+          "role": "reference-shape",
+          "via": "requires:security-domain-technique-3"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Four flow improvements that target the same goal: **make techniques and papers actually used and the experiment loop actually closed**. With the schema in place after #1110/#1111, these are the remaining friction points.

| Idea | Problem | Fix |
|---|---|---|
| **1. Reverse-citation index** | A skill couldn't tell you which 3 techniques and 2 papers cite it. The 4-layer structure was invisible from the atom side. | `citations.json` builder + integration in `precheck.py`; `/hub-show` appends a `Cited by` block. |
| **2. 4-layer pre-impl discovery** | `/hub-suggest` only surfaced skills + knowledge. Papers and techniques that already analyzed the user's task stayed invisible at the moment they were most useful. | `/hub-suggest` now searches all four kinds; paper > technique > skill > knowledge as the same-score tiebreak. |
| **4. Loop-closing flow** | The first paper to close its loop took multiple manual edits across frontmatter sections. 14 of 15 papers stay at `status: draft` partly because closing is high-friction. | `/hub-paper-experiment-run <slug> [<exp>]` collects `result` + `supports_premise` + `observed_at` + `built_as`, prompts a premise rewrite when partial / refute, suggests outcomes, transitions status, runs verify. |
| **7. Paper from technique** | Authoring a paper from scratch is heavy. Authoring one against an existing technique is much lighter — the technique already names atoms, binding, failure cases. | `/hub-paper-from-technique <slug>` pre-fills examines[], 4 default perspectives, 1 proposed build, 1 experiment skeleton. ~1 hour → ~5 min. |

## Changes

**Tooling**
- `bootstrap/tools/_build_citations_index.py` (new) — walks paper/ + technique/ frontmatters, emits `citations.json` keyed by `<kind>/<ref>`. Each entry records source kind+ref, role, and via (composes / examines / requires:<build-slug>). Sorted, deterministic.
- `bootstrap/tools/precheck.py` — runs the citations builder after master/category indexes
- `citations.json` (new) — initial build: 61 atoms cited, 99 paper refs + 62 technique refs

**Commands**
- `bootstrap/commands/hub-show.md` — new step 5 appends `Cited by` block from `citations.json`, grouped technique→paper, ≤8 entries with tail
- `bootstrap/commands/hub-suggest.md` — search all 4 kinds; per-kind UX (paper/technique/skill/knowledge) with tailored prompts
- `bootstrap/commands/hub-paper-experiment-run.md` (new, 150 lines) — guided experiment closure
- `bootstrap/commands/hub-paper-from-technique.md` (new, 175 lines) — paper-from-technique scaffold

## Verification

- `_build_citations_index.py` runs cleanly, output validates as JSON, sorts deterministically
- `_lint_frontmatter.py` PASS, 2032 files, 0 errors
- `precheck.py` runs the citations step (master-index step in precheck has a pre-existing local-path issue unrelated to this PR — needs the `~/.claude/skills-hub/indexes/` dir which only exists on installed environments)
- All 4 new pages register correctly in the bootstrap commands directory

## Test plan

- [ ] Restart Claude Code (new slash commands) and try:
  - `/hub-show retry-with-jitter-backoff` — confirm `Cited by` block renders
  - `/hub-suggest "분산 dispatch 구현해줘"` — confirm paper `parallel-dispatch-breakeven-point` surfaces FIRST
  - `/hub-paper-from-technique safe-bulk-pr-publishing` — confirm draft scaffolds with 4 examines + 4 perspectives + 1 experiment
  - `/hub-paper-experiment-run <a-planned-paper>` — walk a real experiment closure end-to-end
- [ ] After merge, `precheck.py` regenerates `citations.json` on each commit / merge

## What's next (not in this PR)

From the brainstorm we discussed:

- Citation graph SVG/Mermaid in README + wiki Home (idea 3)
- `/hub-paper-list --stale` flagging > 30-day drafts with planned experiments (idea 5)
- Falsifiability lint advisory on `premise.then` (idea 6)
- Outcomes reverse-link writeback to produced corpus entries (idea 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
