### PR TITLE
feat(hub): heuristic falsifiability advisory for paper.premise.then

### DIFF
--- a/bootstrap/commands/hub-paper-verify.md
+++ b/bootstrap/commands/hub-paper-verify.md
@@ -76,6 +76,25 @@ With `--all`, end with aggregate: `<K> papers verified: <pass> pass, <warn> warn
 - `WARN` only → pass with advisory
 - `--strict` upgrades all `WARN` to `FAIL`
 
+## Falsifiability advisory (separate, non-gating)
+
+`/hub-paper-verify` itself stays structural — it does not judge whether a `premise.then` is *checkable*. A complementary audit, `_audit_paper_falsifiability.py`, runs three heuristic detectors over each `type: hypothesis` paper's `premise.then`:
+
+- Comparison operators (`≥`, `≤`, `<`, `>`, `=`, `≈`, `~`, `±`) or comparison phrases ('at least', 'exceeds', 'falls below', etc.)
+- Numeric thresholds (digit followed by `%`, `percent`, `x`, `σ`, units, `N=`, etc.)
+- Functional-form vocabulary (`linearly`, `exponentially`, `power-law`, `saturates`, `crossover`, `inverts`, etc.)
+
+If none fire, the paper is flagged with an advisory WARN — the heuristic's read is "this premise has no measurable predicate the experiment can check; consider rewriting". It is intentionally heuristic; both false positives (papers that are falsifiable but use unusual language) and false negatives (papers with a numeric threshold for a vacuous claim) are possible.
+
+The audit runs automatically via `precheck.py` (post-merge / post-commit hooks) and can be invoked directly:
+
+```
+python ~/.claude/skills-hub/remote/bootstrap/tools/_audit_paper_falsifiability.py
+python ~/.claude/skills-hub/remote/bootstrap/tools/_audit_paper_falsifiability.py --only-flagged
+```
+
+Survey and position papers are exempt by default — their premises are not prediction-shaped. Use `--include-survey-position` to audit them anyway.
+
 ## Rules
 
 - Read-only. No mutation.

--- a/bootstrap/tools/_audit_paper_falsifiability.py
+++ b/bootstrap/tools/_audit_paper_falsifiability.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Heuristic falsifiability advisory for paper.premise.then strings.
+
+A `type: hypothesis` paper's value depends on the premise being *checkable* — capable
+of being supported, refined, or refuted by an experiment. A premise that says "X is
+good" cannot be tested. A premise that says "X drops latency by ≥30% past N=4 calls"
+can be tested.
+
+This tool runs three signal detectors over each paper's `premise.then` and emits an
+advisory WARN when none of them fire. It is intentionally heuristic — false positives
+(papers that are falsifiable but use unusual language) and false negatives (papers
+that have a numeric threshold for a vacuous claim) are both possible. The advisory
+is meant to *invite* a sharper rewrite, not to gate publication.
+
+Signals (any 1+ match → falsifiable):
+
+  A. Comparison operators (≥, ≤, <, >, =, ≈, ~, ±) or comparison phrases
+     ('at least', 'exceeds', 'falls below', 'under <num>', 'over <num>')
+  B. Numeric thresholds (\\d+ followed by %, percent, x, σ, units, or N=)
+  C. Functional-form vocabulary (linearly / exponentially / power-law / saturat /
+     superlinearly / logarithmically / polynomially)
+
+Survey and position papers are exempt by default — their premises are not
+prediction-shaped. Pass --include-survey-position to audit them anyway.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+HUB_ROOT = Path(__file__).resolve().parents[2]
+PAPER_DIR = HUB_ROOT / "paper"
+
+COMPARISON_RE = re.compile(
+    r"[≥≤><=≈~±]"                                         # operators
+    r"|\bat least\b|\bat most\b"                          # phrases
+    r"|\bexceeds?\b|\bfalls? below\b"
+    r"|\bunder \d|\bover \d"
+    r"|\bbelow \d|\babove \d",
+    re.IGNORECASE,
+)
+
+THRESHOLD_RE = re.compile(
+    r"\d+\s*(?:%|percent|x|σ|files?|months?|days?|seconds?|ms|hours?|N=|years?)",
+    re.IGNORECASE,
+)
+
+FUNCTIONAL_FORM_RE = re.compile(
+    r"\b(?:linearly|logarithmically|exponentially|polynomially|"
+    r"power[- ]law|superlinearly|sublinearly|saturat\w+|"
+    r"plateau\w*|inverts?|crossover)\b",
+    re.IGNORECASE,
+)
+
+
+def split_frontmatter(text: str) -> str:
+    if not text.startswith("---\n"):
+        return ""
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return ""
+    return text[4 : end + 1]
+
+
+def parse_frontmatter(path: Path) -> dict | None:
+    fm = split_frontmatter(path.read_text(encoding="utf-8"))
+    if not fm:
+        return None
+    try:
+        return yaml.safe_load(fm) or {}
+    except yaml.YAMLError:
+        return None
+
+
+def detect_signals(text: str) -> list[str]:
+    signals: list[str] = []
+    if COMPARISON_RE.search(text):
+        signals.append("comparison")
+    if THRESHOLD_RE.search(text):
+        signals.append("threshold")
+    if FUNCTIONAL_FORM_RE.search(text):
+        signals.append("functional-form")
+    return signals
+
+
+def audit_paper(path: Path, include_survey_position: bool) -> dict | None:
+    fm = parse_frontmatter(path)
+    if fm is None:
+        return {
+            "slug": path.relative_to(PAPER_DIR).parent.as_posix(),
+            "skipped": "yaml-parse-error",
+        }
+    paper_type = (fm.get("type") or "hypothesis").strip()
+    if paper_type != "hypothesis" and not include_survey_position:
+        return None  # exempt
+    then = (fm.get("premise") or {}).get("then") or ""
+    if isinstance(then, list):
+        then = " ".join(str(x) for x in then)
+    signals = detect_signals(str(then))
+    return {
+        "slug": path.relative_to(PAPER_DIR).parent.as_posix(),
+        "type": paper_type,
+        "signals": signals,
+        "falsifiable": bool(signals),
+        "then_excerpt": str(then)[:140] + ("…" if len(str(then)) > 140 else ""),
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--include-survey-position", action="store_true",
+                   help="Audit survey and position papers too (default: hypothesis only)")
+    p.add_argument("--only-flagged", action="store_true",
+                   help="Print only papers that triggered the advisory")
+    p.add_argument("--json", action="store_true")
+    args = p.parse_args()
+
+    rows = []
+    for paper_md in sorted(PAPER_DIR.glob("**/PAPER.md")):
+        result = audit_paper(paper_md, args.include_survey_position)
+        if result is not None:
+            rows.append(result)
+
+    flagged = [r for r in rows if not r.get("falsifiable") and "skipped" not in r]
+    if args.only_flagged:
+        rows = flagged
+
+    if args.json:
+        print(json.dumps({
+            "summary": {
+                "audited": len(rows),
+                "flagged": len(flagged),
+                "skipped": sum(1 for r in rows if "skipped" in r),
+            },
+            "rows": rows,
+        }, indent=2, ensure_ascii=False))
+        return 0
+
+    if not rows:
+        print("No papers in scope.")
+        return 0
+
+    for r in rows:
+        if "skipped" in r:
+            print(f"[skip ] {r['slug']} — {r['skipped']}")
+            continue
+        flag = "  ! " if not r["falsifiable"] else "    "
+        sig = ",".join(r["signals"]) if r["signals"] else "(none)"
+        print(f"{flag}{r['type']:<10} {sig:<24} {r['slug']}")
+        if not r["falsifiable"]:
+            print(f"        then: {r['then_excerpt']}")
+
+    if flagged:
+        print(
+            f"\n{len(flagged)} paper(s) triggered the falsifiability advisory. "
+            "premise.then has no numeric threshold, comparison operator, or functional-form vocabulary. "
+            "Consider rewriting to add a measurable predicate the experiment can check."
+        )
+    else:
+        print(f"\nAll {len(rows)} hypothesis paper(s) carry at least one falsifiability signal.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bootstrap/tools/precheck.py
+++ b/bootstrap/tools/precheck.py
@@ -60,6 +60,7 @@ def main() -> int:
     # paper/orphan health is informational only — do not abort precheck on their output.
     steps.append(("orphan-audit", [py, "_audit_orphan_atoms.py"]))
     steps.append(("paper-loops-audit", [py, "_audit_paper_loops.py"]))
+    steps.append(("paper-falsifiability-audit", [py, "_audit_paper_falsifiability.py"]))
 
     for label, cmd in steps:
         rc = run(label, cmd)


### PR DESCRIPTION
## Summary

Idea D from the brainstorm: a heuristic check on \`type: hypothesis\` papers' \`premise.then\`. The lint (\`/hub-paper-verify\`) stays strictly structural; this is a separate, **non-gating advisory** that asks "does this premise have a measurable predicate the experiment can actually check?".

## How it works

\`_audit_paper_falsifiability.py\` runs three signal detectors per paper:

- **Comparison operators** — \`≥\`, \`≤\`, \`<\`, \`>\`, \`=\`, \`≈\`, \`~\`, \`±\`, plus phrases like 'at least', 'exceeds', 'falls below', 'under N', 'over N'
- **Numeric thresholds** — digit followed by \`%\`, \`percent\`, \`x\`, \`σ\`, units, \`N=\`, etc.
- **Functional-form vocabulary** — \`linearly\`, \`exponentially\`, \`power-law\`, \`saturates\`, \`crossover\`, \`inverts\`, etc.

Any 1+ match → falsifiable. Zero matches → advisory WARN.

## Why advisory, not strict

Both false positives (papers that *are* falsifiable but use unusual language) and false negatives (papers with a numeric threshold on a vacuous claim) are possible. The signal invites a sharper rewrite; it never blocks publication. \`/hub-paper-verify\` stays structural by design — substance is reviewer judgment.

## Initial measurement (15 hypothesis papers)

13 carry signals; **2 flagged**:

| Paper | premise.then excerpt |
|---|---|
| \`data/backpressure-vs-rate-limit-comparison\` | "Backpressure (consumer-driven feedback) outperforms rate limiting (producer-side cap) when consumer capacity is variable…" |
| \`workflow/technique-layer-composition-value\` | "Durable composition value emerges — recipes that survive atom updates, generalize across shapes…" |

Both are qualitative claims without numeric thresholds. Exactly what the heuristic is designed to flag.

## Changes

- \`bootstrap/tools/_audit_paper_falsifiability.py\` (new, ~150 lines) — three-signal detector with --only-flagged, --json, --include-survey-position flags
- \`bootstrap/tools/precheck.py\` — runs the audit after the existing paper-loops audit (informational; non-zero exits don't abort)
- \`bootstrap/commands/hub-paper-verify.md\` — documents the advisory as complementary to the structural verifier

## Verification

- \`_lint_frontmatter.py\` PASS, 2032 files, 0 errors
- Audit runs cleanly, classifies the 13 quantitative papers as falsifiable, flags the 2 qualitative ones

## Follow-up (not in this PR)

The 2 flagged papers are candidates for premise rewrites — either:
- Tighten the premise to add a measurable predicate (e.g., \`backpressure-vs-rate-limit\` could quantify 'when consumer variance σ ≥ X')
- Or, if the claim is genuinely qualitative, change \`type: hypothesis\` → \`type: position\` so the advisory exempts them

Either path is reviewer judgment; the heuristic just surfaces the choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)