### PR TITLE
feat(infra): /hub-technique-compose verdict prompts (sibling to /hub-paper-compose #1223)

### DIFF
--- a/bootstrap/commands/hub-technique-compose.md
+++ b/bootstrap/commands/hub-technique-compose.md
@@ -25,6 +25,26 @@ Authoring workflow for the `technique/` middle layer. Produces a `.technique-dra
    - `tags` — comma-separated; dedupe.
    - `binding` — default `loose`. Explain tradeoff before asking.
 
+2.5. **Shape claim prompt** (per paper #1188 verdict rule)
+
+   Per #1188's census, the technique layer is shape-diverse (8% cost-displacement vs 36% in papers). Make the technique's primary shape claim explicit so future paper authors can cite accurately.
+
+   AskUserQuestion: "What primary shape claim does this technique make? Pick from:
+   - cost-displacement crossover **(NOTE: rare in techniques per #1188 census; use only if actual shape is genuinely crossover)**
+   - threshold-cliff
+   - log-search
+   - hysteresis
+   - convergence
+   - necessity
+   - pareto distribution
+   - saturation-without-crossover
+   - invariant-only (no shape claim — pattern only)
+   - structural-only (no shape claim — composition recipe only)
+   - other (specify)"
+
+   - **If cost-displacement chosen**: AskUserQuestion: "Why cost-displacement? Per #1188, technique layer is shape-diverse — most techniques are invariant-only or structural-only. Justify the crossover claim."
+   - Capture chosen shape; add to `tags` and surface in recipe.one_line phrasing.
+
 3. **Pick composes[]** (iterative loop, minimum 2 atoms required):
    - Ask user: "search for atom to add? (or `done` to finish)".
    - On keyword: delegate to `/hub-find` flow, show top N results with `kind` badge.
@@ -35,6 +55,19 @@ Authoring workflow for the `technique/` middle layer. Produces a `.technique-dra
    - After each add, show running list.
    - Reject: atom whose `kind` is `technique` (v0 nesting ban).
    - Stop condition: user says `done` AND `composes[].length >= 2`. If `< 2`, warn: "a technique with fewer than 2 atoms is just a skill — continue anyway?".
+
+3.5. **Recipe block (v0.2 §13 required fields)**
+
+   Per `docs/rfc/technique-schema-draft.md` §13, v0.2 techniques carry a `recipe:` block. Collect all 5 required fields:
+
+   - **`recipe.one_line`** (single sentence summarizing what this technique does + key shape claim phrasing if any)
+   - **`recipe.preconditions`** (≥3 bullet points — when does this technique apply?)
+   - **`recipe.anti_conditions`** (≥3 bullet points — when does this technique NOT apply?)
+   - **`recipe.failure_modes`** (≥3 entries — each with `signal`, `atom_ref` linking to a `composes[]` atom, `remediation`)
+   - **`recipe.assembly_order`** (phase sequence — each phase has `phase` name and `uses` reference; branches optional)
+
+   - WARN if any required field is empty. Suggest: "this is a v0.1-only technique without recipe block. Switch to v0.2 by populating recipe? (y/n)".
+   - If yes, version bumps from `0.1.0-draft` → `0.2.0-draft`.
 
 4. **Optional verify hook**:
    - Ask: "scaffold `verify.sh`? (yes/no)".


### PR DESCRIPTION
## Summary

Sibling to #1223 (`/hub-paper-compose` verdict prompts). Extends `/hub-technique-compose` with 2 inject points surfacing verdict rules at technique compose time.

## Bias-correction pipeline now fully symmetric

| Stage | Paper | Technique |
|---|---|---|
| **Compose** | `/hub-paper-compose` (#1223) | **`/hub-technique-compose` (this PR)** |
| **Write (PR)** | `paper.md` (#1221) | `technique.md` (#1224) |
| **Review/Measure** | shape-claim auditor (#1222) — covers both layers |  |

5 PRs together = full bias-correction pipeline across paper + technique authoring.

## Inject points

### Step 2.5 — Shape claim prompt (#1188 verdict)

After frontmatter collection, before composes:
- 10-shape catalog (matches technique.md PR template #1224)
- cost-displacement marked as rare-in-techniques per #1188 census
- If chosen: justification prompt required

### Step 3.5 — Recipe block (v0.2 §13 required fields)

After composes[], before verify hook:
- Collects all 5 required recipe fields:
  - `recipe.one_line`
  - `recipe.preconditions` (≥3)
  - `recipe.anti_conditions` (≥3)
  - `recipe.failure_modes` (≥3 with atom_ref + remediation)
  - `recipe.assembly_order`
- Version bumps `0.1.0-draft` → `0.2.0-draft` when recipe populated
- WARN on incomplete fields

## Why both inject points matter

Without these prompts, technique compose collected v0.1 frontmatter only — recipe block was added post-hoc by audit (`_audit_technique_v02.py`). Author had to manually edit the file to add recipe block, then re-verify.

After this PR: recipe block collected at compose time. v0.2 §13 enforcement no longer reactive (audit catches missing fields) but **proactive** (compose-time prompts).

Same shape-selector phrasing as paper.md / technique.md PR templates ensures consistent author choices across all 5 application points.

## Test plan

- [x] Edits applied to bootstrap/commands/hub-technique-compose.md
- [x] 2 inject points placed at correct sequence positions
- [x] Reference to #1188 census + #1223 paper-compose accurate
- [ ] Reviewer: confirm AskUserQuestion phrasing matches the 10-shape catalog used in technique.md (#1224)
- [ ] Reviewer: dry-run `/hub-technique-compose <test-slug>` to verify prompts fire in order

## Cross-references

- #1221 paper.md PR template
- #1222 shape-claim auditor
- #1223 /hub-paper-compose verdict prompts (this PR's sibling)
- #1224 technique.md PR template

## Application sequence (after merge)

| # | Application | Status |
|---|---|---|
| ✅ 1 | paper.md PR template (#1221) | merged |
| ✅ 2 | shape-claim auditor (#1222) | merged |
| ✅ 3 | /hub-paper-compose verdict prompts (#1223) | merged |
| ✅ 4 | technique.md PR template (#1224) | merged |
| ✅ **5 (this PR)** | **/hub-technique-compose verdict prompts** | this PR |

5-PR sequence completes the symmetric bias-correction pipeline across paper and technique authoring.

## Follow-ups (not blocking)

- After this lands: `/hub-commands-publish` to ship updated commands to all hub installations
- Default PR template (`default.md`) for non-paper, non-technique PRs
- Track adherence on next 5 technique PRs to test whether shape-claim adoption increases

🤖 Generated with [Claude Code](https://claude.com/claude-code)