### PR TITLE
paper: refine 2 falsifiability-flagged papers — quantify one, retype the other

### DIFF
--- a/paper/data/backpressure-vs-rate-limit-comparison/PAPER.md
+++ b/paper/data/backpressure-vs-rate-limit-comparison/PAPER.md
@@ -8,7 +8,13 @@ type: hypothesis
 
 premise:
   if: A system needs to control producer rate to match consumer capacity
-  then: Backpressure (consumer-driven feedback) outperforms rate limiting (producer-side cap) when consumer capacity is variable; rate limiting outperforms backpressure when producer is uncontrolled (untrusted external traffic). Choosing the wrong one causes either dropped traffic or wasted capacity.
+  then: >-
+    Backpressure outperforms rate-limiting (≥30% lower drop rate at the same throughput
+    target) when consumer-capacity coefficient of variation σ/μ ≥ 0.3. Rate-limiting
+    outperforms backpressure (≥50% lower buffer-overflow rate) when the producer is
+    uncontrolled — i.e., ≥10% of inbound traffic originates outside the SLO contract.
+    Below the pair (σ/μ < 0.2, untrusted-share < 5%), both perform within 10% of each
+    other and the default choice is moot.
 
 examines:
   - kind: skill
@@ -53,8 +59,15 @@ proposed_builds:
 
 experiments:
   - name: backpressure-vs-rate-limit-workload-replay
-    hypothesis: Across 4 workload classes (steady, bursty, hostile, slow-consumer), backpressure wins ≥3 cases when producer is trusted; rate-limit wins ≥3 cases when producer is hostile.
-    method: Synthesize 4 workload generators; run each through both control mechanisms; measure p99 latency, drop rate, total throughput.
+    hypothesis: >-
+      In a 4-cell workload matrix (consumer σ/μ ∈ {0.1, 0.5} × untrusted-share ∈ {0%, 25%}),
+      backpressure achieves ≥30% lower drop rate at σ/μ ≥ 0.3 with trusted producer; rate-
+      limiting achieves ≥50% lower buffer-overflow rate with ≥10% untrusted share. The
+      crossover region (σ/μ ≈ 0.2, untrusted-share ≈ 5%) shows <10% delta between the two.
+    method: >-
+      Synthesize 4 workload generators (one per matrix cell). Run each for 5 minutes through
+      both control mechanisms. Measure drop rate, p99 latency, total throughput, and DLQ
+      depth. Compute pairwise % deltas per metric per cell.
     status: planned
     built_as: null
     result: null

--- a/paper/workflow/technique-layer-composition-value/PAPER.md
+++ b/paper/workflow/technique-layer-composition-value/PAPER.md
@@ -9,7 +9,7 @@ tags:
   - hub-architecture
   - technique-layer
 
-type: hypothesis
+type: position
 
 premise:
   if: A skills-hub adds a technique/ layer composing atoms by reference (not copy)
@@ -79,10 +79,16 @@ proposed_builds:
     # A future v0.2.1 may extend requires to allow kind:schema refs.
 
 experiments: []
-# No experiments yet. This paper's premise ("durable composition value") is a
-# long-horizon claim that needs months of usage data. Experiments will be filed
-# against specific sub-claims (e.g. "rename resilience via the lint rule in #1068")
-# once observation windows close.
+# This is a type=position paper — no experiments required by the schema.
+# The original draft was type=hypothesis, but the falsifiability advisory
+# correctly flagged the premise.then as qualitative (no numeric threshold,
+# no comparator). Re-typed to position, which is the honest categorisation:
+# this paper argues for the technique layer's existence based on observed
+# pilots, rather than predicting a specific measurable outcome at scale.
+#
+# Future quantification can spawn separate type=hypothesis papers against
+# specific sub-claims (e.g., paper/arch/technique-layer-roi-after-100-pilots
+# already does this for citation distribution at the layer level).
 
 outcomes:
   - kind: produced_technique


### PR DESCRIPTION
## Summary

Follow-up to #1118 (falsifiability advisory). The advisory flagged 2 of 15 hypothesis papers; this PR resolves both. Different fixes apply because the underlying problems are different:

| Paper | Diagnosis | Fix |
|---|---|---|
| \`data/backpressure-vs-rate-limit-comparison\` | Genuine comparative hypothesis with a planned experiment, just lacking quantification | Tighten premise.then with numeric thresholds; sharpen experiment.method to match |
| \`workflow/technique-layer-composition-value\` | Long-horizon argument for the technique layer's existence; the original draft itself noted experiments would need 'months of usage data' | Retype \`hypothesis → position\`. The falsifiability advisory exempts position papers by design. |

## Changes

### Paper 1 — quantify

**Before:**
\`\`\`
then: Backpressure (consumer-driven feedback) outperforms rate limiting (producer-side cap)
      when consumer capacity is variable; rate limiting outperforms backpressure when
      producer is uncontrolled.
\`\`\`

**After:**
\`\`\`
then: Backpressure outperforms rate-limiting (≥30% lower drop rate at the same throughput
      target) when consumer-capacity coefficient of variation σ/μ ≥ 0.3. Rate-limiting
      outperforms backpressure (≥50% lower buffer-overflow rate) when ≥10% of inbound
      traffic originates outside the SLO contract. Below the pair (σ/μ < 0.2,
      untrusted-share < 5%), both perform within 10% of each other and the default
      choice is moot.
\`\`\`

The experiment.hypothesis and experiment.method were also rewritten to specify a 4-cell workload matrix (σ/μ ∈ {0.1, 0.5} × untrusted-share ∈ {0%, 25%}) measuring drop rate, p99 latency, throughput, and DLQ depth.

### Paper 2 — retype

\`type: hypothesis → type: position\`

The premise (\"durable composition value emerges...\") is an argument for layer existence, not a measurable prediction. The original draft already noted that experiments would have to wait months. \`type: position\` is the honest categorisation — and specific *measurable* sub-claims about the technique layer already live in a separate hypothesis paper (\`paper/arch/technique-layer-roi-after-100-pilots\`).

## Verification

- \`_lint_frontmatter.py\` PASS, 2032 files, 0 errors
- \`_audit_paper_falsifiability.py --only-flagged\`: **0 papers flagged** (was 2/15)

## Brainstorm follow-up state

| Option | Status |
|---|---|
| A — Author Bundle 2 as new technique | Done #1120 |
| B — Refine falsifiability-flagged papers | **This PR** |
| C — Close another paper loop | Pending — pick a draft paper with a feasible synthetic experiment |

🤖 Generated with [Claude Code](https://claude.com/claude-code)