### PR TITLE
feat(hub): paper --stale + atom --orphans (loop-closing pressure + 2nd closed paper-loop signal)

### DIFF
--- a/bootstrap/commands/hub-list.md
+++ b/bootstrap/commands/hub-list.md
@@ -1,6 +1,6 @@
 ---
-description: Unified local-state list (skills + knowledge + techniques + examples). Supersedes /hub-list-skills, /hub-list-knowledge, /hub-list-examples.
-argument-hint: [--kind skills|knowledge|techniques|examples|all] [--category <cat>] [--tag <tag>]
+description: Unified local-state list (skills + knowledge + techniques + examples). Supersedes /hub-list-skills, /hub-list-knowledge, /hub-list-examples. Use --orphans to see uncited atoms.
+argument-hint: [--kind skills|knowledge|techniques|examples|all] [--category <cat>] [--tag <tag>] [--orphans [--list]]
 ---
 
 # /hub-list $ARGUMENTS
@@ -28,6 +28,29 @@ One entry point for "what's installed locally?". Delegates to the specialised fl
    knowledge  | pitfall  | kafka-consumer-hostname... | high         | (n/a)
    ```
 4. End-of-output summary: `<N> skills, <M> knowledge, <T> techniques installed` (and examples count if included).
+
+## `--orphans` flag
+
+When `--orphans` is passed, the command pivots from "what's installed" to "what's uncited" — surfacing atoms (skills + knowledge) that are NOT referenced by any technique's `composes[]` or paper's `examines[]` / `proposed_builds[].requires[]`.
+
+Implementation: invoke `python ~/.claude/skills-hub/remote/bootstrap/tools/_audit_orphan_atoms.py [--kind=skill|knowledge] [--category=<cat>] [--list]` and render its category-grouped table. Output ends with the running orphan rate vs the prediction in `paper/arch/technique-layer-roi-after-100-pilots` (≥80% expected).
+
+```
+KIND:CATEGORY                       TOTAL  CITED  ORPHAN     %
+skill:workflow                        105     13      92  87.6%
+skill:testing                          25      3      22  88.0%
+knowledge:pitfall                     142      8     134  94.4%
+…
+TOTAL                                2000     54    1946  97.3%
+
+[hypothesis support] paper/arch/technique-layer-roi-after-100-pilots predicts ≥80% orphan rate at scale; observed = 97.3%.
+```
+
+The signal cuts both ways:
+- High orphan rate **supports** the long-tail hypothesis paper (and is itself a closed-loop event for that paper)
+- It also highlights atoms ripe for `/hub-technique-compose` — pick uncited skills/knowledge that frequently appear together and turn them into a technique
+
+Add `--list` to enumerate every orphan ref grouped by category. Without `--list`, only counts are shown.
 
 ## Why exists
 

--- a/bootstrap/commands/hub-paper-list.md
+++ b/bootstrap/commands/hub-paper-list.md
@@ -1,6 +1,6 @@
 ---
-description: List locally drafted and installed papers, grouped by status (v0.2 adds type column)
-argument-hint: [--status draft|reviewed|implemented|retracted] [--type hypothesis|survey|position] [--category <cat>] [--drafts-only | --installed-only]
+description: List locally drafted and installed papers, grouped by status (v0.2 adds type column; --stale flags hypothesis papers ready to close)
+argument-hint: [--status draft|reviewed|implemented|retracted] [--type hypothesis|survey|position] [--category <cat>] [--drafts-only | --installed-only] [--stale [--stale-days=N]]
 ---
 
 # /hub-paper-list $ARGUMENTS
@@ -33,6 +33,24 @@ Report papers (hypothesis-driven analyses) present on disk:
    - Empty `proposed_builds[]` → append `(pure-analysis)`
    - `type=position` with empty `experiments[]` and empty `outcomes[]` → append `(opinion-only)` — elevated flag under v0.2 retraction criterion
 8. Trailing summary: `<N> drafts, <M> installed (<d> draft, <r> reviewed, <i> implemented, <ret> retracted; <h> hypothesis, <s> survey, <p> position)`.
+
+## `--stale` flag (v2.7.x)
+
+When `--stale` is passed, restrict the listing to papers that are *ready to close* but haven't been:
+
+- `type: hypothesis` AND
+- `status` ∈ {`draft`, `reviewed`} AND
+- at least one `experiments[]` entry with `status` ∈ {`planned`, `running`} AND
+- first-commit age ≥ `--stale-days` (default 30)
+
+Implementation: invoke `python ~/.claude/skills-hub/remote/bootstrap/tools/_audit_paper_loops.py --only-stale --stale-days=<N>` and render its rows. Stale papers are flagged with `!` in the leftmost column, and the trailing line includes:
+
+```
+3/15 stale (≥30d, hypothesis with planned/running experiments).
+Action: /hub-paper-experiment-run <slug> to close the loop.
+```
+
+Without `--stale`, the audit tool still runs in informational mode (no filter) and the table gains a `CITED` column from `citations.json` so that low-cited drafts surface naturally.
 
 ## v0.2 retraction-criterion signal
 

--- a/bootstrap/tools/_audit_orphan_atoms.py
+++ b/bootstrap/tools/_audit_orphan_atoms.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Find orphan atoms — skills and knowledge entries that are not cited by any technique or paper.
+
+A "0-citation" atom is the empirical signal that `paper/arch/technique-layer-roi-after-100-pilots`
+predicts will dominate the corpus (≥80% under-cited). This tool produces the actual measurement,
+turning a hypothesis into observable data:
+
+  - Reads citations.json (built by _build_citations_index.py)
+  - Walks skills/ + knowledge/ trees and computes the complement
+  - Reports orphan counts grouped by category, with optional per-entry listing
+
+Output formats:
+  - Default human table (counts per category + summary)
+  - --list      append every orphan ref grouped by category
+  - --json      machine-readable for downstream tooling
+  - --kind=skill | knowledge   restrict scope
+  - --category=<cat>           restrict to one category
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+HUB_ROOT = Path(__file__).resolve().parents[2]
+SKILLS_DIR = HUB_ROOT / "skills"
+KNOWLEDGE_DIR = HUB_ROOT / "knowledge"
+CITATIONS = HUB_ROOT / "citations.json"
+
+
+def load_cited_keys() -> set[str]:
+    if not CITATIONS.exists():
+        print("citations.json missing — run _build_citations_index.py first.", file=sys.stderr)
+        return set()
+    try:
+        data = json.loads(CITATIONS.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Failed to read citations.json: {e}", file=sys.stderr)
+        return set()
+    return set(data.get("citations", {}).keys())
+
+
+def walk_skills() -> list[tuple[str, str, str]]:
+    """Return [(kind=skill, ref=<category>/<name>, category)]."""
+    results = []
+    for skill_md in sorted(SKILLS_DIR.glob("**/SKILL.md")):
+        rel = skill_md.relative_to(SKILLS_DIR).parent.as_posix()
+        if "/" in rel:
+            category = rel.split("/", 1)[0]
+        else:
+            category = rel
+        results.append(("skill", rel, category))
+    return results
+
+
+def walk_knowledge() -> list[tuple[str, str, str]]:
+    """Return [(kind=knowledge, ref=<category>/<slug>, category)]."""
+    results = []
+    for k_md in sorted(KNOWLEDGE_DIR.glob("**/*.md")):
+        # Skip files outside category subdirs
+        rel = k_md.relative_to(KNOWLEDGE_DIR).as_posix()
+        # Strip ".md"
+        if rel.endswith(".md"):
+            rel = rel[:-3]
+        # Skip top-level files (need a category folder)
+        if "/" not in rel:
+            continue
+        # Skip "external" — those are imports, not first-party knowledge
+        if rel.startswith("external/"):
+            continue
+        category = rel.split("/", 1)[0]
+        results.append(("knowledge", rel, category))
+    return results
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--kind", choices=["skill", "knowledge"], help="Restrict scope")
+    p.add_argument("--category", help="Restrict to one category")
+    p.add_argument("--list", action="store_true", help="Print every orphan ref")
+    p.add_argument("--json", action="store_true", help="Emit JSON")
+    args = p.parse_args()
+
+    cited = load_cited_keys()
+    if not cited:
+        return 1
+
+    atoms: list[tuple[str, str, str]] = []
+    if args.kind != "knowledge":
+        atoms.extend(walk_skills())
+    if args.kind != "skill":
+        atoms.extend(walk_knowledge())
+    if args.category:
+        atoms = [a for a in atoms if a[2] == args.category]
+
+    by_cat: dict[str, dict] = defaultdict(lambda: {"total": 0, "orphans": [], "cited": 0})
+    for kind, ref, category in atoms:
+        key = f"{kind}/{ref}"
+        bucket = by_cat[f"{kind}:{category}"]
+        bucket["total"] += 1
+        if key in cited:
+            bucket["cited"] += 1
+        else:
+            bucket["orphans"].append(ref)
+
+    total_atoms = sum(b["total"] for b in by_cat.values())
+    total_orphan = sum(len(b["orphans"]) for b in by_cat.values())
+    total_cited = total_atoms - total_orphan
+    pct = (total_orphan / total_atoms * 100) if total_atoms else 0
+
+    if args.json:
+        out = {
+            "summary": {
+                "total_atoms": total_atoms,
+                "cited": total_cited,
+                "orphans": total_orphan,
+                "orphan_pct": round(pct, 1),
+            },
+            "by_category": {k: {"total": v["total"], "cited": v["cited"], "orphans": len(v["orphans"]),
+                               "orphan_refs": sorted(v["orphans"])} for k, v in sorted(by_cat.items())},
+        }
+        print(json.dumps(out, indent=2, ensure_ascii=False))
+        return 0
+
+    print(f"{'KIND:CATEGORY':<32} {'TOTAL':>6} {'CITED':>6} {'ORPHAN':>7} {'%':>6}")
+    for key in sorted(by_cat.keys()):
+        b = by_cat[key]
+        orphan_n = len(b["orphans"])
+        orphan_pct = (orphan_n / b["total"] * 100) if b["total"] else 0
+        print(f"{key:<32} {b['total']:>6} {b['cited']:>6} {orphan_n:>7} {orphan_pct:>5.1f}%")
+
+    print(f"\n{'TOTAL':<32} {total_atoms:>6} {total_cited:>6} {total_orphan:>7} {pct:>5.1f}%")
+
+    # Empirical signal commentary
+    if total_atoms >= 100 and pct >= 80:
+        print(
+            "\n[hypothesis support] paper/arch/technique-layer-roi-after-100-pilots predicts "
+            ">=80% orphan rate at scale; observed = {:.1f}%.".format(pct)
+        )
+    elif total_atoms >= 100:
+        print(
+            "\n[hypothesis status] paper/arch/technique-layer-roi-after-100-pilots predicts "
+            ">=80% orphan; observed = {:.1f}%. Threshold not yet reached.".format(pct)
+        )
+
+    if args.list:
+        print("\nOrphan list:")
+        for key in sorted(by_cat.keys()):
+            orphans = by_cat[key]["orphans"]
+            if not orphans:
+                continue
+            print(f"\n# {key}")
+            for ref in sorted(orphans):
+                print(f"  {ref}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bootstrap/tools/_audit_paper_loops.py
+++ b/bootstrap/tools/_audit_paper_loops.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Per-paper loop-health audit. Surfaces papers stuck in draft with planned experiments past a stale threshold.
+
+For each PAPER.md, reports:
+  - slug, category
+  - type (hypothesis | survey | position)
+  - status (draft | reviewed | implemented | retracted)
+  - experiments by state: planned / running / completed / abandoned
+  - outcomes count
+  - first-commit age in days (git log --diff-filter=A --reverse --format=%aI)
+  - cited_by count (consults citations.json)
+  - stale flag — true when type=hypothesis AND status in {draft, reviewed} AND age >= --stale-days AND any experiment.status in {planned, running}
+
+Stale = "you can close this loop and you haven't yet". The §11 retraction signal fires
+when ≥5 papers carry empty experiments + outcomes; --stale fires earlier and per-paper
+to invite action before the layer-level signal pressure builds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+HUB_ROOT = Path(__file__).resolve().parents[2]
+PAPER_DIR = HUB_ROOT / "paper"
+CITATIONS = HUB_ROOT / "citations.json"
+
+
+def split_frontmatter(text: str) -> str:
+    if not text.startswith("---\n"):
+        return ""
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return ""
+    return text[4 : end + 1]
+
+
+def parse_frontmatter(text: str) -> dict:
+    fm = split_frontmatter(text)
+    if not fm:
+        return {}
+    try:
+        return yaml.safe_load(fm) or {}
+    except yaml.YAMLError:
+        return {}
+
+
+def first_commit_iso(path: Path) -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(HUB_ROOT), "log", "--diff-filter=A", "--reverse",
+             "--format=%aI", str(path.relative_to(HUB_ROOT).as_posix())],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip().splitlines()
+        return out[0] if out else None
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def days_since(iso: str | None) -> int | None:
+    if not iso:
+        return None
+    try:
+        dt = datetime.fromisoformat(iso)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        delta = datetime.now(timezone.utc) - dt
+        return delta.days
+    except ValueError:
+        return None
+
+
+def load_citations_count() -> dict[str, int]:
+    if not CITATIONS.exists():
+        return {}
+    try:
+        data = json.loads(CITATIONS.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return {k: len(v.get("cited_by", [])) for k, v in (data.get("citations") or {}).items()}
+
+
+def audit_paper(path: Path, citations: dict[str, int], stale_days: int) -> dict:
+    fm = parse_frontmatter(path.read_text(encoding="utf-8"))
+    rel_to_paper_dir = path.relative_to(PAPER_DIR).parent.as_posix()
+    paper_key = f"paper/{rel_to_paper_dir}"
+
+    type_ = (fm.get("type") or "hypothesis").strip()
+    status = (fm.get("status") or "").strip()
+    experiments = fm.get("experiments") or []
+    exp_status = Counter()
+    for e in experiments:
+        if isinstance(e, dict):
+            exp_status[(e.get("status") or "unknown").strip()] += 1
+    outcomes = fm.get("outcomes") or []
+
+    age = days_since(first_commit_iso(path))
+    cited_by = citations.get(paper_key, 0)
+
+    # Stale rule: type=hypothesis + status not yet implemented + has at least one planned/running + age >= threshold
+    stale = (
+        type_ == "hypothesis"
+        and status in ("draft", "reviewed")
+        and (exp_status.get("planned", 0) + exp_status.get("running", 0)) > 0
+        and age is not None
+        and age >= stale_days
+    )
+
+    return {
+        "slug": rel_to_paper_dir,
+        "category": (fm.get("category") or "").strip(),
+        "name": (fm.get("name") or "").strip(),
+        "description": (fm.get("description") or "").strip(),
+        "type": type_,
+        "status": status,
+        "experiments": dict(exp_status),
+        "outcomes_count": len(outcomes),
+        "age_days": age,
+        "cited_by": cited_by,
+        "stale": stale,
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--stale-days", type=int, default=30, help="Stale threshold in days (default 30)")
+    p.add_argument("--only-stale", action="store_true", help="Only emit stale papers")
+    p.add_argument("--json", action="store_true", help="Emit JSON instead of human table")
+    args = p.parse_args()
+
+    citations = load_citations_count()
+    rows = [audit_paper(p_, citations, args.stale_days) for p_ in sorted(PAPER_DIR.glob("**/PAPER.md"))]
+    if args.only_stale:
+        rows = [r for r in rows if r["stale"]]
+
+    if args.json:
+        print(json.dumps({"stale_threshold_days": args.stale_days, "papers": rows}, indent=2, ensure_ascii=False))
+        return 0
+
+    if not rows:
+        if args.only_stale:
+            print(f"No papers stale past {args.stale_days} days. Loop pressure is clean.")
+        else:
+            print("No papers found.")
+        return 0
+
+    # Human table
+    headers = ["STALE", "AGE", "TYPE", "STATUS", "EXP", "OUT", "CITED", "SLUG"]
+    print(f"{'STALE':<6} {'AGE':>5} {'TYPE':<10} {'STATUS':<12} {'EXP':<24} {'OUT':>4} {'CITED':>5}  SLUG")
+    for r in rows:
+        flag = "!" if r["stale"] else " "
+        age = "-" if r["age_days"] is None else f"{r['age_days']}d"
+        exp_summary = " ".join(f"{k}={v}" for k, v in sorted(r["experiments"].items())) or "—"
+        print(
+            f"{flag:<6} {age:>5} {r['type']:<10} {r['status']:<12} {exp_summary[:24]:<24} "
+            f"{r['outcomes_count']:>4} {r['cited_by']:>5}  {r['slug']}"
+        )
+
+    stale_n = sum(1 for r in rows if r["stale"])
+    total = len(rows)
+    if stale_n:
+        print(f"\n{stale_n}/{total} stale (≥{args.stale_days}d, hypothesis with planned/running experiments).")
+        print("Action: /hub-paper-experiment-run <slug> to close the loop.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bootstrap/tools/precheck.py
+++ b/bootstrap/tools/precheck.py
@@ -54,6 +54,10 @@ def main() -> int:
     steps.append(("master-index-lite", [py, "_build_master_index_lite.py"]))
     steps.append(("category-indexes", [py, "_build_category_indexes.py"]))
     steps.append(("citations-index", [py, "_build_citations_index.py"]))
+    # Audits run after citations are fresh; they read citations.json. Pre-existing
+    # paper/orphan health is informational only — do not abort precheck on their output.
+    steps.append(("orphan-audit", [py, "_audit_orphan_atoms.py"]))
+    steps.append(("paper-loops-audit", [py, "_audit_paper_loops.py"]))
 
     for label, cmd in steps:
         rc = run(label, cmd)


### PR DESCRIPTION
## Summary

Follow-up to #1113. With `citations.json` shipped, two natural extensions:

1. **`/hub-paper-list --stale`** — filters to papers ready to close (hypothesis + planned/running experiment + age ≥ 30 days). Names the next paper to act on. Companion to `/hub-paper-experiment-run`.
2. **`/hub-list --orphans`** — uncited atoms (skills + knowledge not referenced by any technique or paper), grouped by category, with empirical comparison to the long-tail prediction in `paper/arch/technique-layer-roi-after-100-pilots`.

The orphan audit also produces an unexpected by-product: it **empirically supports** the long-tail paper. Predicted ≥80%, observed **97.3%**. That paper is now ready to transition `draft → implemented` via `/hub-paper-experiment-run` — the second closed loop in the hub.

## Changes

**Tooling**
- `bootstrap/tools/_audit_paper_loops.py` (new) — per-paper loop-health audit. Reports type / status / experiments by state / outcomes / age (git first-commit) / cited_by. Stale flag = type=hypothesis + status not implemented + planned/running experiment + age ≥ N.
- `bootstrap/tools/_audit_orphan_atoms.py` (new) — walks skills + knowledge, computes complement of citations.json keys, groups by category, surfaces empirical orphan rate.
- `bootstrap/tools/precheck.py` — runs both audits after the citations-index step (informational; failures don't abort).

**Commands**
- `bootstrap/commands/hub-paper-list.md` — adds `--stale [--stale-days=N]` flag + a `CITED` column on the default listing
- `bootstrap/commands/hub-list.md` — adds `--orphans [--list]` flag delegating to the orphan audit

## Live measurement

\`\`\`
KIND:CATEGORY                       TOTAL  CITED  ORPHAN     %
skill:workflow                        105     13      92  87.6%
skill:testing                          25      3      22  88.0%
…
TOTAL                                2000     54    1946  97.3%

[hypothesis support] paper/arch/technique-layer-roi-after-100-pilots predicts ≥80% orphan rate at scale; observed = 97.3%.
\`\`\`

\`\`\`
STALE    AGE TYPE       STATUS       EXP                  OUT CITED  SLUG
          0d hypothesis implemented  completed=1            2     3  workflow/parallel-dispatch-breakeven-point
          0d hypothesis draft        planned=1              0     0  ai/coordinator-overhead-vs-parallelism
…
0/15 stale (papers all <30d). Threshold not yet active — natural in a fresh corpus.
\`\`\`

## Verification

- Lint PASS (2032 files, 0 errors)
- Both audit tools run cleanly and produce stable, deterministic output
- Pre-existing master-index failure on local working tree is unrelated to this PR (looks for `bootstrap/indexes/` dir which only exists in installed environments)

## Follow-up (not in this PR)

- The orphan audit's strong support for `paper/arch/technique-layer-roi-after-100-pilots` (97.3% vs ≥80% predicted) means that paper has earned a real loop closure. A follow-up edit can use `/hub-paper-experiment-run` to record this measurement as the experiment result and transition the paper to \`implemented\`. Will be the **second** closed-loop paper in the hub.
- Citation graph viz (Mermaid) — uses citations.json, fits naturally on README + wiki Home (idea 3 from the brainstorm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)