### PR TITLE
feat(paper): preprint package for parallel-dispatch-breakeven-point + schema convention

### DIFF
--- a/docs/rfc/paper-schema-draft.md
+++ b/docs/rfc/paper-schema-draft.md
@@ -220,6 +220,23 @@ The pre-IMRaD convention used `Premise / Background / Perspectives / External Co
 
 The **frontmatter remains canonical**. The body is the human-facing rendering of the same data, structured for portability — frontmatter feeds tooling, IMRaD body feeds reviewers and external preprint venues.
 
+### Optional `preprint/` subdirectory
+
+A paper may carry `paper/<category>/<slug>/preprint/` for venue-ready submissions:
+
+```
+paper/<category>/<slug>/
+  PAPER.md             # source of truth (frontmatter + IMRaD body)
+  preprint/            # optional, venue-ready render
+    paper.tex
+    references.bib
+    build.sh           # pdflatex + bibtex pipeline
+    README.md          # documents the source-of-truth contract
+    .gitignore         # excludes pdflatex aux files + paper.pdf
+```
+
+The preprint is **hand-mirrored** from the IMRaD body — when PAPER.md changes, the preprint must be updated alongside it. A future tool `_paper_to_latex.py` could automate the conversion; the v0.2.2 spec leaves it manual. The preprint exists for venues that need a PDF (arXiv, OpenReview, workshop submissions); the host catalog continues to cite the canonical `PAPER.md` path, not the preprint.
+
 ### Verification
 
 `/hub-paper-verify` does not enforce IMRaD compliance — it stays structural. A separate audit `_audit_paper_imrad.py` (analogous to the falsifiability advisory) reports per-paper non-compliance, runs in `precheck.py`, and is informational. Existing papers can migrate at their own pace; new compose flows generate IMRaD bodies by default.

--- a/paper/workflow/parallel-dispatch-breakeven-point/preprint/.gitignore
+++ b/paper/workflow/parallel-dispatch-breakeven-point/preprint/.gitignore
@@ -1,0 +1,11 @@
+# Build artifacts from pdflatex / bibtex
+*.aux
+*.log
+*.out
+*.toc
+*.bbl
+*.blg
+*.fls
+*.fdb_latexmk
+*.synctex.gz
+paper.pdf

--- a/paper/workflow/parallel-dispatch-breakeven-point/preprint/README.md
+++ b/paper/workflow/parallel-dispatch-breakeven-point/preprint/README.md
@@ -1,0 +1,47 @@
+# Preprint — `parallel-dispatch-breakeven-point`
+
+LaTeX preprint counterpart of [`paper/workflow/parallel-dispatch-breakeven-point/PAPER.md`](../PAPER.md). For venues that need a PDF (arXiv, OpenReview, workshop submissions), this directory carries an arXiv-compatible `paper.tex` rendered from the same content.
+
+## Source of truth
+
+The frontmatter + IMRaD body in `../PAPER.md` is the canonical source. This `paper.tex` is hand-mirrored from that body and is **not** auto-generated. When the source paper changes, this file must be updated alongside it (a future tool `_paper_to_latex.py` could automate this; out of scope for the initial preprint).
+
+## Build
+
+```bash
+bash build.sh
+```
+
+Requires `pdflatex` + `bibtex` (TeX Live, MacTeX, MiKTeX). Outputs `paper.pdf` alongside the source. The build runs `pdflatex` three times (once for layout, once for `\ref` resolution, once for the final TOC) plus `bibtex` between passes — standard for `article`-class papers with a bibliography.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `paper.tex` | LaTeX source. `article` class for portability across arXiv / OpenReview / workshop templates. |
+| `references.bib` | BibTeX file. Empty in v1 — `external_refs[]` in the host paper is currently `[]`. Populates as `/hub-research` adds external context. |
+| `build.sh` | Convenience build script. |
+| `paper.pdf` | Build artifact (gitignored). |
+
+## Submission target
+
+Not yet submitted. The paper's premise and experiment are complete (`status: implemented` with `supports_premise: partial`), and the IMRaD body is publication-shaped. Candidate venues:
+
+- **arXiv** (cs.SE / cs.AI) — preprint, no peer review. Requires institutional endorsement on first submission to a category. Length is fine (~750 words; arXiv has no minimum).
+- **Workshop submissions** — venues focused on LLM tooling, agent frameworks, or developer tooling at large CS conferences. The paper's contribution (a falsified-then-refined cost gate for agent dispatch) fits the "negative result / partial refute" track at such venues.
+- **Internal team-blog or company tech-blog** — for organizations using LLM agent pipelines internally; the paper reads as a research note documenting an internal finding.
+
+## Why this exists
+
+The host catalog's `paper/` layer ships papers as schema-validated YAML+Markdown. That format is great for tooling integration, citation graphs, and the closed-loop verification flow. It is not the format reviewers and venues expect. This directory bridges that gap for one paper as a worked example; future closed-loop papers can follow the same pattern (drop a `preprint/` directory, hand-render `paper.tex` from the IMRaD body).
+
+## What it does NOT do
+
+- Auto-render from PAPER.md. A future `bootstrap/tools/_paper_to_latex.py` could do this; out of scope here.
+- Auto-submit. arXiv submission requires a real account, optional institutional endorsement, and human review of the rendered PDF. This directory just produces the PDF.
+- Track citations to/from the preprint after submission. That's a separate concern handled by the host catalog's `citations.json` for internal references and by external indexing services (Google Scholar, Semantic Scholar) for academic citations once the paper is publicly visible.
+
+## Provenance
+
+- Authored 2026-04-25 as the first preprint companion in the host catalog. Mirrors the IMRaD body structure documented in `docs/rfc/paper-schema-draft.md` §5.
+- Closed-loop status: experiment ran 2026-04-24 and partially refuted the original 70%-coverage premise; the paper rewrote itself to use absolute useful-output count instead. The preprint reflects the refined claim, not the original.

--- a/paper/workflow/parallel-dispatch-breakeven-point/preprint/build.sh
+++ b/paper/workflow/parallel-dispatch-breakeven-point/preprint/build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Build the preprint PDF. Requires a TeX distribution with pdflatex + bibtex.
+#
+# Outputs paper.pdf alongside the source. Aux files (.aux, .log, .out, .bbl,
+# .blg) are also written; the .gitignore in this directory excludes them.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+if ! command -v pdflatex >/dev/null 2>&1; then
+  echo "[error] pdflatex not found. Install TeX Live or MacTeX." >&2
+  exit 1
+fi
+
+pdflatex -interaction=nonstopmode paper.tex
+# bibtex is a no-op while references.bib is empty; left in the pipeline so the
+# build is ready when external_refs[] is populated by /hub-research.
+if command -v bibtex >/dev/null 2>&1; then
+  bibtex paper || true
+fi
+pdflatex -interaction=nonstopmode paper.tex
+pdflatex -interaction=nonstopmode paper.tex
+
+echo
+echo "Built paper.pdf — $(du -h paper.pdf 2>/dev/null | cut -f1 || echo "size unknown")"

--- a/paper/workflow/parallel-dispatch-breakeven-point/preprint/paper.tex
+++ b/paper/workflow/parallel-dispatch-breakeven-point/preprint/paper.tex
@@ -1,0 +1,330 @@
+% arXiv-compatible preprint of paper/workflow/parallel-dispatch-breakeven-point.
+% Source-of-truth for the content remains the PAPER.md frontmatter + body in the
+% parent directory. This LaTeX file is a hand-rendered preprint counterpart that
+% mirrors the IMRaD body for venues that need a PDF.
+%
+% Build:
+%   pdflatex paper.tex
+%   bibtex paper
+%   pdflatex paper.tex
+%   pdflatex paper.tex
+%
+% Or invoke the helper:  bash build.sh
+%
+% Class choice: standard `article` keeps the source portable to arXiv, OpenReview,
+% and most workshop templates. Switch to `acmart` / `IEEEtran` / a venue-specific
+% class only when an actual venue is targeted.
+
+\documentclass[10pt,letterpaper]{article}
+
+\usepackage[margin=1in]{geometry}
+\usepackage[utf8]{inputenc}
+\usepackage{microtype}
+\usepackage{booktabs}
+\usepackage{array}
+\usepackage{hyperref}
+\usepackage{xcolor}
+\usepackage{verbatim}
+\usepackage{amsmath}
+
+\hypersetup{
+  colorlinks=true,
+  linkcolor=blue!50!black,
+  citecolor=blue!50!black,
+  urlcolor=blue!70!black,
+}
+
+\title{When Does Parallel Subagent Dispatch Stop Paying Off?\\
+\large A useful-output cost gate for bulk-modification workloads in LLM agent pipelines}
+
+\author{kjuhwa\thanks{kjuhwa@nkia.co.kr; \texttt{kjuhwa/skills-hub}}}
+
+\date{April 24, 2026 \quad (preprint v1, IMRaD body finalized 2026-04-25)}
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+A bulk-modification task dispatched to $N$ parallel LLM subagents pays a fixed
+startup overhead per agent plus a verification cost per file every agent must
+read before deciding whether to act. When prior-work coverage is high, the
+dispatch can return zero useful changes from most agents while still paying
+the full overhead. The original draft of this work proposed a 70\,\%
+prior-coverage threshold above which parallel dispatch is net negative.
+A cost-model harness applied to five corpus domains in
+\texttt{kjuhwa/skills-hub} (range $36.8\,\%$--$100\,\%$ coverage) refutes
+the 70\,\% claim as a universal constant and identifies a more robust gate:
+\textbf{absolute useful-output count}, not coverage fraction. The revised
+criterion is that parallel dispatch is unjustified when fewer than
+$\sim 5$ files actually need real work, regardless of coverage. The
+directional claim (very high coverage trends toward non-parallel) survives;
+the specific threshold does not. We summarize the cost model, the workload
+selection, and the implications for tool design when the catalog of
+``how to parallelize'' skills lacks a corresponding ``when not to'' gate.
+\end{abstract}
+
+\section{Introduction}
+
+A bulk-modification task dispatched to $N$ parallel subagents pays a fixed
+startup overhead per agent plus a verification cost per file each agent must
+\emph{Read} before deciding whether to act. When prior-work coverage is high,
+the dispatch can return zero useful changes from most agents while still
+paying the full overhead. Existing parallelism guidance focuses on
+\emph{how} to dispatch but not on \emph{when not to}.
+
+This paper sets out to identify the gate criterion: a single rule a
+pre-flight check can apply to refuse a dispatch when waste dominates. The
+original draft proposed a 70\,\% coverage threshold; the experiment in this
+paper tests that claim against measured corpus data.
+
+\subsection{Background}
+
+In the host catalog, three procedure-level entries describe parallel
+dispatch:
+\begin{itemize}
+\item \texttt{workflow/parallel-bulk-annotation} --- canonical \emph{how-to}
+  for annotating many files across parallel agents.
+\item \texttt{workflow/bucket-parallel-java-annotation-dispatch} --- a
+  language-specific variant using bucket partitioning.
+\item \texttt{ai/ai-subagent-scope-narrowing} --- the adjacent concept of
+  narrowing what gets dispatched.
+\end{itemize}
+
+And one pitfall, authored mid-session when the pattern broke:
+\begin{itemize}
+\item \texttt{agent-orchestration/grep-existing-annotations-before-parallel-subagent-dispatch}
+  --- four parallel agents dispatched to annotate Java DTO files; three
+  returned ``zero changes --- already annotated''; three agent rounds
+  wasted because prior coverage was not checked first.
+\end{itemize}
+
+The pitfall is the counter-evidence for this work. The skills tell you
+\emph{how} to parallelize; the pitfall tells you \emph{when it stops paying
+off}. The two pieces are split across kinds and across files; nothing
+enforces that a user reading the skill also encounters the pitfall.
+
+\subsection{Premise revision (2026-04-24)}
+
+The original premise stated a \emph{70\,\% coverage threshold}. The
+experiment in \S\ref{sec:methods}--\S\ref{sec:results} tested that claim
+against five measured corpus domains and found the 70\,\% number was not a
+robust constant --- it shifts with the $\alpha/w$ cost ratio. The meaningful
+gate turned out to be \textbf{absolute useful-output count}, not coverage
+fraction.
+
+\subsection{Prior art}
+
+External references are not yet cited here. Relevant directions include
+parallel-algorithm amortization literature on fork-join break-even, queueing
+theory cost models adapted for agent-as-worker, LLM token-cost analysis in
+developer tooling, and pre-flight gate patterns in other agent frameworks
+(LangGraph, AutoGen, Crew). Filling these in would ground the threshold
+claim in prior art rather than treating it as intuition; this paper makes
+no claim of completeness on that front.
+
+\section{Methods}
+\label{sec:methods}
+
+\subsection{Cost model}
+
+Total dispatch cost is approximately
+\begin{equation}
+C_{\text{total}} = N\alpha + Nv\frac{T}{N} + w \cdot \mathrm{useful},
+\end{equation}
+where $\alpha$ is per-agent startup overhead, $v$ is per-file
+verification cost, $w$ is per-file real-work cost, $T$ is total file
+count split across $N$ agents, and $\mathrm{useful} = (1 - c) \cdot T$
+is the count of files that actually need work given prior coverage
+$c \in [0, 1]$.
+
+Wall-clock for parallel dispatch is approximately
+\begin{equation}
+W_{\parallel} \approx \alpha + v \frac{T}{N} + w \frac{\mathrm{useful}}{N},
+\end{equation}
+while the serial baseline is
+\begin{equation}
+W_{\text{serial}} \approx \alpha + vT + w \cdot \mathrm{useful}.
+\end{equation}
+The crossover is where $C_{\text{total}}$ stops dominating
+$C_{\text{serial}}$, driven by the $\alpha/w$ ratio and the absolute
+$\mathrm{useful}$ count, \emph{not} by $c$ alone. Coverage fraction is a
+proxy that fails when total $T$ varies between domains.
+
+\subsection{Pre-flight probe}
+
+The probe is one second of shell:
+\begin{verbatim}
+total=$(find <scope> -name "*.java" | wc -l)
+hit=$(grep -rln "@Schema" <scope> | wc -l)
+coverage=$((hit * 100 / total))
+useful=$((total - hit))
+\end{verbatim}
+The decision can fire on \texttt{useful} (absolute count) or
+\texttt{coverage} (fraction). The experiment tests which of the two is the
+more robust gate criterion in practice.
+
+\subsection{Workload selection}
+\label{sec:workloads}
+
+Five domains within the host catalog were measured via grep against the
+remote cache (Table~\ref{tab:workloads}).
+
+\begin{table}[h]
+\centering
+\caption{Measured corpus domains (April 2026 snapshot).}
+\label{tab:workloads}
+\begin{tabular}{lllrr}
+\toprule
+ID & Domain & Marker & Total & Hit \\
+\midrule
+A & skills with \texttt{triggers:} populated & YAML key non-empty & 468 & 239 \\
+B & skills with \texttt{content.md} sibling & file exists & 468 & 172 \\
+C & knowledge with \texttt{description:} & YAML key non-empty & 351 & 193 \\
+D & knowledge with \texttt{tags:} & YAML key present & 351 & 351 \\
+E & skills with stable version $\geq 1.0$ & semver gate & 468 & 376 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\subsection{Cost-model harness}
+
+A small classifier (\texttt{example/workflow/coverage-gate-benchmark} in
+the host catalog) consumes the tuple $(N, \alpha, v, w, \mathrm{useful}, T)$
+and emits one of \texttt{PARALLEL}, \texttt{BORDERLINE}, \texttt{SAMPLING},
+\texttt{NO DISPATCH}. Default weights for this run:
+$\alpha = 30$\,s, $v = 5$\,s, $w = 60$\,s, $N = 4$. The classifier output is
+compared per-domain against the original 70\,\%-coverage rule.
+
+\section{Results}
+\label{sec:results}
+
+The 70\,\% coverage threshold as a \emph{universal} constant is not
+supported. Under the default weights, parallel wall-clock savings dominate
+up to $\sim 90\,\%$ coverage for any domain with non-zero useful output.
+The crossover shifts with the $\alpha/w$ ratio; it is not a robust
+constant.
+
+\begin{table}[h]
+\centering
+\caption{Per-domain classification under cost model vs original 70\,\% rule.}
+\label{tab:results}
+\begin{tabular}{lrrll}
+\toprule
+ID & Coverage $c$ & Useful & Cost-model verdict & 70\,\%-rule verdict \\
+\midrule
+A & 51.1\,\% & 229 & \textsc{PARALLEL} & \textsc{PARALLEL} \\
+B & 36.8\,\% & 296 & \textsc{PARALLEL} & \textsc{PARALLEL} \\
+C & 55.0\,\% & 158 & \textsc{PARALLEL} & \textsc{PARALLEL} \\
+D & 100.0\,\% & 0 & \textsc{NO DISPATCH} & \textsc{NO DISPATCH} \\
+E & 80.3\,\% & 92 & \textbf{\textsc{PARALLEL}} & \textsc{SAMPLING} (mismatch) \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+Domain D (zero useful output, full coverage) is correctly rejected by both
+rules. Domain E exposes the discrepancy: at 80.3\,\% coverage, the original
+rule says ``switch to sampling,'' but the cost model says ``still
+parallelize'' because $92 \times w = 92$ minutes of real work dwarfs
+$N \times \alpha = 2$ minutes of agent startup. Coverage fraction alone
+misclassifies.
+
+The discovered gate is not coverage percentage but
+\textbf{useful-output absolute count}: when fewer than $\sim 5$ files
+actually need work, parallel dispatch is pure waste regardless of $c$. The
+directional claim (very high coverage trends toward non-parallel) holds;
+the specific 70\,\% number was a single-session observation, not a robust
+threshold. We classify the verdict as \emph{partial support} and rewrite
+the premise to match.
+
+\section{Discussion}
+\label{sec:discussion}
+
+\subsection{Why coverage fraction misled}
+
+Coverage is a ratio, not an absolute. A domain with 92 useful files at
+80\,\% coverage has the same parallel justification as a domain with 92
+useful files at 30\,\% coverage --- the parallel work scales with the
+absolute, the agent startup is paid once. The original premise inherited
+an intuition from one pitfall session (where useful output was small
+because total was small) and over-generalized to fraction.
+
+\subsection{Asymmetric discoverability}
+
+``How to parallelize'' is a teachable procedure that composes well as a
+catalog skill. ``When not to parallelize'' is a judgment call requiring
+a cost-curve mental model the author has to encode. The host catalog has
+many \emph{how-to} skills and one pitfall; these are asymmetric in
+discoverability --- how-to skills get triggered by keyword matching
+(``bulk annotation''), the pitfall gets found only if the user searches
+for ``wasted agent parallel.'' The proposed remedy is a dedicated gate
+skill whose entire job is the decision, so the gate is found first.
+
+\subsection{Failure modes are silent}
+
+A parallel dispatch that wastes tokens fails silently --- all $N$ agents
+return success, wall-clock looks similar to the productive case, the only
+signal is the token bill. Silent failure accumulates across sessions. The
+gate converts silent waste into a visible decision: \emph{``coverage
+92\,\%, useful 3 --- parallel not justified, switch to sampling.''} The
+user can override, but the override is explicit and auditable.
+
+\subsection{Limitations}
+
+\begin{itemize}
+\item \textbf{$n=1$ original evidence.} The 70\,\% threshold rested on one
+  observed session. Even after the experiment runs, the data points are
+  five hub-internal domains; cross-organization replication is needed
+  to claim full generality.
+\item \textbf{Cost weights are illustrative.} $\alpha$, $v$, $w$ are
+  plausible values from agent-runner observation, not measured per
+  deployment. A team with much faster startup or much slower
+  verification will see a different crossover.
+\item \textbf{Gate skill is unbuilt.} The proposed builds are
+  POC-scoped; the paper is a call for work, not a claim of completed
+  work.
+\item \textbf{Counter-argument unexplored.} In deployments where token
+  costs are negligible (local models, fixed-cost inference), the gate's
+  value drops. The assumption that tokens cost enough to justify the
+  gate may not hold universally.
+\end{itemize}
+
+\subsection{Future work}
+
+\begin{enumerate}
+\item Re-run the harness against domains in 2--3 other repositories to
+  test cross-corpus stability of the useful-output gate.
+\item Decide whether the coverage probe should be automatic (a hook on
+  any \texttt{/hub-make --parallel} invocation) or opt-in via the gate
+  skill. Automatic risks false positives; opt-in risks being forgotten.
+\item Decide whether existing parallel skills should be \emph{retracted}
+  and replaced with gate-mediated variants, or just annotated with a
+  ``Phase 0 --- pre-flight'' section. The annotation is pragmatic; the
+  retraction is more honest about the asymmetry.
+\end{enumerate}
+
+\section*{Provenance and source of truth}
+
+This is a preprint counterpart of the source-of-truth paper at\\
+\texttt{paper/workflow/parallel-dispatch-breakeven-point/PAPER.md} in the
+\texttt{kjuhwa/skills-hub} repository. The PAPER.md frontmatter carries
+\texttt{premise.if/then}, \texttt{examines[]}, \texttt{experiments[]} (with
+\texttt{result}, \texttt{supports\_premise}, \texttt{observed\_at}), and
+\texttt{outcomes[]} entries (\texttt{produced\_knowledge:
+decision/parallel-dispatch-useful-output-gate};
+\texttt{produced\_example: workflow/coverage-gate-benchmark}).
+The body adopts the IMRaD structure documented in
+\texttt{docs/rfc/paper-schema-draft.md} \S 5. The status is
+\texttt{implemented}: experiments[0] completed with
+\texttt{supports\_premise: partial} and the corpus changes above were
+shipped.
+
+\paragraph{Schema and tooling.}
+The paper schema, the auto-injected references block, the IMRaD
+compliance audit, and the citations index that powers the host catalog's
+discovery flow are all open-source under the same repository. See the
+\texttt{bootstrap/tools/} directory for the audit and indexer pipeline.
+
+\bibliographystyle{plain}
+\bibliography{references}
+
+\end{document}

--- a/paper/workflow/parallel-dispatch-breakeven-point/preprint/references.bib
+++ b/paper/workflow/parallel-dispatch-breakeven-point/preprint/references.bib
@@ -1,0 +1,14 @@
+% References for the preprint of paper/workflow/parallel-dispatch-breakeven-point.
+%
+% The host paper currently has external_refs[] = []. As /hub-research populates
+% the external context (parallel-algorithm amortization, queueing-theory cost
+% models adapted for agent-as-worker, LLM token-cost analysis, pre-flight gate
+% patterns in other agent frameworks), entries should be added here in the
+% same order they appear in the PAPER.md frontmatter.
+%
+% Internal corpus citations (skills, knowledge, techniques, sibling papers) are
+% not duplicated here — they are flat references in the host catalog and
+% appear in the paper text as plain monospace path references rather than
+% formal academic citations.
+
+% --- placeholder; no external citations as of this preprint v1 ---


### PR DESCRIPTION
## Summary

Follow-up to #1124 (IMRaD adoption). The IMRaD body migration made one paper publication-shaped. This PR ships the venue-ready LaTeX render as a worked example for how closed-loop papers go from internal YAML+Markdown to an external-reviewer PDF.

## Convention

\`paper/<category>/<slug>/preprint/\` is now an optional subdirectory documented in \`docs/rfc/paper-schema-draft.md\` §5:

\`\`\`
paper/<category>/<slug>/
  PAPER.md             # source of truth — frontmatter + IMRaD body
  preprint/            # optional, venue-ready render
    paper.tex          # arXiv-compatible LaTeX (article class)
    references.bib     # BibTeX, populates as external_refs[] grows
    build.sh           # pdflatex + bibtex pipeline
    README.md          # source-of-truth contract documented
    .gitignore         # paper.pdf + aux files excluded
\`\`\`

The preprint is **hand-mirrored** from the IMRaD body. Frontmatter remains canonical; the preprint must be updated alongside body changes. A future \`_paper_to_latex.py\` could auto-render; this PR stays manual to avoid the round-trip complexity until at least 2-3 papers are using the preprint format.

## Pilot: parallel-dispatch-breakeven-point

The first preprint companion. \`paper.tex\` is 330 lines, ~750 words, translating the IMRaD body into LaTeX with:

- Native math notation for the cost model (\$C_{total}\$, \$\alpha/w\$ ratio, etc.)
- Booktabs tables for the workload selection and per-domain results
- Standard article-class formatting for portability across arXiv / OpenReview / workshop templates
- Microtype + hyperref for clean rendering

The Provenance section closes by linking back to the source-of-truth path and noting the IMRaD structure documented in the schema doc.

## Submission target

**Not chosen here.** The README.md inside \`preprint/\` lists candidates:

- arXiv cs.SE / cs.AI — preprint, no peer review; needs first-time institutional endorsement on category
- Workshop submissions at LLM-tooling / agent-framework / developer-tooling tracks at major CS conferences; the paper's negative-result-then-refinement shape fits venues that accept refutations
- Internal team tech-blog or company engineering blog — for organizations using LLM agent pipelines

The act of submission requires a real account and human review of the rendered PDF; this PR just produces the source.

## Why this matters

The host catalog's \`paper/\` layer is great for tooling integration (citation graphs, closed-loop verification, \`/hub-paper-experiment-run\`, etc.) but doesn't speak the format reviewers and venues expect. This convention bridges the gap for one paper as a worked example. Future closed-loop papers can follow the same pattern.

## Verification

- \`_lint_frontmatter.py\` PASS, 2032 files, 0 errors
- The preprint files don't have YAML frontmatter so they're outside the lint scope (correctly)
- LaTeX source uses only standard packages; no exotic dependencies that arXiv would reject
- The build script runs the full \`pdflatex × 3 + bibtex × 1\` pipeline; bibtex is a no-op while \`references.bib\` is empty but stays in the pipeline for when external_refs[] is populated

## Follow-up (not in this PR)

- \`_paper_to_latex.py\` auto-converter (waits until 2-3 preprints exist so the conversion patterns are clear)
- \`_audit_preprint_drift.py\` advisory that warns when PAPER.md was edited without a corresponding preprint update
- Submission of the pilot to a real venue (separate from this PR; needs human review of the rendered PDF and account/endorsement steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)