### PR TITLE
feat(infra): /hub-paper-compose verdict prompts at compose time (#3 of paper-verdict-application)

### DIFF
--- a/bootstrap/commands/hub-paper-compose.md
+++ b/bootstrap/commands/hub-paper-compose.md
@@ -25,6 +25,24 @@ Authoring workflow for the `paper/` exploration layer. Produces `.paper-draft/<c
    - AskUserQuestion: `premise.then` — "THEN predicted outcome, single sentence: ..."
    - Warn if either is empty or < 20 chars; confirm continue.
 
+2.5. **Shape category prompt** (per paper #1188 verdict rule)
+
+   AskUserQuestion: "What primary shape claim does this paper make? Pick from:
+   - cost-displacement crossover **(NOTE: per #1188 verdict, this is the corpus default-bias to resist; use only if the technique's actual shape is genuinely crossover)**
+   - threshold-cliff
+   - log-search
+   - hysteresis
+   - convergence
+   - necessity
+   - pareto distribution
+   - self-improvement (meta-corpus)
+   - cross-domain universality (meta-shape)
+   - saturation-without-crossover
+   - other (specify)"
+
+   - **If cost-displacement chosen**: AskUserQuestion: "Why cost-displacement? Per #1188, default to the technique's ACTUAL shape, not crossover lens. Justify in 1-2 sentences."
+   - Capture chosen shape; will be referenced in step 5.5 for cluster check and step 12 for write.
+
 3. **Paper type**
    - If `--type` not provided, ask:
      - `hypothesis` — claims something; must run experiments to reach `status=implemented` (default, most papers)
@@ -42,6 +60,18 @@ Authoring workflow for the `paper/` exploration layer. Produces `.paper-draft/<c
    - Capture `ref` as kind-root-relative physical path; verify file exists
    - Reject `kind: paper` (v0 nesting ban)
    - Prompt for `role` (free-text)
+
+5.5. **Cluster context check** (per paper #1205 verdict rule — N=3 saturation)
+
+   - Run `bootstrap/tools/_audit_paper_shape_claim.py --json` (from #1222) to tally existing papers in the selected shape category
+   - Report: "Shape `<chosen>` currently has **N papers** in the corpus."
+   - **If N == 0**: this is the 1st paper (single, opens new shape). No additional prompt.
+   - **If N == 1**: this is the 2nd paper (cluster forming). AskUserQuestion: "What sub-question does this paper cover (existence / calibration / variant)?"
+   - **If N == 2**: this is the 3rd paper (completes 3-paper cluster). AskUserQuestion: "What sub-question does this paper close (existence / calibration / variant)?"
+   - **If N == 3**: WARN — "Shape `<chosen>` has reached the N=3 saturation point per paper #1205. Adding a 4th paper requires explicit distinct sub-question justification (else it is corpus padding)."
+     - AskUserQuestion: "What distinct sub-question does this paper cover that the existing 3 don't? (e.g., variant within variant, cross-tool, multi-author replication, durability past observation)"
+     - **Block authoring if justification is empty or matches an existing sub-question** — author must either rephrase or pick a different shape.
+   - **If N >= 4**: STRONG WARN — "Shape already past saturation. Confirm justification is genuinely distinct from prior 4+ papers."
 
 6. **Write perspectives[]** (≥2 required)
    - Loop: `name` + `summary` (1-2 lines)
@@ -73,6 +103,17 @@ Authoring workflow for the `paper/` exploration layer. Produces `.paper-draft/<c
     - Allowed values: `produced_skill | produced_knowledge | produced_technique | produced_pitfall | produced_example | updated_skill | updated_knowledge | updated_technique`
 
 11. **status** — default `draft`. `retraction_reason` stays null.
+
+11.5. **Adherence checklist** (per paper #1200 verdict rule)
+
+   Before writing, confirm the bias-correction discipline is followed. Show 4 explicit checkboxes; require all 4 to be ticked or have explicit justification:
+
+   - [ ] **Checked the technique's actual shape claim BEFORE writing premise** (#1188 rule)
+   - [ ] **Picked shape from the catalog**, not by default-lens
+   - [ ] **Cluster position justified** (4+ papers in shape category requires distinct sub-question per #1205)
+   - [ ] **PR description will reference this paper's worked-example index** (paper #N of bias-correction sequence; auditor in #1222 reports the running count)
+
+   - If any checkbox is unticked: print rationale prompt and either tick or proceed with WARN (logged to draft frontmatter as `compose_adherence_unticked: ["..."]`)
 
 12. **Write the file** to `.paper-draft/<category>/<slug>/PAPER.md` with v0.2 frontmatter + body scaffold:
     ```


### PR DESCRIPTION
## Summary

Third and final hub-infra application of paper verdict rules. Extends `/hub-paper-compose` with 3 inject points that surface verdict rules at **compose time** — earliest possible intervention point.

Completes the recommended 3-PR application order from #1220 follow-ups.

## Bias-correction pipeline (now complete)

| Stage | PR | What it does |
|---|---|---|
| **Compose** | **this PR** | Verdict prompts at `/hub-paper-compose` invocation |
| Write | #1221 (paper PR template) | Verdict checklist in PR description |
| Review | #1222 (shape-claim auditor) | Auto-classify + measure cross-layer ratio |
| Measure | #1222 + future surveys | Authoritative ratio tracking |

3 PRs together: bias-correction methodology now embedded across the entire paper authoring workflow.

## 3 inject points

### Step 2.5 — Shape category prompt (#1188 verdict)

After premise, before paper-type:
- Present 9-shape catalog (cost-displacement, threshold-cliff, log-search, hysteresis, convergence, necessity, pareto, self-improvement, cross-domain universality, saturation, other)
- **Cost-displacement marked as default-bias to resist**
- If chosen: justification prompt required

### Step 5.5 — Cluster context check (#1205 verdict, N=3 saturation)

After examines, before perspectives:
- Runs `_audit_paper_shape_claim.py --json` (from #1222) to tally existing papers in chosen shape
- **N=0**: opens new shape (single)
- **N=1-2**: cluster forming, asks sub-question coverage (existence / calibration / variant)
- **N=3**: WARN — saturation point reached, requires distinct sub-question
- **N≥4**: STRONG WARN — blocks unless explicit distinct justification

### Step 11.5 — Adherence checklist (#1200 verdict)

After status, before write:
- 4 explicit checkboxes:
  1. Checked technique's actual shape BEFORE writing premise
  2. Picked shape from catalog (not default-lens)
  3. Cluster position justified
  4. PR description references worked-example index
- Unticked → rationale prompt + logged to draft frontmatter

## Why compose-time injection matters most

Earlier PRs surface verdicts AFTER author has written:
- PR #1221: PR template fires after PR creation
- PR #1222: auditor fires after file is committed

This PR surfaces verdicts **before** authoring happens. Author chooses shape, validates cluster position, ticks adherence — all before writing premise.

In paper #1200's framework: this is **per-step adherence tracking** vs **per-PR adherence tracking**. The earlier the intervention, the higher the adherence rate (limit = 100% if author follows prompts).

## Verdict rules baked at each step

| Step | Rule (paper) |
|---|---|
| 2.5 | #1188 — don't default to cost-displacement |
| 5.5 | #1205 — cluster saturates at N=3, 4+ needs distinct sub-question |
| 11.5 | #1200 — track adherence per-PR (now per-compose) |

## Test plan

- [x] Edits applied to bootstrap/commands/hub-paper-compose.md
- [x] 3 inject points placed at correct sequence positions
- [x] References to #1188/#1200/#1205/#1222 are accurate
- [ ] Reviewer: confirm AskUserQuestion phrasing is unambiguous
- [ ] Reviewer: dry-run `/hub-paper-compose <test-slug>` to verify prompts fire in order

## Cross-references

- PR #1221: paper PR template (write-time verdict surface)
- PR #1222: shape-claim auditor (post-hoc measurement)
- This PR: compose-time verdict prompts
- All 3 ship from the verdict-rule application sequence in #1220's follow-ups

## Application sequence complete

| # | Application | Status |
|---|---|---|
| ✅ 1 | Paper PR template (#1221) | merged |
| ✅ 2 | shape-claim auditor + precheck integration (#1222) | merged |
| ✅ **3 (this PR)** | **/hub-paper-compose verdict prompts** | this PR |

## Follow-ups (not blocking)

- After this lands: track adherence on the next 5 paper PRs via /hub-paper-compose to test whether 100% adherence (per #1200) replicates with compose-time prompts
- Multi-template extension to /hub-technique-compose (technique authoring also has verdict-relevance per #1188)
- /hub-commands-publish to ship updated /hub-paper-compose to all hub installations

🤖 Generated with [Claude Code](https://claude.com/claude-code)