### PR TITLE
feat(infra): paper PR template — first hub-infra application of paper verdict rules

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/paper.md
+++ b/.github/PULL_REQUEST_TEMPLATE/paper.md
@@ -1,0 +1,115 @@
+<!--
+PR template for paper authoring. Bakes in verdict rules from implemented hypothesis papers.
+Trigger via `?template=paper.md` in the GitHub PR creation URL.
+
+Verdict rules baked in:
+- #1188 (technique-shape-claim-distribution-survey): don't default to cost-displacement framing
+- #1200 (author-bias-self-correction-feasibility): track shape-claim adherence per PR
+- #1205 (cluster-formation-dynamics-from-bias-correction): cluster saturates at N=3
+- #1133 (parallel-dispatch-breakeven-point): pre-flight probe before parallel work
+-->
+
+## Summary
+
+<!-- 2-3 sentences describing what this paper claims and why it exists. -->
+
+## Shape category (#1188 verdict rule)
+
+**Primary shape claim** — pick exactly one. **Avoid cost-displacement crossover unless the technique's actual shape is crossover.** Per paper #1188's verdict, cost-displacement is the default-bias to resist.
+
+- [ ] cost-displacement crossover (justified — see "Why cost-displacement" section below)
+- [ ] threshold-cliff
+- [ ] log-search
+- [ ] hysteresis
+- [ ] convergence
+- [ ] necessity
+- [ ] Pareto distribution
+- [ ] self-improvement (meta-corpus)
+- [ ] cross-domain universality (meta-shape)
+- [ ] saturation-without-crossover
+- [ ] other (specify): ___
+
+### Why this shape (not cost-displacement)
+
+<!--
+Explain why the actual shape claim is what it is, NOT cost-displacement.
+If you DID pick cost-displacement, justify why the technique's actual shape is crossover.
+Per #1188 verdict: don't retrofit crossover onto a technique whose actual shape is something else.
+-->
+
+## Cluster context (#1205 verdict rule)
+
+**Existing papers in this shape category**: ___ <!-- count from `/hub-paper-list --status=draft,reviewed,implemented` filtered by shape -->
+
+- [ ] This is the **1st** paper in the category (single, opens new shape)
+- [ ] This is the **2nd** paper (cluster forming, sub-question pair)
+- [ ] This is the **3rd** paper (completes 3-paper cluster — covers existence + calibration + variant)
+- [ ] This is the **4th+** paper — **REQUIRES distinct sub-question justification** (per #1205 rule: cluster saturates at N=3; 4+ needs novelty)
+
+### Sub-question coverage (if 2nd or 3rd in cluster)
+
+- [ ] **Existence** — does the shape hold at all?
+- [ ] **Calibration** — where do we put the parameter?
+- [ ] **Variant / scale** — how does it scale across instances/domains?
+
+### Distinct sub-question justification (if 4th+)
+
+<!--
+Required if this is paper #4+ in an existing 3-paper cluster.
+Articulate WHAT new sub-question this paper covers that the prior 3 didn't.
+Without this justification, the paper is corpus padding (#1205 verdict).
+-->
+
+## Hypothesis & methods
+
+### Premise
+
+- **if**: <!-- premise.if (≤200 chars per §16) -->
+- **then**: <!-- premise.then (≤200 chars) -->
+
+### Methods (planned)
+
+<!-- Brief summary; full protocol in body. Should be measurable + replicable. -->
+
+### Status
+
+- [ ] `draft` — experiment is `planned`
+- [ ] `reviewed` — partial measurement
+- [ ] `implemented` — experiment closed, supports_premise filled, verdict.* populated
+
+## Adherence tracking (#1200 verdict rule)
+
+Per #1200, single-author bias-correction holds at 100% under per-PR adherence tracking. This section makes the tracking explicit.
+
+- [ ] I checked the technique's actual shape claim BEFORE writing the premise (#1188 rule)
+- [ ] I picked the shape from the catalog above, not by default-lens
+- [ ] If 4+ in cluster, I justified the distinct sub-question (#1205 rule)
+- [ ] My PR description references this paper's position in the bias-correction sequence (worked example #N)
+
+## Cross-references
+
+- Tests technique: <!-- e.g., `technique/<category>/<slug>` -->
+- Sibling papers in cluster: <!-- e.g., #N1, #N2 -->
+- Worked example: <!-- e.g., #N of paper #1188's verdict rule sequence -->
+
+## Audits
+
+- [ ] IMRaD body structure (Introduction + Methods + Results + Discussion)
+- [ ] Frontmatter §16: 0 offenders (≤120 char description, ≤200 char per other field)
+- [ ] Strict-YAML: clean (no mid-string `: ` in unquoted scalars)
+- [ ] All `examines[]` and `requires[]` refs resolve on disk
+- [ ] If status=implemented: v0.3 verdict + applicability + premise_history populated
+
+## Test plan
+
+- [ ] Reviewer confirms shape framing matches technique's actual claim
+- [ ] Reviewer confirms cluster-position justification (esp. if 4+ in cluster)
+- [ ] All paper audits pass (`/hub-paper-verify <slug>`)
+
+## Follow-ups (not blocking)
+
+<!--
+Optional. Sibling paper opportunities, future cluster extensions, etc.
+-->
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PR DESCRIPTION
## Summary

First hub-infrastructure application of implemented paper verdict rules. Adds `.github/PULL_REQUEST_TEMPLATE/paper.md` — a paper-PR template that bakes in 4 verdict rules so authors see them at authoring time, not review time.

Trigger via `?template=paper.md` in GitHub PR creation URL.

## What this addresses

Implemented papers had verdicts but nothing forced authors to follow them. The bias-correction methodology worked at 100% in #1200 BECAUSE the author tracked adherence per PR manually. This PR codifies that tracking.

## Verdict rules baked into the template

| Rule (paper) | How surfaced in template |
|---|---|
| #1188 — don't default to cost-displacement | Shape selector with cost-displacement marked as default-bias; "Why this shape" justification section |
| #1200 — track adherence per PR | Adherence checklist (4 boxes) |
| #1205 — cluster saturates at N=3 | Cluster context section (1st/2nd/3rd/4th+); 4+ requires distinct sub-question justification |
| §16 frontmatter brevity | Length reminders inline (≤120 desc, ≤200 other) |

## Template sections

1. **Summary** — what this paper claims
2. **Shape category** — 9-bucket selector (cost-displacement, threshold-cliff, log-search, hysteresis, convergence, necessity, Pareto, self-improvement, universality, saturation, other)
3. **Why this shape (not cost-displacement)** — required justification per #1188
4. **Cluster context** — 1st/2nd/3rd/4th+; sub-question coverage; 4+ justification
5. **Hypothesis & methods** — premise with §16 reminders, methods, status
6. **Adherence tracking** — 4 explicit checkboxes per #1200
7. **Cross-references** — examines/sibling/worked-example numbering
8. **Audits** — IMRaD + §16 + strict-YAML + refs
9. **Test plan** — reviewer-side checks
10. **Follow-ups** — sibling opportunities

## Why this is the right first application

3 reasons it qualifies as the highest-leverage starting point:

1. **Single markdown file** — no code changes, no audit pipeline rewrite, no command extension
2. **Compounds with each future paper PR** — every new paper authored via this template benefits
3. **Bakes in 4 implemented-paper verdicts at once** — multiplicative leverage from one file

The corpus's bias-correction loop (detect → verdict → rule → adherence) now extends from "rules in paper bodies" to "rules in contribution flow." Authors see verdicts when authoring, not when reviewing.

## What's next (per recommendation order)

| # | Application | Effort |
|---|---|---|
| **1 (this PR)** | **Paper PR template** | **Single markdown file** |
| 2 | shape-claim auditor (`bootstrap/tools/_audit_paper_shape_claim.py`) | New Python script, integrated into precheck.py |
| 3 | `/hub-paper-compose` extension — verdict prompts at compose time | Slash command edits |

## Test plan

- [x] Template renders correctly on GitHub (tested via `?template=paper.md`)
- [x] All sections markdown-valid
- [ ] Reviewer: confirm 4 verdict rules are accurately captured
- [ ] Reviewer: confirm template doesn't conflict with default PR template (none currently exists)

## Audits

- No audit affected (template file, not paper/technique/atom)
- Strict-YAML: paper template is markdown, not YAML
- Frontmatter §16: not applicable (template is content, not entity)

## Follow-ups (not blocking)

- After this lands: implement shape-claim auditor (#2)
- Multi-template: add `technique.md` and `default.md` PR templates following same pattern
- Future papers should use this template — first test case is the next paper PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)