### PR TITLE
fix: bulk-quote-wrap 61 strict-YAML offenders — corpus to 100% (closes #1182)

### DIFF
--- a/knowledge/arch/dual-redis-lock-vs-access-control.md
+++ b/knowledge/arch/dual-redis-lock-vs-access-control.md
@@ -4,7 +4,7 @@ version: 0.1.0-draft
 tags: [arch, dual, redis, lock, access, control]
 title: Two Redis instances — one for distributed locks, one for access control
 category: arch
-summary: The service connects to two separate Redis instances: Lock Control (default port 6399) and Access Control (default port 6389). They are not interchangeable.
+summary: "The service connects to two separate Redis instances: Lock Control (default port 6399) and Access Control (default port 6389). They are not interchangeable."
 source:
   kind: project
   ref: lucida-cm@0c4edd30

--- a/knowledge/build-system/debug-vs-release-build-differences.md
+++ b/knowledge/build-system/debug-vs-release-build-differences.md
@@ -3,7 +3,7 @@ version: 0.1.0-draft
 name: debug-vs-release-build-differences
 type: knowledge
 category: build-system
-summary: Release: optimized codecs + LTO. Debug: flexi_logger on desktop, android_logger on Android.
+summary: "Release: optimized codecs + LTO. Debug: flexi_logger on desktop, android_logger on Android."
 confidence: medium
 tags: [build, debug, differences, release, system]
 linked_skills: []

--- a/knowledge/codecs/audio-device-enumeration-platform-divergence.md
+++ b/knowledge/codecs/audio-device-enumeration-platform-divergence.md
@@ -3,7 +3,7 @@ version: 0.1.0-draft
 name: audio-device-enumeration-platform-divergence
 type: knowledge
 category: codecs
-summary: Audio device enumeration: CPAL (Win/Mac), PulseAudio (Linux non-headless), default fallback.
+summary: "Audio device enumeration: CPAL (Win/Mac), PulseAudio (Linux non-headless), default fallback."
 confidence: medium
 tags: [audio, codecs, device, divergence, enumeration, platform]
 linked_skills: []

--- a/knowledge/codecs/cross-platform-codec-initialization-order.md
+++ b/knowledge/codecs/cross-platform-codec-initialization-order.md
@@ -3,7 +3,7 @@ version: 0.1.0-draft
 name: cross-platform-codec-initialization-order
 type: knowledge
 category: codecs
-summary: Codec precedence at runtime: hwcodec > vram > software, chosen by probing device capability and user config.
+summary: "Codec precedence at runtime: hwcodec > vram > software, chosen by probing device capability and user config."
 confidence: high
 tags: [codec, codecs, cross, initialization, order, platform]
 linked_skills: []

--- a/knowledge/codecs/hardware-codec-feature-matrix.md
+++ b/knowledge/codecs/hardware-codec-feature-matrix.md
@@ -3,7 +3,7 @@ version: 0.1.0-draft
 name: hardware-codec-feature-matrix
 type: knowledge
 category: codecs
-summary: hwcodec backend coverage: Intel QSV (Windows/Linux), NVIDIA NVENC (all platforms), AMD AVC/HEVC (Windows), Android MediaCodec.
+summary: "hwcodec backend coverage: Intel QSV (Windows/Linux), NVIDIA NVENC (all platforms), AMD AVC/HEVC (Windows), Android MediaCodec."
 confidence: high
 tags: [codec, codecs, feature, hardware, matrix]
 linked_skills: []

--- a/knowledge/codecs/multi-audio-resampling-backends.md
+++ b/knowledge/codecs/multi-audio-resampling-backends.md
@@ -3,7 +3,7 @@ version: 0.1.0-draft
 name: multi-audio-resampling-backends
 type: knowledge
 category: codecs
-summary: Resampling backends: Dasp (pure Rust, slow), Rubato (FFT, faster), SampleRate (libsamplerate, fastest).
+summary: "Resampling backends: Dasp (pure Rust, slow), Rubato (FFT, faster), SampleRate (libsamplerate, fastest)."
 confidence: medium
 tags: [audio, backends, codecs, multi, resampling]
 linked_skills: []

--- a/knowledge/codecs/screen-capture-api-evolution-macos.md
+++ b/knowledge/codecs/screen-capture-api-evolution-macos.md
@@ -3,7 +3,7 @@ version: 0.1.0-draft
 name: screen-capture-api-evolution-macos
 type: knowledge
 category: codecs
-summary: macOS capture has shifted: legacy Quartz CGDisplayCreateImage → ScreenCaptureKit (Monterey+) behind a feature flag.
+summary: "macOS capture has shifted: legacy Quartz CGDisplayCreateImage → ScreenCaptureKit (Monterey+) behind a feature flag."
 confidence: high
 tags: [api, capture, codecs, evolution, macos, screen]
 linked_skills: []

--- a/knowledge/configuration/config-system-four-tiers.md
+++ b/knowledge/configuration/config-system-four-tiers.md
@@ -3,7 +3,7 @@ version: 0.1.0-draft
 name: config-system-four-tiers
 type: knowledge
 category: configuration
-summary: Four config tiers: Settings (persistent), Local (user), Display (per-display), Built-in (defaults).
+summary: "Four config tiers: Settings (persistent), Local (user), Display (per-display), Built-in (defaults)."
 confidence: medium
 tags: [config, configuration, four, system, tiers]
 linked_skills: []

--- a/knowledge/decision/mcp-design-principles-for-agent-tools.md
+++ b/knowledge/decision/mcp-design-principles-for-agent-tools.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: mcp-design-principles-for-agent-tools
-summary: Seven design principles that make MCP tool servers usable by LLM agents: agent-agnostic protocol, token-optimized returns, small deterministic primitives, self-healing errors, dual human+machine output, progressive complexity, and reference-over-value for heavy assets.
+summary: "Seven design principles that make MCP tool servers usable by LLM agents: agent-agnostic protocol, token-optimized returns, small deterministic primitives, self-healing errors, dual human+machine output, progressive complexity, and reference-over-value for heavy assets."
 category: decision
 confidence: high
 tags: [mcp, design-principles, agent-ux, token-budget, api-design]

--- a/knowledge/decision/redact-network-headers-by-default.md
+++ b/knowledge/decision/redact-network-headers-by-default.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: redact-network-headers-by-default
-summary: Network request formatters default to redacting headers (`redactNetworkHeaders: true`) because cookies, Authorization, API keys live there; users opt into raw headers explicitly for debugging auth flows.
+summary: "Network request formatters default to redacting headers (`redactNetworkHeaders: true`) because cookies, Authorization, API keys live there; users opt into raw headers explicitly for debugging auth flows."
 category: decision
 confidence: medium
 tags: [privacy, network, redaction, headers, security]

--- a/knowledge/devops/electron-builder-per-platform-filtering.md
+++ b/knowledge/devops/electron-builder-per-platform-filtering.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: electron-builder-per-platform-filtering
-summary: electron-builder.yml uses per-platform extraResources + files: exclusions to ship only the target's Bun/Codex/Copilot binaries and the matching ripgrep vendor — trimming installer size by 60-80%.
+summary: "electron-builder.yml uses per-platform extraResources + files: exclusions to ship only the target's Bun/Codex/Copilot binaries and the matching ripgrep vendor — trimming installer size by 60-80%."
 category: devops
 tags: [electron-builder, packaging, per-platform, installer-size]
 confidence: medium

--- a/knowledge/flutter/session-id-window-mapping.md
+++ b/knowledge/flutter/session-id-window-mapping.md
@@ -3,7 +3,7 @@ version: 0.1.0-draft
 name: session-id-window-mapping
 type: knowledge
 category: flutter
-summary: Desktop: unique session_id per connection; multi-window mapping via params['window_id'].
+summary: "Desktop: unique session_id per connection; multi-window mapping via params['window_id']."
 confidence: medium
 tags: [flutter, mapping, session, window]
 linked_skills: []

--- a/knowledge/flutter/text-rendering-font-fallback.md
+++ b/knowledge/flutter/text-rendering-font-fallback.md
@@ -3,7 +3,7 @@ version: 0.1.0-draft
 name: text-rendering-font-fallback
 type: knowledge
 category: flutter
-summary: Flutter text rendering falls back: system defaults + bundled Google Fonts for CJK coverage.
+summary: "Flutter text rendering falls back: system defaults + bundled Google Fonts for CJK coverage."
 confidence: medium
 tags: [fallback, flutter, font, rendering, text]
 linked_skills: []

--- a/knowledge/input/input-event-queue-semantics.md
+++ b/knowledge/input/input-event-queue-semantics.md
@@ -3,7 +3,7 @@ version: 0.1.0-draft
 name: input-event-queue-semantics
 type: knowledge
 category: input
-summary: Input processing: queue events, batch per frame, avoid stale state during handoff.
+summary: "Input processing: queue events, batch per frame, avoid stale state during handoff."
 confidence: medium
 tags: [event, input, queue, semantics]
 linked_skills: []

--- a/knowledge/input/input-mode-keyboard-layout-dependency.md
+++ b/knowledge/input/input-mode-keyboard-layout-dependency.md
@@ -3,7 +3,7 @@ version: 0.1.0-draft
 name: input-mode-keyboard-layout-dependency
 type: knowledge
 category: input
-summary: Two input modes: Unicode (layout-independent) vs Layout (layout-dependent; needed for modifiers).
+summary: "Two input modes: Unicode (layout-independent) vs Layout (layout-dependent; needed for modifiers)."
 confidence: high
 tags: [dependency, input, keyboard, layout, mode]
 linked_skills: []

--- a/knowledge/ipc/unix-socket-json-rpc-length-prefixed-framing.md
+++ b/knowledge/ipc/unix-socket-json-rpc-length-prefixed-framing.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: unix-socket-json-rpc-length-prefixed-framing
-summary: Length-prefixed JSON over a Unix domain socket (4-byte big-endian length header + JSON body) provides portable, framing-safe RPC: one-shot connections for synchronous request/response and a persistent connection for server-pushed events.
+summary: "Length-prefixed JSON over a Unix domain socket (4-byte big-endian length header + JSON body) provides portable, framing-safe RPC: one-shot connections for synchronous request/response and a persistent connection for server-pushed events."
 category: ipc
 tags: [unix-socket, json-rpc, ipc, framing, length-prefix, node.js, daemon, protocol]
 source_type: extracted-from-git

--- a/knowledge/linux/linux-desktop-manager-detection-heuristics.md
+++ b/knowledge/linux/linux-desktop-manager-detection-heuristics.md
@@ -3,7 +3,7 @@ version: 0.1.0-draft
 name: linux-desktop-manager-detection-heuristics
 type: knowledge
 category: linux
-summary: DE detection: check $XDG_CURRENT_DESKTOP, parse .desktop files, fallback to sysinfo.
+summary: "DE detection: check $XDG_CURRENT_DESKTOP, parse .desktop files, fallback to sysinfo."
 confidence: medium
 tags: [desktop, detection, heuristics, linux, manager, platform]
 linked_skills: []

--- a/knowledge/llm-fundamentals/huggingface-transformers-text-classification-pipeline.md
+++ b/knowledge/llm-fundamentals/huggingface-transformers-text-classification-pipeline.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: huggingface-transformers-text-classification-pipeline
-summary: Pre-trained BERT-style models can be fine-tuned for text classification in two ways: a fully decoupled custom pipeline for learning purposes, or the integrated run_classification.py script from HuggingFace examples.
+summary: "Pre-trained BERT-style models can be fine-tuned for text classification in two ways: a fully decoupled custom pipeline for learning purposes, or the integrated run_classification.py script from HuggingFace examples."
 category: llm-fundamentals
 tags: [huggingface, transformers, bert, classification, fine-tuning]
 confidence: medium

--- a/knowledge/macos/macos-ax-trusted-check-prompt.md
+++ b/knowledge/macos/macos-ax-trusted-check-prompt.md
@@ -3,7 +3,7 @@ version: 0.1.0-draft
 name: macos-ax-trusted-check-prompt
 type: knowledge
 category: macos
-summary: macOS accessibility check: use kAXTrustedCheckOptionPrompt to auto-prompt the user for consent.
+summary: "macOS accessibility check: use kAXTrustedCheckOptionPrompt to auto-prompt the user for consent."
 confidence: medium
 tags: [check, macos, platform, prompt, trusted]
 linked_skills: []

--- a/knowledge/mobile/android-ios-feature-parity-gap.md
+++ b/knowledge/mobile/android-ios-feature-parity-gap.md
@@ -3,7 +3,7 @@ version: 0.1.0-draft
 name: android-ios-feature-parity-gap
 type: knowledge
 category: mobile
-summary: Android: full codecs + input; iOS: limited input, screen share only, no clipboard file transfer (due to iOS entitlements).
+summary: "Android: full codecs + input; iOS: limited input, screen share only, no clipboard file transfer (due to iOS entitlements)."
 confidence: high
 tags: [android, feature, gap, ios, mobile, parity]
 linked_skills: []

--- a/knowledge/model-architecture/voxcpm2-four-stage-pipeline.md
+++ b/knowledge/model-architecture/voxcpm2-four-stage-pipeline.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: voxcpm2-four-stage-pipeline
-summary: VoxCPM2 generates speech via a four-stage pipeline: LocEnc → TSLM → RALM → LocDiT diffusion
+summary: "VoxCPM2 generates speech via a four-stage pipeline: LocEnc → TSLM → RALM → LocDiT diffusion"
 category: model-architecture
 tags: [voxcpm, architecture, tts, diffusion, pipeline]
 confidence: high

--- a/knowledge/native-modules/native-module-stub-layered-fallback.md
+++ b/knowledge/native-modules/native-module-stub-layered-fallback.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: native-module-stub-layered-fallback
-summary: When stubbing a missing native module for a different OS, use a layered fallback strategy: route to the framework equivalent where one exists (e.g., `BrowserWindow.isMaximized()`), no-op for OS-specific features with no equivalent, and an explicit stub for auth flows that signals unavailability without crashing.
+summary: "When stubbing a missing native module for a different OS, use a layered fallback strategy: route to the framework equivalent where one exists (e.g., `BrowserWindow.isMaximized()`), no-op for OS-specific features with no equivalent, and an explicit stub for auth flows that signals unavailability without crashing."
 category: native-modules
 tags: [native-modules, stub, electron, linux, platform-compatibility, node-gyp, fallback]
 source_type: extracted-from-git

--- a/knowledge/networking/connection-type-enum-design.md
+++ b/knowledge/networking/connection-type-enum-design.md
@@ -3,7 +3,7 @@ version: 0.1.0-draft
 name: connection-type-enum-design
 type: knowledge
 category: networking
-summary: ConnType enum: RDP (over relay), Direct TCP, Direct UDP, LAN discovery — drives fallback logic.
+summary: "ConnType enum: RDP (over relay), Direct TCP, Direct UDP, LAN discovery — drives fallback logic."
 confidence: medium
 tags: [connection, design, enum, networking, type]
 linked_skills: []

--- a/knowledge/networking/udp-kcp-protocol-choice-justification.md
+++ b/knowledge/networking/udp-kcp-protocol-choice-justification.md
@@ -3,7 +3,7 @@ version: 0.1.0-draft
 name: udp-kcp-protocol-choice-justification
 type: knowledge
 category: networking
-summary: KCP-over-UDP is preferred for WAN: better than pure TCP on lossy/high-latency links; faster RPC than QUIC in this app's domain.
+summary: "KCP-over-UDP is preferred for WAN: better than pure TCP on lossy/high-latency links; faster RPC than QUIC in this app's domain."
 confidence: high
 tags: [choice, justification, kcp, networking, protocol, udp]
 linked_skills: []

--- a/knowledge/pitfall/api-versioning-implementation-pitfall.md
+++ b/knowledge/pitfall/api-versioning-implementation-pitfall.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: api-versioning-implementation-pitfall
-description: Common traps when building API version visualizations: off-by-one lifecycle states, diff semantic loss, and traffic share math
+description: "Common traps when building API version visualizations: off-by-one lifecycle states, diff semantic loss, and traffic share math"
 category: pitfall
 tags:
   - api

--- a/knowledge/pitfall/cdc-implementation-pitfall.md
+++ b/knowledge/pitfall/cdc-implementation-pitfall.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: cdc-implementation-pitfall
-description: Common CDC mistakes: losing position state, mishandling tombstones, and breaking transaction boundaries
+description: "Common CDC mistakes: losing position state, mishandling tombstones, and breaking transaction boundaries"
 category: pitfall
 tags:
   - cdc

--- a/knowledge/pitfall/crdt-implementation-pitfall.md
+++ b/knowledge/pitfall/crdt-implementation-pitfall.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: crdt-implementation-pitfall
-description: Common CRDT bugs: naive LWW tiebreaking, OR-Set tag reuse, and counter double-counting on replay
+description: "Common CRDT bugs: naive LWW tiebreaking, OR-Set tag reuse, and counter double-counting on replay"
 category: pitfall
 tags:
   - crdt

--- a/knowledge/pitfall/dead-letter-queue-implementation-pitfall.md
+++ b/knowledge/pitfall/dead-letter-queue-implementation-pitfall.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: dead-letter-queue-implementation-pitfall
-description: Common failure modes when building DLQ tooling: replay loops, payload loss, and silent growth
+description: "Common failure modes when building DLQ tooling: replay loops, payload loss, and silent growth"
 category: pitfall
 tags:
   - dead

--- a/knowledge/pitfall/finite-state-machine-implementation-pitfall.md
+++ b/knowledge/pitfall/finite-state-machine-implementation-pitfall.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: finite-state-machine-implementation-pitfall
-description: Common FSM bugs: undefined-transition silent no-ops, guard side effects, and async timer drift during state changes.
+description: "Common FSM bugs: undefined-transition silent no-ops, guard side effects, and async timer drift during state changes."
 category: pitfall
 tags:
   - finite

--- a/knowledge/pitfall/health-check-implementation-pitfall.md
+++ b/knowledge/pitfall/health-check-implementation-pitfall.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: health-check-implementation-pitfall
-description: Common failure modes when building health-check systems: self-check blind spots, probe-induced load, and stale-cache green lies
+description: "Common failure modes when building health-check systems: self-check blind spots, probe-induced load, and stale-cache green lies"
 category: pitfall
 tags:
   - health

--- a/knowledge/pitfall/lantern-implementation-pitfall.md
+++ b/knowledge/pitfall/lantern-implementation-pitfall.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: lantern-implementation-pitfall
-description: Common failure modes when building lantern visualizations: additive-blend saturation, flicker desync, and ember leak
+description: "Common failure modes when building lantern visualizations: additive-blend saturation, flicker desync, and ember leak"
 category: pitfall
 tags:
   - lantern

--- a/knowledge/pitfall/log-aggregation-implementation-pitfall.md
+++ b/knowledge/pitfall/log-aggregation-implementation-pitfall.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: log-aggregation-implementation-pitfall
-description: Common failure modes when building log aggregation visualizations: memory blowup, scroll jank, and meaningless heatmaps
+description: "Common failure modes when building log aggregation visualizations: memory blowup, scroll jank, and meaningless heatmaps"
 category: pitfall
 tags:
   - log

--- a/knowledge/pitfall/redos-in-dns-detector-character-class.md
+++ b/knowledge/pitfall/redos-in-dns-detector-character-class.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: redos-in-dns-detector-character-class
-summary: DNS-style hostname detectors with patterns like (.label)+ are vulnerable to catastrophic backtracking (ReDoS) flagged by CodeQL. Fix: exclude '.' from the inner character class so the outer alternation cannot ambiguously match the same characters.
+summary: "DNS-style hostname detectors with patterns like (.label)+ are vulnerable to catastrophic backtracking (ReDoS) flagged by CodeQL. Fix: exclude '.' from the inner character class so the outer alternation cannot ambiguously match the same characters."
 category: pitfall
 tags: [regex, redos, security, codeql, hostname-detector]
 source_type: extracted-from-git

--- a/knowledge/pitfall/retry-strategy-implementation-pitfall.md
+++ b/knowledge/pitfall/retry-strategy-implementation-pitfall.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: retry-strategy-implementation-pitfall
-description: Common failure modes when building retry strategy demos: unbounded growth, jitter miscalculation, and thundering herd blind spots
+description: "Common failure modes when building retry strategy demos: unbounded growth, jitter miscalculation, and thundering herd blind spots"
 category: pitfall
 tags:
   - retry

--- a/knowledge/pitfall/service-mesh-implementation-pitfall.md
+++ b/knowledge/pitfall/service-mesh-implementation-pitfall.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: service-mesh-implementation-pitfall
-description: Common traps when building service mesh tooling: stale config, identity confusion, and sidecar startup races
+description: "Common traps when building service mesh tooling: stale config, identity confusion, and sidecar startup races"
 category: pitfall
 tags:
   - service

--- a/knowledge/pitfall/strangler-fig-implementation-pitfall.md
+++ b/knowledge/pitfall/strangler-fig-implementation-pitfall.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: strangler-fig-implementation-pitfall
-description: Common failure modes when building strangler-fig migration tooling: premature legacy retirement, shadow drift, dependency blindness
+description: "Common failure modes when building strangler-fig migration tooling: premature legacy retirement, shadow drift, dependency blindness"
 category: pitfall
 tags:
   - strangler

--- a/knowledge/pitfall/websocket-implementation-pitfall.md
+++ b/knowledge/pitfall/websocket-implementation-pitfall.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: websocket-implementation-pitfall
-description: Common WebSocket mistakes: missing masking, ignored close codes, no heartbeat, reconnect storms
+description: "Common WebSocket mistakes: missing masking, ignored close codes, no heartbeat, reconnect storms"
 category: pitfall
 tags:
   - websocket

--- a/knowledge/platform/portable-app-detection-env-var.md
+++ b/knowledge/platform/portable-app-detection-env-var.md
@@ -3,7 +3,7 @@ version: 0.1.0-draft
 name: portable-app-detection-env-var
 type: knowledge
 category: platform
-summary: Portable mode detection: check RUSTDESK_APPNAME env var; changes temp dir and config paths.
+summary: "Portable mode detection: check RUSTDESK_APPNAME env var; changes temp dir and config paths."
 confidence: medium
 tags: [app, detection, env, platform, portable, var]
 linked_skills: []

--- a/knowledge/powersync/powersync-sharedworker-multi-tab-constraint.md
+++ b/knowledge/powersync/powersync-sharedworker-multi-tab-constraint.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: powersync-sharedworker-multi-tab-constraint
-description: When `enableMultiTabs: true` (the default on Chrome/Edge/Firefox), PowerSync spawns a SharedWorker that manages a sin...
+description: "When `enableMultiTabs: true` (the default on Chrome/Edge/Firefox), PowerSync spawns a SharedWorker that manages a sin..."
 type: knowledge
 category: pitfall
 confidence: high

--- a/knowledge/reference/craft-cli-command-surface.md
+++ b/knowledge/reference/craft-cli-command-surface.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: craft-cli-command-surface
-summary: One-page reference for the craft-cli command taxonomy: info/health, resource listing, session ops, streaming send, power-user invoke/listen, self-contained run, and the 21-step --validate-server.
+summary: "One-page reference for the craft-cli command taxonomy: info/health, resource listing, session ops, streaming send, power-user invoke/listen, self-contained run, and the 21-step --validate-server."
 category: reference
 tags: [cli, rpc, reference]
 confidence: medium

--- a/knowledge/reference/langgraph-state-update-merge-semantics.md
+++ b/knowledge/reference/langgraph-state-update-merge-semantics.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: langgraph-state-update-merge-semantics
-summary: LangGraph nodes return partial dicts that the framework merges into state. OpenSRE's _merge_state helper shows the convention: messages are appended (not replaced), other keys overwrite — useful for replicating LangGraph behaviour outside a graph (testing, CLI runners).
+summary: "LangGraph nodes return partial dicts that the framework merges into state. OpenSRE's _merge_state helper shows the convention: messages are appended (not replaced), other keys overwrite — useful for replicating LangGraph behaviour outside a graph (testing, CLI runners)."
 category: reference
 tags: [langgraph, state, merge, conventions]
 source_type: extracted-from-git

--- a/knowledge/reference/sessions-status-workflow.md
+++ b/knowledge/reference/sessions-status-workflow.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: sessions-status-workflow
-summary: Sessions carry a dynamic status (default: Todo → In Progress → Needs Review → Done) stored per-workspace; customizable via statuses/ folder and used by UI + automations (SessionStatusChange event).
+summary: "Sessions carry a dynamic status (default: Todo → In Progress → Needs Review → Done) stored per-workspace; customizable via statuses/ folder and used by UI + automations (SessionStatusChange event)."
 category: reference
 tags: [sessions, status, workflow, dynamic]
 confidence: medium

--- a/knowledge/rust-rules/feature-flag-rust-unwrap-policy.md
+++ b/knowledge/rust-rules/feature-flag-rust-unwrap-policy.md
@@ -3,7 +3,7 @@ version: 0.1.0-draft
 name: feature-flag-rust-unwrap-policy
 type: knowledge
 category: rust-rules
-summary: Policy: no unwrap()/expect() except in tests (readability) and lock acquisition (poison only).
+summary: "Policy: no unwrap()/expect() except in tests (readability) and lock acquisition (poison only)."
 confidence: medium
 tags: [feature, flag, policy, rules, rust, unwrap]
 linked_skills: []

--- a/knowledge/windows/privacy-mode-implementation-choices.md
+++ b/knowledge/windows/privacy-mode-implementation-choices.md
@@ -3,7 +3,7 @@ version: 0.1.0-draft
 name: privacy-mode-implementation-choices
 type: knowledge
 category: windows
-summary: Three privacy-mode strategies coexist: MAG (fast but limited), exclude-from-capture (Win10 2004+), virtual-display (fullscreen gaming).
+summary: "Three privacy-mode strategies coexist: MAG (fast but limited), exclude-from-capture (Win10 2004+), virtual-display (fullscreen gaming)."
 confidence: high
 tags: [choices, implementation, mode, platform, privacy, windows]
 linked_skills: []

--- a/knowledge/workflow/session-story-lifecycle.md
+++ b/knowledge/workflow/session-story-lifecycle.md
@@ -1,7 +1,7 @@
 ---
 version: 0.1.0-draft
 name: session-story-lifecycle
-summary: End-to-end story lifecycle example: readiness check, implementation, review, and completion
+summary: "End-to-end story lifecycle example: readiness check, implementation, review, and completion"
 category: workflow
 confidence: medium
 tags: [game-studios, ccgs, story, lifecycle, session-example, dev-story]

--- a/skills/ai/ai-call-with-mock-fallback/SKILL.md
+++ b/skills/ai/ai-call-with-mock-fallback/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-call-with-mock-fallback
-description: Wrap unreliable LLM/AI calls with a deterministic mock fallback so the UI always receives a valid shape — annotate the response with a `mock: true` or `error:` field so the client can show a badge.
+description: "Wrap unreliable LLM/AI calls with a deterministic mock fallback so the UI always receives a valid shape — annotate the response with a `mock: true` or `error:` field so the client can show a badge."
 category: ai
 tags: [llm, resilience, fallback, mock, ux, error-handling]
 triggers: ["AI 생성 실패", "mock data", "ANTHROPIC_API_KEY", "fallback response", "mock: true", "degraded mode"]

--- a/skills/architecture/workspace-directory-convention/SKILL.md
+++ b/skills/architecture/workspace-directory-convention/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workspace-directory-convention
-description: Workspace-as-a-directory: a single ~/.craft-agent/workspaces/{id}/ folder holds config.json, automations.json, sessions/, sources/, skills/, statuses/ — every feature reads/writes its own subtree so the workspace is portable in one zip.
+description: "Workspace-as-a-directory: a single ~/.craft-agent/workspaces/{id}/ folder holds config.json, automations.json, sessions/, sources/, skills/, statuses/ — every feature reads/writes its own subtree so the workspace is portable in one zip."
 category: architecture
 version: 1.0.0
 version_origin: extracted

--- a/skills/cli/gstack/openclaw/skills/gstack-openclaw-ceo-review/SKILL.md
+++ b/skills/cli/gstack/openclaw/skills/gstack-openclaw-ceo-review/SKILL.md
@@ -2,7 +2,7 @@
 category: cli
 tags: [cli, gstack, openclaw, ceo, review]
 name: gstack-openclaw-ceo-review
-description: CEO/founder-mode plan review. Rethink the problem, find the 10-star product, challenge premises, expand scope when it creates a better product. Four modes: SCOPE EXPANSION (dream big), SELECTIVE EXPANSION (hold scope + cherry-pick), HOLD SCOPE (maximum rigor), SCOPE REDUCTION (strip to essentials). Use when asked to review a plan, challenge this, CEO review, poke holes, think bigger, or expand scope.
+description: "CEO/founder-mode plan review. Rethink the problem, find the 10-star product, challenge premises, expand scope when it creates a better product. Four modes: SCOPE EXPANSION (dream big), SELECTIVE EXPANSION (hold scope + cherry-pick), HOLD SCOPE (maximum rigor), SCOPE REDUCTION (strip to essentials). Use when asked to review a plan, challenge this, CEO review, poke holes, think bigger, or expand scope."
 version: 1.0.0
 metadata: { "openclaw": { "emoji": "👑" } }
 source_type: external-git

--- a/skills/cli/gstack/openclaw/skills/gstack-openclaw-investigate/SKILL.md
+++ b/skills/cli/gstack/openclaw/skills/gstack-openclaw-investigate/SKILL.md
@@ -2,7 +2,7 @@
 category: cli
 tags: [cli, gstack, openclaw, investigate]
 name: gstack-openclaw-investigate
-description: Systematic debugging with root cause investigation. Four phases: investigate, analyze, hypothesize, implement. Iron Law: no fixes without root cause. Use when asked to debug, fix a bug, investigate an error, or root cause analysis. Proactively use when user reports errors, stack traces, unexpected behavior, or says something stopped working.
+description: "Systematic debugging with root cause investigation. Four phases: investigate, analyze, hypothesize, implement. Iron Law: no fixes without root cause. Use when asked to debug, fix a bug, investigate an error, or root cause analysis. Proactively use when user reports errors, stack traces, unexpected behavior, or says something stopped working."
 version: 1.0.0
 metadata: { "openclaw": { "emoji": "🔍" } }
 source_type: external-git

--- a/skills/cli/gstack/openclaw/skills/gstack-openclaw-office-hours/SKILL.md
+++ b/skills/cli/gstack/openclaw/skills/gstack-openclaw-office-hours/SKILL.md
@@ -2,7 +2,7 @@
 category: cli
 tags: [cli, gstack, openclaw, office, hours]
 name: gstack-openclaw-office-hours
-description: Product interrogation with six forcing questions. Two modes: startup diagnostic (demand reality, status quo, desperate specificity, narrowest wedge, observation, future-fit) and builder brainstorm. Use when asked to brainstorm, "is this worth building", "I have an idea", "office hours", or "help me think through this". Proactively use when user describes a new product idea or wants to think through design decisions before any code is written.
+description: "Product interrogation with six forcing questions. Two modes: startup diagnostic (demand reality, status quo, desperate specificity, narrowest wedge, observation, future-fit) and builder brainstorm. Use when asked to brainstorm, \"is this worth building\", \"I have an idea\", \"office hours\", or \"help me think through this\". Proactively use when user describes a new product idea or wants to think through design decisions before any code is written."
 version: 1.0.0
 metadata: { "openclaw": { "emoji": "🎯" } }
 source_type: external-git

--- a/skills/codecs/platform-screen-capture-abstraction/SKILL.md
+++ b/skills/codecs/platform-screen-capture-abstraction/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: platform-screen-capture-abstraction
-description: Pluggable screen-capture backends: Windows DXGI, macOS Quartz, Linux X11/Wayland behind one Capturer trait.
+description: "Pluggable screen-capture backends: Windows DXGI, macOS Quartz, Linux X11/Wayland behind one Capturer trait."
 category: codecs
 version: 1.0.0
 version_origin: extracted

--- a/skills/codegen/type-safe-enum-generation-per-language/SKILL.md
+++ b/skills/codegen/type-safe-enum-generation-per-language/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: type-safe-enum-generation-per-language
-description: Generate per-language enums from a single content_types JSON: Rust enum, Python StrEnum, TypeScript union literal, Go const iota — with from_string, to_string, and SIZE constants.
+description: "Generate per-language enums from a single content_types JSON: Rust enum, Python StrEnum, TypeScript union literal, Go const iota — with from_string, to_string, and SIZE constants."
 category: codegen
 version: 1.0.0
 version_origin: extracted

--- a/skills/inference/ort-crate-onnx-runtime-session-configuration/SKILL.md
+++ b/skills/inference/ort-crate-onnx-runtime-session-configuration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ort-crate-onnx-runtime-session-configuration
-description: Configure ONNX Runtime via the ort crate's session builder: inter/intra threads, optimization level, parallel execution, embedded model bytes.
+description: "Configure ONNX Runtime via the ort crate's session builder: inter/intra threads, optimization level, parallel execution, embedded model bytes."
 category: inference
 version: 1.0.0
 version_origin: extracted

--- a/skills/ipc/unix-socket-permission-attributes/SKILL.md
+++ b/skills/ipc/unix-socket-permission-attributes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unix-socket-permission-attributes
-description: parity-tokio-ipc SecurityAttributes for Unix socket permissions (Windows equivalent: DACLs).
+description: "parity-tokio-ipc SecurityAttributes for Unix socket permissions (Windows equivalent: DACLs)."
 category: ipc
 version: 1.0.0
 version_origin: extracted

--- a/skills/monorepo/pnpm-catalog-version-pinning/SKILL.md
+++ b/skills/monorepo/pnpm-catalog-version-pinning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pnpm-catalog-version-pinning
-description: Use pnpm's catalog: references in pnpm-workspace.yaml to guarantee a single version of shared deps across all monorepo packages.
+description: "Use pnpm's catalog: references in pnpm-workspace.yaml to guarantee a single version of shared deps across all monorepo packages."
 category: monorepo
 version: 1.0.0
 tags: [pnpm, monorepo, versioning, workspace, react]

--- a/skills/observability/anonymous-posthog-telemetry/SKILL.md
+++ b/skills/observability/anonymous-posthog-telemetry/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: anonymous-posthog-telemetry
-description: Ship anonymous PostHog telemetry from an OSS CLI using an embedded write-only key, a silentFetch wrapper that masks SDK stderr noise, DO_NOT_TRACK / per-tool opt-out, and `$process_person_profile: false` to stay in PostHog's anonymous tier.
+description: "Ship anonymous PostHog telemetry from an OSS CLI using an embedded write-only key, a silentFetch wrapper that masks SDK stderr noise, DO_NOT_TRACK / per-tool opt-out, and `$process_person_profile: false` to stay in PostHog's anonymous tier."
 category: observability
 version: 1.0.0
 version_origin: extracted

--- a/skills/platform/display-device-enumeration-platform/SKILL.md
+++ b/skills/platform/display-device-enumeration-platform/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: display-device-enumeration-platform
-description: Per-OS display enumeration: Windows EnumDisplayDevices, macOS CGDisplayCopyAllDisplays, Linux XRandR.
+description: "Per-OS display enumeration: Windows EnumDisplayDevices, macOS CGDisplayCopyAllDisplays, Linux XRandR."
 category: platform
 version: 1.0.0
 version_origin: extracted

--- a/skills/platform/privacy-mode-trait-abstraction/SKILL.md
+++ b/skills/platform/privacy-mode-trait-abstraction/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: privacy-mode-trait-abstraction
-description: Pluggable privacy-mode implementations: Windows MAG, exclude-from-capture, virtual-display drivers.
+description: "Pluggable privacy-mode implementations: Windows MAG, exclude-from-capture, virtual-display drivers."
 category: platform
 version: 1.0.0
 version_origin: extracted

--- a/skills/process/orphaned-daemon-termination-guard/SKILL.md
+++ b/skills/process/orphaned-daemon-termination-guard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orphaned-daemon-termination-guard
-description: Kill an orphaned background daemon when no non-daemon sibling process is alive. Prevents LevelDB/file lock contention after unclean parent shutdown. Pattern: scan for daemon PIDs, then check if any non-daemon parent process exists before killing.
+description: "Kill an orphaned background daemon when no non-daemon sibling process is alive. Prevents LevelDB/file lock contention after unclean parent shutdown. Pattern: scan for daemon PIDs, then check if any non-daemon parent process exists before killing."
 category: process
 version: 1.0.0
 tags: [daemon, orphan, process, bash, leveldb, lock, cleanup, startup]

--- a/skills/release/pre-release-version-validation-script/SKILL.md
+++ b/skills/release/pre-release-version-validation-script/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pre-release-version-validation-script
-description: Pre-release script validates: tag matches pyproject version, copyright headers exist on all source files, package metadata fields complete, type checker passes.
+description: "Pre-release script validates: tag matches pyproject version, copyright headers exist on all source files, package metadata fields complete, type checker passes."
 category: release
 version: 1.0.0
 version_origin: extracted

--- a/skills/session-management/deep-link-url-routing/SKILL.md
+++ b/skills/session-management/deep-link-url-routing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deep-link-url-routing
-description: Custom URL scheme (craftagents://) routes directly into the app: allSessions, specific session, settings, new-chat actions — maps each URL path segment to a renderer-side navigation intent.
+description: "Custom URL scheme (craftagents://) routes directly into the app: allSessions, specific session, settings, new-chat actions — maps each URL path segment to a renderer-side navigation intent."
 category: session-management
 version: 1.0.0
 version_origin: extracted


### PR DESCRIPTION
## Summary

Bulk cleanup PR resolving the **61 latent strict-YAML offenders** surfaced by the audit extension in #1181. All offenders are mid-string `: ` patterns in unquoted YAML scalar values that PyYAML accepted but GitHub Preview / Ruby Psych reject as malformed mapping.

## Distribution

| Kind | Count | Field |
|---|---:|---|
| skill | ~16 | `description` |
| knowledge | ~45 | `summary` |

## Fix strategy

**Wrap entire offending value in double quotes.** This:
- Preserves original semantic content (including legitimate colons like `process_person_profile: false` or `validates: tag matches`)
- Makes YAML strict-parser-safe
- Zero semantic changes — only YAML quoting added

Sample diff (representative):

```diff
- description: Use pnpm's catalog: references in pnpm-workspace.yaml
+ description: "Use pnpm's catalog: references in pnpm-workspace.yaml"

- summary: Audio device enumeration: CPAL (Win/Mac), PulseAudio (Linux non-headless)...
+ summary: "Audio device enumeration: CPAL (Win/Mac), PulseAudio (Linux non-headless)..."
```

## Audit progression (full strict-YAML series)

```
#1153 (initial paper+technique scope):  100% (38/38)
#1181 (extended scope):                  97.0% (1985/2046)
THIS PR (bulk cleanup):                  100% (2046/2046) ✓
```

## Mechanical fixer used

The fix was applied via Python script:
1. Run `_audit_paper_yaml_strict.py --json --only-flagged` to enumerate flagged files
2. For each, find the offending line by `key:` match
3. Wrap value in double quotes (escape any internal quotes — none in practice)
4. Write back

The fixer is in commit history — could be lifted to a `bootstrap/tools/_fix_yaml_strict_quote_wrap.py` if future cleanups are needed. (Probably not — precheck.py runs the audit on every commit, future authoring is pre-gated.)

## Verification

```
$ python bootstrap/tools/_audit_paper_yaml_strict.py
audited:    2046 file(s)
compliant:  2046/2046
flagged:    0
compliance: 100.0%
```

## Compatibility

- 61 files changed, 61 insertions, 61 deletions (perfectly mechanical 1-line swaps per file)
- No body content changes; only frontmatter quoting
- All other audits (paper-v03, frontmatter-length, technique-v02) unaffected
- Body markdown rendering unchanged (frontmatter is not rendered into body)

## Closes

This PR closes:
- **#1182** (Cleanup: 61 latent strict-YAML offenders in skill/knowledge frontmatter)

Issue auto-closes on merge via `Closes #1182` in commit message.

## Refs

- #1158 (canonical pitfall — `pitfall/yaml-mid-string-colon-strict-parser-mismatch`)
- #1170/#1181 (audit extension that found these)
- #1153 (original audit)

Generated with Claude Code (https://claude.com/claude-code).