### PR TITLE
feat(infra): default PR template — completes 3-template trio (A2 of recommendation order)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,0 +1,84 @@
+<!--
+Default PR template for non-paper, non-technique PRs.
+- For paper PRs: use ?template=paper.md
+- For technique PRs: use ?template=technique.md
+- Otherwise (audits, slash commands, schema amendments, README, infra): use this default
+
+Renamed file: this is the catch-all template for everything that isn't paper or technique authoring.
+-->
+
+## Summary
+
+<!-- 2-3 sentences. What changed and why. -->
+
+## Type
+
+Pick one (helps reviewer focus):
+
+- [ ] **Bug fix** — corrects a defect; preserves existing behavior
+- [ ] **Audit / lint script** — new or modified `bootstrap/tools/_audit_*.py`
+- [ ] **Slash command** — `bootstrap/commands/*.md` edits
+- [ ] **Schema amendment** — `docs/rfc/*.md` proposed change
+- [ ] **Infrastructure** — installer, hooks, CI, PR templates, repo metadata
+- [ ] **Documentation** — README, wiki content, command help
+- [ ] **Refactor** — internal change with no external behavior delta
+- [ ] **Cleanup** — bulk fixes (e.g., strict-YAML quote-wrap, frontmatter trims)
+- [ ] **Other** — specify: ___
+
+## What changed
+
+<!-- File-level breakdown. Be precise. Skip if a single file. -->
+
+- `path/to/file.py` — <!-- one-liner per file -->
+- `path/to/other.md` —
+
+## Why
+
+<!--
+Justification. Cite the verdict / issue / paper that motivates this change.
+Examples:
+- "Per #1188 verdict — cost-displacement default-bias should be auto-detected"
+- "Closes #1234"
+- "Surfaced as TODO in PR #5678 follow-ups"
+-->
+
+## Test plan
+
+- [ ] <!-- e.g., audit runs without errors -->
+- [ ] <!-- e.g., new command dry-runs correctly -->
+- [ ] <!-- e.g., schema audit passes on existing corpus -->
+
+## Audits affected
+
+<!--
+Mark which audits this PR could impact and confirm they still pass.
+Skip if no audit relevance.
+-->
+
+- [ ] `_audit_paper_v03.py`
+- [ ] `_audit_paper_imrad.py`
+- [ ] `_audit_paper_yaml_strict.py`
+- [ ] `_audit_paper_frontmatter_length.py`
+- [ ] `_audit_technique_v02.py`
+- [ ] `_audit_paper_shape_claim.py` (#1222)
+- [ ] `_audit_paper_loops.py`
+- [ ] `_audit_paper_falsifiability.py`
+- [ ] `_audit_orphan_atoms.py`
+- [ ] None applicable
+
+## Cross-references
+
+<!--
+- Related PRs: #
+- Related issues: #
+- Schema docs: docs/rfc/...
+-->
+
+## Follow-ups (not blocking)
+
+<!--
+Optional: TODOs that surface during this PR but don't block merge.
+Filing as issues is recommended (per memory rule).
+-->
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PR DESCRIPTION
## Summary

Adds `.github/PULL_REQUEST_TEMPLATE/default.md` for non-paper, non-technique PRs.

Completes the 3-template trio:
- `paper.md` (#1221) — paper authoring with verdict checklists
- `technique.md` (#1224) — technique authoring with v0.2 §13 recipe checklist
- **`default.md` (this PR)** — catch-all for infra/audit/docs/refactor

## Sections

1. **Summary** — what changed and why
2. **Type** — 9 checkbox options (bug fix / audit / command / schema / infra / docs / refactor / cleanup / other) — helps reviewer focus
3. **What changed** — file-level breakdown
4. **Why** — verdict / issue / paper motivation citation
5. **Test plan**
6. **Audits affected** — 9 audit-script checkboxes for confirming non-regression
7. **Cross-references**
8. **Follow-ups (not blocking)**

## Why default.md matters

Until now, non-paper / non-technique PRs (audits, commands, infra, README updates) had no template guidance. Authors freeforked their PR descriptions, missing structure for:
- Which audit might be affected
- What kind of change this is (helps reviewer)
- What motivates the change (verdict / issue)

This template gives a uniform skeleton without dictating content depth.

## Type-section helps reviewer focus

Each PR type signals different review priority:
- Bug fix → focus on regression
- Audit → focus on shape coverage
- Schema → focus on backward-compat
- Refactor → focus on no behavior delta
- Cleanup → focus on bulk-correctness

## Audits-affected section

When PRs touch non-paper / non-technique files (e.g., `_inject_references_section.py`, `precheck.py`, `install.sh`), it can be unclear which audits might be impacted. The 9-checkbox list makes confirmation trivial.

## Test plan

- [x] Renders correctly on GitHub
- [x] No conflicts with paper.md or technique.md
- [x] All 9 audit names match `bootstrap/tools/_audit_*.py` filenames
- [ ] Reviewer: confirm Type taxonomy covers known PR categories

## Application sequence (recommendation order)

| # | Application | Status |
|---|---|---|
| ✅ A1 | README 9-cluster milestone update (#1226) | merged |
| ✅ **A2 (this PR)** | **Default PR template** | this PR |
| A3 | About/topics update (gh repo edit) | next |
| B5 | 9-cluster census paper (meta survey) | next |

## Cross-references

- #1221 paper.md PR template
- #1224 technique.md PR template
- This PR completes the trio for hub PR conventions

## Follow-ups (not blocking)

- After all 3 templates land: GitHub PR creation auto-suggests template via `?template=` query param
- Future improvement: include screenshot-suggester button in template chooser

🤖 Generated with [Claude Code](https://claude.com/claude-code)