### PR TITLE
papers: IMRaD sweep across 12 drafts — 100% compliance (15/15) + migration tool

### DIFF
--- a/bootstrap/tools/_migrate_paper_to_imrad.py
+++ b/bootstrap/tools/_migrate_paper_to_imrad.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""One-shot migration helper: rewrites a legacy paper body into IMRaD layout.
+
+Legacy body convention (pre-v0.2.2):
+  ## Premise
+  ## Background
+  ## (auto-injected references-section block — preserved verbatim by position)
+  ## Perspectives
+  ## External Context
+  ## Proposed Builds
+  ## Open Questions
+  ## Limitations
+  ## Provenance
+
+IMRaD body convention (v0.2.2+):
+  ## Introduction        (opening + Background subsection + Prior art subsection)
+  ## Methods             (hypothesis only; stub for drafts)
+  ## Results             (hypothesis only; stub `(pending)` for drafts)
+  ## Discussion          (Perspectives + Proposed-build rationale + Limitations + Future work)
+  ## (auto-injected references-section block — placed by _inject_references_section.py)
+  ## Provenance
+
+The migration is structural — content is moved between sections, not rewritten.
+For hypothesis papers in draft, Methods + Results sections are added as stubs
+(satisfying the IMRaD audit's presence requirement; substance is enforced only
+at status=implemented).
+
+Idempotent: a paper already in IMRaD layout (i.e., already has Introduction,
+Methods, Results, Discussion at the top level) is left unchanged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+HUB_ROOT = Path(__file__).resolve().parents[2]
+PAPER_DIR = HUB_ROOT / "paper"
+
+H2_RE = re.compile(r"(?m)^##\s+(.+?)\s*$")
+MANAGED_RE = re.compile(
+    r"<!-- references-section:begin -->.*?<!-- references-section:end -->\n*",
+    re.DOTALL,
+)
+
+
+def split_frontmatter(text: str) -> tuple[str, str]:
+    if not text.startswith("---\n"):
+        return "", text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return "", text
+    return text[: end + len("\n---\n")], text[end + len("\n---\n") :]
+
+
+def parse_frontmatter(fm_text: str) -> dict:
+    if not fm_text.startswith("---\n"):
+        return {}
+    inner = fm_text[4:]
+    if inner.endswith("---\n"):
+        inner = inner[:-4]
+    try:
+        return yaml.safe_load(inner) or {}
+    except yaml.YAMLError:
+        return {}
+
+
+def split_sections(body: str) -> list[tuple[str, str]]:
+    """Return [(heading_or_None, content_chunk)]. The first item with heading=None
+    captures any preamble before the first '## ' heading (typically the title line)."""
+    matches = list(H2_RE.finditer(body))
+    if not matches:
+        return [(None, body)]
+    sections: list[tuple[str, str]] = []
+    if matches[0].start() > 0:
+        sections.append((None, body[: matches[0].start()]))
+    for i, m in enumerate(matches):
+        heading = m.group(1).strip()
+        chunk_start = m.end()
+        chunk_end = matches[i + 1].start() if i + 1 < len(matches) else len(body)
+        sections.append((heading, body[chunk_start:chunk_end]))
+    return sections
+
+
+def already_imrad(headings: list[str]) -> bool:
+    """If body already has Introduction / Methods / Results / Discussion as top-level
+    headings, treat as IMRaD-converted. Survey/position papers without Methods+Results
+    but with Introduction + Discussion also count as IMRaD-shaped."""
+    has_intro = any(h.startswith("Introduction") for h in headings if h)
+    has_discussion = any(h.startswith("Discussion") for h in headings if h)
+    return has_intro and has_discussion
+
+
+def is_managed_block(content: str) -> bool:
+    """Check if content is purely the auto-injected references-section block."""
+    stripped = content.strip()
+    return stripped.startswith("<!-- references-section:begin -->") and \
+           stripped.endswith("<!-- references-section:end -->")
+
+
+def migrate_body(body: str, paper_type: str, status: str) -> tuple[str, bool]:
+    """Return (new_body, mutated_flag). If already IMRaD or unrecognized, leave as-is."""
+    # Critical: strip the auto-injected references-section block from the WHOLE body
+    # BEFORE splitting into sections. The block contains '## ' headings (e.g.
+    # '## References (examines)', '## Build dependencies') which would otherwise
+    # be parsed as top-level sections, leaving the begin/end markers split across
+    # those false sections — and breaking the downstream injector's MANAGED_RE
+    # match (which would then delete the IMRaD body wholesale on the next run).
+    references_block = ""
+    m = MANAGED_RE.search(body)
+    if m:
+        references_block = m.group(0)
+        body = MANAGED_RE.sub("", body)
+
+    sections = split_sections(body)
+    headings = [h for h, _ in sections if h]
+
+    if already_imrad(headings):
+        # Re-attach the references_block we stripped — the body was already IMRaD
+        # but we still need to put the managed block back so the file is unchanged.
+        # Place it before Provenance if present, else append.
+        if references_block:
+            prov_match = re.search(r"(?m)^## Provenance[ \t]*$", body)
+            if prov_match:
+                body = body[: prov_match.start()] + references_block.rstrip() + "\n\n" + body[prov_match.start() :]
+            else:
+                body = body.rstrip() + "\n\n" + references_block.rstrip() + "\n"
+        return body, False
+
+    # Bucket legacy sections
+    preamble_chunk = ""
+    premise_chunk = ""
+    background_chunk = ""
+    external_chunk = ""
+    perspectives_chunk = ""
+    proposed_builds_chunk = ""
+    open_questions_chunk = ""
+    limitations_chunk = ""
+    provenance_chunk = ""
+    other_chunks: list[tuple[str, str]] = []
+    # references_block is already stripped from the whole body above; sections do
+    # not contain begin/end markers anymore.
+
+    for heading, content in sections:
+        if heading is None:
+            preamble_chunk = content
+            continue
+        h_lower = heading.lower()
+        if h_lower == "premise":
+            premise_chunk = content.strip()
+        elif h_lower == "background":
+            background_chunk = content.strip()
+        elif h_lower == "external context":
+            external_chunk = content.strip()
+        elif h_lower == "perspectives":
+            perspectives_chunk = content.strip()
+        elif h_lower == "proposed builds":
+            proposed_builds_chunk = content.strip()
+        elif h_lower in ("open questions", "future work"):
+            open_questions_chunk = content.strip()
+        elif h_lower == "limitations":
+            limitations_chunk = content.strip()
+        elif h_lower == "provenance":
+            provenance_chunk = content.strip()
+        else:
+            other_chunks.append((heading, content.strip()))
+
+    # Build IMRaD body
+    out: list[str] = []
+    if preamble_chunk:
+        out.append(preamble_chunk.rstrip() + "\n\n")
+
+    # Introduction
+    out.append("## Introduction\n\n")
+    if premise_chunk:
+        out.append(premise_chunk + "\n\n")
+    if background_chunk:
+        out.append("### Background\n\n")
+        out.append(background_chunk + "\n\n")
+    if external_chunk:
+        out.append("### Prior art\n\n")
+        out.append(external_chunk + "\n\n")
+
+    # Methods + Results — only for hypothesis papers
+    if paper_type == "hypothesis":
+        out.append("## Methods\n\n")
+        out.append(
+            "(planned — see `experiments[0].method` in frontmatter for the full design. "
+            "This section becomes substantive when `status: implemented` and is checked "
+            "for length by `_audit_paper_imrad.py` at that point.)\n\n"
+        )
+        out.append("## Results\n\n")
+        out.append(
+            "(pending — experiment status: planned. "
+            "Run `/hub-paper-experiment-run <slug>` once the experiment completes to "
+            "populate this section from `experiments[0].result`.)\n\n"
+        )
+
+    # Discussion
+    out.append("## Discussion\n\n")
+    if perspectives_chunk:
+        out.append(perspectives_chunk + "\n\n")
+    if proposed_builds_chunk:
+        out.append("### Proposed builds (rationale)\n\n")
+        out.append(proposed_builds_chunk + "\n\n")
+    if limitations_chunk:
+        out.append("### Limitations\n\n")
+        out.append(limitations_chunk + "\n\n")
+    if open_questions_chunk:
+        out.append("### Future work\n\n")
+        out.append(open_questions_chunk + "\n\n")
+
+    # Other unrecognized chunks (rare; preserve at end of Discussion to avoid losing data)
+    for h, c in other_chunks:
+        out.append(f"### {h}\n\n{c}\n\n")
+
+    # References block — re-inject managed block (will be repositioned by the injector)
+    if references_block:
+        out.append(references_block.rstrip() + "\n\n")
+
+    # Provenance
+    if provenance_chunk:
+        out.append("## Provenance\n\n")
+        # Append migration note
+        migration_note = (
+            "- Body migrated to IMRaD structure 2026-04-25 per "
+            "`docs/rfc/paper-schema-draft.md` §5 by `_migrate_paper_to_imrad.py`. "
+            "Pre-IMRaD body is preserved in git history; no semantic claims were "
+            "rewritten during the migration. For hypothesis-type drafts, Methods + "
+            "Results sections are stubs until the experiment completes."
+        )
+        if migration_note not in provenance_chunk:
+            out.append(provenance_chunk + "\n" + migration_note + "\n")
+        else:
+            out.append(provenance_chunk + "\n")
+
+    return "".join(out), True
+
+
+def process(path: Path, write: bool) -> tuple[bool, str]:
+    text = path.read_text(encoding="utf-8")
+    fm_text, body = split_frontmatter(text)
+    fm = parse_frontmatter(fm_text)
+    paper_type = (fm.get("type") or "hypothesis").strip()
+    status = (fm.get("status") or "").strip()
+    new_body, mutated = migrate_body(body, paper_type, status)
+    if not mutated:
+        return False, "already-imrad-or-unrecognized"
+    new_text = fm_text + new_body
+    if new_text == text:
+        return False, "no-change"
+    if write:
+        path.write_text(new_text, encoding="utf-8")
+    return True, "migrated"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--write", action="store_true")
+    p.add_argument("--path", help="Operate on a single PAPER.md path")
+    p.add_argument("--limit", type=int, default=0)
+    args = p.parse_args()
+
+    if args.path:
+        targets = [Path(args.path).resolve()]
+    else:
+        targets = sorted(PAPER_DIR.glob("**/PAPER.md"))
+        if args.limit:
+            targets = targets[: args.limit]
+
+    changed = 0
+    for path in targets:
+        mutated, status = process(path, args.write)
+        rel = path.relative_to(HUB_ROOT).as_posix() if str(path).startswith(str(HUB_ROOT)) else str(path)
+        if mutated:
+            changed += 1
+            print(f"[{'WRITE' if args.write else 'DRY '}] {rel} — {status}")
+        else:
+            print(f"[SKIP ] {rel} — {status}")
+    mode = "applied" if args.write else "dry-run"
+    print(f"\n{mode}: {changed}/{len(targets)} papers migrated")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/paper/ai/coordinator-overhead-vs-parallelism/PAPER.md
+++ b/paper/ai/coordinator-overhead-vs-parallelism/PAPER.md
@@ -71,13 +71,35 @@ retraction_reason: null
 
 # Multi-Agent Coordinator: Overhead vs Parallelism
 
-## Premise
+## Introduction
 
 (see frontmatter)
 
-## Background
+### Background
 
 `technique/ai/multi-agent-fan-out-with-isolation` describes the shape; this paper measures the curve.
+
+### Prior art
+
+`paper/workflow/parallel-dispatch-breakeven-point` already established that parallel dispatch can be net negative at high prior coverage; this paper extends that finding to the coordinator-overhead axis.
+
+## Methods
+
+(planned — see `experiments[0].method` in frontmatter for the full design. This section becomes substantive when `status: implemented` and is checked for length by `_audit_paper_imrad.py` at that point.)
+
+## Results
+
+(pending — experiment status: planned. Run `/hub-paper-experiment-run <slug>` once the experiment completes to populate this section from `experiments[0].result`.)
+
+## Discussion
+
+(see frontmatter)
+
+### Limitations
+
+- Highly task-dependent; "typical workloads" assumption is fragile
+- Coordinator overhead is partly an artifact of current LLM token-based pricing; cheaper inference would shift the curve right
+- Parallelism gain assumes independent sub-tasks; real tasks have implicit dependencies that compound at high N
 
 <!-- references-section:begin -->
 ## References (examines)
@@ -110,21 +132,8 @@ pre-flight-check-pattern
 
 <!-- references-section:end -->
 
-## Perspectives
-
-(see frontmatter)
-
-## External Context
-
-`paper/workflow/parallel-dispatch-breakeven-point` already established that parallel dispatch can be net negative at high prior coverage; this paper extends that finding to the coordinator-overhead axis.
-
-## Limitations
-
-- Highly task-dependent; "typical workloads" assumption is fragile
-- Coordinator overhead is partly an artifact of current LLM token-based pricing; cheaper inference would shift the curve right
-- Parallelism gain assumes independent sub-tasks; real tasks have implicit dependencies that compound at high N
-
 ## Provenance
 
 - Authored 2026-04-25, batch of 10
 - Sibling: `paper/parallel-dispatch-breakeven-point` (different axis, same parent claim that parallelism has a ceiling)
+- Body migrated to IMRaD structure 2026-04-25 per `docs/rfc/paper-schema-draft.md` §5 by `_migrate_paper_to_imrad.py`. Pre-IMRaD body is preserved in git history; no semantic claims were rewritten during the migration. For hypothesis-type drafts, Methods + Results sections are stubs until the experiment completes.

--- a/paper/ai/llm-fallback-cost-displacement/PAPER.md
+++ b/paper/ai/llm-fallback-cost-displacement/PAPER.md
@@ -121,7 +121,7 @@ retraction_reason: null
 
 # Do LLM fallback ladders save cost, or displace it?
 
-## Premise
+## Introduction
 
 **If** a multi-tier LLM fallback ladder is added to a call pipeline expecting cheaper tiers to absorb most traffic, **then** the nominal token cost drops as expected, but two other costs rise:
 
@@ -130,7 +130,7 @@ retraction_reason: null
 
 Net cost is lower **only** when primary failure rate is < 15 percent AND downstream consumers actually validate tier output schema. Below the first condition, tiers 2/3 are dead weight. Above it, cascade storms dominate. Without the second condition, the ladder is a schema-drift generator dressed as resilience.
 
-## Background
+### Background
 
 The hub carries the baseline ingredients:
 
@@ -140,6 +140,91 @@ The hub carries the baseline ingredients:
 - `knowledge/pitfall/retry-strategy-implementation-pitfall` — retry-within-tier vs fall-through confusion, which compounds latency in ladder scenarios.
 
 A proposed technique `ai/agent-fallback-ladder` composes these atoms into a hierarchical ladder with per-tier circuit state. The technique answers "what is the shape?". This paper answers **"does the shape actually save money?"**
+
+### Prior art
+
+`external_refs[]` is empty. Useful sources to pull in via `/hub-research`:
+
+- Anthropic / OpenAI pricing tables for typical tier deltas (Opus vs Haiku, GPT-4 vs GPT-4-mini)
+- Chaos-engineering literature on cascade failures (Netflix Hystrix post-mortems) — the LLM version is the same shape on a new surface
+- Academic work on "partial ordering of quality-of-service tiers" (QoS literature from networking)
+- Prior empirical studies on multi-provider LLM routing cost tradeoffs, if any exist
+
+## Methods
+
+(planned — see `experiments[0].method` in frontmatter for the full design. This section becomes substantive when `status: implemented` and is checked for length by `_audit_paper_imrad.py` at that point.)
+
+## Results
+
+(pending — experiment status: planned. Run `/hub-paper-experiment-run <slug>` once the experiment completes to populate this section from `experiments[0].result`.)
+
+## Discussion
+
+### 1. Nominal vs Tail Cost
+
+Cost is usually quoted as "mean tokens per call times price." For a ladder, the mean is optimistic — it assumes most calls terminate at the cheap tier, which is exactly what the ladder is designed for on the happy path. The **tail** tells a different story:
+
+```
+p50 call: served by tier 1  → 1 tier traversal,  1x latency
+p99 call: primary fails, retry fails, tier 2 fails → 3-4 tier traversals, 3-5x latency
+```
+
+If the user-facing SLO is latency-based (e.g., 99 percent of responses under 2 s), the ladder may satisfy the mean-cost budget while breaking the latency SLO. This is the first form of cost displacement — cost shifts from "dollars per month" to "tail latency the user notices."
+
+### 2. Schema Drift
+
+A tier 1 model trained to return `{"answer": ..., "reasoning": [...]}` is not contract-bound to the tier 3 model. Tier 3 may return plain text. Without downstream validation:
+
+```python
+response = call_with_fallback(prompt)
+answer = response["answer"]       # works for tier 1
+                                  # raises KeyError for tier 3
+```
+
+The exception is loud if the downstream bothers to parse. The **silent** case is worse — the downstream accepts whatever it gets and forwards a malformed payload to yet another consumer. This is the LLM-era manifestation of the `circuit-breaker-implementation-pitfall` — silent fallback poisoning the consumer.
+
+### 3. Cost-Budget Trigger
+
+Token cost is measured per call. Budget is measured per month. A ladder without a budget governor can consume a month of budget in an afternoon during a primary-outage cascade storm — every request traverses all tiers because tier 1 is hard-down. The per-call cost looks fine; the cumulative cost is catastrophic.
+
+The budget must be a first-class circuit-breaker signal, not just a cost ceiling. When exceeded, the ladder should refuse further traversals and return explicit degradation — the pattern the third proposed build prototypes.
+
+### 4. Failure Rate Threshold
+
+The premise asserts a 15 percent primary-failure-rate threshold. The intuition:
+
+- **Below 15 percent**: fallback tiers activate rarely; ladder cost is pure insurance at modest premium.
+- **Around 15 percent**: ladder is break-even — savings from primary-tier discounts are offset by cascade-induced latency and secondary token spend.
+- **Above 15 percent**: cascade storms dominate — tier 2 becomes the default, tier 3 activates frequently, p99 breaks down.
+
+The 15 percent number is a working estimate. The planned experiment tightens it.
+
+### Proposed builds (rationale)
+
+### `llm-fallback-latency-cost-dashboard` (POC)
+
+Per-tier activation rate, per-tier latency contribution to p50/p95/p99, schema-validation failure count. Makes the mean-vs-tail gap visible in one screen. Without this, adoption of the ladder is based on nominal cost alone and the tail cost is invisible.
+
+### `llm-fallback-schema-validator-middleware` (POC)
+
+Middleware that validates every tier's output against a registered schema. Rejection triggers an explicit error. Prevents the silent-schema-drift failure mode that the `circuit-breaker-implementation-pitfall` warns against in the generic case.
+
+### `llm-fallback-cost-budget-governor` (DEMO)
+
+Budget governor that short-circuits the entire ladder when month-to-date cost exceeds a ceiling. Returns explicit "budget exceeded, degraded response" instead of silently cascading into the next tier during a cascade storm.
+
+### Limitations
+
+- **No measurement yet.** The experiment is planned, not executed. The 15 percent threshold is an estimate.
+- **Single provider-family assumption.** The ladder model assumes tiers within one provider (or across providers with similar output schemas). Cross-family ladders (e.g., Anthropic → local Llama) have additional drift dimensions this paper does not address.
+- **Ignores caching.** A proper cost model includes a response cache layer in front of the ladder. Cache-hit rate interacts with the ladder in ways the simple premise does not capture.
+- **No multi-region effects.** Cross-region tier fallback adds network latency that compounds the tail; this paper treats all tiers as network-equivalent.
+
+### Future work
+
+1. Is the 15 percent primary-failure-rate threshold stable across provider pairings, or is it a function of the price delta between tiers? (Larger delta → ladder tolerates higher failure rates before cost displacement dominates.)
+2. Can the schema-validation middleware be implemented **generically** across LLM tiers, or does it need a per-task schema registry? The latter is higher overhead but more correct.
+3. Is cost displacement an unconditional red flag, or a legitimate engineering tradeoff in some domains? For a user-facing chat product, tail latency is the killer. For a batch data-enrichment pipeline, tail latency is a non-issue and the ladder is a clean win.
 
 <!-- references-section:begin -->
 ## References (examines)
@@ -194,83 +279,6 @@ retry-storm behavior is the class of failure the governor catches
 
 <!-- references-section:end -->
 
-## Perspectives
-
-### 1. Nominal vs Tail Cost
-
-Cost is usually quoted as "mean tokens per call times price." For a ladder, the mean is optimistic — it assumes most calls terminate at the cheap tier, which is exactly what the ladder is designed for on the happy path. The **tail** tells a different story:
-
-```
-p50 call: served by tier 1  → 1 tier traversal,  1x latency
-p99 call: primary fails, retry fails, tier 2 fails → 3-4 tier traversals, 3-5x latency
-```
-
-If the user-facing SLO is latency-based (e.g., 99 percent of responses under 2 s), the ladder may satisfy the mean-cost budget while breaking the latency SLO. This is the first form of cost displacement — cost shifts from "dollars per month" to "tail latency the user notices."
-
-### 2. Schema Drift
-
-A tier 1 model trained to return `{"answer": ..., "reasoning": [...]}` is not contract-bound to the tier 3 model. Tier 3 may return plain text. Without downstream validation:
-
-```python
-response = call_with_fallback(prompt)
-answer = response["answer"]       # works for tier 1
-                                  # raises KeyError for tier 3
-```
-
-The exception is loud if the downstream bothers to parse. The **silent** case is worse — the downstream accepts whatever it gets and forwards a malformed payload to yet another consumer. This is the LLM-era manifestation of the `circuit-breaker-implementation-pitfall` — silent fallback poisoning the consumer.
-
-### 3. Cost-Budget Trigger
-
-Token cost is measured per call. Budget is measured per month. A ladder without a budget governor can consume a month of budget in an afternoon during a primary-outage cascade storm — every request traverses all tiers because tier 1 is hard-down. The per-call cost looks fine; the cumulative cost is catastrophic.
-
-The budget must be a first-class circuit-breaker signal, not just a cost ceiling. When exceeded, the ladder should refuse further traversals and return explicit degradation — the pattern the third proposed build prototypes.
-
-### 4. Failure Rate Threshold
-
-The premise asserts a 15 percent primary-failure-rate threshold. The intuition:
-
-- **Below 15 percent**: fallback tiers activate rarely; ladder cost is pure insurance at modest premium.
-- **Around 15 percent**: ladder is break-even — savings from primary-tier discounts are offset by cascade-induced latency and secondary token spend.
-- **Above 15 percent**: cascade storms dominate — tier 2 becomes the default, tier 3 activates frequently, p99 breaks down.
-
-The 15 percent number is a working estimate. The planned experiment tightens it.
-
-## External Context
-
-`external_refs[]` is empty. Useful sources to pull in via `/hub-research`:
-
-- Anthropic / OpenAI pricing tables for typical tier deltas (Opus vs Haiku, GPT-4 vs GPT-4-mini)
-- Chaos-engineering literature on cascade failures (Netflix Hystrix post-mortems) — the LLM version is the same shape on a new surface
-- Academic work on "partial ordering of quality-of-service tiers" (QoS literature from networking)
-- Prior empirical studies on multi-provider LLM routing cost tradeoffs, if any exist
-
-## Proposed Builds
-
-### `llm-fallback-latency-cost-dashboard` (POC)
-
-Per-tier activation rate, per-tier latency contribution to p50/p95/p99, schema-validation failure count. Makes the mean-vs-tail gap visible in one screen. Without this, adoption of the ladder is based on nominal cost alone and the tail cost is invisible.
-
-### `llm-fallback-schema-validator-middleware` (POC)
-
-Middleware that validates every tier's output against a registered schema. Rejection triggers an explicit error. Prevents the silent-schema-drift failure mode that the `circuit-breaker-implementation-pitfall` warns against in the generic case.
-
-### `llm-fallback-cost-budget-governor` (DEMO)
-
-Budget governor that short-circuits the entire ladder when month-to-date cost exceeds a ceiling. Returns explicit "budget exceeded, degraded response" instead of silently cascading into the next tier during a cascade storm.
-
-## Open Questions
-
-1. Is the 15 percent primary-failure-rate threshold stable across provider pairings, or is it a function of the price delta between tiers? (Larger delta → ladder tolerates higher failure rates before cost displacement dominates.)
-2. Can the schema-validation middleware be implemented **generically** across LLM tiers, or does it need a per-task schema registry? The latter is higher overhead but more correct.
-3. Is cost displacement an unconditional red flag, or a legitimate engineering tradeoff in some domains? For a user-facing chat product, tail latency is the killer. For a batch data-enrichment pipeline, tail latency is a non-issue and the ladder is a clean win.
-
-## Limitations
-
-- **No measurement yet.** The experiment is planned, not executed. The 15 percent threshold is an estimate.
-- **Single provider-family assumption.** The ladder model assumes tiers within one provider (or across providers with similar output schemas). Cross-family ladders (e.g., Anthropic → local Llama) have additional drift dimensions this paper does not address.
-- **Ignores caching.** A proper cost model includes a response cache layer in front of the ladder. Cache-hit rate interacts with the ladder in ways the simple premise does not capture.
-- **No multi-region effects.** Cross-region tier fallback adds network latency that compounds the tail; this paper treats all tiers as network-equivalent.
-
 ## Provenance
 
 - Authored: 2026-04-24
@@ -281,3 +289,4 @@ Budget governor that short-circuits the entire ladder when month-to-date cost ex
   - `paper/workflow/technique-layer-composition-value` (meta)
   - `paper/workflow/parallel-dispatch-breakeven-point` (implemented)
   - `paper/testing/llm-ci-triage-boundary-conditions` (boundary-conditions)
+- Body migrated to IMRaD structure 2026-04-25 per `docs/rfc/paper-schema-draft.md` §5 by `_migrate_paper_to_imrad.py`. Pre-IMRaD body is preserved in git history; no semantic claims were rewritten during the migration. For hypothesis-type drafts, Methods + Results sections are stubs until the experiment completes.

--- a/paper/arch/quorum-scaling-curve/PAPER.md
+++ b/paper/arch/quorum-scaling-curve/PAPER.md
@@ -70,13 +70,35 @@ retraction_reason: null
 
 # Quorum Scaling Curve: Where is the Sweet Spot?
 
-## Premise
+## Introduction
 
 (see frontmatter)
 
-## Background
+### Background
 
 The hub's `technique/arch/multi-peer-quorum-decision-loop` describes the shape but not the optimal N. Engineering folklore says "3 or 5"; this paper attempts to ground that with a measurable curve.
+
+### Prior art
+
+Etcd, Consul, ZooKeeper deployment guides recommend N=3 or N=5; this paper would compare those recommendations against a benchmark.
+
+## Methods
+
+(planned — see `experiments[0].method` in frontmatter for the full design. This section becomes substantive when `status: implemented` and is checked for length by `_audit_paper_imrad.py` at that point.)
+
+## Results
+
+(pending — experiment status: planned. Run `/hub-paper-experiment-run <slug>` once the experiment completes to populate this section from `experiments[0].result`.)
+
+## Discussion
+
+(see frontmatter)
+
+### Limitations
+
+- "Sweet spot" is workload-dependent; this paper assumes a generic mixed read/write workload
+- Network topology (single AZ, multi-AZ, multi-region) drastically shifts the curve; the paper's N=5 sweet-spot claim assumes single-AZ
+- Failure tolerance requirements may force higher N regardless of performance
 
 <!-- references-section:begin -->
 ## References (examines)
@@ -106,20 +128,7 @@ avoid-known-bugs-in-harness
 
 <!-- references-section:end -->
 
-## Perspectives
-
-(see frontmatter)
-
-## External Context
-
-Etcd, Consul, ZooKeeper deployment guides recommend N=3 or N=5; this paper would compare those recommendations against a benchmark.
-
-## Limitations
-
-- "Sweet spot" is workload-dependent; this paper assumes a generic mixed read/write workload
-- Network topology (single AZ, multi-AZ, multi-region) drastically shifts the curve; the paper's N=5 sweet-spot claim assumes single-AZ
-- Failure tolerance requirements may force higher N regardless of performance
-
 ## Provenance
 
 - Authored 2026-04-25, batch of 10
+- Body migrated to IMRaD structure 2026-04-25 per `docs/rfc/paper-schema-draft.md` §5 by `_migrate_paper_to_imrad.py`. Pre-IMRaD body is preserved in git history; no semantic claims were rewritten during the migration. For hypothesis-type drafts, Methods + Results sections are stubs until the experiment completes.

--- a/paper/arch/saga-vs-2pc-cost-curve/PAPER.md
+++ b/paper/arch/saga-vs-2pc-cost-curve/PAPER.md
@@ -68,13 +68,39 @@ retraction_reason: null
 
 # Saga vs 2PC: At what N does saga become cheaper?
 
-## Premise
+## Introduction
 
 **If** a multi-step distributed transaction can be implemented as either saga (forward + compensation) or 2PC (synchronous prepare / commit), **then** saga is cheaper when N ≥ 3 services AND failure rate is non-trivial; 2PC is cheaper when N = 2. The crossover sits between N=2 and N=3 in typical workloads.
 
-## Background
+### Background
 
 The hub carries the saga shape (`workflow/saga-pattern-data-simulation`) and pitfall (`pitfall/saga-pattern-implementation-pitfall`), but no comparable 2PC technique. The community wisdom — "use saga for distributed transactions" — is true for N ≥ 3 but is often wrongly applied at N = 2 where 2PC's simplicity wins.
+
+### Prior art
+
+`/hub-research` would pull: Google Spanner's TrueTime+2PC vs choreography-based saga deployments, academic papers on coordination cost in distributed transactions.
+
+## Methods
+
+(planned — see `experiments[0].method` in frontmatter for the full design. This section becomes substantive when `status: implemented` and is checked for length by `_audit_paper_imrad.py` at that point.)
+
+## Results
+
+(pending — experiment status: planned. Run `/hub-paper-experiment-run <slug>` once the experiment completes to populate this section from `experiments[0].result`.)
+
+## Discussion
+
+(see frontmatter)
+
+### Proposed builds (rationale)
+
+(see frontmatter)
+
+### Limitations
+
+- Crossover claim is qualitative-quantitative (between N=2 and N=3) but needs the experiment to fix the constant
+- Real systems blend the two — practical "saga that uses 2PC for the inner pair" hybrids exist; this paper treats them as pure
+- N treats services as homogeneous; real systems have heterogeneous failure rates per service
 
 <!-- references-section:begin -->
 ## References (examines)
@@ -104,25 +130,8 @@ avoid-known-saga-bugs-in-benchmark
 
 <!-- references-section:end -->
 
-## Perspectives
-
-(see frontmatter)
-
-## External Context
-
-`/hub-research` would pull: Google Spanner's TrueTime+2PC vs choreography-based saga deployments, academic papers on coordination cost in distributed transactions.
-
-## Proposed Builds
-
-(see frontmatter)
-
-## Limitations
-
-- Crossover claim is qualitative-quantitative (between N=2 and N=3) but needs the experiment to fix the constant
-- Real systems blend the two — practical "saga that uses 2PC for the inner pair" hybrids exist; this paper treats them as pure
-- N treats services as homogeneous; real systems have heterogeneous failure rates per service
-
 ## Provenance
 
 - Authored 2026-04-25, batch of 10 papers
 - Schema: `docs/rfc/paper-schema-draft.md`
+- Body migrated to IMRaD structure 2026-04-25 per `docs/rfc/paper-schema-draft.md` §5 by `_migrate_paper_to_imrad.py`. Pre-IMRaD body is preserved in git history; no semantic claims were rewritten during the migration. For hypothesis-type drafts, Methods + Results sections are stubs until the experiment completes.

--- a/paper/data/backpressure-vs-rate-limit-comparison/PAPER.md
+++ b/paper/data/backpressure-vs-rate-limit-comparison/PAPER.md
@@ -82,13 +82,35 @@ retraction_reason: null
 
 # Backpressure vs Rate Limiting: Which Tool When?
 
-## Premise
+## Introduction
 
 (see frontmatter)
 
-## Background
+### Background
 
 The hub has both the backpressure technique (`technique/data/producer-consumer-backpressure-loop`) and pitfalls for both backpressure and rate limiting. What is missing is the **decision rule** for when to pick which. Most teams default to one based on familiarity rather than the problem shape.
+
+### Prior art
+
+Useful sources via `/hub-research`: AWS API Gateway vs SQS-with-Lambda case studies, the "Tail at Scale" paper, Netflix's Hystrix retrospective.
+
+## Methods
+
+(planned — see `experiments[0].method` in frontmatter for the full design. This section becomes substantive when `status: implemented` and is checked for length by `_audit_paper_imrad.py` at that point.)
+
+## Results
+
+(pending — experiment status: planned. Run `/hub-paper-experiment-run <slug>` once the experiment completes to populate this section from `experiments[0].result`.)
+
+## Discussion
+
+(see frontmatter)
+
+### Limitations
+
+- The premise's "trusted producer" axis is binary; real systems have gradients (semi-trusted internal services)
+- Paper treats latency and drop-rate as primary; production also cares about cost, observability, ops complexity
+- 4 workload classes are a simplification of real distributions
 
 <!-- references-section:begin -->
 ## References (examines)
@@ -118,21 +140,8 @@ seed-data-point
 
 <!-- references-section:end -->
 
-## Perspectives
-
-(see frontmatter)
-
-## External Context
-
-Useful sources via `/hub-research`: AWS API Gateway vs SQS-with-Lambda case studies, the "Tail at Scale" paper, Netflix's Hystrix retrospective.
-
-## Limitations
-
-- The premise's "trusted producer" axis is binary; real systems have gradients (semi-trusted internal services)
-- Paper treats latency and drop-rate as primary; production also cares about cost, observability, ops complexity
-- 4 workload classes are a simplification of real distributions
-
 ## Provenance
 
 - Authored 2026-04-25, batch of 10
 - Sibling: `paper/parallel-dispatch-breakeven-point` (related cost-model paper)
+- Body migrated to IMRaD structure 2026-04-25 per `docs/rfc/paper-schema-draft.md` §5 by `_migrate_paper_to_imrad.py`. Pre-IMRaD body is preserved in git history; no semantic claims were rewritten during the migration. For hypothesis-type drafts, Methods + Results sections are stubs until the experiment completes.

--- a/paper/db/migration-checkpoint-overhead/PAPER.md
+++ b/paper/db/migration-checkpoint-overhead/PAPER.md
@@ -66,13 +66,31 @@ retraction_reason: null
 
 # Migration Checkpoint Granularity
 
-## Premise
+## Introduction
 
 (see frontmatter)
 
-## Background
+### Background
 
 `technique/db/idempotent-migration-with-resume-checkpoint` describes the pattern but does not specify granularity. Practitioners default to either too-fine (per-row) or no-checkpoint. This paper argues for per-batch as the canonical choice.
+
+## Methods
+
+(planned — see `experiments[0].method` in frontmatter for the full design. This section becomes substantive when `status: implemented` and is checked for length by `_audit_paper_imrad.py` at that point.)
+
+## Results
+
+(pending — experiment status: planned. Run `/hub-paper-experiment-run <slug>` once the experiment completes to populate this section from `experiments[0].result`.)
+
+## Discussion
+
+(see frontmatter)
+
+### Limitations
+
+- Database-specific; SQLite, Postgres, MongoDB have different write-amplification characteristics
+- Crash-frequency assumption is hard to validate; this paper assumes well-tested production infra
+- Does not consider distributed migrations across multiple workers (different checkpointing concerns)
 
 <!-- references-section:begin -->
 ## References (examines)
@@ -102,16 +120,7 @@ idempotency-pattern
 
 <!-- references-section:end -->
 
-## Perspectives
-
-(see frontmatter)
-
-## Limitations
-
-- Database-specific; SQLite, Postgres, MongoDB have different write-amplification characteristics
-- Crash-frequency assumption is hard to validate; this paper assumes well-tested production infra
-- Does not consider distributed migrations across multiple workers (different checkpointing concerns)
-
 ## Provenance
 
 - Authored 2026-04-25, batch of 10
+- Body migrated to IMRaD structure 2026-04-25 per `docs/rfc/paper-schema-draft.md` §5 by `_migrate_paper_to_imrad.py`. Pre-IMRaD body is preserved in git history; no semantic claims were rewritten during the migration. For hypothesis-type drafts, Methods + Results sections are stubs until the experiment completes.

--- a/paper/devops/canary-auto-revert-calibration/PAPER.md
+++ b/paper/devops/canary-auto-revert-calibration/PAPER.md
@@ -67,13 +67,35 @@ retraction_reason: null
 
 # Canary Auto-Revert: Calibrating Thresholds
 
-## Premise
+## Introduction
 
 (see frontmatter)
 
-## Background
+### Background
 
 The `technique/devops/canary-rollout-with-auto-revert` describes the auto-revert shape but specifies thresholds as "configurable" without guidance. This paper proposes the calibration rule.
+
+### Prior art
+
+Datadog, Prometheus, Spinnaker provide KPI monitoring; few document threshold-tuning methodology. Useful research: anomaly detection literature, Tukey fences, EWMA-based thresholds.
+
+## Methods
+
+(planned — see `experiments[0].method` in frontmatter for the full design. This section becomes substantive when `status: implemented` and is checked for length by `_audit_paper_imrad.py` at that point.)
+
+## Results
+
+(pending — experiment status: planned. Run `/hub-paper-experiment-run <slug>` once the experiment completes to populate this section from `experiments[0].result`.)
+
+## Discussion
+
+(see frontmatter)
+
+### Limitations
+
+- Replay-based validation assumes historical data is representative
+- "False positive" definition relies on retrospective verdict; some judgment calls
+- Slow-burn issues are explicitly out of scope
 
 <!-- references-section:begin -->
 ## References (examines)
@@ -103,20 +125,7 @@ failure-modes-to-validate-against
 
 <!-- references-section:end -->
 
-## Perspectives
-
-(see frontmatter)
-
-## External Context
-
-Datadog, Prometheus, Spinnaker provide KPI monitoring; few document threshold-tuning methodology. Useful research: anomaly detection literature, Tukey fences, EWMA-based thresholds.
-
-## Limitations
-
-- Replay-based validation assumes historical data is representative
-- "False positive" definition relies on retrospective verdict; some judgment calls
-- Slow-burn issues are explicitly out of scope
-
 ## Provenance
 
 - Authored 2026-04-25, batch of 10
+- Body migrated to IMRaD structure 2026-04-25 per `docs/rfc/paper-schema-draft.md` §5 by `_migrate_paper_to_imrad.py`. Pre-IMRaD body is preserved in git history; no semantic claims were rewritten during the migration. For hypothesis-type drafts, Methods + Results sections are stubs until the experiment completes.

--- a/paper/frontend/optimistic-ui-flicker-tolerance/PAPER.md
+++ b/paper/frontend/optimistic-ui-flicker-tolerance/PAPER.md
@@ -66,13 +66,31 @@ retraction_reason: null
 
 # Optimistic UI: Flicker Tolerance Curve
 
-## Premise
+## Introduction
 
 (see frontmatter)
 
-## Background
+### Background
 
 `technique/frontend/optimistic-mutation-with-server-reconcile` documents the shape but leaves the question of *when* to use it open. This paper claims optimistic UI is conditionally good — bounded by server reliability.
+
+## Methods
+
+(planned — see `experiments[0].method` in frontmatter for the full design. This section becomes substantive when `status: implemented` and is checked for length by `_audit_paper_imrad.py` at that point.)
+
+## Results
+
+(pending — experiment status: planned. Run `/hub-paper-experiment-run <slug>` once the experiment completes to populate this section from `experiments[0].result`.)
+
+## Discussion
+
+(see frontmatter)
+
+### Limitations
+
+- User-study methodology — small samples have wide confidence intervals
+- Subjective satisfaction is hard to compare across user populations
+- Mitigation techniques (mentioned in perspectives) shift the curve; the paper's claim is for the unmitigated case
 
 <!-- references-section:begin -->
 ## References (examines)
@@ -102,16 +120,7 @@ realistic-failure-shape
 
 <!-- references-section:end -->
 
-## Perspectives
-
-(see frontmatter)
-
-## Limitations
-
-- User-study methodology — small samples have wide confidence intervals
-- Subjective satisfaction is hard to compare across user populations
-- Mitigation techniques (mentioned in perspectives) shift the curve; the paper's claim is for the unmitigated case
-
 ## Provenance
 
 - Authored 2026-04-25, batch of 10
+- Body migrated to IMRaD structure 2026-04-25 per `docs/rfc/paper-schema-draft.md` §5 by `_migrate_paper_to_imrad.py`. Pre-IMRaD body is preserved in git history; no semantic claims were rewritten during the migration. For hypothesis-type drafts, Methods + Results sections are stubs until the experiment completes.

--- a/paper/security/credential-rotation-window-tradeoff/PAPER.md
+++ b/paper/security/credential-rotation-window-tradeoff/PAPER.md
@@ -66,13 +66,31 @@ retraction_reason: null
 
 # Credential Rotation Window: Sweet Spot
 
-## Premise
+## Introduction
 
 (see frontmatter)
 
-## Background
+### Background
 
 `technique/security/credential-rotation-overlap-window` describes the overlap-window shape but leaves window length as "domain choice." Industry default of 7-30d is rarely revisited. This paper proposes shorter is better.
+
+## Methods
+
+(planned — see `experiments[0].method` in frontmatter for the full design. This section becomes substantive when `status: implemented` and is checked for length by `_audit_paper_imrad.py` at that point.)
+
+## Results
+
+(pending — experiment status: planned. Run `/hub-paper-experiment-run <slug>` once the experiment completes to populate this section from `experiments[0].result`.)
+
+## Discussion
+
+(see frontmatter)
+
+### Limitations
+
+- Migration distributions vary wildly across deployments; this paper's claim assumes mid-quartile distributions
+- "Compromise probability per hour" is hard to ground empirically; uses worst-case assumption
+- Does not account for organizational constraints (PR-cycle deadlines, ticket-based rotation)
 
 <!-- references-section:begin -->
 ## References (examines)
@@ -102,16 +120,7 @@ failure-modes-to-account-for
 
 <!-- references-section:end -->
 
-## Perspectives
-
-(see frontmatter)
-
-## Limitations
-
-- Migration distributions vary wildly across deployments; this paper's claim assumes mid-quartile distributions
-- "Compromise probability per hour" is hard to ground empirically; uses worst-case assumption
-- Does not account for organizational constraints (PR-cycle deadlines, ticket-based rotation)
-
 ## Provenance
 
 - Authored 2026-04-25, batch of 10
+- Body migrated to IMRaD structure 2026-04-25 per `docs/rfc/paper-schema-draft.md` §5 by `_migrate_paper_to_imrad.py`. Pre-IMRaD body is preserved in git history; no semantic claims were rewritten during the migration. For hypothesis-type drafts, Methods + Results sections are stubs until the experiment completes.

--- a/paper/testing/contract-test-staleness-curve/PAPER.md
+++ b/paper/testing/contract-test-staleness-curve/PAPER.md
@@ -66,13 +66,31 @@ retraction_reason: null
 
 # Contract Test Staleness Curve
 
-## Premise
+## Introduction
 
 (see frontmatter)
 
-## Background
+### Background
 
 `technique/testing/contract-test-with-consumer-verification` proposes quorum-vote contract tests but assumes votes are informed. This paper questions that assumption.
+
+## Methods
+
+(planned — see `experiments[0].method` in frontmatter for the full design. This section becomes substantive when `status: implemented` and is checked for length by `_audit_paper_imrad.py` at that point.)
+
+## Results
+
+(pending — experiment status: planned. Run `/hub-paper-experiment-run <slug>` once the experiment completes to populate this section from `experiments[0].result`.)
+
+## Discussion
+
+(see frontmatter)
+
+### Limitations
+
+- "Stale" definition is judgment-laden; this paper uses behavioral relevance which is harder to automate
+- 5-codebase sample is small; generalization is qualitative
+- Doesn't account for organizational discipline differences across teams
 
 <!-- references-section:begin -->
 ## References (examines)
@@ -102,16 +120,7 @@ test-execution-discipline
 
 <!-- references-section:end -->
 
-## Perspectives
-
-(see frontmatter)
-
-## Limitations
-
-- "Stale" definition is judgment-laden; this paper uses behavioral relevance which is harder to automate
-- 5-codebase sample is small; generalization is qualitative
-- Doesn't account for organizational discipline differences across teams
-
 ## Provenance
 
 - Authored 2026-04-25, batch of 10
+- Body migrated to IMRaD structure 2026-04-25 per `docs/rfc/paper-schema-draft.md` §5 by `_migrate_paper_to_imrad.py`. Pre-IMRaD body is preserved in git history; no semantic claims were rewritten during the migration. For hypothesis-type drafts, Methods + Results sections are stubs until the experiment completes.

--- a/paper/testing/llm-ci-triage-boundary-conditions/PAPER.md
+++ b/paper/testing/llm-ci-triage-boundary-conditions/PAPER.md
@@ -119,13 +119,13 @@ retraction_reason: null
 
 # Where does LLM-based CI failure triage help vs silently hurt?
 
-## Premise
+## Introduction
 
 **If** an LLM-based triage step (exemplified by the Auto-Diagnose pattern in [`testing/llm-integration-test-failure-diagnosis`](../../../skills/testing/llm-integration-test-failure-diagnosis/SKILL.md)) is wired into a CI integration-test failure pipeline, **then** it reduces mean-time-to-diagnose for noise-heavy classes (flakes, environment drift, dependency churn) but introduces silent misclassification on novel logic bugs — making it net positive ONLY when the team's failure mix is roughly > 60 percent noise. Below that ratio, the cost of regressions hidden as "known flakes" exceeds the triage-time savings.
 
 This claim has two halves. The first half (noise reduction) is what vendors advertise. The second half (silent cost on novel bugs) is rarely measured because the failure mode is invisible by definition — a mislabeled regression is found only when production bites back.
 
-## Background
+### Background
 
 The hub carries the baseline ingredients:
 
@@ -138,6 +138,105 @@ And one knowledge entry directly relevant:
 - `decision/caveats-absence-confidence-cap` — a hub-wide position that LLM output confidence should be capped when caveats are absent. Central to this paper's silent-failure argument.
 
 This paper does NOT claim the LLM approach is wrong. It claims the effectiveness is **conditional on failure-mix composition**, and the conditioning is unmeasured in most adoption stories.
+
+### Prior art
+
+`external_refs[]` is empty. The paper would be strengthened by pulling in:
+
+- Google's Auto-Diagnose paper (the system `testing/llm-integration-test-failure-diagnosis` is based on) and its 71-case study methodology
+- LLM calibration literature (Tetlock-style forecasting, Brier score) applied to code-triage outputs
+- Prior art on ROC/precision-recall measurement in test classification
+- Any other framework (LangGraph, Humanloop, etc.) that ships CI-triage with calibration as a first-class feature vs bolted on
+
+`/hub-research` would populate this list.
+
+## Methods
+
+(planned — see `experiments[0].method` in frontmatter for the full design. This section becomes substantive when `status: implemented` and is checked for length by `_audit_paper_imrad.py` at that point.)
+
+## Results
+
+(pending — experiment status: planned. Run `/hub-paper-experiment-run <slug>` once the experiment completes to populate this section from `experiments[0].result`.)
+
+## Discussion
+
+### 1. Noise-vs-Signal Boundary
+
+Classification accuracy for an LLM-based triager is not a single number. It factors across failure classes:
+
+- **Flakes** (timing, retry-able): very high recognition rate — the LLM sees ten thousand similar logs in training.
+- **Environment drift** (dependency version skew, missing env var): high.
+- **Dependency churn** (new major version breaks API): moderate — depends on how recent.
+- **Novel logic bugs** (off-by-one, rare race, domain-specific invariant violation): **low and rarely admitted as low by the LLM itself**.
+
+The last class is the killer. The LLM produces a plausible diagnosis even when its actual confidence should be near zero. Auto-Diagnose's 90 percent headline is a weighted average that obscures the per-class breakdown.
+
+### 2. Escalation Path
+
+What happens to an LLM verdict determines whether the triage step is a gain or a loss:
+
+- **Auto-close as "known flake"**: regression-hiding risk. Silent failure mode.
+- **Always file a ticket**: the triage step saves no human time — it just moves the label upstream.
+- **Hybrid routing**: LLM-confident verdicts auto-close or auto-escalate; low-confidence verdicts go to human systematic investigation. This is what the paper's third proposed build prototypes.
+
+No adoption path is neutral. The decision happens implicitly if not explicitly.
+
+### 3. Cost Model
+
+Back-of-envelope:
+
+```
+llm_cost_per_triage   ≈ N_tokens × token_price
+engineer_cost_saved   ≈ (mean_human_triage_time − residual_human_triage_time) × eng_rate
+                      × fraction_correctly_triaged_by_llm
+```
+
+Break-even depends on:
+- Flake rate (the LLM's best class) as fraction of total failures
+- Engineer hourly rate
+- LLM token cost per triage (~100 k tokens for a noisy log is common)
+- Per-failure time savings
+
+At 80 percent flake rate and typical current token pricing, LLM triage is clearly net positive. At 30 percent flake rate with high novel-bug rate, the silent-misclass risk can flip the sign. The 60 percent threshold in the premise is the paper's rough estimate; the experiment tightens it.
+
+### 4. Silent Failure Mode
+
+The worst failure is not an obvious misclassification (which a reviewer catches) but a confident "known flake" label on what is actually a new regression. This is the same failure shape flagged in paper [`workflow/parallel-dispatch-breakeven-point`](../../workflow/parallel-dispatch-breakeven-point/PAPER.md) — loud failures teach the team; silent failures accumulate.
+
+A team that adopts LLM triage without a confidence calibration dashboard cannot distinguish a 92 percent-accurate triager from a 75 percent-accurate-but-overconfident triager. Both produce the same log volume. The second one ships regressions.
+
+### Proposed builds (rationale)
+
+### `llm-triage-confidence-dashboard` (POC)
+
+A dashboard showing LLM triage confidence vs retrospectively verified outcome over N weeks. Surfaces:
+
+- Per-class accuracy (flake / env / dep / novel) as time series
+- Calibration curve: did 90 percent-confident verdicts actually hit 90 percent accuracy?
+- Regression-hit rate attributable to mislabeled "known flake" verdicts
+
+Without this, adoption is faith-based. With it, the break-even from the premise can be measured.
+
+### `llm-triage-false-known-flake-pitfall` (POC)
+
+A new pitfall knowledge entry documenting the specific silent-failure shape, with reproduction heuristics and the escalation check that would have caught it. Seed from `decision/caveats-absence-confidence-cap`. This entry is the paper's minimal corpus contribution if nothing else ships.
+
+### `hybrid-llm-human-triage-router` (DEMO)
+
+A new skill that routes CI failures through LLM triage first, then escalates to human systematic investigation (`debug/investigate`) when LLM confidence is below a threshold OR when the failure signature is novel (no seen-before match in a running fingerprint log). Completes the loop that the confidence dashboard measures.
+
+### Limitations
+
+- **No measurement yet.** The 60 percent threshold is an estimate. The experiment is planned but not run.
+- **LLM capability is a moving target.** A 2025-era LLM's per-class accuracy will likely improve. The paper's conclusions may have a 12–18 month shelf life before needing a refresh.
+- **Assumes retrospective ground truth.** The experiment requires known post-mortem verdicts for historical CI failures. Teams without rigorous post-mortems cannot reproduce the measurement directly.
+- **Single pattern examined.** The paper generalizes from one specific auto-diagnose skill. Other LLM-triage approaches (chain-of-thought, multi-agent debate, retrieval-augmented) may have different accuracy profiles.
+
+### Future work
+
+1. Is the 60 percent noise-mix threshold stable across organizations, or is it a moving target driven by the LLM's training data recency? The experiment addresses the former; only longitudinal observation can answer the latter.
+2. Can the LLM reliably self-flag low-confidence verdicts? If yes, the hybrid router is trivial. If no, the router needs an external signal (e.g. embedding similarity to previously seen failures).
+3. Is "silent misclassification" genuinely worse than "slow human triage" in terms of production impact, or is it just a different distribution of cost? The answer depends on how regressions manifest in the specific system.
 
 <!-- references-section:begin -->
 ## References (examines)
@@ -192,97 +291,6 @@ the shared downstream both paths feed into
 
 <!-- references-section:end -->
 
-## Perspectives
-
-### 1. Noise-vs-Signal Boundary
-
-Classification accuracy for an LLM-based triager is not a single number. It factors across failure classes:
-
-- **Flakes** (timing, retry-able): very high recognition rate — the LLM sees ten thousand similar logs in training.
-- **Environment drift** (dependency version skew, missing env var): high.
-- **Dependency churn** (new major version breaks API): moderate — depends on how recent.
-- **Novel logic bugs** (off-by-one, rare race, domain-specific invariant violation): **low and rarely admitted as low by the LLM itself**.
-
-The last class is the killer. The LLM produces a plausible diagnosis even when its actual confidence should be near zero. Auto-Diagnose's 90 percent headline is a weighted average that obscures the per-class breakdown.
-
-### 2. Escalation Path
-
-What happens to an LLM verdict determines whether the triage step is a gain or a loss:
-
-- **Auto-close as "known flake"**: regression-hiding risk. Silent failure mode.
-- **Always file a ticket**: the triage step saves no human time — it just moves the label upstream.
-- **Hybrid routing**: LLM-confident verdicts auto-close or auto-escalate; low-confidence verdicts go to human systematic investigation. This is what the paper's third proposed build prototypes.
-
-No adoption path is neutral. The decision happens implicitly if not explicitly.
-
-### 3. Cost Model
-
-Back-of-envelope:
-
-```
-llm_cost_per_triage   ≈ N_tokens × token_price
-engineer_cost_saved   ≈ (mean_human_triage_time − residual_human_triage_time) × eng_rate
-                      × fraction_correctly_triaged_by_llm
-```
-
-Break-even depends on:
-- Flake rate (the LLM's best class) as fraction of total failures
-- Engineer hourly rate
-- LLM token cost per triage (~100 k tokens for a noisy log is common)
-- Per-failure time savings
-
-At 80 percent flake rate and typical current token pricing, LLM triage is clearly net positive. At 30 percent flake rate with high novel-bug rate, the silent-misclass risk can flip the sign. The 60 percent threshold in the premise is the paper's rough estimate; the experiment tightens it.
-
-### 4. Silent Failure Mode
-
-The worst failure is not an obvious misclassification (which a reviewer catches) but a confident "known flake" label on what is actually a new regression. This is the same failure shape flagged in paper [`workflow/parallel-dispatch-breakeven-point`](../../workflow/parallel-dispatch-breakeven-point/PAPER.md) — loud failures teach the team; silent failures accumulate.
-
-A team that adopts LLM triage without a confidence calibration dashboard cannot distinguish a 92 percent-accurate triager from a 75 percent-accurate-but-overconfident triager. Both produce the same log volume. The second one ships regressions.
-
-## External Context
-
-`external_refs[]` is empty. The paper would be strengthened by pulling in:
-
-- Google's Auto-Diagnose paper (the system `testing/llm-integration-test-failure-diagnosis` is based on) and its 71-case study methodology
-- LLM calibration literature (Tetlock-style forecasting, Brier score) applied to code-triage outputs
-- Prior art on ROC/precision-recall measurement in test classification
-- Any other framework (LangGraph, Humanloop, etc.) that ships CI-triage with calibration as a first-class feature vs bolted on
-
-`/hub-research` would populate this list.
-
-## Proposed Builds
-
-### `llm-triage-confidence-dashboard` (POC)
-
-A dashboard showing LLM triage confidence vs retrospectively verified outcome over N weeks. Surfaces:
-
-- Per-class accuracy (flake / env / dep / novel) as time series
-- Calibration curve: did 90 percent-confident verdicts actually hit 90 percent accuracy?
-- Regression-hit rate attributable to mislabeled "known flake" verdicts
-
-Without this, adoption is faith-based. With it, the break-even from the premise can be measured.
-
-### `llm-triage-false-known-flake-pitfall` (POC)
-
-A new pitfall knowledge entry documenting the specific silent-failure shape, with reproduction heuristics and the escalation check that would have caught it. Seed from `decision/caveats-absence-confidence-cap`. This entry is the paper's minimal corpus contribution if nothing else ships.
-
-### `hybrid-llm-human-triage-router` (DEMO)
-
-A new skill that routes CI failures through LLM triage first, then escalates to human systematic investigation (`debug/investigate`) when LLM confidence is below a threshold OR when the failure signature is novel (no seen-before match in a running fingerprint log). Completes the loop that the confidence dashboard measures.
-
-## Open Questions
-
-1. Is the 60 percent noise-mix threshold stable across organizations, or is it a moving target driven by the LLM's training data recency? The experiment addresses the former; only longitudinal observation can answer the latter.
-2. Can the LLM reliably self-flag low-confidence verdicts? If yes, the hybrid router is trivial. If no, the router needs an external signal (e.g. embedding similarity to previously seen failures).
-3. Is "silent misclassification" genuinely worse than "slow human triage" in terms of production impact, or is it just a different distribution of cost? The answer depends on how regressions manifest in the specific system.
-
-## Limitations
-
-- **No measurement yet.** The 60 percent threshold is an estimate. The experiment is planned but not run.
-- **LLM capability is a moving target.** A 2025-era LLM's per-class accuracy will likely improve. The paper's conclusions may have a 12–18 month shelf life before needing a refresh.
-- **Assumes retrospective ground truth.** The experiment requires known post-mortem verdicts for historical CI failures. Teams without rigorous post-mortems cannot reproduce the measurement directly.
-- **Single pattern examined.** The paper generalizes from one specific auto-diagnose skill. Other LLM-triage approaches (chain-of-thought, multi-agent debate, retrieval-augmented) may have different accuracy profiles.
-
 ## Provenance
 
 - Authored: 2026-04-24
@@ -291,3 +299,4 @@ A new skill that routes CI failures through LLM triage first, then escalates to 
 - Sibling papers:
   - `paper/workflow/technique-layer-composition-value` (meta, self-referential)
   - `paper/workflow/parallel-dispatch-breakeven-point` (implemented, produced a knowledge outcome)
+- Body migrated to IMRaD structure 2026-04-25 per `docs/rfc/paper-schema-draft.md` §5 by `_migrate_paper_to_imrad.py`. Pre-IMRaD body is preserved in git history; no semantic claims were rewritten during the migration. For hypothesis-type drafts, Methods + Results sections are stubs until the experiment completes.

--- a/paper/workflow/technique-layer-composition-value/PAPER.md
+++ b/paper/workflow/technique-layer-composition-value/PAPER.md
@@ -106,13 +106,13 @@ retraction_reason: null
 
 # Does the `technique/` middle layer produce durable composition value?
 
-## Premise
+## Introduction
 
 **If** a skills-hub adds a `technique/` layer that composes atoms by reference (not by copy), **then** durable composition value emerges — recipes that survive atom updates, generalize across shapes (linear pipelines and branching decision trees), and serve as cite-able units for papers and apps — value that `hub-merge` alone cannot reproduce.
 
 This is a proposal, not a proof. The evidence below is from one rollout across roughly thirty hours and fifteen PRs; the claim is that the value is **durable**, which is a longer-horizon bet. What the rollout can show is whether the **shape** of the value is the shape the claim predicts.
 
-## Background
+### Background
 
 Before this rollout the hub had two tiers with a gap:
 
@@ -132,43 +132,18 @@ Two pilots shipped on purpose different shapes:
 
 Schema supported both without modification.
 
-<!-- references-section:begin -->
-## References (examines)
+### Prior art
 
-**technique — `workflow/safe-bulk-pr-publishing`**
-pilot #1 (linear pipeline, 4 composes)
+`external_refs[]` is deliberately empty at first draft. Relevant searches for `/hub-research`:
 
-**technique — `debug/root-cause-to-tdd-plan`**
-pilot #2 (decision tree, 4 composes)
+- "Composition layers between primitive and application" in developer-tool ecosystems (build tools, package managers, agent frameworks).
+- UNIX pipes and small-tools philosophy as a reference model for by-reference composition.
+- "Behavior trees" and "state machines" literature for decision-tree shape validation (relevant to pilot #2).
+- Prior work on documentation-as-code where structured prose cites structured artifacts (literate programming, Jupyter, MDX).
 
-**skill — `workflow/parallel-build-sequential-publish`**
-atom whose relocation surfaced the layout mismatch (RFC §4 evidence)
+A reviewer filling these in would strengthen the paper materially. Absence is flagged but not fatal.
 
-**knowledge — `workflow/batch-pr-conflict-recovery`**
-atom demonstrating failure-mode role in pilot #1
-
-
-## Build dependencies (proposed_builds)
-
-### `hub-paper-commands`  _(scope: poc)_
-
-**technique — `workflow/safe-bulk-pr-publishing`**
-shape template for composition-by-reference commands
-
-**technique — `debug/root-cause-to-tdd-plan`**
-second shape template — tests command generality across paper shapes
-
-### `security-domain-technique-3`  _(scope: poc)_
-
-**technique — `workflow/safe-bulk-pr-publishing`**
-reference shape (linear pipeline)
-
-**technique — `debug/root-cause-to-tdd-plan`**
-reference shape (decision tree)
-
-<!-- references-section:end -->
-
-## Perspectives
+## Discussion
 
 ### 1. Maintainability
 
@@ -248,18 +223,7 @@ What the rollout was *not*:
 - Not free of user feedback. #1061 (language consistency) would not have been caught by any automated check — it took the user noticing.
 - Not obvious in size. The 13 PRs were not budgeted in advance. If the pattern is replicable, the estimate for a paper-layer rollout is ~8–12 PRs, with similar open-ended tail.
 
-## External Context
-
-`external_refs[]` is deliberately empty at first draft. Relevant searches for `/hub-research`:
-
-- "Composition layers between primitive and application" in developer-tool ecosystems (build tools, package managers, agent frameworks).
-- UNIX pipes and small-tools philosophy as a reference model for by-reference composition.
-- "Behavior trees" and "state machines" literature for decision-tree shape validation (relevant to pilot #2).
-- Prior work on documentation-as-code where structured prose cites structured artifacts (literate programming, Jupyter, MDX).
-
-A reviewer filling these in would strengthen the paper materially. Absence is flagged but not fatal.
-
-## Proposed Builds
+### Proposed builds (rationale)
 
 ### `hub-paper-commands` (POC)
 
@@ -290,18 +254,54 @@ Extension of `/hub-make` that takes a paper slug, reads its `proposed_builds[]`,
 
 Carries a specific risk: if the paper's `proposed_builds[]` are too abstract, the scaffolds are empty folders. `/hub-make-from-paper` should refuse to scaffold a build whose `summary` is under ~60 characters, forcing the paper author to write a concrete-enough stub.
 
-## Open Questions
-
-1. When a `proposed_builds[]` item becomes a real `example/` entry, how is the back-link recorded? (§12 Q2 of the schema draft.) Proposal: add optional `example_ref` to each proposed_build; transition `status` to `implemented` when any proposed_build has a resolved `example_ref`.
-2. Is `examines[].kind: doc` (for citing `docs/rfc/...`) worth adding? Avoided in v0 for scope, but documents in the repo are legitimately cite-able subjects. Probably yes in v0.1.x or v0.2.
-3. Does the `no paper-to-paper citation` rule (§7) survive first contact with real writing? Academic papers cite papers. Watch for authors routing around it via `external_refs` (citing the paper by URL to its GitHub blob) — if that happens, v0.2 should lift the restriction.
-
-## Limitations
+### Limitations
 
 - **n=1** paper. Generalization claims rest on one test. A second paper on an unrelated topic is needed before the layer's generality is anything more than asserted.
 - **Self-referential pilot.** This paper's subject is the layer immediately above it in the hub and its proposed builds include the tooling for its own layer. That is not a neutral test. A paper on something the author did not recently ship would be a stronger check.
 - **Durability is asserted, not measured.** The premise claims value "survives atom updates" and "generalizes across shapes." The evidence is one rename event (#1063) and two shapes (n=2). A longer window and more pilots are required before that claim is anything more than plausible.
 - **Retraction criteria not exercised.** §11 of the schema says the layer retracts if the first pilot looks like an RFC or blog post. This paper does enough differently (structured citations, multi-angle, concrete proposed builds) to not obviously trigger retraction, but the determination requires a reviewer who did not author it.
+
+### Future work
+
+1. When a `proposed_builds[]` item becomes a real `example/` entry, how is the back-link recorded? (§12 Q2 of the schema draft.) Proposal: add optional `example_ref` to each proposed_build; transition `status` to `implemented` when any proposed_build has a resolved `example_ref`.
+2. Is `examines[].kind: doc` (for citing `docs/rfc/...`) worth adding? Avoided in v0 for scope, but documents in the repo are legitimately cite-able subjects. Probably yes in v0.1.x or v0.2.
+3. Does the `no paper-to-paper citation` rule (§7) survive first contact with real writing? Academic papers cite papers. Watch for authors routing around it via `external_refs` (citing the paper by URL to its GitHub blob) — if that happens, v0.2 should lift the restriction.
+
+<!-- references-section:begin -->
+## References (examines)
+
+**technique — `workflow/safe-bulk-pr-publishing`**
+pilot #1 (linear pipeline, 4 composes)
+
+**technique — `debug/root-cause-to-tdd-plan`**
+pilot #2 (decision tree, 4 composes)
+
+**skill — `workflow/parallel-build-sequential-publish`**
+atom whose relocation surfaced the layout mismatch (RFC §4 evidence)
+
+**knowledge — `workflow/batch-pr-conflict-recovery`**
+atom demonstrating failure-mode role in pilot #1
+
+
+## Build dependencies (proposed_builds)
+
+### `hub-paper-commands`  _(scope: poc)_
+
+**technique — `workflow/safe-bulk-pr-publishing`**
+shape template for composition-by-reference commands
+
+**technique — `debug/root-cause-to-tdd-plan`**
+second shape template — tests command generality across paper shapes
+
+### `security-domain-technique-3`  _(scope: poc)_
+
+**technique — `workflow/safe-bulk-pr-publishing`**
+reference shape (linear pipeline)
+
+**technique — `debug/root-cause-to-tdd-plan`**
+reference shape (decision tree)
+
+<!-- references-section:end -->
 
 ## Provenance
 
@@ -309,3 +309,4 @@ Carries a specific risk: if the paper's `proposed_builds[]` are too abstract, th
 - Status: pilot #1 for the `paper/` layer schema v0.1
 - Schema doc: `paper-schema-draft.md`
 - Subject material: shipped in PRs #1058 through #1070 on `kjuhwa/skills-hub`, tags `bootstrap/v2.6.14` through `bootstrap/v2.6.17`
+- Body migrated to IMRaD structure 2026-04-25 per `docs/rfc/paper-schema-draft.md` §5 by `_migrate_paper_to_imrad.py`. Pre-IMRaD body is preserved in git history; no semantic claims were rewritten during the migration. For hypothesis-type drafts, Methods + Results sections are stubs until the experiment completes.


### PR DESCRIPTION
## Summary

Sweep the 12 remaining draft hypothesis papers into IMRaD layout in one shot via a new automation helper. Combined with the 3 closed-loop papers already converted (#1124, #1127, #1128), the corpus reaches **15/15 IMRaD compliance** for the first time.

## New tool: \`_migrate_paper_to_imrad.py\`

Mechanical body restructurer. Takes a legacy paper body and emits the IMRaD layout:

| Legacy section | IMRaD destination |
|---|---|
| Premise | Introduction (opening) |
| Background | Introduction (### Background) |
| External Context | Introduction (### Prior art) |
| Perspectives | Discussion (top of section) |
| Proposed Builds | Discussion (### Proposed builds rationale) |
| Open Questions | Discussion (### Future work) |
| Limitations | Discussion (### Limitations) |
| (auto-injected References block) | References slot before Provenance |
| Provenance | Provenance (with migration note appended) |

For \`type: hypothesis\` drafts, \`Methods\` and \`Results\` are added as stubs:
- Methods: \`(planned — see experiments[0].method in frontmatter for the full design.)\`
- Results: \`(pending — run /hub-paper-experiment-run <slug> once the experiment completes.)\`

The IMRaD audit only enforces Methods + Results length once \`status: implemented\`, so stubs satisfy compliance for drafts.

Idempotent — papers already in IMRaD layout (Introduction + Discussion top-level headings) are left unchanged.

## Critical bug discovered + fixed during the sweep

The v1 migrator had a subtle defect that wasn't visible in single-paper testing:

Legacy bodies embed the auto-injected references-section block (HTML-marker bounded) mid-body, with **internal \`## \` headings inside the block** (e.g. \`## References (examines)\`, \`## Build dependencies\`). A naive section-splitter parses those internal headings as top-level sections, leaving the begin/end markers split across false sections. The downstream \`_inject_references_section.py\` runs after migration and applies its non-greedy DOTALL \`MANAGED_RE\` across the orphaned markers — silently deleting everything between them, including the just-emitted Methods/Results/Discussion sections.

The fix: strip the references-section block from the **whole body** before splitting into sections. The 12 affected papers were reverted to main and re-migrated with the fixed logic.

## Results

| State | Count |
|---|---|
| Closed-loop papers (already IMRaD pre-PR) | 3 |
| Hypothesis drafts migrated by this PR | 11 |
| Position drafts migrated by this PR | 1 |
| Flagged by \`_audit_paper_imrad.py\` | **0** |

## Verification

\`\`\`
$ python bootstrap/tools/_audit_paper_imrad.py
…
All 15 paper(s) compliant with IMRaD body structure.

$ python bootstrap/tools/_lint_frontmatter.py
PASS — 모든 파일이 스키마를 만족합니다.
\`\`\`

## Diff scope

13 files changed, +706/-316 — most of the change is the body restructuring. No frontmatter content was touched (citations.json and the citation graph were regenerated but emit identical data — the structural relationships are unchanged).

## Migration tool's place going forward

The tool stays in \`bootstrap/tools/\` for future use. Any paper authored against the pre-IMRaD template (legacy compose flow before #1124) can be migrated by running:

\`\`\`
python bootstrap/tools/_migrate_paper_to_imrad.py --path paper/<…>/<…>/PAPER.md --write
python bootstrap/tools/_inject_references_section.py --write   # idempotent re-position of references block
\`\`\`

Going forward, \`/hub-paper-compose\` and \`/hub-paper-from-technique\` produce IMRaD bodies directly — the migrator is for legacy / external imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)