### PR TITLE
fix(paper): YAML strict-parser mid-string colon in change-stream-lock-contention-scaling-curve

### DIFF
--- a/paper/backend/change-stream-lock-contention-scaling-curve/PAPER.md
+++ b/paper/backend/change-stream-lock-contention-scaling-curve/PAPER.md
@@ -41,7 +41,7 @@ examines:
 
 perspectives:
   - name: Lock Granularity Tradeoff
-    summary: Per-event lock guarantees event-level exclusivity but pays N×lock-acquire on hot keys. Per-bucket lock loses event exclusivity for bounded contention. Tradeoff: correctness vs throughput.
+    summary: Per-event lock guarantees event-level exclusivity but pays N×lock-acquire on hot keys. Per-bucket lock loses event exclusivity for bounded contention — correctness granularity vs throughput.
   - name: Workload Shape Determines Crossover
     summary: Lock contention scales with event_rate × 1/key_cardinality. Low-card+high-rate (100 events/s on 5 hot keys) hits the wall fast; high-card+low-rate (1 event/s on 1000 keys) never contends at N=32.
   - name: Failure-Mode Shift Under Contention


### PR DESCRIPTION
## Summary

GitHub's strict YAML parser rejects `Tradeoff: correctness vs throughput` inside an unquoted scalar in `paper/backend/change-stream-lock-contention-scaling-curve/PAPER.md` (line 44, perspectives[0].summary). PyYAML (used by local audits) is more lenient and accepted it, so the issue slipped past `_audit_paper_v03.py` and merged via #1151.

This fix is what was pushed to PR #1151 in commit `985371e6` after the YAML error was reported — but the PR was merged at the prior commit `ca887bf6` before the fix was visible. Re-applying as a one-line follow-up.

## Change

```diff
-    summary: ... contention. Tradeoff: correctness vs throughput.
+    summary: ... contention — correctness granularity vs throughput.
```

Replaces the `Tradeoff: correctness` mid-string colon with em-dash punctuation. **No semantic change** — same tradeoff between correctness granularity and throughput.

## Followup

A separate PR ships `_audit_paper_yaml_strict.py` — an informational reporter that scans frontmatter unquoted scalars for this exact pattern across the corpus. The next mid-string colon won't slip through the local audit fleet.

## Why the local audit missed it

PyYAML's `safe_load` accepts:
```yaml
key: value with mid-string colon: like this
```
because it parses the whole line as a string when the colon isn't followed by clear structure. GitHub uses Ruby's Psych which is stricter and parses the mid-colon as a nested mapping start, then errors when the indentation doesn't support it.

The new audit will catch this regardless of which parser is used by the consumer.

Generated with Claude Code (https://claude.com/claude-code).