### PR TITLE
feat(hub-paper-verify): enforce v0.3 §15.2 rules 16-18 as FAIL on implemented hypothesis papers

### DIFF
--- a/bootstrap/commands/hub-paper-verify.md
+++ b/bootstrap/commands/hub-paper-verify.md
@@ -1,11 +1,11 @@
 ---
-description: Validate a paper against schema v0.2 — structure only (premise, examines, perspectives, description, name, status, type, experiments, requires). No substance checks.
+description: Validate a paper against schema v0.2 + v0.3 — structure only (premise, examines, perspectives, description, name, status, type, experiments, requires, verdict, applicability, premise_history). No substance checks.
 argument-hint: <slug> | --all [--strict]
 ---
 
 # /hub-paper-verify $ARGUMENTS
 
-Run schema v0.2 §6 rules against one paper (or all). **Structure-only by design** — this command does NOT evaluate the correctness of the premise, the accuracy of the perspectives, or the truth of the external_refs.
+Run schema v0.2 §6 + v0.3 §15.2 rules against one paper (or all). **Structure-only by design** — this command does NOT evaluate the correctness of the premise, the accuracy of the perspectives, the truth of the external_refs, or whether the verdict actually follows from the experiments. Lint enforces presence; reviewer judges substance.
 
 ## Input resolution
 
@@ -39,6 +39,23 @@ Run schema v0.2 §6 rules against one paper (or all). **Structure-only by design
 14. **Built-as resolves**: `experiments[i].built_as` if present must resolve to `example/<ref>/`. Missing build with `status=completed` is a WARN.
 15. **Completed experiment completeness**: `experiments[i].status=completed` requires `result`, `supports_premise`, and `observed_at` all non-null.
 
+### v0.3 additions (rules 16-18 required + a-d advisory)
+
+The v0.3 amendment (paper-schema-draft.md §15) adds optional frontmatter fields for LLM-consumption injection. Rules 16-18 fire **only when** `type=hypothesis` AND `status=implemented` — survey/position/draft/reviewed papers are exempt.
+
+16. **Verdict line populated**: `verdict.one_line` non-empty (≥1 char after strip). The action-oriented summary surfaced by `/hub-find` and `/hub-paper-show` per §15.3.
+17. **Decision rule populated**: `verdict.rule.do` non-empty. The machine-checkable action a future PR-lint can grep against.
+18. **Applicability bounds set**: `applicability.applies_when` length ≥1. Without applicability bounds, an implemented verdict over-applies — at least one positive precondition must be stated.
+
+Advisory rules (a-d) — WARN, never FAIL on their own; `--strict` upgrades to FAIL like other v0.2 advisories. They fire across all paper statuses but only when the trigger condition is met:
+
+- **a. threshold-on-numeric-result**: `verdict.rule.threshold` empty when `status=implemented` and any completed experiment's `result` contains numeric tokens. Likely a missed extraction.
+- **b. partial-without-rewrite-log**: `premise_history` empty when any completed experiment has `supports_premise: partial`. Partial verdicts almost always imply a premise rewrite — capture the trail.
+- **c. partial-without-does-not-apply**: `applicability.does_not_apply_when` empty when any completed experiment has `supports_premise` in {`no`, `partial`}. The "no/partial" cells are the does-not-apply conditions.
+- **d. rewrites-without-before-reading**: `verdict.belief_revision.before_reading` empty when `premise_history` length ≥2. The original assumption that drove revision 1 should be captured.
+
+**v0.3 §15.6 grace period**: rules 16-18 are FAIL on new implemented papers immediately. The amendment was merged 2026-04-26; all 3 pre-existing implemented papers were dogfooded in #1133/#1135 (parallel-dispatch, feature-flag-flap, technique-layer-roi). No backward-compat carve-out is needed because the three pre-existing in-scope papers are already compliant. If a future maintenance window finds an implemented paper that pre-dates v0.3 and lacks the fields, downgrade temporarily via `--no-v03` (not yet implemented; add when needed).
+
 ### v0.2.1 (opportunistic)
 
 - `outcomes[].kind` accepts `produced_example` alongside the core enum (formalized via schema update; older consumers just ignore unknown kinds).
@@ -65,8 +82,14 @@ PAPER: <category>/<slug>  (v<version>, type=<type>, status=<status>)
   [WARN]  proposed_builds[2].requires is empty — non-triviality guard
   [PASS]  experiments[0].status=completed, result non-null, supports_premise=partial, observed_at=2026-04-24
   [PASS]  status=implemented (hypothesis type + 1 completed experiment)
-RESULT: PASS (1 warning)
+  [PASS]  v0.3 rule 16: verdict.one_line populated (182 chars)
+  [PASS]  v0.3 rule 17: verdict.rule.do populated
+  [PASS]  v0.3 rule 18: applicability.applies_when (3 entries)
+  [WARN]  v0.3 advisory b: premise_history empty but supports_premise=partial — capture the rewrite
+RESULT: PASS (2 warnings)
 ```
+
+A v0.3-compliant implemented hypothesis paper produces 3 PASS lines for rules 16-18 plus 0-4 advisory entries depending on populated fields. A non-compliant one shows `[FAIL]` lines and exits non-zero.
 
 With `--all`, end with aggregate: `<K> papers verified: <pass> pass, <warn> warn, <fail> fail`.
 
@@ -94,6 +117,29 @@ python ~/.claude/skills-hub/remote/bootstrap/tools/_audit_paper_falsifiability.p
 ```
 
 Survey and position papers are exempt by default — their premises are not prediction-shaped. Use `--include-survey-position` to audit them anyway.
+
+## v0.3 compliance audit (separate, non-gating)
+
+`/hub-paper-verify` enforces v0.3 §15.2 rules 16-18 as FAIL on new implemented hypothesis papers. The complementary `_audit_paper_v03.py` reports the **same rules informationally across the entire corpus** plus the §15.6 adoption signal — useful for monitoring drift over time without blocking publish.
+
+Differences:
+
+| Concern | `/hub-paper-verify` | `_audit_paper_v03.py` |
+|---|---|---|
+| Posture | Gating (FAIL exits non-zero) | Informational (always exits 0) |
+| Scope | One paper at a time, or `--all` | Always full corpus |
+| Adoption % | Not reported | Reports `adoption_pct_implemented_hypothesis` |
+| §15.6 retraction signal | Not reported | Warns when adoption < 30 % past 2026-07-26 |
+| When to use | Pre-publish gate, draft author check | Periodic health monitor, retraction-gate decisioning |
+
+Run the audit directly:
+```
+python ~/.claude/skills-hub/remote/bootstrap/tools/_audit_paper_v03.py
+python ~/.claude/skills-hub/remote/bootstrap/tools/_audit_paper_v03.py --only-flagged
+python ~/.claude/skills-hub/remote/bootstrap/tools/_audit_paper_v03.py --json
+```
+
+It also runs automatically via `precheck.py` after `paper-imrad-audit`.
 
 ## Rules
 


### PR DESCRIPTION
## Summary

Promotes the v0.3 amendment from informational reporting (via `_audit_paper_v03.py`) to **gating enforcement** at publish time. New implemented hypothesis papers FAIL `/hub-paper-verify` if they lack `verdict.one_line` / `verdict.rule.do` / `applicability.applies_when`.

This closes the v0.3 wiring loop end-to-end:

| PR | Layer | Posture |
|---|---|---|
| #1132 | Schema (paper-schema-draft.md §15) | spec |
| #1133, #1135 | Dogfood (3 implemented papers) | data |
| #1134 | `_audit_paper_v03.py` | informational |
| #1136 | `/hub-find` injection contract | render |
| #1137 | `/hub-paper-show` full-paper rendering | render |
| **THIS PR** | **`/hub-paper-verify`** | **gating** |

The verify command is the only one of the six that BLOCKS publish. After merge, v0.3 fields are no longer optional for new implemented hypothesis papers — they're a publish prerequisite.

## What changes (spec-only — markdown command file)

`/hub-paper-verify` is a slash-command markdown spec that Claude (the agent) runs at invocation. No Python tool to update; this PR edits the spec to instruct Claude to run additional rules.

### Frontmatter description

`v0.2` → `v0.2 + v0.3`. Field list expanded.

### New §`v0.3 additions (rules 16-18 required + a-d advisory)`

Inserted between the v0.2 and v0.2.1 sections.

**Required (FAIL when `type=hypothesis` AND `status=implemented`)**:

- 16. `verdict.one_line` non-empty
- 17. `verdict.rule.do` non-empty
- 18. `applicability.applies_when` length ≥1

Survey/position/draft/reviewed papers are exempt — they don't carry experimental verdicts.

**Advisory WARN** (rules a-d):

- a. `verdict.rule.threshold` empty when status=implemented + numeric experiment results
- b. `premise_history` empty when any completed experiment has `supports_premise: partial`
- c. `applicability.does_not_apply_when` empty when any completed experiment has `supports_premise` in `{no, partial}`
- d. `verdict.belief_revision.before_reading` empty when `premise_history` length ≥2

`--strict` upgrades all WARN to FAIL, matching the existing v0.2 advisory pattern.

### v0.3 §15.6 grace-period note

The amendment was merged 2026-04-26; all 3 pre-existing implemented papers (`parallel-dispatch-breakeven-point`, `feature-flag-flap-prevention-policies`, `technique-layer-roi-after-100-pilots`) were dogfooded in #1133/#1135 and are already compliant. **No backward-compat carve-out is needed** — every in-scope paper currently passes. A future maintenance window finding an implemented paper that pre-dates v0.3 and lacks the fields can downgrade temporarily via `--no-v03` (not yet implemented; add when needed).

### Output format example extended

Adds illustrative v0.3 PASS lines (rules 16-18) and one advisory WARN to the per-paper output snippet, so reviewers see what compliant + advisory output looks like.

### New §`v0.3 compliance audit (separate, non-gating)`

Cross-references `_audit_paper_v03.py`. Mirror of the existing falsifiability-advisory section. Includes a comparison table:

| Concern | `/hub-paper-verify` | `_audit_paper_v03.py` |
|---|---|---|
| Posture | Gating (FAIL → exit non-zero) | Informational (always exits 0) |
| Scope | One paper or `--all` | Always full corpus |
| Adoption % | Not reported | Reports `adoption_pct_implemented_hypothesis` |
| §15.6 retraction signal | Not reported | Warns when adoption < 30% past 2026-07-26 |
| When to use | Pre-publish gate, draft author check | Periodic health monitor |

Both tools share rules 16-18; the audit also checks adoption rate and the retraction trigger.

## Compatibility / blast radius

- **Existing 3 implemented hypothesis papers**: all v0.3-compliant after #1135. Verify produces 3 new PASS lines per paper, zero new FAILs. No regression.
- **Draft hypothesis papers**: rules 16-18 do not fire (gated on `status=implemented`). Unaffected.
- **Survey / position papers**: exempt. Unaffected.
- **Future implemented hypothesis papers without v0.3 fields**: FAIL verify, blocked at publish. **This is the intended new behavior.**
- **Future drafts that backfill v0.3 fields early**: WARN advisories may fire (rules a-d), still pass. Encourages early authoring.

## Test plan

- [x] Spec markdown is well-formed (`grep` confirms 14 numbered sections + new v0.3 rules block + 152 lines total).
- [x] Output format example reflects realistic v0.3 PASS/WARN flow.
- [x] Audit cross-reference mirrors the existing falsifiability advisory pattern (consistent doc voice).
- [x] Pre-existing 3 implemented papers verified compliant by `_audit_paper_v03.py` (#1135) — verify post-merge expected to pass.
- [ ] Manual: invoke `/hub-paper-verify --all` post-merge — confirm all 15 papers pass (3 implemented hypothesis show new PASS lines for rules 16-18; 12 others unaffected).
- [ ] Manual: synthetically clear `verdict.one_line` on one paper, run `/hub-paper-verify <slug>`, confirm rule 16 FAILs and produces a non-zero exit signal that the publish flow can gate on.

## Follow-ups (the only remaining v0.3 wiring)

- `/hub-paper-extract-verdict <slug>` — propose draft `verdict` + `applicability` + `premise_history` blocks for an existing implemented paper by reading body + experiments. Useful for future paper authors who want to backfill v0.3 fields without reading the spec; also useful as a maintenance-window tool when an old paper pre-dates v0.3 and the carve-out flag becomes necessary.

After this PR merges, the v0.3 amendment is fully wired: schema → dogfood → audit → search injection → full-paper render → publish gate. Adoption is at 100% and the §15.6 retraction signal cannot fire while the current corpus shape holds.

Generated with Claude Code (https://claude.com/claude-code).
