### PR TITLE
docs: sync README + wiki with IMRaD + preprint conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,10 @@ status: draft | reviewed | implemented | retracted
 ```
 Schema: `docs/rfc/paper-schema-draft.md`. Verification is **structure only** — claim correctness is reviewer judgment, never a lint check. The complementary [falsifiability advisory](./bootstrap/tools/_audit_paper_falsifiability.py) flags `type: hypothesis` papers whose `premise.then` lacks a measurable predicate.
 
+**Body structure — IMRaD.** Per [§5 of the schema doc](./docs/rfc/paper-schema-draft.md), bodies follow the international convention: `## Introduction / ## Methods / ## Results / ## Discussion`. Methods + Results apply only to `type: hypothesis`; survey/position papers carry just Introduction + Discussion. Compliance is audited by [`_audit_paper_imrad.py`](./bootstrap/tools/_audit_paper_imrad.py); migration is incremental.
+
+**Optional `preprint/` directory.** A paper may carry a venue-ready LaTeX render at `paper/<category>/<slug>/preprint/paper.tex` for submission to arXiv / OpenReview / workshop venues. The first such package lives at [`paper/workflow/parallel-dispatch-breakeven-point/preprint/`](./paper/workflow/parallel-dispatch-breakeven-point/preprint/) — frontmatter remains canonical, the preprint is hand-mirrored from the IMRaD body.
+
 ---
 
 ## Stats (live)
@@ -274,7 +278,9 @@ The corpus measures itself:
 | Hypothesis papers with closed loop | 3 / 13 | `_audit_paper_loops.py` |
 | Stale hypothesis papers (≥30d, planned exp) | 0 / 13 | `_audit_paper_loops.py --only-stale` |
 | Falsifiability-flagged papers | 0 / 13 hypothesis | `_audit_paper_falsifiability.py` |
-| §11 retraction signal | not fired | empty-loop ratio = 12/15 (80%); threshold 60% at N≥5, but ratio is dropping as loops close |
+| IMRaD-compliant body structure | 1 / 15 | `_audit_paper_imrad.py` |
+| Papers with `preprint/` package | 1 / 15 | `paper/<…>/<…>/preprint/paper.tex` |
+| §11 retraction signal | not fired | strict ratio (`experiments[]` AND `outcomes[]` both empty) is 0/15 — every paper carries at least planned experiments. Threshold 60 % at N≥5. |
 | Suggested technique bundles ≥3 atoms | 2 strong candidates | `_suggest_techniques.py` |
 
 These numbers are recomputed by `precheck.py` on every post-merge / post-commit hook fire. See [`bootstrap/tools/`](./bootstrap/tools/) for the audit + index pipeline.


### PR DESCRIPTION
## Summary

Documentation pass after #1124 (IMRaD body structure) and #1125 (first preprint package). README and the wiki Paper Layer concept page now reflect those conventions.

## Changes

**README.md**
- Stats (live): added 2 new rows (\`IMRaD-compliant body: 1/15\`, \`Papers with preprint/ package: 1/15\`); sharpened the §11 retraction-signal row to its strict definition (0/15 papers strictly empty, since every paper has at least planned experiments)
- Authoring → Paper: added two short paragraphs linking the schema-doc IMRaD spec, the audit tool, and the first preprint package

**Wiki — Concepts-Paper-Layer.md** (already pushed via \`skills-hub.wiki.git\`)
- New section \`Body structure — IMRaD (v0.2.2)\` between Schema rules and the non-triviality gate
- New subsection \`Optional preprint/ directory\` documenting the venue-ready LaTeX convention

## Verification

- \`_lint_frontmatter.py\` PASS
- All counts in the new Stats rows are accurate as of \`citations.json\` schema 2 + \`_audit_paper_imrad.py\` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)