### PR TITLE
feat(tools): _audit_paper_frontmatter_length.py — §16 compliance reporter (PR 2 of 3)

### DIFF
--- a/bootstrap/tools/_audit_paper_frontmatter_length.py
+++ b/bootstrap/tools/_audit_paper_frontmatter_length.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""§16 frontmatter brevity convention audit for paper/<…>/PAPER.md.
+
+The §16 amendment (docs/rfc/paper-schema-draft.md, merged 2026-04-26) defines
+a soft convention that frontmatter string values stay short (≤200 chars,
+with tighter caps on short-label fields). Long-form prose belongs in the
+body (IMRaD ## Methods / ## Results / ## Discussion).
+
+This audit walks all PAPER.md frontmatters, scores each string field against
+the cap table, and reports per-paper offenders plus the corpus-wide
+compliance percentage. The §16.6 self-corrective gate fires if compliance
+stays below 60 % past 90 days from the amendment merge — this audit produces
+the signal.
+
+Output is informational; exit code 0 even with offenders, matching
+_audit_paper_imrad.py / _audit_paper_v03.py / _audit_paper_falsifiability.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+# Force UTF-8 output so ⚠ / em-dash / ≤ in hints don't crash on cp949 / cp1252
+# default consoles. Same posture as _audit_paper_v03.py.
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except (AttributeError, OSError):
+    pass
+
+HUB_ROOT = Path(__file__).resolve().parents[2]
+PAPER_DIR = HUB_ROOT / "paper"
+
+# §16.2 cap table — string-length limit by frontmatter path pattern.
+# Path syntax: list indices stripped to '[*]' so the cap applies to every
+# element. The default cap (DEFAULT_CAP) covers any field not in the table.
+DEFAULT_CAP = 200
+CAPS: dict[str, int] = {
+    "description": 120,                                  # v0.1 rule 5
+    "premise.if": 200,
+    "premise.then": 200,
+    "examines[*].role": 80,
+    "examines[*].note": 80,
+    "perspectives[*].summary": 200,
+    "proposed_builds[*].summary": 200,
+    "proposed_builds[*].requires[*].role": 80,
+    "proposed_builds[*].requires[*].note": 80,
+    "experiments[*].method": 200,
+    "experiments[*].result": 200,
+    "experiments[*].hypothesis": 200,
+    "experiments[*].measured[*].condition": 120,
+    "outcomes[*].note": 200,
+    "verdict.one_line": 200,
+    "verdict.rule.when": 200,
+    "verdict.rule.do": 200,
+    "verdict.rule.threshold": 200,
+    "verdict.belief_revision.before_reading": 200,
+    "verdict.belief_revision.after_reading": 200,
+    "applicability.applies_when[*]": 120,
+    "applicability.does_not_apply_when[*]": 120,
+    "applicability.invalidated_if_observed[*]": 120,
+    "applicability.decay.half_life": 120,
+    "applicability.decay.why": 200,
+    "premise_history[*].if": 200,
+    "premise_history[*].then": 200,
+    "premise_history[*].cause": 200,
+}
+
+# §16.6 self-corrective gate
+AMENDMENT_MERGE_DATE = "2026-04-26"
+COMPLIANCE_RETRACTION_THRESHOLD_PCT = 60.0
+
+
+def split_frontmatter(text: str) -> tuple[str, str]:
+    if not text.startswith("---\n"):
+        return "", text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return "", text
+    return text[4 : end + 1], text[end + len("\n---\n") :]
+
+
+def parse_frontmatter(fm_text: str) -> dict:
+    if not fm_text:
+        return {}
+    try:
+        return yaml.safe_load(fm_text) or {}
+    except yaml.YAMLError:
+        return {}
+
+
+def cap_for(path: str) -> int:
+    """Return the cap for the given normalized path. Falls back to DEFAULT_CAP."""
+    return CAPS.get(path, DEFAULT_CAP)
+
+
+def walk_strings(obj, path_parts: list[str], offenders: list[dict]) -> None:
+    """Recursively visit every string leaf in obj; record those exceeding the cap."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            walk_strings(v, path_parts + [str(k)], offenders)
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            walk_strings(item, path_parts + [f"[{i}]"], offenders)
+    elif isinstance(obj, str):
+        # Build normalized path with list indices flattened to [*] for cap lookup
+        normalized: list[str] = []
+        for p in path_parts:
+            if p.startswith("[") and p.endswith("]"):
+                normalized.append("[*]")
+            else:
+                if normalized and normalized[-1].endswith("[*]"):
+                    normalized[-1] = normalized[-1] + "." + p
+                else:
+                    normalized.append(p)
+        # Re-join with dots, accounting for list-index runs
+        norm_path = ""
+        for i, p in enumerate(normalized):
+            if i == 0:
+                norm_path = p
+            elif p.startswith("[*]"):
+                norm_path += p
+            else:
+                norm_path += "." + p
+        cap = cap_for(norm_path)
+        length = len(obj)
+        if length > cap:
+            # Display path uses real indices for human readability
+            display = ".".join(path_parts).replace(".[", "[")
+            offenders.append({
+                "path": display,
+                "cap_path": norm_path,
+                "length": length,
+                "cap": cap,
+                "over_by": length - cap,
+            })
+
+
+def check_paper(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    fm_text, _body = split_frontmatter(text)
+    fm = parse_frontmatter(fm_text)
+    offenders: list[dict] = []
+    walk_strings(fm, [], offenders)
+    offenders.sort(key=lambda o: -o["length"])
+    return {
+        "slug": path.relative_to(PAPER_DIR).parent.as_posix(),
+        "type": (fm.get("type") or "hypothesis").strip() if isinstance(fm.get("type"), str) else "hypothesis",
+        "status": (fm.get("status") or "").strip() if isinstance(fm.get("status"), str) else "",
+        "offenders": offenders,
+        "compliant": not offenders,
+        "max_length": offenders[0]["length"] if offenders else 0,
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--only-flagged", action="store_true", help="only show non-compliant papers")
+    p.add_argument("--json", action="store_true")
+    p.add_argument("--top", type=int, default=5,
+                   help="show top N offenders per paper (default 5)")
+    args = p.parse_args()
+
+    rows = [check_paper(p_) for p_ in sorted(PAPER_DIR.glob("**/PAPER.md"))]
+    flagged = [r for r in rows if not r["compliant"]]
+    compliance_pct = (
+        100.0 * (len(rows) - len(flagged)) / len(rows) if rows else 0.0
+    )
+
+    display_rows = flagged if args.only_flagged else rows
+
+    if args.json:
+        # Top N per paper to keep payload tractable
+        for r in display_rows:
+            r["offenders"] = r["offenders"][: args.top]
+        print(json.dumps({
+            "summary": {
+                "audited": len(rows),
+                "compliant": len(rows) - len(flagged),
+                "flagged": len(flagged),
+                "compliance_pct": round(compliance_pct, 1),
+                "amendment_merge_date": AMENDMENT_MERGE_DATE,
+                "retraction_threshold_pct": COMPLIANCE_RETRACTION_THRESHOLD_PCT,
+            },
+            "rows": display_rows,
+        }, indent=2, ensure_ascii=False))
+        return 0
+
+    if not display_rows:
+        print("No papers in scope.")
+        return 0
+
+    for r in display_rows:
+        marker = "  ! " if not r["compliant"] else "    "
+        oc = len(r["offenders"])
+        print(f"{marker}{r['type']:<10} status={r['status']:<12} offenders={oc:<3} max={r['max_length']:<5} {r['slug']}")
+        for o in r["offenders"][: args.top]:
+            print(f"        {o['path']:<60s} {o['length']:>5} chars (cap {o['cap']}, over by {o['over_by']})")
+        if oc > args.top:
+            print(f"        ... and {oc - args.top} more (use --top {oc} to see all)")
+
+    print(
+        "\n§16 frontmatter brevity audit (docs/rfc/paper-schema-draft.md §16):\n"
+        f"  audited:        {len(rows)} paper(s)\n"
+        f"  compliant:      {len(rows) - len(flagged)}/{len(rows)}\n"
+        f"  flagged:        {len(flagged)}\n"
+        f"  compliance:     {compliance_pct:.1f}%"
+    )
+    if rows and compliance_pct < COMPLIANCE_RETRACTION_THRESHOLD_PCT:
+        print(
+            f"  [§16.6] compliance < {COMPLIANCE_RETRACTION_THRESHOLD_PCT:.0f}% — if this persists "
+            f"past 90 days from {AMENDMENT_MERGE_DATE}, the §16 convention is a "
+            "candidate for retraction or hardening per the self-corrective gate."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bootstrap/tools/precheck.py
+++ b/bootstrap/tools/precheck.py
@@ -63,6 +63,7 @@ def main() -> int:
     steps.append(("paper-falsifiability-audit", [py, "_audit_paper_falsifiability.py"]))
     steps.append(("paper-imrad-audit", [py, "_audit_paper_imrad.py"]))
     steps.append(("paper-v03-audit", [py, "_audit_paper_v03.py"]))
+    steps.append(("paper-frontmatter-length-audit", [py, "_audit_paper_frontmatter_length.py"]))
     steps.append(("technique-suggestions", [py, "_suggest_techniques.py"]))
 
     for label, cmd in steps:


### PR DESCRIPTION
## Summary

Implements the audit promised in `docs/rfc/paper-schema-draft.md` §16.4 (merged in #1140). Walks all PAPER.md frontmatters, scores each string field against the §16.2 cap table, and reports per-paper offenders plus the corpus-wide compliance percentage.

This is **PR 2 of 3** in the §16 frontmatter brevity series:

| PR | Layer | Status |
|---|---|---|
| #1140 | §16 schema amendment | merged |
| **#1141 (this)** | `_audit_paper_frontmatter_length.py` informational reporter | open |
| TBD | Bulk migration — compress `experiments[].result` and `experiments[].method` across 15 papers | pending |

## Cap table (§16.2)

| Field | Cap |
|---|---|
| `description` | 120 (v0.1 rule 5) |
| `premise.if` / `premise.then` | 200 |
| `examines[*].role` / `.note` | 80 each |
| `perspectives[*].summary` | 200 |
| `proposed_builds[*].summary` | 200 |
| `experiments[*].method` / `.result` / `.hypothesis` | 200 |
| `experiments[*].measured[*].condition` | 120 |
| `outcomes[*].note` | 200 |
| `verdict.one_line` | 200 |
| `verdict.rule.{when, do, threshold}` | 200 each |
| `verdict.belief_revision.{before, after}` | 200 each |
| `applicability.{applies_when, does_not_apply_when, invalidated_if_observed}[*]` | 120 each |
| `applicability.decay.{half_life, why}` | 120 / 200 |
| `premise_history[*].{if, then, cause}` | 200 each |
| default (any other string field) | 200 |

## Baseline measurement (current corpus)

```
§16 frontmatter brevity audit (docs/rfc/paper-schema-draft.md §16):
  audited:        15 paper(s)
  compliant:      2/15
  flagged:        13
  compliance:     13.3%
  [§16.6] compliance < 60% — if this persists past 90 days from
          2026-04-26, the §16 convention is a candidate for
          retraction or hardening per the self-corrective gate.
```

The §16.6 self-corrective gate warning fires immediately because the corpus is 86.7% non-compliant. **PR 3 will compress `experiments[].result` and `experiments[].method` to bring compliance above 60%.**

### Worst flagged papers

| Paper | Offenders | Max char count | Pivotal field |
|---|---:|---:|---|
| `arch/feature-flag-flap-prevention-policies` | 18 | 1465 | `experiments[0].result` |
| `arch/technique-layer-roi-after-100-pilots` | 16 | 1147 | `experiments[0].result` |
| `workflow/parallel-dispatch-breakeven-point` | 21 | 968 | `experiments[0].result` |
| `testing/llm-ci-triage-boundary-conditions` | 12 | 366 | `premise.then` |
| `data/backpressure-vs-rate-limit-comparison` | 4 | 446 | `premise.then` |

The 3 closed-loop hypothesis papers (the ones with completed experiments) carry the largest offenders — `experiments[].result` runs 968-1465 chars on each. Body `## Results` already carries the same content; the frontmatter copy is redundant. **PR 3 targets these specifically.**

### Compliant papers

```
ai/coordinator-overhead-vs-parallelism    0 offenders  (status=draft)
devops/canary-auto-revert-calibration     0 offenders  (status=draft)
```

Both are short drafts with no completed experiments — the natural shape that §16 wants to encourage corpus-wide.

## CLI

```bash
py _audit_paper_frontmatter_length.py                  # full report
py _audit_paper_frontmatter_length.py --only-flagged   # offenders only
py _audit_paper_frontmatter_length.py --top 50         # show all per-paper
py _audit_paper_frontmatter_length.py --json           # machine-readable
```

JSON summary shape:

```json
{
  "audited": 15,
  "compliant": 2,
  "flagged": 13,
  "compliance_pct": 13.3,
  "amendment_merge_date": "2026-04-26",
  "retraction_threshold_pct": 60.0
}
```

## Implementation notes

- **Posture**: informational, not blocking. Exit 0 even with offenders, matching the rest of the audit fleet.
- **Recursive walk**: the audit visits every string leaf in the frontmatter dict. Path normalization flattens list indices to `[*]` for cap lookup so a single cap entry covers every list element (e.g. `examines[*].role` covers `examines[0].role`, `examines[1].role`, ...).
- **Default cap**: any string field not in the explicit cap table inherits the 200-char default. Errs on the permissive side — false negatives are cheap (we miss flagging an oversized field), false positives would over-warn.
- **UTF-8 stdout reconfiguration**: same posture as other audits emitting Unicode (`≤`, em-dash, ⚠).
- **Wired into `precheck.py`** after `paper-v03-audit`. Audit fleet now runs: `loops → falsifiability → imrad → v03 → frontmatter-length`.

## Compatibility

- No schema change (the schema landed in #1140).
- No paper changes.
- `precheck.py` gains one step; existing steps unchanged.
- Existing audits unaffected.
- The audit is informational — does not block publish, does not modify files.

## Test plan

- [x] Standalone run on 15-paper corpus: 13 flagged, 2 compliant, 13.3% compliance, §16.6 gate warning fires.
- [x] JSON mode parses cleanly via downstream `json.load`.
- [x] `--top` flag controls how many offenders shown per paper.
- [x] `--only-flagged` filters to non-compliant papers only.
- [x] UTF-8 output renders ⚠ / em-dash / ≤ correctly.
- [ ] Full `precheck.py` run on a fresh clone (skipped here — pre-existing local environment issue with `bootstrap/indexes/` directory unrelated to this PR).

## Next: PR 3 (bulk migration)

After this PR merges, PR 3 will:
1. Compress `experiments[].result` to ≤200 chars on the 3 implemented papers (cross-reference to body `## Results` which already carries the full table).
2. Compress `experiments[].method` to ≤200 chars where it currently exceeds.
3. Optionally tighten `premise.then` on draft papers where it exceeds (case-by-case based on whether shortening preserves meaning).

Expected post-migration baseline: compliance ≥60%, §16.6 retraction warning suppressed, GitHub frontmatter rendering no longer triggers horizontal scroll on the worst-affected papers.

Generated with Claude Code (https://claude.com/claude-code).
