### PR TITLE
knowledge(pitfall/yaml-mid-string-colon-strict-parser-mismatch): document parser disagreement that broke #1151

### DIFF
--- a/knowledge/pitfall/yaml-mid-string-colon-strict-parser-mismatch.md
+++ b/knowledge/pitfall/yaml-mid-string-colon-strict-parser-mismatch.md
@@ -1,0 +1,32 @@
+---
+version: 0.1.0-draft
+name: yaml-mid-string-colon-strict-parser-mismatch
+description: PyYAML accepts mid-string colon-space in unquoted scalars but Ruby Psych and GitHub renderer reject as malformed mapping
+category: pitfall
+source:
+  kind: corpus
+  ref: skills-hub@1152
+confidence: high
+linked_skills: []
+tags: [yaml, parser-strictness, frontmatter, github-render, pyyaml, psych]
+---
+
+**Fact:** YAML parsers disagree on mid-string `: ` (colon followed by space) inside unquoted plain scalars. PyYAML's `safe_load` accepts the entire line as a single string. Ruby Psych (GitHub's web YAML renderer, Jekyll, many CI lints) rejects it as `mapping values are not allowed in this context`, errorring at the column where the second colon appears.
+
+**Why:** YAML spec leaves plain-scalar termination ambiguous in edge cases. PyYAML extends the scalar greedily — once it has started a string value, it keeps consuming until end-of-line. Psych follows a stricter interpretation that treats `: <alpha>` mid-line as a potential nested mapping start, which then fails the indentation check because the apparent sub-key has the wrong indent. Same input file, two different parse trees, one error.
+
+**How to apply:**
+- Replace mid-string `: ` with `—` (em-dash), `;`, or `,` in unquoted scalars. The fix is purely punctuational — no semantic content changes.
+- Wrap the entire value in quotes (`"value: with colon"`) — quoted scalars terminate at the closing quote regardless of inner content.
+- Use block scalars (`|` or `>`) for multi-line values that might contain colons. Block scalars terminate at de-indented lines, not at colons.
+- Don't rely on local PyYAML acceptance — even if your local lint passes, GitHub Preview tab and any Psych-based consumer may reject the same file.
+- Lint with multiple parsers (or a regex scan) if your YAML targets multiple consumers (web display, server config, CI). PyYAML alone is not sufficient coverage.
+
+**Evidence:**
+- skills-hub PR #1151 merged with `summary: ... Tradeoff: correctness vs throughput.` in a paper frontmatter — passed local PyYAML audits, GitHub Preview tab errored "mapping values are not allowed in this context at line 43 column 173" immediately on merge.
+- PR #1152 fixed with em-dash replacement (1-line diff): `Tradeoff: correctness vs throughput` → `— correctness granularity vs throughput`. No semantic loss.
+- PR #1153 added `_audit_paper_yaml_strict.py` — pure-regex scan that catches the pattern regardless of consumer parser. PyYAML-based audits cannot catch it because they accept the input.
+- Second offender found by the new audit on first run: `paper/db/migration-checkpoint-overhead` line 11 had `Recommended granularity: per-batch, not per-row.` — same pattern, latent. Fixed in PR #1154.
+- Final state: `_audit_paper_yaml_strict.py` reports 100% compliance (39/39 files) across paper + technique frontmatters.
+
+**Why this matters for AI agents:** AI-authored YAML frontmatter routinely uses prose patterns like "Tradeoff: X vs Y" or "Recommended approach: Z" because they read naturally. PyYAML's lenient acceptance reinforces the pattern by passing every local test. The mismatch only surfaces at consumer time (GitHub render, Jekyll build, CI lint). The audit-fleet pattern of "use a different parser than the one your authors run locally" applies anywhere multiple parsers consume the same file.


### PR DESCRIPTION
## Summary

New `knowledge/pitfall` entry documenting the parser disagreement that broke PR #1151 in this session: PyYAML accepts mid-string `: ` in unquoted plain scalars, but Ruby Psych (GitHub's web YAML renderer, Jekyll, many CI lints) rejects it as a malformed mapping value.

## Why this entry exists

The skills-hub corpus is meta — a knowledge pitfall about the corpus's own authoring tools is corpus-derived, not project-derived. This is the **first session-discovery atom** added across the 26 PRs in this session.

The path that produced this pitfall:

1. **PR #1151** merged with `summary: ... Tradeoff: correctness vs throughput.` in a paper frontmatter. Every local PyYAML-based audit passed.
2. GitHub's Preview tab errored on merge: `mapping values are not allowed in this context at line 43 column 173`.
3. **PR #1152** fixed with em-dash replacement (1-line diff). No semantic loss.
4. **PR #1153** added `_audit_paper_yaml_strict.py` — pure-regex scan that catches the pattern regardless of consumer parser. PyYAML-based audits cannot catch it because they accept the input.
5. **First-run finding**: PR #1153's audit immediately surfaced a SECOND latent offender in `paper/db/migration-checkpoint-overhead` line 11 (`Recommended granularity: per-batch`) that had been sitting in main, also unflagged by PyYAML.
6. **PR #1154** fixed the second offender. Final state: 100% strict-YAML compliance (39/39 files).

The pitfall captures the lesson: **don't assume your local parser matches your consumer's parser**. PyYAML alone is not sufficient coverage when YAML targets web display or other strict-parser consumers.

## Body structure

Standard pitfall sections (Fact / Why / How to apply / Evidence) plus an extra **Why this matters for AI agents** because AI authoring routinely reproduces the broken pattern (prose like `Tradeoff: X vs Y` reads naturally; PyYAML's lenient parsing reinforces it).

## Audits

| Audit | Status |
|---|---|
| description length (v0.1 rule 5, ≤120) | 120/120 — exactly at cap |
| YAML parse (PyYAML) | OK |
| strict-YAML manual scan | 0 mid-string colons in frontmatter |

## Why first knowledge entry of the session

26 PRs into this session and zero new atom-layer entries before this one. Prior PRs focused on:
- Schema amendments (paper §15, technique §13, paper §16)
- Audits (`_audit_paper_v03.py`, `_audit_paper_frontmatter_length.py`, `_audit_technique_v02.py`, `_audit_paper_yaml_strict.py`)
- Slash command extensions
- Papers (4 hypothesis + 1 survey)
- Techniques (3 greenfield)
- Bulk migrations + fixes

The atom layer is by far the largest in the corpus (~2000 entries) but had received no contributions this session. This PR adds one corpus-meta atom that documents a real session-derived learning. The pattern is reusable — future sessions that hit similar parser mismatches can cite this entry rather than re-discovering.

## Followup options

- A complementary `knowledge/decision/yaml-frontmatter-strict-parser-validation` could be added — the *decision* to run multi-parser checks (vs the pitfall describing what goes wrong without them). Distinct atom, similar evidence base.
- The skills-hub `_audit_paper_yaml_strict.py` could be extracted as a `skill/devops/multi-parser-yaml-lint` (general-purpose, not skills-hub-specific). Lower priority — the skill is currently coupled to skills-hub directory layout.

Generated with Claude Code (https://claude.com/claude-code).