### PR TITLE
feat(hub-paper-show): render v0.3 verdict / applicability / premise_history blocks

### DIFF
--- a/bootstrap/commands/hub-paper-show.md
+++ b/bootstrap/commands/hub-paper-show.md
@@ -15,8 +15,54 @@ Same as `/hub-paper-verify`: first match in `./.paper-draft/**/<slug>/PAPER.md`,
 
 1. Read the paper file.
 2. Print the frontmatter block verbatim.
-3. **Expand examines[]** — for each entry:
-   - Resolve path per kind (skill/knowledge/technique); reject paper kind
+3. **VERDICT banner** (v0.3 §15.3) — when `status=implemented` AND `verdict.one_line` is non-empty:
+   ```
+   ════════════════════════════════════════════════════════════════
+   VERDICT  (refined <N>×, last <YYYY-MM>)
+   ════════════════════════════════════════════════════════════════
+   <verdict.one_line>
+
+   Decision rule:
+     WHEN    <verdict.rule.when>
+     DO      <verdict.rule.do>
+     THRESH  <verdict.rule.threshold>      # omit row if empty
+
+   Belief delta:
+     BEFORE  <verdict.belief_revision.before_reading>
+     AFTER   <verdict.belief_revision.after_reading>
+   ```
+   - `<N>` and `<YYYY-MM>` come from `len(premise_history)` and `premise_history[-1].date[:7]`. Suffix omitted when no revisions.
+   - When `status=implemented` AND `verdict.one_line` is empty, print `⚠ [verdict missing]` instead of the banner.
+   - On `status=retracted`, the retraction banner (see Rules) takes precedence; the VERDICT block is skipped.
+4. **APPLICABILITY block** (v0.3) — when any `applicability.*` sub-list is non-empty:
+   ```
+   ════════════════════════════════════════════════════════════════
+   APPLICABILITY
+   ════════════════════════════════════════════════════════════════
+   Applies when (<N>):
+     • <each applies_when entry>
+   Does NOT apply when (<N>):
+     • <each does_not_apply_when entry>
+   Invalidated if observed (<N>):
+     • <each invalidated_if_observed entry>
+   Decay: <decay.half_life>
+     <decay.why>
+   ```
+   Render only sub-blocks with entries; silently skip empty ones.
+5. **PREMISE TRAIL** (v0.3) — when `premise_history[]` is non-empty:
+   ```
+   ════════════════════════════════════════════════════════════════
+   PREMISE TRAIL  (<N> revision(s))
+   ════════════════════════════════════════════════════════════════
+   [1] <date>
+       IF:    <prior premise.if>
+       THEN:  <prior premise.then>
+       CAUSE: <cause>
+   [2] ...
+   ```
+   Listed in frontmatter order. The current `premise.if/then` is the latest; this block shows what *was* believed before.
+6. **Expand examines[]** — for each entry:
+   - Resolve path per kind (skill/knowledge/technique/paper); v0.2.1 allows `kind: paper`
    - Read the resolved file's frontmatter; extract `name`, `version`, `description`/`summary`
    - Print an annotated line:
      ```
@@ -24,8 +70,8 @@ Same as `/hub-paper-verify`: first match in `./.paper-draft/**/<slug>/PAPER.md`,
                  → Build N projects in parallel ... batch conflict recovery
      ```
    - If ref resolves to missing file, mark `[MISSING]` and continue
-4. **Render perspectives[]** — numbered sections with `name` and `summary`
-5. **Render experiments[]** (v0.2) — table showing:
+7. **Render perspectives[]** — numbered sections with `name` and `summary`
+8. **Render experiments[]** (v0.2 + v0.3) — table showing:
    ```
    EXPERIMENTS
      [1] coverage-threshold-measurement
@@ -33,13 +79,28 @@ Same as `/hub-paper-verify`: first match in `./.paper-draft/**/<slug>/PAPER.md`,
          status: completed  supports_premise: partial  observed: 2026-04-24
          built_as: example/workflow/coverage-gate-benchmark → Interactive cost-model benchmark
          result: ...
+         measured (<N>):                            # v0.3, omit block if empty
+           <metric>  <value> <unit>  — <condition>
+         refutes:                                   # v0.3, omit block if empty
+           • <each phrase>
+         confirms:                                  # v0.3, omit block if empty
+           • <each phrase>
    ```
    If `experiments[]` is empty AND `type=hypothesis`, print a WARN banner: `paper cannot reach status=implemented without a completed experiment`.
-6. **Render proposed_builds[]** with `requires[]` expanded — for each build, show its `requires` refs inline with one-line descriptions (same pattern as examines expansion).
-7. **Render outcomes[]** (v0.2) — for each outcome, resolve the `ref` to its current description if possible; show the `note`.
-8. Print the paper body verbatim (the markdown after the frontmatter).
-9. **Trailing status line**:
-   `<N> examines resolved (<M> missing); <P> perspectives; <E_c>/<E_p> experiments completed/planned; <O> outcomes; <B> proposed builds; type=<type>; status=<status>`
+9. **Render proposed_builds[]** with `requires[]` expanded — for each build, show its `requires` refs inline with one-line descriptions (same pattern as examines expansion).
+10. **Render outcomes[]** (v0.2) — for each outcome, resolve the `ref` to its current description if possible; show the `note`.
+11. Print the paper body verbatim (the markdown after the frontmatter).
+12. **Trailing status line** (v0.2 + v0.3):
+    ```
+    <N> examines resolved (<M> missing); <P> perspectives; <E_c>/<E_p> experiments completed/planned;
+    <O> outcomes; <B> proposed builds; type=<type>; status=<status>;
+    verdict=<yes|no|n/a>; applicability=<sum>; revisions=<N>; measured_metrics=<sum>
+    ```
+    - `verdict` is `yes` if `verdict.one_line` populated, `no` if status=implemented + missing, `n/a` otherwise (draft/reviewed/retracted).
+    - `applicability` is the count of entries across all four sub-lists; `0` when applicability block omitted entirely.
+    - `revisions` is `len(premise_history)`.
+    - `measured_metrics` is `sum(len(e.measured) for e in experiments)`.
+    - The v0.3 fields are appended only when at least one v0.3 field is populated; pure v0.2 papers see the original three-clause line.
 
 ## Flags
 
@@ -56,6 +117,14 @@ Same as `/hub-paper-verify`: first match in `./.paper-draft/**/<slug>/PAPER.md`,
 
 - If `outcomes[].kind == produced_example`, resolve against `example/<ref>/README.md` (or `manifest.json`) and print the one-line description. This works because paper #2's `built_as` + `outcomes` pattern expects this resolution.
 - If a paper has `experiments[]` with mixed statuses (some `completed`, some `planned`), show both so readers see the in-progress work.
+
+## v0.3 behaviors worth flagging
+
+- **Verdict-first ordering**: when `status=implemented` and `verdict.one_line` is populated, the VERDICT banner (step 3) appears immediately after the frontmatter and before EXAMINES. This applies the §15.3 "verdict-first" spirit to the full-paper view — readers see the action-oriented summary before the analytical scaffolding.
+- **Empty verdict on implemented paper**: prints `⚠ [verdict missing]` in place of the banner, and the trailing status line shows `verdict=no` so reviewers can flag the paper for `_audit_paper_v03.py`.
+- **Premise rewrite trail**: `premise_history[]` is the structured form of what used to be inline `# Rewritten YYYY-MM-DD` YAML comments in v0.2 papers. The PREMISE TRAIL block (step 5) makes the trail readable; the inline comments in v0.3 papers can be retired (see `paper/workflow/parallel-dispatch-breakeven-point` for the canonical pattern).
+- **Numeric experiment results**: `experiments[i].measured[]` is the structured form of what used to be free-form result tables. Both representations should match — `measured[]` is grep-able by `_audit_paper_v03.py` and other tools, but the body's IMRaD `## Results` section remains the human-facing rendering.
+- **Truncation**: VERDICT banner does NOT truncate `verdict.one_line` (unlike `/hub-find` which caps at 200 chars). Full-paper view assumes the reader has the page; injection contracts compress, full-view doesn't.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Extends the `/hub-paper-show` slash-command spec (markdown-only — Claude agent renders at invocation, no Python tool involved) to surface v0.3 amendment fields prominently in the full-paper view. Completes the §15.3-spirited rendering pipeline: hub-find shows the verdict in search snippets (#1136), and now `/hub-paper-show` shows the verdict + applicability + premise trail when the user opens the full paper.

## Why

Up through #1136, the v0.3 amendment had a verdict-first injection contract for **search snippets**, but no analogous treatment in the **full-paper view**. A user who saw the action-oriented verdict in `/hub-find` and ran `/hub-paper-show` to read more would land on the same description-first IMRaD body as before, with the verdict block buried inside the verbatim YAML frontmatter. This PR makes the full-paper view consistent with the search snippet — verdict and applicability appear at the top, before the analytical scaffolding.

## Rendering pipeline (new flow)

```
1. Read the paper file
2. Print frontmatter verbatim
3. VERDICT banner       <- NEW (when status=implemented + verdict.one_line)
4. APPLICABILITY block  <- NEW (when applicability.* populated)
5. PREMISE TRAIL        <- NEW (when premise_history populated)
6. Expand examines[]    (existing)
7. Render perspectives[] (existing)
8. Render experiments[]  <- extended for measured/refutes/confirms (v0.3)
9. Render proposed_builds[] (existing)
10. Render outcomes[] (existing)
11. Body verbatim (existing)
12. Trailing status line <- extended for v0.3 metrics
```

## Sample rendered output (dogfood preview)

For `paper/workflow/parallel-dispatch-breakeven-point` (status=implemented, verdict populated):

```text
[... frontmatter verbatim, ~120 lines ...]

================================================================
VERDICT  (refined 1x, last 2026-04)
================================================================
Before parallel-dispatching to N agents, count useful_output absolute
(not coverage %); if useful_output < ~5 files, skip parallel — alpha*N
startup is pure waste regardless of coverage.

Decision rule:
  WHEN    About to dispatch a bulk-modification task to N parallel
          subagents on a corpus with non-trivial prior coverage
  DO      Run a ~1-second pre-flight probe (grep / find) to compute
          useful_output = (1 - coverage) * total_files; route to
          sampling or single-agent serial when below threshold
  THRESH  useful_output < 5 files

Belief delta:
  BEFORE  Parallel dispatch becomes a net negative beyond ~70%
          prior-work coverage; gate the dispatch on coverage fraction.
  AFTER   Coverage fraction misleads. The gate is useful_output
          absolute count. 80% coverage with 92 useful files still
          parallelizes well; 100% coverage with 0 files trivially
          must not. The 70% number was a single-session artifact.

================================================================
APPLICABILITY
================================================================
Applies when (3):
  - Bulk-modification task across many files (annotation, refactor, codemod)
  - alpha non-trivial relative to w (typical alpha ~ 30s, w ~ 60s)
  - Token cost or wall-clock cost matters
Does NOT apply when (4):
  - useful_output is large (>>5 files)
  - Token cost negligible — local models, fixed-cost inference
  - alpha << w — startup amortizes regardless
  - Sampling/auditing rather than modification
Invalidated if observed (4):
  - Agent-runner alpha drops to single-digit seconds
  - Pre-flight probe takes >5s on representative corpora
  - Cross-corpus replication shows threshold differs by >2x from ~5
  - Warm-pool / persistent-agent runners ship — alpha effectively zero

Decay: 12 months or until agent-runner startup model changes substantially
  Cost weights (alpha, v, w) tied to current agent-runner implementation.

================================================================
PREMISE TRAIL  (1 revision)
================================================================
[1] 2026-04-24
    IF:    A bulk-modification task is dispatched to N parallel
           subagents without a pre-flight coverage check
    THEN:  Beyond a prior-work coverage threshold of roughly 70%, the
           parallel pattern becomes a net negative — serial single-
           agent scan with targeted dispatch is cheaper, yet existing
           skills describe HOW to parallelize uniformly without
           surfacing WHEN NOT to.
    CAUSE: experiments[0] (coverage-threshold-measurement). Domain E
           (80.3% coverage, 92 useful files) was classified SAMPLING
           by the original 70%-rule but PARALLEL by the cost model.
           The 70% threshold was a single-session observation, not a
           robust constant.

[... existing examines/perspectives/experiments expansion ...]

EXPERIMENTS
  [1] coverage-threshold-measurement
      hypothesis: ...
      status: completed  supports_premise: partial  observed: 2026-04-24
      built_as: example/workflow/coverage-gate-benchmark -> ...
      result: ...
      measured (11):
        coverage          51.1 percent  — Domain A (skills with triggers populated)
        useful_output     229 files     — Domain A — classified PARALLEL by both rules
        coverage          100 percent   — Domain D (knowledge with tags key)
        useful_output     0 files       — Domain D — NO DISPATCH consensus
        coverage          80.3 percent  — Domain E (skills with stable v1+)
        useful_output     92 files      — Domain E — pivotal mismatch
        alpha_over_w_ratio 0.5 dimensionless — default cost weights
        useful_output_threshold 5 files — discovered gate criterion
        domains_measured  5 count       — single-org evidence, cross-corpus pending
        ...
      refutes:
        - the 70 percent break-even threshold is approximately correct across >=3 corpus domains
        - coverage percentage alone determines parallel viability
        - a domain at 80% coverage should switch to sampling
      confirms:
        - very high coverage trends toward non-parallel
        - existing parallel skills do not include a pre-flight gate as step 0
        - silent waste accumulates without an explicit gate
        - the pre-flight probe is cheap (~1s grep) — gate cost negligible

[... body verbatim ...]

11 examines resolved (0 missing); 4 perspectives; 1/0 experiments completed/planned;
2 outcomes; 3 proposed builds; type=hypothesis; status=implemented;
verdict=yes; applicability=11; revisions=1; measured_metrics=11
```

## Compatibility

- **v0.2-only papers**: render identically to before. The new VERDICT/APPLICABILITY/PREMISE TRAIL blocks are conditionally rendered only when their respective frontmatter fields are populated; pure v0.2 papers see the original flow unchanged.
- **Trailing status line**: v0.3 metrics appended only when at least one v0.3 field is populated. Pure v0.2 papers see the original three-clause line.
- **Empty verdict on implemented paper**: prints a verdict-missing advisory in place of the banner, status line shows `verdict=no` so reviewers can flag the paper for `_audit_paper_v03.py`.
- **Retracted papers**: existing retraction banner takes precedence; VERDICT block skipped (verdict no longer recommended).

## Truncation policy

VERDICT banner does **not** truncate `verdict.one_line`. Compare with `/hub-find` (#1136) which caps at 200 chars to fit search-result density. The full-paper view assumes the reader has the page; injection contracts compress, full-view doesn't.

## Test plan

- [x] Spec markdown renders cleanly (`grep` confirms 12 numbered steps + new v0.3 behaviors section + 136 lines total).
- [x] Sample dogfood preview generated for `parallel-dispatch-breakeven-point` (above) — all 3 new sections render with the populated v0.3 fields, no missing data, no formatting glitches.
- [ ] Manual: invoke `/hub-paper-show parallel-dispatch-breakeven-point` post-merge — verify the rendered output matches the dogfood preview shape.
- [ ] Manual: invoke `/hub-paper-show ai/coordinator-overhead-vs-parallelism` (draft, no v0.3 fields) — verify the original v0.2 flow renders unchanged.
- [ ] Manual: confirm `/hub-paper-show --raw` still bypasses all expansion (the spec explicitly preserves this flag).

## Follow-ups (out of scope, the remaining v0.3 wiring)

- `/hub-paper-verify` enforcement — promote rules 16-18 from advisory to lint failures (currently only `_audit_paper_v03.py` reports them; `/hub-paper-show` shows the advisory; lint should refuse to publish).
- `/hub-paper-extract-verdict <slug>` — propose draft `verdict` + `applicability` + `premise_history` blocks for an existing implemented paper by reading body + experiments. Useful for future paper authors who want to backfill v0.3 fields.

Generated with Claude Code (https://claude.com/claude-code).
