### PR TITLE
feat(hub): technique-suggestion scanner from atom bundle co-occurrence

### DIFF
--- a/bootstrap/commands/hub-technique-compose.md
+++ b/bootstrap/commands/hub-technique-compose.md
@@ -90,6 +90,30 @@ Authoring workflow for the `technique/` middle layer. Produces a `.technique-dra
 - **Never silently reject draft atoms**. If an atom is `*-draft`, prompt: "this atom is still in draft — compose anyway? (y/n)" — don't assume.
 - Authoring is a **write pass**; verification is a **separate pass** (step 7). Do not collapse them — keep the separation so the user sees the draft before it gets validated.
 
+## Discovery — _suggest_techniques.py
+
+If you don't already have a technique idea, run:
+
+```
+python ~/.claude/skills-hub/remote/bootstrap/tools/_suggest_techniques.py
+```
+
+The tool walks every existing technique's `composes[]` AND every paper's `proposed_builds[].requires[]`, finds atom bundles that recur in ≥2 different parent entries, and ranks them as candidate new techniques. Output looks like:
+
+```
+--- Bundle 1 (4 atoms) ---
+  • knowledge/pitfall/idempotency-implementation-pitfall
+  • skill/architecture/optimistic-mutation-pattern
+  • skill/backend/migration-processor-pipeline
+  • skill/workflow/idempotency-data-simulation
+  Parents containing ≥2 of these atoms:
+    [technique] db/idempotent-migration-with-resume-checkpoint  (3 of 4)
+    [technique] frontend/optimistic-mutation-with-server-reconcile  (3 of 4)
+    [build] db/migration-checkpoint-overhead/migration-checkpoint-granularity-benchmark  (2 of 4)
+```
+
+The tool runs automatically via `precheck.py` (post-merge / post-commit hooks). Bundles are *suggestions* — false positives include common dependencies that aren't worth their own technique. Use the parent list to judge whether the bundle is a genuine pattern or coincidental overlap.
+
 ## Out of scope (v0.1)
 
 - Publishing to remote hub (`/hub-technique-publish` — later).

--- a/bootstrap/tools/_suggest_techniques.py
+++ b/bootstrap/tools/_suggest_techniques.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Find atom bundles that recur across techniques and paper proposed_builds.
+
+When the same set of skills/knowledge is referenced together in multiple parent entries
+(a technique's composes[] OR a paper's proposed_builds[].requires[]), that bundle is a
+candidate for being formalized as a *new* technique. The current corpus has 17 techniques;
+this tool surfaces patterns hiding inside the citation graph that haven't been named yet.
+
+Why this matters
+----------------
+The technique layer's value comes from having canonical names for recurring compositions.
+A skill bundle that appears in 3+ parent entries but is not itself a technique is leaving
+that value unrealized — every author re-discovers the bundle from scratch.
+
+How
+---
+1. Walk every technique's composes[] → collect (parent, atom_set)
+2. Walk every paper's proposed_builds[].requires[] → collect (parent, atom_set)
+3. For each pair (a, b) of atoms, count parents containing both
+4. Pairs with count ≥ 2 are co-occurrence candidates
+5. Connected components in the co-occurrence graph become candidate bundles
+6. For each candidate bundle: report the parents containing ≥2 of its atoms,
+   so the human can judge whether the pattern is real or coincidental
+
+This is heuristic — bundles are *suggestions*, not refactor commands. False positives
+include "common dependencies" (every workflow technique uses parallel-build-sequential-publish)
+and false negatives include "patterns expressible only in prose, not by atom set".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from itertools import combinations
+from pathlib import Path
+
+import yaml
+
+HUB_ROOT = Path(__file__).resolve().parents[2]
+PAPER_DIR = HUB_ROOT / "paper"
+TECHNIQUE_DIR = HUB_ROOT / "technique"
+
+
+def split_frontmatter(text: str) -> str:
+    if not text.startswith("---\n"):
+        return ""
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return ""
+    return text[4 : end + 1]
+
+
+def parse_frontmatter(path: Path) -> dict:
+    fm = split_frontmatter(path.read_text(encoding="utf-8"))
+    if not fm:
+        return {}
+    try:
+        return yaml.safe_load(fm) or {}
+    except yaml.YAMLError:
+        return {}
+
+
+def atom_key(entry: dict) -> str | None:
+    kind = (entry.get("kind") or "").strip()
+    ref = (entry.get("ref") or "").strip()
+    if not kind or not ref:
+        return None
+    if kind not in ("skill", "knowledge"):
+        return None
+    return f"{kind}/{ref}"
+
+
+def gather_parents() -> list[tuple[str, str, frozenset[str]]]:
+    """Return [(parent_kind, parent_ref, frozenset_of_atom_keys)]."""
+    out: list[tuple[str, str, frozenset[str]]] = []
+
+    # Techniques
+    for tech_md in sorted(TECHNIQUE_DIR.glob("**/TECHNIQUE.md")):
+        fm = parse_frontmatter(tech_md)
+        ref = tech_md.relative_to(TECHNIQUE_DIR).parent.as_posix()
+        atoms = set()
+        for entry in fm.get("composes") or []:
+            if isinstance(entry, dict):
+                k = atom_key(entry)
+                if k:
+                    atoms.add(k)
+        if atoms:
+            out.append(("technique", ref, frozenset(atoms)))
+
+    # Paper proposed_builds.requires
+    for paper_md in sorted(PAPER_DIR.glob("**/PAPER.md")):
+        fm = parse_frontmatter(paper_md)
+        paper_ref = paper_md.relative_to(PAPER_DIR).parent.as_posix()
+        for build in fm.get("proposed_builds") or []:
+            if not isinstance(build, dict):
+                continue
+            slug = (build.get("slug") or "").strip()
+            atoms = set()
+            for entry in build.get("requires") or []:
+                if isinstance(entry, dict):
+                    k = atom_key(entry)
+                    if k:
+                        atoms.add(k)
+            if atoms:
+                out.append(("build", f"{paper_ref}/{slug}", frozenset(atoms)))
+
+    return out
+
+
+def pair_counts(parents: list[tuple[str, str, frozenset[str]]]) -> Counter:
+    counts: Counter = Counter()
+    for _, _, atoms in parents:
+        for pair in combinations(sorted(atoms), 2):
+            counts[pair] += 1
+    return counts
+
+
+def cluster_by_pairs(frequent_pairs: list[tuple[tuple[str, str], int]]) -> list[set[str]]:
+    """Connected components in the co-occurrence graph."""
+    adjacency: dict[str, set[str]] = defaultdict(set)
+    for (a, b), _ in frequent_pairs:
+        adjacency[a].add(b)
+        adjacency[b].add(a)
+
+    visited: set[str] = set()
+    components: list[set[str]] = []
+    for atom in adjacency:
+        if atom in visited:
+            continue
+        component: set[str] = set()
+        stack = [atom]
+        while stack:
+            n = stack.pop()
+            if n in visited:
+                continue
+            visited.add(n)
+            component.add(n)
+            stack.extend(adjacency[n])
+        if len(component) >= 2:
+            components.append(component)
+    return components
+
+
+def parents_containing(parents, bundle: set[str], min_overlap: int) -> list[tuple[str, str, int]]:
+    """Return parents that contain ≥ min_overlap atoms from the bundle."""
+    out = []
+    for kind, ref, atoms in parents:
+        overlap = len(atoms & bundle)
+        if overlap >= min_overlap:
+            out.append((kind, ref, overlap))
+    return sorted(out, key=lambda x: (-x[2], x[0], x[1]))
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--min-pair-count", type=int, default=2,
+                   help="Minimum parents that share a pair to count as co-occurring (default 2)")
+    p.add_argument("--min-bundle-overlap", type=int, default=2,
+                   help="Min atoms a parent must share with a bundle to be reported (default 2)")
+    p.add_argument("--top", type=int, default=10, help="Show top N candidate bundles (default 10)")
+    p.add_argument("--json", action="store_true")
+    args = p.parse_args()
+
+    parents = gather_parents()
+    if not parents:
+        print("No parent entries found.")
+        return 0
+
+    pc = pair_counts(parents)
+    frequent = [(p_, c) for p_, c in pc.items() if c >= args.min_pair_count]
+    frequent.sort(key=lambda x: -x[1])
+
+    bundles = cluster_by_pairs(frequent)
+    bundles.sort(key=lambda s: -len(s))
+    bundles = bundles[: args.top]
+
+    if args.json:
+        out = {
+            "parent_count": len(parents),
+            "frequent_pairs": [
+                {"a": p[0], "b": p[1], "shared_parents": c}
+                for p, c in frequent[: args.top * 4]
+            ],
+            "candidate_bundles": [
+                {
+                    "atoms": sorted(b),
+                    "parents": [
+                        {"kind": k, "ref": r, "overlap": o}
+                        for k, r, o in parents_containing(parents, b, args.min_bundle_overlap)
+                    ],
+                }
+                for b in bundles
+            ],
+        }
+        print(json.dumps(out, indent=2, ensure_ascii=False))
+        return 0
+
+    print(f"Scanned {len(parents)} parents (techniques + paper proposed_builds).")
+    print(f"Frequent atom pairs (shared by ≥{args.min_pair_count} parents): {len(frequent)}")
+    if not frequent:
+        print("\nNo recurring atom pairs found. The corpus is sparse — try lowering --min-pair-count "
+              "or wait for more techniques / proposed_builds.")
+        return 0
+
+    print("\nTop frequent pairs:")
+    for (a, b), c in frequent[: args.top]:
+        print(f"  {c}x  {a}  +  {b}")
+
+    if not bundles:
+        print("\nNo bundles formed (all frequent pairs are isolated).")
+        return 0
+
+    print(f"\n{len(bundles)} candidate bundle(s) for new techniques:\n")
+    for i, bundle in enumerate(bundles, 1):
+        print(f"--- Bundle {i} ({len(bundle)} atoms) ---")
+        for atom in sorted(bundle):
+            print(f"  • {atom}")
+        parents_match = parents_containing(parents, bundle, args.min_bundle_overlap)
+        if parents_match:
+            print(f"  Parents containing ≥{args.min_bundle_overlap} of these atoms:")
+            for kind, ref, overlap in parents_match[:8]:
+                print(f"    [{kind}] {ref}  ({overlap} of {len(bundle)})")
+            if len(parents_match) > 8:
+                print(f"    … and {len(parents_match) - 8} more")
+        print()
+
+    print("Action: candidates above are *suggestions*. To formalize one as a technique:")
+    print("  /hub-technique-compose <slug>   # then pick the bundle's atoms")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bootstrap/tools/precheck.py
+++ b/bootstrap/tools/precheck.py
@@ -61,6 +61,7 @@ def main() -> int:
     steps.append(("orphan-audit", [py, "_audit_orphan_atoms.py"]))
     steps.append(("paper-loops-audit", [py, "_audit_paper_loops.py"]))
     steps.append(("paper-falsifiability-audit", [py, "_audit_paper_falsifiability.py"]))
+    steps.append(("technique-suggestions", [py, "_suggest_techniques.py"]))
 
     for label, cmd in steps:
         rc = run(label, cmd)


### PR DESCRIPTION
## Summary

Idea F (re-scoped to fit the actual data we have): scan the citation graph for **atom bundles that recur in ≥2 different parent entries**, and surface them as candidate new techniques.

The original brainstorm phrasing ("detect repeated install patterns from telemetry") needs per-machine \`registry.json\` data the public hub doesn't see. The same intent — surface recurring atom co-occurrence — works against a data source we already have: each technique's \`composes[]\` and each paper's \`proposed_builds[].requires[]\` are explicit atom bundles. Atoms that always show up together are exactly the technique-recommendation signal.

## How it works

\`_suggest_techniques.py\` walks every technique + every paper proposed_build:

1. Each parent contributes a frozenset of atom keys
2. For each pair (a, b), count parents containing both → \`pair_count[(a,b)]\`
3. Pairs with \`count ≥ 2\` are co-occurrence candidates
4. Connected components in the co-occurrence graph become candidate bundles
5. For each bundle, list parents that already contain ≥2 of its atoms — so the human can judge whether the pattern is genuine

## Initial scan (36 parents)

14 atom pairs co-occur in ≥2 parents. Strongest candidates:

| Bundle | Atoms | Where it shows up |
|---|---|---|
| 1 | idempotency-pitfall + optimistic-mutation + migration-processor + idempotency-simulation | technique \`db/idempotent-migration-with-resume-checkpoint\` (3/4), technique \`frontend/optimistic-mutation-with-server-reconcile\` (3/4), 3 paper builds |
| 2 | circuit-breaker pitfall + ai-call-with-mock-fallback + conditional-feature-flag-rollout | technique \`ai/agent-fallback-ladder\` (2/3), technique \`arch/feature-flag-killswitch\` (2/3), 3 paper builds |
| 3 | debug/investigate + debug/triage-issue | technique \`debug/root-cause-to-tdd-plan\`, technique \`testing/fuzz-crash-to-fix-loop\`, 1 paper build |

Both Bundle 1 and Bundle 2 are real patterns (idempotent-mutation-with-rollback and circuit-breaker resilience respectively) — strong candidates for new techniques.

## Why advisory, not prescriptive

Bundles are *suggestions*, not refactor commands. False positives include:
- Common dependencies (every workflow technique uses parallel-build-sequential-publish)
- Atoms that co-occur for unrelated reasons in unrelated parents

The parent list under each bundle lets the reviewer judge whether the pattern is genuine or coincidental before invoking \`/hub-technique-compose\`.

## Changes

- \`bootstrap/tools/_suggest_techniques.py\` (new, ~190 lines) — bundle scanner with --json, --top, --min-pair-count flags
- \`bootstrap/tools/precheck.py\` — runs scanner alongside other audits; non-zero exits don't abort
- \`bootstrap/commands/hub-technique-compose.md\` — documents the tool as a discovery flow before blank-slate authoring

## Verification

- \`_lint_frontmatter.py\` PASS, 2032 files, 0 errors
- Scanner runs cleanly, output is deterministic, classifies parent counts correctly

## Where this fits

This was the last item from the original brainstorm thread. The hub now has:

- citations.json (forward + reverse) (#1113, #1117)
- atom-side surfacing in /hub-show (Cited by + Produced by) (#1113, #1117)
- 4-layer pre-impl discovery (#1113)
- /hub-paper-experiment-run + /hub-paper-from-technique flows (#1113)
- /hub-paper-list --stale + /hub-list --orphans (#1114)
- 2nd closed-loop paper landed (#1115)
- citation graph mermaid + architecture diagram (#1116)
- outcomes back-links + 2 papers' YAML hygiene (#1117)
- falsifiability advisory (#1118)
- **technique-suggestion scanner** (this PR)

The flow infrastructure is now reasonably complete. Future work likely shifts from infrastructure to *content*: closing more paper loops, authoring the suggested-bundle techniques, refining the flagged falsifiability papers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)