### PR TITLE
feat(tools): _audit_paper_yaml_strict.py — strict-parser YAML hazard detector

### DIFF
--- a/bootstrap/tools/_audit_paper_yaml_strict.py
+++ b/bootstrap/tools/_audit_paper_yaml_strict.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Strict-YAML compliance audit for paper/<…>/PAPER.md and technique/<…>/TECHNIQUE.md.
+
+PyYAML's safe_load is lenient about mid-string colons inside unquoted plain
+scalars: it accepts strings like "Tradeoff: correctness vs throughput" as a
+single value. GitHub's web UI and stricter YAML parsers (Ruby Psych, Go yaml.v3
+in strict mode) reject these as malformed mappings.
+
+This audit scans frontmatter line-by-line for unquoted plain scalars containing
+mid-string ": " followed by an alpha character — the exact pattern that fails
+under strict parsers but passes under PyYAML.
+
+Background: this issue surfaced when paper #1151 merged with line 44 reading
+`summary: ... Tradeoff: correctness vs throughput.`. The paper passed local
+audits (PyYAML lenient) but GitHub's frontmatter renderer threw "mapping values
+are not allowed in this context at line 43 column 173". Fix #1152 replaced ": "
+with " — ". This audit prevents the next instance from slipping through.
+
+Output is informational; exit code 0 even with offenders, matching the broader
+audit fleet (_audit_paper_v03.py, _audit_paper_imrad.py, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# UTF-8 stdout reconfiguration so non-ASCII content (em-dash, ≥, ≤) doesn't
+# crash on cp949 / cp1252 default consoles.
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except (AttributeError, OSError):
+    pass
+
+HUB_ROOT = Path(__file__).resolve().parents[2]
+PAPER_DIR = HUB_ROOT / "paper"
+TECHNIQUE_DIR = HUB_ROOT / "technique"
+
+# Match an unquoted scalar entry: <indent>(- )?<key>: <value>
+# Captures (indent, list-marker, key, value) so the value can be inspected.
+KV_LINE_RE = re.compile(r"^(\s*)(- )?([A-Za-z_][\w-]*): (.*)$")
+
+# Block-scalar indicator at end of line — value is the literal | / > etc.
+BLOCK_SCALAR_INDICATORS = {"|", ">", "|-", ">-", "|+", ">+", "|2", ">2", "|2-", ">2-"}
+
+# A mid-string ": " followed by an alpha character is the strict-parser hazard.
+# We anchor to mid-string by requiring the ": " to NOT be the first content of
+# the value (it can't be — the line was already split on the first ": " by
+# KV_LINE_RE). Any subsequent ": <letter>" is suspicious.
+MID_STRING_COLON_RE = re.compile(r": [A-Za-z]")
+
+
+def split_frontmatter_lines(text: str) -> tuple[int, int] | None:
+    """Return (start_line_idx, end_line_idx) of the frontmatter block, or None."""
+    if not text.startswith("---\n"):
+        return None
+    lines = text.splitlines()
+    if not lines or lines[0] != "---":
+        return None
+    for i, line in enumerate(lines[1:], start=1):
+        if line == "---":
+            return (1, i)  # frontmatter content lines are [1, i)
+    return None
+
+
+def line_indent(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def scan_frontmatter(path: Path) -> list[dict]:
+    """Return offending entries: [{line, key, value, snippet}, ...]."""
+    text = path.read_text(encoding="utf-8")
+    fm_range = split_frontmatter_lines(text)
+    if fm_range is None:
+        return []
+    fm_start, fm_end = fm_range
+    lines = text.splitlines()
+
+    offenders: list[dict] = []
+    in_block_scalar = False
+    block_scalar_indent = -1
+
+    for line_idx in range(fm_start, fm_end):
+        line = lines[line_idx]
+        line_no = line_idx + 1  # 1-based for human display
+
+        # If we're inside a block scalar, skip lines until indentation drops back.
+        if in_block_scalar:
+            if line.strip() == "" or line_indent(line) > block_scalar_indent:
+                continue
+            in_block_scalar = False  # fall through and re-evaluate this line
+
+        m = KV_LINE_RE.match(line)
+        if not m:
+            continue
+
+        indent_str, _list_marker, key, value = m.groups()
+        value_stripped = value.rstrip()
+
+        # Block-scalar starter (|, >, etc.) — switch state and skip
+        if value_stripped in BLOCK_SCALAR_INDICATORS:
+            in_block_scalar = True
+            block_scalar_indent = len(indent_str)
+            continue
+
+        # Quoted values are safe — strict parser handles them
+        if value_stripped.startswith(('"', "'")):
+            continue
+
+        # Empty / null / flow style — safe
+        if value_stripped in ("", "[]", "{}", "null", "~"):
+            continue
+
+        # Flow-style mapping or list (e.g., {a: 1, b: 2}) — safe
+        if value_stripped.startswith(("{", "[")):
+            continue
+
+        # The hazard: mid-string ": <letter>" in an unquoted plain scalar
+        match = MID_STRING_COLON_RE.search(value_stripped)
+        if match:
+            # Build a short snippet around the hazard for the report
+            offset = match.start()
+            window_start = max(0, offset - 20)
+            window_end = min(len(value_stripped), offset + 20)
+            snippet = value_stripped[window_start:window_end]
+            if window_start > 0:
+                snippet = "…" + snippet
+            if window_end < len(value_stripped):
+                snippet = snippet + "…"
+            offenders.append({
+                "line": line_no,
+                "key": key,
+                "value_length": len(value_stripped),
+                "hazard_offset": offset,
+                "snippet": snippet,
+            })
+
+    return offenders
+
+
+def check_file(path: Path, kind_root: Path, kind_label: str) -> dict:
+    offenders = scan_frontmatter(path)
+    return {
+        "kind": kind_label,
+        "slug": path.relative_to(kind_root).parent.as_posix(),
+        "offenders": offenders,
+        "compliant": not offenders,
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--only-flagged", action="store_true",
+                   help="only show files with strict-YAML hazards")
+    p.add_argument("--json", action="store_true")
+    p.add_argument("--include-techniques", action="store_true", default=True,
+                   help="also scan technique/<…>/TECHNIQUE.md (default: on)")
+    p.add_argument("--papers-only", action="store_true",
+                   help="restrict scan to paper/<…>/PAPER.md")
+    args = p.parse_args()
+
+    rows: list[dict] = []
+    for p_ in sorted(PAPER_DIR.glob("**/PAPER.md")):
+        rows.append(check_file(p_, PAPER_DIR, "paper"))
+    if not args.papers_only and args.include_techniques and TECHNIQUE_DIR.exists():
+        for t_ in sorted(TECHNIQUE_DIR.glob("**/TECHNIQUE.md")):
+            rows.append(check_file(t_, TECHNIQUE_DIR, "technique"))
+
+    flagged = [r for r in rows if not r["compliant"]]
+    compliance_pct = (
+        100.0 * (len(rows) - len(flagged)) / len(rows) if rows else 0.0
+    )
+
+    display_rows = flagged if args.only_flagged else rows
+
+    if args.json:
+        print(json.dumps({
+            "summary": {
+                "audited": len(rows),
+                "compliant": len(rows) - len(flagged),
+                "flagged": len(flagged),
+                "compliance_pct": round(compliance_pct, 1),
+            },
+            "rows": display_rows,
+        }, indent=2, ensure_ascii=False))
+        return 0
+
+    if not display_rows:
+        print("No files in scope.")
+        return 0
+
+    for r in display_rows:
+        marker = "  ! " if not r["compliant"] else "    "
+        oc = len(r["offenders"])
+        print(f"{marker}{r['kind']:<10} offenders={oc:<2} {r['slug']}")
+        for o in r["offenders"]:
+            print(f"        L{o['line']:<4} {o['key']:<20s} → {o['snippet']}")
+
+    print(
+        "\nStrict-YAML audit (mid-string ': ' in unquoted plain scalars):\n"
+        f"  audited:    {len(rows)} file(s)\n"
+        f"  compliant:  {len(rows) - len(flagged)}/{len(rows)}\n"
+        f"  flagged:    {len(flagged)}\n"
+        f"  compliance: {compliance_pct:.1f}%"
+    )
+    if flagged:
+        print(
+            "\nRemediation: replace mid-string ': ' with em-dash (—), semicolon, "
+            "or wrap the entire value in quotes. PyYAML accepts the unquoted form, "
+            "but GitHub's web YAML renderer and Ruby Psych reject it as a "
+            "malformed mapping."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bootstrap/tools/precheck.py
+++ b/bootstrap/tools/precheck.py
@@ -65,6 +65,7 @@ def main() -> int:
     steps.append(("paper-v03-audit", [py, "_audit_paper_v03.py"]))
     steps.append(("paper-frontmatter-length-audit", [py, "_audit_paper_frontmatter_length.py"]))
     steps.append(("technique-v02-audit", [py, "_audit_technique_v02.py"]))
+    steps.append(("paper-yaml-strict-audit", [py, "_audit_paper_yaml_strict.py"]))
     steps.append(("technique-suggestions", [py, "_suggest_techniques.py"]))
 
     for label, cmd in steps:


### PR DESCRIPTION
## Summary

New informational audit detecting **mid-string `: ` in unquoted plain scalars** in `paper/<…>/PAPER.md` and `technique/<…>/TECHNIQUE.md` frontmatters. Same pattern that caused GitHub to reject paper #1151 line 44 ("Tradeoff: correctness vs throughput") despite PyYAML accepting it locally — the issue surfaced in #1152 and motivated this audit.

## Why

PyYAML's `safe_load` is lenient: it accepts unquoted plain scalars containing mid-string `: ` as a single string value. GitHub's Psych-based YAML renderer is stricter — it parses the mid-string `: ` as a nested mapping start, then errors when the indentation can't support it.

The local audit fleet (`_audit_paper_v03.py`, `_audit_paper_imrad.py`, etc.) all use PyYAML, so the lenient acceptance let the issue slip past every existing check. This regex-based audit catches the pattern regardless of consumer parser.

## Baseline measurement

```
Strict-YAML audit (mid-string ': ' in unquoted plain scalars):
  audited:    38 file(s)
  compliant:  36/38
  flagged:    2
  compliance: 94.7%
```

### The two flagged files

| File | Line | Field | Snippet |
|---|---:|---|---|
| `paper/backend/change-stream-lock-contention-scaling-curve` | 44 | `summary` | `…Tradeoff: correctness vs thr…` |
| `paper/db/migration-checkpoint-overhead` | 11 | `then` | `…Recommended granularity: per-batch…` |

The first is already fixed in PR #1152 (in flight). The second is a **new finding** — `db/migration-checkpoint-overhead` line 11 reads "Recommended granularity: per-batch, not per-row." which GitHub may also be erroring on. Will be addressed in a separate one-line fix PR after this audit lands.

This is the audit's first immediate value: it found a previously unflagged issue that was lurking in the corpus.

## How it works

```
1. Walk paper/**/PAPER.md and technique/**/TECHNIQUE.md
2. Split frontmatter; track block-scalar state (skip multi-line values)
3. For each unquoted plain scalar (regex-matched on `key: value` pattern):
   - Skip quoted (`"..."` / `'...'`) and flow-style (`{...}` / `[...]`)
   - Skip null / empty / block-scalar starters (`|`, `>`)
   - Search remaining unquoted scalar for `: <letter>` pattern
   - Flag with snippet showing the hazard in context
4. Report per-file findings + corpus-wide compliance %
```

False-positive risk: the regex pattern matches `: <letter>` anywhere mid-string, but quoted/flow/null/block scalars are skipped. Empirical false-positive rate on the current corpus: 0 (both flagged offenders are real strict-parser hazards).

## Posture

- **Informational**, not blocking. Exit 0 even with offenders, matching `_audit_paper_v03.py` / `_audit_paper_imrad.py` / `_audit_paper_frontmatter_length.py` posture.
- Wired into `precheck.py` after `technique-v02-audit`. Audit fleet now runs: `loops → falsifiability → imrad → v03 → frontmatter-length → technique-v02 → yaml-strict`.
- Flags emit a remediation hint when found: replace `: ` with em-dash, semicolon, or wrap value in quotes.

## CLI

```bash
py _audit_paper_yaml_strict.py                  # full report
py _audit_paper_yaml_strict.py --only-flagged   # offenders only
py _audit_paper_yaml_strict.py --papers-only    # restrict to paper/
py _audit_paper_yaml_strict.py --json           # machine-readable
```

JSON summary shape:

```json
{
  "audited": 38,
  "compliant": 36,
  "flagged": 2,
  "compliance_pct": 94.7
}
```

## Implementation notes

- **Regex-based, not parser-based**: PyYAML can't catch this since it accepts the input. ruamel.yaml or other strict parsers would need extra deps. Pure-regex approach catches the pattern with zero new dependencies.
- **Block-scalar tracking**: state machine skips multi-line block scalar bodies (after `|`, `>`, etc.) until indentation drops back. Required because block scalars can contain anything, including mid-string colons that are perfectly valid.
- **UTF-8 stdout reconfiguration**: same posture as other audits emitting Unicode.

## Compatibility

- No schema change.
- No paper or technique changes (the broken file is fixed in #1152, not here).
- `precheck.py` gains one step; existing steps unchanged.
- Existing audits unaffected.

## Test plan

- [x] Standalone run on full corpus: 36/38 compliant, 2 flagged with correct line numbers and snippets.
- [x] JSON mode parses cleanly via downstream `json.load`.
- [x] `--only-flagged` filters correctly.
- [x] `--papers-only` excludes techniques.
- [x] Block-scalar bodies (e.g., `experiments[].method: |-`) are skipped — no false positives on multi-line values that legitimately contain colons.
- [x] Quoted values are skipped — verified by inspection (no current paper has quoted strings with mid-string colons).
- [ ] Manual: re-run after #1152 + the followup migration-checkpoint-overhead fix → expect 38/38 compliant, 100%.

## Followups

1. **One-line fix for `db/migration-checkpoint-overhead`**: replace `Recommended granularity: per-batch, not per-row.` with em-dash variant. Will ship as a separate PR once this audit lands so the audit's first finding has a paper trail.
2. **Consider extending to `knowledge/<…>.md` and `skill/<…>/SKILL.md`** — current scope is paper + technique. Knowledge entries can have the same issue but their frontmatters tend to be shorter.
3. **Consider promoting to `--strict` FAIL in `/hub-paper-verify`** if the audit consistently catches real hazards over the next few weeks.

Generated with Claude Code (https://claude.com/claude-code).
